### PR TITLE
[FIX] Validar siglas duplicadas con UX mejorada

### DIFF
--- a/app/routes/usuarios.py
+++ b/app/routes/usuarios.py
@@ -33,6 +33,12 @@ def index():
             password = request.form['password']
             confirm_password = request.form['confirm_password']
             
+            # VALIDACIÓN PREVENTIVA: Verificar si las siglas ya existen
+            if Usuario.query.filter_by(siglas=siglas).first():
+                flash(f'Las siglas "{siglas}" ya están en uso. Por favor, elige otras.', 'warning')
+                usuarios = Usuario.query.all()
+                return render_template('usuarios/index.html', usuarios=usuarios, roles=todos_los_roles)
+            
             # Validación de contraseñas
             if password != confirm_password:
                 flash('Las contraseñas no coinciden', 'danger')
@@ -95,6 +101,14 @@ def editar(id):
     
     if request.method == 'POST':
         try:
+            # VALIDACIÓN PREVENTIVA: Verificar si las siglas ya existen (excepto el usuario actual)
+            nuevas_siglas = request.form['siglas']
+            if nuevas_siglas != usuario.siglas:  # Solo validar si cambiaron las siglas
+                usuario_existente = Usuario.query.filter_by(siglas=nuevas_siglas).first()
+                if usuario_existente:
+                    flash(f'Las siglas "{nuevas_siglas}" ya están en uso. Por favor, elige otras.', 'warning')
+                    return render_template('usuarios/editar.html', usuario=usuario, roles=todos_los_roles)
+            
             # VALIDACIÓN 1: No permitir quitar rol ADMIN al último ADMIN
             roles_ids = request.form.getlist('roles')
             roles_seleccionados = Rol.query.filter(Rol.id.in_(roles_ids)).all()
@@ -147,7 +161,7 @@ def editar(id):
                         return redirect(url_for('usuarios.editar', id=id))
             
             # Actualizar datos personales
-            usuario.siglas = request.form['siglas']
+            usuario.siglas = nuevas_siglas
             usuario.nombre = request.form['nombre']
             usuario.apellido1 = request.form['apellido1']
             usuario.apellido2 = request.form.get('apellido2')

--- a/app/routes/usuarios.py
+++ b/app/routes/usuarios.py
@@ -21,6 +21,11 @@ def current_user_es_admin():
 def index():
     # Recuperamos todos los roles para el formulario
     todos_los_roles = Rol.query.all()
+    usuarios = Usuario.query.all()
+    
+    # Variable para controlar si mostrar modal y preservar datos
+    form_data = None
+    error_siglas = None
 
     if request.method == 'POST':
         # Lógica para crear usuario
@@ -33,27 +38,47 @@ def index():
             password = request.form['password']
             confirm_password = request.form['confirm_password']
             
+            # Capturar roles seleccionados para preservarlos
+            roles_ids = request.form.getlist('roles')
+            
+            # Preparar datos del formulario para devolver en caso de error
+            form_data = {
+                'siglas': siglas,
+                'nombre': nombre,
+                'apellido1': apellido1,
+                'apellido2': apellido2,
+                'roles_ids': roles_ids
+            }
+            
             # VALIDACIÓN PREVENTIVA: Verificar si las siglas ya existen
             if Usuario.query.filter_by(siglas=siglas).first():
-                flash(f'Las siglas "{siglas}" ya están en uso. Por favor, elige otras.', 'warning')
-                usuarios = Usuario.query.all()
-                return render_template('usuarios/index.html', usuarios=usuarios, roles=todos_los_roles)
+                error_siglas = f'Las siglas "{siglas}" ya están en uso. Por favor, elige otras.'
+                return render_template('usuarios/index.html', 
+                                     usuarios=usuarios, 
+                                     roles=todos_los_roles,
+                                     form_data=form_data,
+                                     error_siglas=error_siglas,
+                                     show_modal=True)
             
             # Validación de contraseñas
             if password != confirm_password:
                 flash('Las contraseñas no coinciden', 'danger')
-                return redirect(url_for('usuarios.index'))
-            
-            # Recuperar roles seleccionados (lista de IDs)
-            roles_ids = request.form.getlist('roles')
+                return render_template('usuarios/index.html', 
+                                     usuarios=usuarios, 
+                                     roles=todos_los_roles,
+                                     form_data=form_data,
+                                     show_modal=True)
             
             # NUEVA VALIDACIÓN: SUPERVISOR no puede asignar rol ADMIN
             if not current_user_es_admin():
                 rol_admin = Rol.query.filter_by(nombre='ADMIN').first()
                 if rol_admin and str(rol_admin.id) in roles_ids:
                     flash('No tienes permisos para asignar el rol ADMIN', 'danger')
-                    usuarios = Usuario.query.all()
-                    return render_template('usuarios/index.html', usuarios=usuarios, roles=todos_los_roles)
+                    return render_template('usuarios/index.html', 
+                                         usuarios=usuarios, 
+                                         roles=todos_los_roles,
+                                         form_data=form_data,
+                                         show_modal=True)
             
             # Crear instancia del modelo
             nuevo_usuario = Usuario(
@@ -81,9 +106,13 @@ def index():
         except Exception as e:
             db.session.rollback()
             flash(f'Error al crear usuario: {str(e)}', 'danger')
+            return render_template('usuarios/index.html', 
+                                 usuarios=usuarios, 
+                                 roles=todos_los_roles,
+                                 form_data=form_data,
+                                 show_modal=True)
 
     # GET: Listar todos los usuarios
-    usuarios = Usuario.query.all()
     return render_template('usuarios/index.html', usuarios=usuarios, roles=todos_los_roles)
 
 
@@ -99,6 +128,9 @@ def editar(id):
         flash('No tienes permisos para editar usuarios ADMIN', 'danger')
         return redirect(url_for('usuarios.index'))
     
+    # Variable para error de siglas
+    error_siglas = None
+    
     if request.method == 'POST':
         try:
             # VALIDACIÓN PREVENTIVA: Verificar si las siglas ya existen (excepto el usuario actual)
@@ -106,8 +138,22 @@ def editar(id):
             if nuevas_siglas != usuario.siglas:  # Solo validar si cambiaron las siglas
                 usuario_existente = Usuario.query.filter_by(siglas=nuevas_siglas).first()
                 if usuario_existente:
-                    flash(f'Las siglas "{nuevas_siglas}" ya están en uso. Por favor, elige otras.', 'warning')
-                    return render_template('usuarios/editar.html', usuario=usuario, roles=todos_los_roles)
+                    error_siglas = f'Las siglas "{nuevas_siglas}" ya están en uso. Por favor, elige otras.'
+                    # Preparar form_data para mantener los valores
+                    form_data = {
+                        'siglas': nuevas_siglas,
+                        'nombre': request.form['nombre'],
+                        'apellido1': request.form['apellido1'],
+                        'apellido2': request.form.get('apellido2'),
+                        'email': request.form.get('email'),
+                        'activo': 'activo' in request.form,
+                        'roles_ids': request.form.getlist('roles')
+                    }
+                    return render_template('usuarios/editar.html', 
+                                         usuario=usuario, 
+                                         roles=todos_los_roles,
+                                         error_siglas=error_siglas,
+                                         form_data=form_data)
             
             # VALIDACIÓN 1: No permitir quitar rol ADMIN al último ADMIN
             roles_ids = request.form.getlist('roles')

--- a/app/templates/usuarios/editar.html
+++ b/app/templates/usuarios/editar.html
@@ -17,42 +17,73 @@
                     <div class="row mb-3">
                         <div class="col-md-4">
                             <label for="siglas" class="form-label">Siglas *</label>
-                            <input type="text" class="form-control" id="siglas" name="siglas" 
-                                   value="{{ usuario.siglas }}" required maxlength="50">
+                            <input type="text" 
+                                   class="form-control {% if error_siglas %}is-invalid{% endif %}" 
+                                   id="siglas" 
+                                   name="siglas" 
+                                   value="{{ form_data.siglas if form_data else usuario.siglas }}" 
+                                   required 
+                                   maxlength="50">
+                            {% if error_siglas %}
+                            <div class="invalid-feedback">
+                                {{ error_siglas }}
+                            </div>
+                            {% endif %}
                         </div>
                         <div class="col-md-8">
                             <label for="nombre" class="form-label">Nombre *</label>
-                            <input type="text" class="form-control" id="nombre" name="nombre" 
-                                   value="{{ usuario.nombre }}" required maxlength="100">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="nombre" 
+                                   name="nombre" 
+                                   value="{{ form_data.nombre if form_data else usuario.nombre }}" 
+                                   required 
+                                   maxlength="100">
                         </div>
                     </div>
                     
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="apellido1" class="form-label">Primer Apellido *</label>
-                            <input type="text" class="form-control" id="apellido1" name="apellido1" 
-                                   value="{{ usuario.apellido1 }}" required maxlength="50">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="apellido1" 
+                                   name="apellido1" 
+                                   value="{{ form_data.apellido1 if form_data else usuario.apellido1 }}" 
+                                   required 
+                                   maxlength="50">
                         </div>
                         <div class="col-md-6">
                             <label for="apellido2" class="form-label">Segundo Apellido</label>
-                            <input type="text" class="form-control" id="apellido2" name="apellido2" 
-                                   value="{{ usuario.apellido2 or '' }}" maxlength="50">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="apellido2" 
+                                   name="apellido2" 
+                                   value="{{ form_data.apellido2 if form_data else (usuario.apellido2 or '') }}" 
+                                   maxlength="50">
                         </div>
                     </div>
                     
                     <div class="row mb-3">
                         <div class="col-md-12">
                             <label for="email" class="form-label">Email</label>
-                            <input type="email" class="form-control" id="email" name="email" 
-                                   value="{{ usuario.email or '' }}" placeholder="usuario@ejemplo.com">
+                            <input type="email" 
+                                   class="form-control" 
+                                   id="email" 
+                                   name="email" 
+                                   value="{{ form_data.email if form_data else (usuario.email or '') }}" 
+                                   placeholder="usuario@ejemplo.com">
                         </div>
                     </div>
 
                     <!-- Estado -->
                     <h6 class="border-bottom pb-2 mb-3 mt-4">Estado del Usuario</h6>
                     <div class="form-check form-switch mb-3">
-                        <input class="form-check-input" type="checkbox" id="activo" name="activo" 
-                               {% if usuario.activo %}checked{% endif %}>
+                        <input class="form-check-input" 
+                               type="checkbox" 
+                               id="activo" 
+                               name="activo" 
+                               {% if form_data %}{{ 'checked' if form_data.activo else '' }}{% else %}{{ 'checked' if usuario.activo else '' }}{% endif %}>
                         <label class="form-check-label" for="activo">
                             <strong>Usuario activo</strong>
                             <small class="text-muted d-block">Desactivar impide el acceso sin eliminar datos</small>
@@ -83,9 +114,12 @@
                             {% for rol in roles %}
                             <div class="col-md-6">
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="roles" 
-                                           value="{{ rol.id }}" id="rol_{{ rol.id }}"
-                                           {% if rol in usuario.roles %}checked{% endif %}>
+                                    <input class="form-check-input" 
+                                           type="checkbox" 
+                                           name="roles" 
+                                           value="{{ rol.id }}" 
+                                           id="rol_{{ rol.id }}"
+                                           {% if form_data %}{{ 'checked' if (rol.id|string) in form_data.roles_ids else '' }}{% else %}{{ 'checked' if rol in usuario.roles else '' }}{% endif %}>
                                     <label class="form-check-label" for="rol_{{ rol.id }}">
                                         <strong>{{ rol.nombre }}</strong>
                                         <small class="text-muted d-block">{{ rol.descripcion }}</small>

--- a/app/templates/usuarios/index.html
+++ b/app/templates/usuarios/index.html
@@ -101,21 +101,50 @@
                     <div class="row mb-3">
                         <div class="col-md-4">
                             <label for="siglas" class="form-label">Siglas *</label>
-                            <input type="text" class="form-control" id="siglas" name="siglas" required maxlength="50" placeholder="Ej: CGL">
+                            <input type="text" 
+                                   class="form-control {% if error_siglas %}is-invalid{% endif %}" 
+                                   id="siglas" 
+                                   name="siglas" 
+                                   required 
+                                   maxlength="50" 
+                                   placeholder="Ej: CGL"
+                                   value="{{ form_data.siglas if form_data else '' }}">
+                            {% if error_siglas %}
+                            <div class="invalid-feedback">
+                                {{ error_siglas }}
+                            </div>
+                            {% endif %}
                         </div>
                         <div class="col-md-8">
                             <label for="nombre" class="form-label">Nombre *</label>
-                            <input type="text" class="form-control" id="nombre" name="nombre" required maxlength="100">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="nombre" 
+                                   name="nombre" 
+                                   required 
+                                   maxlength="100"
+                                   value="{{ form_data.nombre if form_data else '' }}">
                         </div>
                     </div>
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="apellido1" class="form-label">Primer Apellido *</label>
-                            <input type="text" class="form-control" id="apellido1" name="apellido1" required maxlength="50">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="apellido1" 
+                                   name="apellido1" 
+                                   required 
+                                   maxlength="50"
+                                   value="{{ form_data.apellido1 if form_data else '' }}">
                         </div>
                         <div class="col-md-6">
                             <label for="apellido2" class="form-label">Segundo Apellido</label>
-                            <input type="text" class="form-control" id="apellido2" name="apellido2" maxlength="50">
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="apellido2" 
+                                   name="apellido2" 
+                                   maxlength="50"
+                                   value="{{ form_data.apellido2 if form_data else '' }}">
                         </div>
                     </div>
 
@@ -147,7 +176,12 @@
                                 {% for rol in roles %}
                                 <div class="col-md-6">
                                     <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" name="roles" value="{{ rol.id }}" id="rol_{{ rol.id }}">
+                                        <input class="form-check-input" 
+                                               type="checkbox" 
+                                               name="roles" 
+                                               value="{{ rol.id }}" 
+                                               id="rol_{{ rol.id }}"
+                                               {% if form_data and (rol.id|string) in form_data.roles_ids %}checked{% endif %}>
                                         <label class="form-check-label" for="rol_{{ rol.id }}">
                                             <strong>{{ rol.nombre }}</strong> <small class="text-muted d-block">{{ rol.descripcion }}</small>
                                         </label>
@@ -173,5 +207,13 @@ function togglePassword(fieldId) {
     const field = document.getElementById(fieldId);
     field.type = field.type === 'password' ? 'text' : 'password';
 }
+
+// Abrir modal automáticamente si hay errores
+{% if show_modal %}
+document.addEventListener('DOMContentLoaded', function() {
+    var modal = new bootstrap.Modal(document.getElementById('crearUsuarioModal'));
+    modal.show();
+});
+{% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Resumen
Mejora la validación de siglas duplicadas al crear/editar usuarios con mejor experiencia de usuario.

## Cambios realizados
- ✅ Validación preventiva antes de INSERT (evita error PostgreSQL)
- ✅ Modal permanece abierto en caso de error
- ✅ Preserva todos los valores del formulario
- ✅ Mensaje de error inline en el campo de siglas (Bootstrap `is-invalid`)
- ✅ Usuario puede modificar siglas sin perder el resto de datos

## Commits incluidos
- [3628aef](https://github.com/genete/bddat/commit/3628aefe97be9b6360e3268fc09898af6db81927) - Validar siglas duplicadas antes de crear/editar usuario
- [27b289d](https://github.com/genete/bddat/commit/27b289daf84160f5ddebe19b5ed1759b6b535905) - Preservar datos formulario en validación siglas
- [e38afd2](https://github.com/genete/bddat/commit/e38afd2936ace3fff3ab1d548ca9d715e30a9ed8) - Mantener modal abierto y preservar valores en error
- [108066b](https://github.com/genete/bddat/commit/108066ba6b4112c2a2d5dfa7cfce75fa8ac2a12f) - Preservar valores y mostrar error inline en editar

## Testing
Probado localmente con éxito.