### PR TITLE
[FIX] Corregir wrapping de etiquetas y formato de textos largos

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,7 @@ def create_app(config_name='default'):
     
     from app import models
     
+    # Registrar blueprints
     from app.routes.usuarios import bp as usuarios_bp
     app.register_blueprint(usuarios_bp)
     
@@ -37,5 +38,8 @@ def create_app(config_name='default'):
     
     from app.routes.perfil import bp as perfil_bp
     app.register_blueprint(perfil_bp)
+    
+    from app.routes.expedientes import bp as expedientes_bp
+    app.register_blueprint(expedientes_bp)
     
     return app

--- a/app/models/expedientes.py
+++ b/app/models/expedientes.py
@@ -11,5 +11,18 @@ class Expediente(db.Model):
     heredado = db.Column(db.Boolean)
     proyecto_id = db.Column(db.Integer, db.ForeignKey('proyectos.id'), nullable=False, unique=True)
     
+    # Relaciones SQLAlchemy
+    responsable = db.relationship('Usuario', 
+                                  foreign_keys=[responsable_id],
+                                  backref='expedientes_responsable')
+    
+    proyecto = db.relationship('Proyecto',
+                              foreign_keys=[proyecto_id],
+                              backref=db.backref('expediente', uselist=False))
+    
+    tipo_expediente = db.relationship('TipoExpediente',
+                                     foreign_keys=[tipo_expediente_id],
+                                     backref='expedientes')
+    
     def __repr__(self):
         return f'<Expediente {self.numero_at}>'

--- a/app/models/usuarios.py
+++ b/app/models/usuarios.py
@@ -78,8 +78,21 @@ class Usuario(UserMixin, db.Model):
         self.reset_token_expiry = None
 
     # Helpers de permisos
-    def tiene_rol(self, nombre_rol):
-        return any(rol.nombre == nombre_rol for rol in self.roles)
+    def tiene_rol(self, *nombres_roles):
+        """Verifica si el usuario tiene al menos uno de los roles especificados
+        
+        Args:
+            *nombres_roles: Uno o más nombres de roles a verificar
+            
+        Returns:
+            bool: True si el usuario tiene al menos uno de los roles
+            
+        Ejemplos:
+            usuario.tiene_rol('ADMIN')
+            usuario.tiene_rol('ADMIN', 'SUPERVISOR')
+            usuario.tiene_rol('ADMIN', 'SUPERVISOR', 'TRAMITADOR')
+        """
+        return any(rol.nombre in nombres_roles for rol in self.roles)
 
     @property
     def es_admin(self):

--- a/app/routes/expedientes.py
+++ b/app/routes/expedientes.py
@@ -1,0 +1,166 @@
+"""
+Blueprint para gestión de expedientes.
+
+Rutas:
+- GET  /expedientes/        - Listar expedientes (filtrados por rol)
+- GET  /expedientes/nuevo   - Formulario crear expediente
+- POST /expedientes/nuevo   - Crear expediente + proyecto
+- GET  /expedientes/<id>    - Ver detalle expediente
+- GET  /expedientes/<id>/editar  - Formulario editar expediente
+- POST /expedientes/<id>/editar  - Actualizar expediente + proyecto
+"""
+from flask import Blueprint, render_template, request, flash, redirect, url_for
+from flask_login import login_required, current_user
+from app import db
+from app.models.expedientes import Expediente
+from app.models.proyectos import Proyecto
+from app.models.usuarios import Usuario
+from app.models.tipos_expedientes import TipoExpediente
+from app.models.tipos_ia import TipoIA
+from app.decorators import role_required
+from app.utils.permisos import (
+    puede_cambiar_responsable,
+    verificar_acceso_expediente
+)
+
+# Blueprint con convención snake_case
+bp = Blueprint('expedientes', __name__, url_prefix='/expedientes')
+
+
+@bp.route('/')
+@login_required
+def index():
+    """Lista todos los expedientes (filtrados según rol del usuario)"""
+    # TRAMITADOR solo ve sus expedientes
+    if not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+        expedientes = Expediente.query.filter_by(
+            responsable_id=current_user.id
+        ).order_by(Expediente.numero_at.desc()).all()
+    else:
+        # ADMIN/SUPERVISOR ven todos
+        expedientes = Expediente.query.order_by(
+            Expediente.numero_at.desc()
+        ).all()
+    
+    return render_template('expedientes/index.html', expedientes=expedientes)
+
+
+@bp.route('/nuevo', methods=['GET', 'POST'])
+@login_required
+@role_required('ADMIN', 'SUPERVISOR', 'TRAMITADOR')
+def nuevo():
+    """Crear nuevo expediente con proyecto asociado (relación 1:1)"""
+    if request.method == 'POST':
+        try:
+            # Crear PROYECTO - PostgreSQL aplicará defaults automáticamente
+            nuevo_proyecto = Proyecto(
+                titulo=request.form.get('titulo_proyecto') or None,
+                descripcion=request.form.get('descripcion_proyecto') or None,
+                finalidad=request.form.get('finalidad') or None,
+                emplazamiento=request.form.get('emplazamiento') or None,
+                ia_id=request.form.get('ia_id') or None
+            )
+            db.session.add(nuevo_proyecto)
+            db.session.flush()  # Obtener ID del proyecto sin commit
+            
+            # Generar número AT automático (próximo disponible)
+            ultimo_numero = db.session.query(
+                db.func.max(Expediente.numero_at)
+            ).scalar() or 0
+            numero_at = ultimo_numero + 1
+            
+            # Crear EXPEDIENTE vinculado al proyecto
+            nuevo_expediente = Expediente(
+                numero_at=numero_at,
+                responsable_id=request.form.get('responsable_id') or current_user.id,
+                tipo_expediente_id=request.form.get('tipo_expediente_id') or None,
+                heredado=request.form.get('heredado') == 'on',
+                proyecto_id=nuevo_proyecto.id
+            )
+            
+            db.session.add(nuevo_expediente)
+            db.session.commit()
+            
+            flash(f'Expediente AT-{numero_at} creado correctamente', 'success')
+            return redirect(url_for('expedientes.detalle', id=nuevo_expediente.id))
+            
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error al crear expediente: {str(e)}', 'danger')
+            return redirect(url_for('expedientes.nuevo'))
+    
+    # GET: Mostrar formulario
+    tipos_expedientes = TipoExpediente.query.all()
+    tipos_ia = TipoIA.query.all()
+    usuarios = Usuario.query.filter_by(activo=True).all()
+    
+    return render_template('expedientes/nuevo.html', 
+                         tipos_expedientes=tipos_expedientes,
+                         tipos_ia=tipos_ia,
+                         usuarios=usuarios)
+
+
+@bp.route('/<int:id>')
+@login_required
+def detalle(id):
+    """Vista detallada de un expediente con toda su información"""
+    expediente = Expediente.query.get_or_404(id)
+    
+    # Verificación usando la utilidad
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+    
+    return render_template('expedientes/detalle.html', expediente=expediente)
+
+
+@bp.route('/<int:id>/editar', methods=['GET', 'POST'])
+@login_required
+def editar(id):
+    """Editar expediente y proyecto asociado"""
+    expediente = Expediente.query.get_or_404(id)
+    
+    # Verificación usando la utilidad
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+    
+    if request.method == 'POST':
+        try:
+            # Actualizar EXPEDIENTE
+            expediente.tipo_expediente_id = request.form.get('tipo_expediente_id') or None
+            expediente.heredado = request.form.get('heredado') == 'on'
+            
+            # Solo ADMIN/SUPERVISOR puede cambiar responsable (usando utilidad)
+            if puede_cambiar_responsable():
+                nuevo_responsable_id = request.form.get('responsable_id')
+                if nuevo_responsable_id:
+                    expediente.responsable_id = nuevo_responsable_id
+            
+            # Actualizar PROYECTO - PostgreSQL mantiene defaults si vienen None
+            proyecto = expediente.proyecto
+            proyecto.titulo = request.form.get('titulo_proyecto') or None
+            proyecto.descripcion = request.form.get('descripcion_proyecto') or None
+            proyecto.finalidad = request.form.get('finalidad') or None
+            proyecto.emplazamiento = request.form.get('emplazamiento') or None
+            proyecto.ia_id = request.form.get('ia_id') or None
+            
+            db.session.commit()
+            
+            flash(f'Expediente AT-{expediente.numero_at} actualizado correctamente', 'success')
+            return redirect(url_for('expedientes.detalle', id=expediente.id))
+            
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error al actualizar expediente: {str(e)}', 'danger')
+    
+    # GET: Mostrar formulario
+    tipos_expedientes = TipoExpediente.query.all()
+    tipos_ia = TipoIA.query.all()
+    usuarios = Usuario.query.filter_by(activo=True).all()
+    
+    return render_template('expedientes/editar.html',
+                         expediente=expediente,
+                         tipos_expedientes=tipos_expedientes,
+                         tipos_ia=tipos_ia,
+                         usuarios=usuarios)

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -69,17 +69,23 @@
                 
                 <div class="mb-3">
                     <h6 class="text-muted">Descripción</h6>
-                    <p class="mb-0">{{ expediente.proyecto.descripcion or 'Sin descripción' }}</p>
+                    <p class="mb-0" style="max-height: 300px; overflow-y: auto; white-space: pre-wrap;">
+                        {{- expediente.proyecto.descripcion or 'Sin descripción' -}}
+                    </p>
                 </div>
                 
                 <div class="row">
                     <div class="col-md-6 mb-3">
                         <h6 class="text-muted">Finalidad</h6>
-                        <p class="mb-0">{{ expediente.proyecto.finalidad or 'Sin finalidad' }}</p>
+                        <p class="mb-0" style="max-height: 150px; overflow-y: auto; white-space: pre-wrap;">
+                            {{- expediente.proyecto.finalidad or 'Sin finalidad' -}}
+                        </p>
                     </div>
                     <div class="col-md-6 mb-3">
                         <h6 class="text-muted">Emplazamiento</h6>
-                        <p class="mb-0">{{ expediente.proyecto.emplazamiento or 'Sin emplazamiento' }}</p>
+                        <p class="mb-0" style="max-height: 150px; overflow-y: auto; white-space: pre-wrap;">
+                            {{- expediente.proyecto.emplazamiento or 'Sin emplazamiento' -}}
+                        </p>
                     </div>
                 </div>
                 

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -23,52 +23,46 @@
     </div>
 </div>
 
-<!-- Layout Vertical: Info General arriba, Proyecto abajo -->
-<div class="row">
-    <div class="col-12">
-        <!-- Información General -->
-        <div class="card shadow-sm mb-3">
+<!-- FILA 1: Información General (estrecha) + Proyecto (ancha) -->
+<div class="row mb-3">
+    <div class="col-lg-3 col-md-4">
+        <div class="card shadow-sm h-100">
             <div class="card-header bg-success text-white">
                 <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>Información General</h5>
             </div>
             <div class="card-body">
-                <dl class="mb-0">
-                    <dt style="font-weight: bold; margin-top: 0;">Número AT:</dt>
-                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
-                        <strong class="text-primary">{{ expediente.numero_at }}</strong>
-                    </dd>
-                    
-                    <dt style="font-weight: bold; margin-top: 0.5rem;">Tipo:</dt>
-                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
+                <!-- Número AT -->
+                <div class="mb-3">
+                    <div class="text-muted small" style="white-space: nowrap;">Número AT:</div>
+                    <div><strong class="text-primary">{{ expediente.numero_at }}</strong></div>
+                </div>
+                
+                <!-- Tipo -->
+                <div class="mb-3">
+                    <div class="text-muted small" style="white-space: nowrap;">Tipo:</div>
+                    <div>
                         {% if expediente.tipo_expediente %}
                             <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.tipo }}</span>
                         {% else %}
                             <span class="text-muted">Sin tipo</span>
                         {% endif %}
-                    </dd>
-                    
-                    <dt style="font-weight: bold; margin-top: 0.5rem;">Responsable:</dt>
-                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
-                        <strong>{{ expediente.responsable.siglas }}</strong><br>
-                        <small class="text-muted">
-                            {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
-                        </small>
-                    </dd>
-                    
-                    <dt style="font-weight: bold; margin-top: 0.5rem;">Heredado:</dt>
-                    <dd style="margin-left: 2rem; margin-bottom: 0;">
-                        {% if expediente.heredado %}
-                            <span class="badge bg-warning text-dark">Sí</span>
-                        {% else %}
-                            <span class="badge bg-secondary">No</span>
-                        {% endif %}
-                    </dd>
-                </dl>
+                    </div>
+                </div>
+                
+                <!-- Responsable -->
+                <div>
+                    <div class="text-muted small" style="white-space: nowrap;">Responsable:</div>
+                    <div>
+                        <strong>{{ expediente.responsable.siglas }}</strong> - 
+                        {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
+                    </div>
+                </div>
             </div>
         </div>
-        
-        <!-- Proyecto -->
-        <div class="card shadow-sm mb-3">
+    </div>
+    
+    <div class="col-lg-9 col-md-8">
+        <div class="card shadow-sm h-100">
             <div class="card-header bg-primary text-white">
                 <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Proyecto</h5>
             </div>
@@ -94,7 +88,7 @@
                 {% if expediente.proyecto.ia %}
                 <div class="alert alert-warning mb-0">
                     <i class="fas fa-exclamation-triangle me-2"></i>
-                    <strong>Instalación de Alta Tensión:</strong> {{ expediente.proyecto.ia.nombre }}
+                    <strong>Instalación de Alta Tensión:</strong> {{ expediente.proyecto.ia.siglas }} - {{ expediente.proyecto.ia.descripcion }}
                 </div>
                 {% endif %}
             </div>

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -1,0 +1,129 @@
+{% extends 'base.html' %}
+
+{% block title %}Expediente AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-md-8">
+        <h2>
+            <i class="fas fa-folder-open me-2"></i>
+            Expediente AT-{{ expediente.numero_at }}
+            {% if expediente.heredado %}
+                <span class="badge bg-warning text-dark ms-2">Heredado</span>
+            {% endif %}
+        </h2>
+    </div>
+    <div class="col-md-4 text-end">
+        <a href="{{ url_for('expedientes.index') }}" class="btn btn-secondary me-2">
+            <i class="fas fa-arrow-left me-1"></i> Volver
+        </a>
+        <a href="{{ url_for('expedientes.editar', id=expediente.id) }}" class="btn btn-primary">
+            <i class="fas fa-edit me-1"></i> Editar
+        </a>
+    </div>
+</div>
+
+<!-- Información del Expediente -->
+<div class="row">
+    <div class="col-md-4">
+        <div class="card shadow-sm mb-3">
+            <div class="card-header bg-success text-white">
+                <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>Información General</h5>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-5">Número AT:</dt>
+                    <dd class="col-sm-7"><strong class="text-primary">{{ expediente.numero_at }}</strong></dd>
+                    
+                    <dt class="col-sm-5">Tipo:</dt>
+                    <dd class="col-sm-7">
+                        {% if expediente.tipo_expediente %}
+                            <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.nombre }}</span>
+                        {% else %}
+                            <span class="text-muted">Sin tipo</span>
+                        {% endif %}
+                    </dd>
+                    
+                    <dt class="col-sm-5">Responsable:</dt>
+                    <dd class="col-sm-7">
+                        <strong>{{ expediente.responsable.siglas }}</strong><br>
+                        <small class="text-muted">
+                            {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
+                        </small>
+                    </dd>
+                    
+                    <dt class="col-sm-5">Heredado:</dt>
+                    <dd class="col-sm-7">
+                        {% if expediente.heredado %}
+                            <span class="badge bg-warning text-dark">Sí</span>
+                        {% else %}
+                            <span class="badge bg-secondary">No</span>
+                        {% endif %}
+                    </dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-8">
+        <!-- Datos del Proyecto -->
+        <div class="card shadow-sm mb-3">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Proyecto</h5>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">{{ expediente.proyecto.titulo }}</h5>
+                
+                <div class="mb-3">
+                    <h6 class="text-muted">Descripción</h6>
+                    <p class="mb-0">{{ expediente.proyecto.descripcion or 'Sin descripción' }}</p>
+                </div>
+                
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <h6 class="text-muted">Finalidad</h6>
+                        <p class="mb-0">{{ expediente.proyecto.finalidad or 'Sin finalidad' }}</p>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <h6 class="text-muted">Emplazamiento</h6>
+                        <p class="mb-0">{{ expediente.proyecto.emplazamiento or 'Sin emplazamiento' }}</p>
+                    </div>
+                </div>
+                
+                {% if expediente.proyecto.ia %}
+                <div class="alert alert-warning mb-0">
+                    <i class="fas fa-exclamation-triangle me-2"></i>
+                    <strong>Instalación de Alta Tensión:</strong> {{ expediente.proyecto.ia.nombre }}
+                </div>
+                {% endif %}
+            </div>
+        </div>
+        
+        <!-- Secciones futuras (placeholders) -->
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card shadow-sm mb-3">
+                    <div class="card-header bg-light">
+                        <h6 class="mb-0"><i class="fas fa-tasks me-2"></i>Tramitación</h6>
+                    </div>
+                    <div class="card-body text-center text-muted py-4">
+                        <i class="fas fa-clipboard-list fa-2x mb-2"></i>
+                        <p class="mb-0 small">Próximamente</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card shadow-sm mb-3">
+                    <div class="card-header bg-light">
+                        <h6 class="mb-0"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
+                    </div>
+                    <div class="card-body text-center text-muted py-4">
+                        <i class="fas fa-folder fa-2x mb-2"></i>
+                        <p class="mb-0 small">Próximamente</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -23,22 +23,23 @@
     </div>
 </div>
 
-<!-- FILA 1: Información General (estrecha) + Proyecto (ancha) -->
-<div class="row mb-3">
-    <div class="col-lg-3 col-md-4">
-        <div class="card shadow-sm h-100">
+<!-- Layout Vertical: Info General arriba, Proyecto abajo -->
+<div class="row">
+    <div class="col-12">
+        <!-- Información General -->
+        <div class="card shadow-sm mb-3">
             <div class="card-header bg-success text-white">
                 <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>Información General</h5>
             </div>
             <div class="card-body">
-                <dl class="row mb-0">
-                    <!-- Número AT: 2 columnas -->
-                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Número AT:</dt>
-                    <dd class="col-sm-7"><strong class="text-primary">{{ expediente.numero_at }}</strong></dd>
+                <dl class="mb-0">
+                    <dt style="font-weight: bold; margin-top: 0;">Número AT:</dt>
+                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
+                        <strong class="text-primary">{{ expediente.numero_at }}</strong>
+                    </dd>
                     
-                    <!-- Tipo: 2 columnas -->
-                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Tipo:</dt>
-                    <dd class="col-sm-7">
+                    <dt style="font-weight: bold; margin-top: 0.5rem;">Tipo:</dt>
+                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
                         {% if expediente.tipo_expediente %}
                             <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.tipo }}</span>
                         {% else %}
@@ -46,18 +47,16 @@
                         {% endif %}
                     </dd>
                     
-                    <!-- Responsable: etiqueta arriba, valor abajo -->
-                    <dt class="col-12 mt-2" style="white-space: nowrap;">Responsable:</dt>
-                    <dd class="col-12">
+                    <dt style="font-weight: bold; margin-top: 0.5rem;">Responsable:</dt>
+                    <dd style="margin-left: 2rem; margin-bottom: 0.5rem;">
                         <strong>{{ expediente.responsable.siglas }}</strong><br>
                         <small class="text-muted">
                             {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
                         </small>
                     </dd>
                     
-                    <!-- Heredado: 2 columnas -->
-                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Heredado:</dt>
-                    <dd class="col-sm-7">
+                    <dt style="font-weight: bold; margin-top: 0.5rem;">Heredado:</dt>
+                    <dd style="margin-left: 2rem; margin-bottom: 0;">
                         {% if expediente.heredado %}
                             <span class="badge bg-warning text-dark">Sí</span>
                         {% else %}
@@ -67,10 +66,9 @@
                 </dl>
             </div>
         </div>
-    </div>
-    
-    <div class="col-lg-9 col-md-8">
-        <div class="card shadow-sm h-100">
+        
+        <!-- Proyecto -->
+        <div class="card shadow-sm mb-3">
             <div class="card-header bg-primary text-white">
                 <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Proyecto</h5>
             </div>

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -32,27 +32,31 @@
             </div>
             <div class="card-body">
                 <dl class="row mb-0">
-                    <dt class="col-sm-5">Número AT:</dt>
+                    <!-- Número AT: 2 columnas -->
+                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Número AT:</dt>
                     <dd class="col-sm-7"><strong class="text-primary">{{ expediente.numero_at }}</strong></dd>
                     
-                    <dt class="col-sm-5">Tipo:</dt>
+                    <!-- Tipo: 2 columnas -->
+                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Tipo:</dt>
                     <dd class="col-sm-7">
                         {% if expediente.tipo_expediente %}
-                            <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.nombre }}</span>
+                            <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.tipo }}</span>
                         {% else %}
                             <span class="text-muted">Sin tipo</span>
                         {% endif %}
                     </dd>
                     
-                    <dt class="col-sm-5">Responsable:</dt>
-                    <dd class="col-sm-7">
+                    <!-- Responsable: etiqueta arriba, valor abajo -->
+                    <dt class="col-12 mt-2" style="white-space: nowrap;">Responsable:</dt>
+                    <dd class="col-12">
                         <strong>{{ expediente.responsable.siglas }}</strong><br>
                         <small class="text-muted">
                             {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
                         </small>
                     </dd>
                     
-                    <dt class="col-sm-5">Heredado:</dt>
+                    <!-- Heredado: 2 columnas -->
+                    <dt class="col-sm-5 text-end" style="white-space: nowrap;">Heredado:</dt>
                     <dd class="col-sm-7">
                         {% if expediente.heredado %}
                             <span class="badge bg-warning text-dark">Sí</span>

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -23,10 +23,10 @@
     </div>
 </div>
 
-<!-- Información del Expediente -->
-<div class="row">
-    <div class="col-md-4">
-        <div class="card shadow-sm mb-3">
+<!-- FILA 1: Información General (estrecha) + Proyecto (ancha) -->
+<div class="row mb-3">
+    <div class="col-lg-3 col-md-4">
+        <div class="card shadow-sm h-100">
             <div class="card-header bg-success text-white">
                 <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>Información General</h5>
             </div>
@@ -65,9 +65,8 @@
         </div>
     </div>
     
-    <div class="col-md-8">
-        <!-- Datos del Proyecto -->
-        <div class="card shadow-sm mb-3">
+    <div class="col-lg-9 col-md-8">
+        <div class="card shadow-sm h-100">
             <div class="card-header bg-primary text-white">
                 <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Proyecto</h5>
             </div>
@@ -98,30 +97,31 @@
                 {% endif %}
             </div>
         </div>
-        
-        <!-- Secciones futuras (placeholders) -->
-        <div class="row">
-            <div class="col-md-6">
-                <div class="card shadow-sm mb-3">
-                    <div class="card-header bg-light">
-                        <h6 class="mb-0"><i class="fas fa-tasks me-2"></i>Tramitación</h6>
-                    </div>
-                    <div class="card-body text-center text-muted py-4">
-                        <i class="fas fa-clipboard-list fa-2x mb-2"></i>
-                        <p class="mb-0 small">Próximamente</p>
-                    </div>
-                </div>
+    </div>
+</div>
+
+<!-- FILA 2: Tramitación (50%) + Documentos (50%) -->
+<div class="row">
+    <div class="col-md-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-light">
+                <h6 class="mb-0"><i class="fas fa-tasks me-2"></i>Tramitación</h6>
             </div>
-            <div class="col-md-6">
-                <div class="card shadow-sm mb-3">
-                    <div class="card-header bg-light">
-                        <h6 class="mb-0"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
-                    </div>
-                    <div class="card-body text-center text-muted py-4">
-                        <i class="fas fa-folder fa-2x mb-2"></i>
-                        <p class="mb-0 small">Próximamente</p>
-                    </div>
-                </div>
+            <div class="card-body text-center text-muted py-4">
+                <i class="fas fa-clipboard-list fa-2x mb-2"></i>
+                <p class="mb-0 small">Próximamente</p>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-light">
+                <h6 class="mb-0"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
+            </div>
+            <div class="card-body text-center text-muted py-4">
+                <i class="fas fa-folder fa-2x mb-2"></i>
+                <p class="mb-0 small">Próximamente</p>
             </div>
         </div>
     </div>

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -32,26 +32,24 @@
             </div>
             <div class="card-body">
                 <!-- Número AT -->
-                <div class="mb-3">
-                    <div class="text-muted small" style="white-space: nowrap;">Número AT:</div>
-                    <div><strong class="text-primary">{{ expediente.numero_at }}</strong></div>
+                <div class="mb-2">
+                    <span class="text-muted small" style="white-space: nowrap;">Número AT:</span>
+                    <strong class="text-primary ms-2">{{ expediente.numero_at }}</strong>
                 </div>
                 
                 <!-- Tipo -->
                 <div class="mb-3">
-                    <div class="text-muted small" style="white-space: nowrap;">Tipo:</div>
-                    <div>
-                        {% if expediente.tipo_expediente %}
-                            <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.tipo }}</span>
-                        {% else %}
-                            <span class="text-muted">Sin tipo</span>
-                        {% endif %}
-                    </div>
+                    <span class="text-muted small" style="white-space: nowrap;">Tipo:</span>
+                    {% if expediente.tipo_expediente %}
+                        <span class="badge bg-info text-dark ms-2">{{ expediente.tipo_expediente.tipo }}</span>
+                    {% else %}
+                        <span class="text-muted ms-2">Sin tipo</span>
+                    {% endif %}
                 </div>
                 
                 <!-- Responsable -->
                 <div>
-                    <div class="text-muted small" style="white-space: nowrap;">Responsable:</div>
+                    <div class="text-muted small mb-1" style="white-space: nowrap;">Responsable:</div>
                     <div>
                         <strong>{{ expediente.responsable.siglas }}</strong> - 
                         {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}

--- a/app/templates/expedientes/editar.html
+++ b/app/templates/expedientes/editar.html
@@ -36,7 +36,7 @@
                             {% for tipo in tipos_expedientes %}
                                 <option value="{{ tipo.id }}" 
                                         {% if expediente.tipo_expediente_id == tipo.id %}selected{% endif %}>
-                                    {{ tipo.nombre }}
+                                    {{ tipo.tipo }}
                                 </option>
                             {% endfor %}
                         </select>
@@ -116,7 +116,7 @@
                             {% for tipo_ia in tipos_ia %}
                                 <option value="{{ tipo_ia.id }}" 
                                         {% if expediente.proyecto.ia_id == tipo_ia.id %}selected{% endif %}>
-                                    {{ tipo_ia.nombre }}
+                                    {{ tipo_ia.siglas }} - {{ tipo_ia.descripcion }}
                                 </option>
                             {% endfor %}
                         </select>

--- a/app/templates/expedientes/editar.html
+++ b/app/templates/expedientes/editar.html
@@ -1,0 +1,141 @@
+{% extends 'base.html' %}
+
+{% block title %}Editar Expediente AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-md-12">
+        <h2>
+            <i class="fas fa-edit me-2"></i>Editar Expediente AT-{{ expediente.numero_at }}
+        </h2>
+        <p class="text-muted">Modificar datos del expediente y su proyecto asociado</p>
+    </div>
+</div>
+
+<form action="{{ url_for('expedientes.editar', id=expediente.id) }}" method="POST">
+    <div class="row">
+        <!-- Columna Izquierda: Datos del Expediente -->
+        <div class="col-md-4">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-success text-white">
+                    <h5 class="mb-0"><i class="fas fa-folder me-2"></i>Datos del Expediente</h5>
+                </div>
+                <div class="card-body">
+                    <!-- Número AT (bloqueado) -->
+                    <div class="mb-3">
+                        <label class="form-label">Número AT</label>
+                        <input type="text" class="form-control" value="AT-{{ expediente.numero_at }}" disabled>
+                        <small class="form-text text-muted">No se puede modificar</small>
+                    </div>
+                    
+                    <!-- Tipo Expediente -->
+                    <div class="mb-3">
+                        <label for="tipo_expediente_id" class="form-label">Tipo de Expediente</label>
+                        <select class="form-select" id="tipo_expediente_id" name="tipo_expediente_id">
+                            <option value="">-- Sin tipo --</option>
+                            {% for tipo in tipos_expedientes %}
+                                <option value="{{ tipo.id }}" 
+                                        {% if expediente.tipo_expediente_id == tipo.id %}selected{% endif %}>
+                                    {{ tipo.nombre }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    
+                    <!-- Responsable -->
+                    <div class="mb-3">
+                        <label for="responsable_id" class="form-label">Responsable</label>
+                        <select class="form-select" id="responsable_id" name="responsable_id" 
+                                {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}disabled{% endif %}>
+                            {% for usuario in usuarios %}
+                                <option value="{{ usuario.id }}" 
+                                        {% if expediente.responsable_id == usuario.id %}selected{% endif %}>
+                                    {{ usuario.siglas }} - {{ usuario.nombre }} {{ usuario.apellido1 }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}
+                            <small class="form-text text-muted">Solo ADMIN/SUPERVISOR puede cambiar responsable</small>
+                        {% endif %}
+                    </div>
+                    
+                    <!-- Heredado -->
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="heredado" name="heredado" 
+                                   {% if expediente.heredado %}checked{% endif %}>
+                            <label class="form-check-label" for="heredado">
+                                Expediente Heredado
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Columna Derecha: Datos del Proyecto -->
+        <div class="col-md-8">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Datos del Proyecto</h5>
+                </div>
+                <div class="card-body">
+                    <!-- Título -->
+                    <div class="mb-3">
+                        <label for="titulo_proyecto" class="form-label">Título del Proyecto</label>
+                        <input type="text" class="form-control" id="titulo_proyecto" name="titulo_proyecto" 
+                               value="{{ expediente.proyecto.titulo }}">
+                    </div>
+                    
+                    <!-- Descripción -->
+                    <div class="mb-3">
+                        <label for="descripcion_proyecto" class="form-label">Descripción</label>
+                        <textarea class="form-control" id="descripcion_proyecto" name="descripcion_proyecto" 
+                                  rows="3">{{ expediente.proyecto.descripcion }}</textarea>
+                    </div>
+                    
+                    <!-- Finalidad -->
+                    <div class="mb-3">
+                        <label for="finalidad" class="form-label">Finalidad</label>
+                        <input type="text" class="form-control" id="finalidad" name="finalidad" 
+                               value="{{ expediente.proyecto.finalidad }}">
+                    </div>
+                    
+                    <!-- Emplazamiento -->
+                    <div class="mb-3">
+                        <label for="emplazamiento" class="form-label">Emplazamiento</label>
+                        <input type="text" class="form-control" id="emplazamiento" name="emplazamiento" 
+                               value="{{ expediente.proyecto.emplazamiento }}">
+                    </div>
+                    
+                    <!-- Tipo IA -->
+                    <div class="mb-3">
+                        <label for="ia_id" class="form-label">Tipo de Instalación de Alta Tensión</label>
+                        <select class="form-select" id="ia_id" name="ia_id">
+                            <option value="">-- Sin tipo IA --</option>
+                            {% for tipo_ia in tipos_ia %}
+                                <option value="{{ tipo_ia.id }}" 
+                                        {% if expediente.proyecto.ia_id == tipo_ia.id %}selected{% endif %}>
+                                    {{ tipo_ia.nombre }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Botones de Acción -->
+    <div class="row">
+        <div class="col-md-12 text-end">
+            <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}" class="btn btn-secondary me-2">
+                <i class="fas fa-times me-1"></i> Cancelar
+            </a>
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-save me-1"></i> Guardar Cambios
+            </button>
+        </div>
+    </div>
+</form>
+{% endblock %}

--- a/app/templates/expedientes/index.html
+++ b/app/templates/expedientes/index.html
@@ -1,0 +1,110 @@
+{% extends 'base.html' %}
+
+{% block title %}Expedientes - BDDAT{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-md-8">
+        <h2><i class="fas fa-folder-open me-2"></i>Expedientes</h2>
+        <p class="text-muted">
+            {% if current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}
+                Vista completa de todos los expedientes del sistema
+            {% else %}
+                Tus expedientes asignados
+            {% endif %}
+        </p>
+    </div>
+    <div class="col-md-4 text-end">
+        <a href="{{ url_for('expedientes.nuevo') }}" class="btn btn-success">
+            <i class="fas fa-plus me-1"></i> Nuevo Expediente
+        </a>
+    </div>
+</div>
+
+<!-- Tabla de Expedientes con columnas responsive -->
+<div class="card shadow-sm">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover table-striped mb-0">
+                <thead class="table-success">
+                    <tr>
+                        <th>Número AT</th>
+                        <th>Proyecto</th>
+                        <th class="d-none d-md-table-cell">Tipo</th>
+                        <th class="d-none d-lg-table-cell">Responsable</th>
+                        <th class="d-none d-xl-table-cell">Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for expediente in expedientes %}
+                    <tr>
+                        <td>
+                            <strong class="text-primary">AT-{{ expediente.numero_at }}</strong>
+                            {% if expediente.heredado %}
+                                <span class="badge bg-warning text-dark ms-1" title="Expediente heredado">
+                                    <i class="fas fa-history"></i>
+                                </span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="text-truncate" style="max-width: 300px;" title="{{ expediente.proyecto.titulo }}">
+                                {{ expediente.proyecto.titulo }}
+                            </div>
+                            <small class="text-muted">{{ expediente.proyecto.finalidad or 'Sin finalidad' }}</small>
+                        </td>
+                        <td class="d-none d-md-table-cell">
+                            {% if expediente.tipo_expediente %}
+                                <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.nombre }}</span>
+                            {% else %}
+                                <span class="text-muted small">Sin tipo</span>
+                            {% endif %}
+                        </td>
+                        <td class="d-none d-lg-table-cell">
+                            <span title="{{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}">
+                                {{ expediente.responsable.siglas }}
+                            </span>
+                            {% if expediente.responsable_id == current_user.id %}
+                                <span class="badge bg-primary ms-1">Tú</span>
+                            {% endif %}
+                        </td>
+                        <td class="d-none d-xl-table-cell">
+                            <span class="badge bg-secondary">En tramitación</span>
+                        </td>
+                        <td>
+                            <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}" 
+                               class="btn btn-sm btn-outline-primary me-1" title="Ver detalle">
+                                <i class="fas fa-eye"></i>
+                            </a>
+                            <a href="{{ url_for('expedientes.editar', id=expediente.id) }}" 
+                               class="btn btn-sm btn-outline-secondary" title="Editar">
+                                <i class="fas fa-edit"></i>
+                            </a>
+                        </td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="6" class="text-center py-4 text-muted">
+                            <i class="fas fa-folder-open fa-3x mb-3 d-block"></i>
+                            No hay expedientes disponibles. ¡Crea el primero!
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- Estadísticas rápidas (opcional) -->
+{% if expedientes %}
+<div class="row mt-4">
+    <div class="col-md-12">
+        <div class="alert alert-info">
+            <i class="fas fa-info-circle me-2"></i>
+            Total de expedientes: <strong>{{ expedientes|length }}</strong>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/templates/expedientes/index.html
+++ b/app/templates/expedientes/index.html
@@ -55,7 +55,7 @@
                         </td>
                         <td class="d-none d-md-table-cell">
                             {% if expediente.tipo_expediente %}
-                                <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.nombre }}</span>
+                                <span class="badge bg-info text-dark">{{ expediente.tipo_expediente.tipo }}</span>
                             {% else %}
                                 <span class="text-muted small">Sin tipo</span>
                             {% endif %}

--- a/app/templates/expedientes/nuevo.html
+++ b/app/templates/expedientes/nuevo.html
@@ -32,7 +32,7 @@
                         <select class="form-select" id="tipo_expediente_id" name="tipo_expediente_id">
                             <option value="">-- Sin tipo --</option>
                             {% for tipo in tipos_expedientes %}
-                                <option value="{{ tipo.id }}">{{ tipo.nombre }}</option>
+                                <option value="{{ tipo.id }}">{{ tipo.tipo }}</option>
                             {% endfor %}
                         </select>
                     </div>
@@ -105,7 +105,7 @@
                         <select class="form-select" id="ia_id" name="ia_id">
                             <option value="">-- Sin tipo IA --</option>
                             {% for tipo_ia in tipos_ia %}
-                                <option value="{{ tipo_ia.id }}">{{ tipo_ia.nombre }}</option>
+                                <option value="{{ tipo_ia.id }}">{{ tipo_ia.siglas }} - {{ tipo_ia.descripcion }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/app/templates/expedientes/nuevo.html
+++ b/app/templates/expedientes/nuevo.html
@@ -1,0 +1,129 @@
+{% extends 'base.html' %}
+
+{% block title %}Nuevo Expediente - BDDAT{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col-md-12">
+        <h2><i class="fas fa-plus-circle me-2"></i>Nuevo Expediente</h2>
+        <p class="text-muted">Crear un expediente genera automáticamente su proyecto asociado (relación 1:1)</p>
+    </div>
+</div>
+
+<form action="{{ url_for('expedientes.nuevo') }}" method="POST">
+    <div class="row">
+        <!-- Columna Izquierda: Datos del Expediente -->
+        <div class="col-md-4">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-success text-white">
+                    <h5 class="mb-0"><i class="fas fa-folder me-2"></i>Datos del Expediente</h5>
+                </div>
+                <div class="card-body">
+                    <!-- Número AT (auto) -->
+                    <div class="mb-3">
+                        <label class="form-label">Número AT</label>
+                        <input type="text" class="form-control" value="Generación automática" disabled>
+                        <small class="form-text text-muted">Se asignará el siguiente número disponible</small>
+                    </div>
+                    
+                    <!-- Tipo Expediente -->
+                    <div class="mb-3">
+                        <label for="tipo_expediente_id" class="form-label">Tipo de Expediente</label>
+                        <select class="form-select" id="tipo_expediente_id" name="tipo_expediente_id">
+                            <option value="">-- Sin tipo --</option>
+                            {% for tipo in tipos_expedientes %}
+                                <option value="{{ tipo.id }}">{{ tipo.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    
+                    <!-- Responsable -->
+                    <div class="mb-3">
+                        <label for="responsable_id" class="form-label">Responsable</label>
+                        <select class="form-select" id="responsable_id" name="responsable_id">
+                            {% for usuario in usuarios %}
+                                <option value="{{ usuario.id }}" {% if usuario.id == current_user.id %}selected{% endif %}>
+                                    {{ usuario.siglas }} - {{ usuario.nombre }} {{ usuario.apellido1 }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <small class="form-text text-muted">Por defecto: tú</small>
+                    </div>
+                    
+                    <!-- Heredado -->
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="heredado" name="heredado">
+                            <label class="form-check-label" for="heredado">
+                                Expediente Heredado
+                            </label>
+                        </div>
+                        <small class="form-text text-muted">Marcar si proviene de sistema anterior</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Columna Derecha: Datos del Proyecto -->
+        <div class="col-md-8">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0"><i class="fas fa-project-diagram me-2"></i>Datos del Proyecto</h5>
+                </div>
+                <div class="card-body">
+                    <!-- Título -->
+                    <div class="mb-3">
+                        <label for="titulo_proyecto" class="form-label">Título del Proyecto</label>
+                        <input type="text" class="form-control" id="titulo_proyecto" name="titulo_proyecto" 
+                               placeholder="Ej: Línea aérea de MT 20kV para suministro a CTARE">
+                    </div>
+                    
+                    <!-- Descripción -->
+                    <div class="mb-3">
+                        <label for="descripcion_proyecto" class="form-label">Descripción</label>
+                        <textarea class="form-control" id="descripcion_proyecto" name="descripcion_proyecto" 
+                                  rows="3" placeholder="Descripción detallada del proyecto"></textarea>
+                    </div>
+                    
+                    <!-- Finalidad -->
+                    <div class="mb-3">
+                        <label for="finalidad" class="form-label">Finalidad</label>
+                        <input type="text" class="form-control" id="finalidad" name="finalidad" 
+                               placeholder="Ej: Suministro eléctrico a nueva industria">
+                    </div>
+                    
+                    <!-- Emplazamiento -->
+                    <div class="mb-3">
+                        <label for="emplazamiento" class="form-label">Emplazamiento</label>
+                        <input type="text" class="form-control" id="emplazamiento" name="emplazamiento" 
+                               placeholder="Ej: Polígono Industrial Los Olivares, Sevilla">
+                    </div>
+                    
+                    <!-- Tipo IA -->
+                    <div class="mb-3">
+                        <label for="ia_id" class="form-label">Tipo de Instalación de Alta Tensión</label>
+                        <select class="form-select" id="ia_id" name="ia_id">
+                            <option value="">-- Sin tipo IA --</option>
+                            {% for tipo_ia in tipos_ia %}
+                                <option value="{{ tipo_ia.id }}">{{ tipo_ia.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Botones de Acción -->
+    <div class="row">
+        <div class="col-md-12 text-end">
+            <a href="{{ url_for('expedientes.index') }}" class="btn btn-secondary me-2">
+                <i class="fas fa-times me-1"></i> Cancelar
+            </a>
+            <button type="submit" class="btn btn-success">
+                <i class="fas fa-save me-1"></i> Crear Expediente
+            </button>
+        </div>
+    </div>
+</form>
+{% endblock %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,16 @@
+"""
+Módulo de utilidades de la aplicación.
+"""
+from app.utils.permisos import (
+    puede_acceder_expediente,
+    puede_editar_expediente,
+    puede_cambiar_responsable,
+    verificar_acceso_expediente
+)
+
+__all__ = [
+    'puede_acceder_expediente',
+    'puede_editar_expediente',
+    'puede_cambiar_responsable',
+    'verificar_acceso_expediente'
+]

--- a/app/utils/permisos.py
+++ b/app/utils/permisos.py
@@ -1,0 +1,74 @@
+"""
+Utilidades para control de permisos sobre expedientes.
+
+Centraliza la lógica de acceso según roles para evitar duplicación
+y facilitar el mantenimiento de las reglas de negocio.
+"""
+from flask import flash, redirect, url_for
+from flask_login import current_user
+
+
+def puede_acceder_expediente(expediente):
+    """
+    Verifica si el usuario actual puede acceder a un expediente.
+    
+    Reglas:
+    - ADMIN/SUPERVISOR: Acceso total a todos los expedientes
+    - TRAMITADOR/ADMINISTRATIVO: Solo sus expedientes asignados
+    
+    Args:
+        expediente: Instancia del modelo Expediente
+        
+    Returns:
+        bool: True si tiene acceso, False si no
+    """
+    # ADMIN y SUPERVISOR pueden acceder a cualquier expediente
+    if current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+        return True
+    
+    # Otros roles solo a expedientes donde son responsables
+    return expediente.responsable_id == current_user.id
+
+
+def puede_editar_expediente(expediente):
+    """
+    Verifica si el usuario actual puede editar un expediente.
+    
+    Actualmente usa las mismas reglas que puede_acceder_expediente,
+    pero está separado por si en el futuro las reglas difieren
+    (por ejemplo, permitir lectura pero no escritura).
+    
+    Args:
+        expediente: Instancia del modelo Expediente
+        
+    Returns:
+        bool: True si puede editar, False si no
+    """
+    return puede_acceder_expediente(expediente)
+
+
+def puede_cambiar_responsable():
+    """
+    Verifica si el usuario actual puede cambiar el responsable de un expediente.
+    
+    Returns:
+        bool: True si puede cambiar responsable, False si no
+    """
+    return current_user.tiene_rol('ADMIN', 'SUPERVISOR')
+
+
+def verificar_acceso_expediente(expediente, accion='acceder'):
+    """
+    Verifica acceso y redirige con mensaje si no tiene permisos.
+    
+    Args:
+        expediente: Instancia del modelo Expediente
+        accion: Texto descriptivo de la acción ('acceder', 'ver', 'editar', etc.)
+        
+    Returns:
+        None si tiene acceso, Response (redirect) si no tiene acceso
+    """
+    if not puede_acceder_expediente(expediente):
+        flash(f'No tienes permisos para {accion} este expediente', 'danger')
+        return redirect(url_for('expedientes.index'))
+    return None


### PR DESCRIPTION
## Resumen
Corrige el problema de wrapping de etiquetas en la vista de detalle del expediente y mejora el formato de textos largos.

## Cambios realizados

### 1. Fix wrapping de etiquetas (#2)
- **Layout 2 columnas optimizado**: Información General (col-lg-3) + Proyecto (col-lg-9)
- **Etiquetas inline con `white-space: nowrap`**: Las etiquetas nunca se parten en múltiples líneas
- **Campos inline**: Número AT y Tipo muestran etiqueta:valor en la misma línea
- **Campo Heredado**: Eliminado de la lista (ya aparece como badge en el título)
- **Responsable**: Formato compacto "CLG - Carlos López" en una sola línea

### 2. Mejoras adicionales de formato
- **Textos largos con límite de altura**: Descripción (300px), Finalidad y Emplazamiento (150px)
- **Preservación de saltos de línea**: `white-space: pre-wrap` para respetar formato del textarea
- **Scrollbar automática**: `overflow-y: auto` cuando el contenido excede la altura máxima
- **Campo tipo_expediente**: Corregido acceso a `.tipo` en lugar de `.nombre`

## Testing
- ✅ Probado en diferentes tamaños de pantalla (responsive)
- ✅ Etiquetas no se parten nunca
- ✅ Textos largos con scroll funcional
- ✅ Saltos de línea preservados correctamente

## Relacionado
Closes #2