### PR TITLE
[FIX] Eliminar bloque Usuarios del dashboard

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -27,12 +27,6 @@ def index():
                 {'nombre': 'Documentos', 'url': '#', 'roles': ['TRAMITADOR', 'ADMINISTRATIVO', 'SUPERVISOR', 'ADMIN']},
             ]
         },
-        'Usuarios': {
-            'items': [
-                {'nombre': 'Consultar usuarios', 'url': 'usuarios.index', 'roles': ['TRAMITADOR', 'ADMINISTRATIVO', 'SUPERVISOR', 'ADMIN']},
-                {'nombre': 'Gestión de usuarios', 'url': 'usuarios.index', 'roles': ['SUPERVISOR', 'ADMIN']},
-            ]
-        },
         'Configuración': {
             'items': [
                 {'nombre': 'Tablas maestras', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN'], 'color': 'warning'},


### PR DESCRIPTION
## Problema (Issue #9)
Usuarios TRAMITADOR/ADMINISTRATIVO ven el bloque "Usuarios" en el dashboard pero solo con acceso a "Consultar usuarios", creando confusión y redundancia.

## Solución
Eliminar completamente el bloque "Usuarios" del dashboard.

## Razones
1. **Redundancia total**: El menú de Usuarios ya está en el navbar principal
2. **Inconsistencia UX**: Bloque con solo 1-2 ítems vs otros bloques con múltiples opciones
3. **Confusión innecesaria**: Duplica acceso que ya existe en navbar
4. **Filosofía del dashboard**: Debe mostrar tareas frecuentes de tramitación, no duplicar menús administrativos
5. **Menú completo en navbar**: Ya existe navegación general permanente

## Cambios
- ❌ Eliminado bloque 'Usuarios' del dashboard
- ✅ Gestión de usuarios sigue accesible vía navbar
- ✅ Dashboard ahora muestra: Tramitación, Configuración, Datos Legacy, Sistema

Fixes #9