### PR TITLE
[STYLE] Aplicar colores oficiales Junta de Andalucía

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -29,19 +29,19 @@ def index():
         },
         'Configuración': {
             'items': [
-                {'nombre': 'Tablas maestras', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN'], 'color': 'warning'},
-                {'nombre': 'Gestión estructura', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN'], 'color': 'danger'},
+                {'nombre': 'Tablas maestras', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN']},
+                {'nombre': 'Gestión estructura', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN']},
             ]
         },
         'Datos Legacy': {
             'items': [
                 {'nombre': 'Consultar legacy', 'url': '#', 'roles': ['TRAMITADOR', 'ADMINISTRATIVO', 'SUPERVISOR', 'ADMIN']},
-                {'nombre': 'Gestión legacy', 'url': '#', 'roles': ['ADMIN'], 'color': 'danger'},
+                {'nombre': 'Gestión legacy', 'url': '#', 'roles': ['ADMIN']},
             ]
         },
         'Sistema': {
             'items': [
-                {'nombre': 'Migraciones BD', 'url': '#', 'roles': ['ADMIN'], 'color': 'danger'},
+                {'nombre': 'Migraciones BD', 'url': '#', 'roles': ['ADMIN']},
                 {'nombre': 'Logs del sistema', 'url': '#', 'roles': ['SUPERVISOR', 'ADMIN']},
             ]
         },

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -14,7 +14,7 @@
                 Bienvenido/a, <strong>{{ current_user.nombre }} {{ current_user.apellido1 }}</strong>
                 <span class="badge bg-secondary ms-2">{{ current_user.siglas }}</span>
                 {% for rol in current_user.roles %}
-                <span class="badge bg-info ms-1">{{ rol.nombre }}</span>
+                <span class="badge ms-1" style="background-color: #e6e6e5; color: #54585a;">{{ rol.nombre }}</span>
                 {% endfor %}
             </p>
         </div>
@@ -51,18 +51,6 @@
                             </a>
                             {% else %}
                             <span class="text-muted">{{ item.nombre }}</span>
-                            {% endif %}
-                            
-                            {% if item.color is defined %}
-                                {% if item.color == 'warning' %}
-                                <span class="badge bg-warning text-dark ms-2" title="Requiere precaución">
-                                    <i class="fas fa-exclamation-triangle"></i>
-                                </span>
-                                {% elif item.color == 'danger' %}
-                                <span class="badge bg-danger ms-2" title="Operación crítica">
-                                    <i class="fas fa-exclamation-circle"></i>
-                                </span>
-                                {% endif %}
                             {% endif %}
                         </li>
                         {% endfor %}

--- a/app/templates/usuarios/index.html
+++ b/app/templates/usuarios/index.html
@@ -42,7 +42,7 @@
                     <td>{{ usuario.nombre }} {{ usuario.apellido1 }} {{ usuario.apellido2 or '' }}</td>
                     <td>
                         {% for rol in usuario.roles %}
-                            <span class="badge bg-info text-dark me-1">{{ rol.nombre }}</span>
+                            <span class="badge me-1" style="background-color: #e6e6e5; color: #54585a;">{{ rol.nombre }}</span>
                         {% else %}
                             <span class="text-muted small">Sin roles</span>
                         {% endfor %}
@@ -59,7 +59,7 @@
                                        onchange="if(confirm('¿Cambiar estado de {{ usuario.siglas }}?')) this.form.submit();">
                                 <label class="form-check-label" for="switch_{{ usuario.id }}">
                                     {% if usuario.activo %}
-                                        <span class="badge bg-success">Activo</span>
+                                        <span class="badge" style="background-color: #00695c; color: white;">Activo</span>
                                     {% else %}
                                         <span class="badge bg-secondary">Inactivo</span>
                                     {% endif %}


### PR DESCRIPTION
## Resumen
Aplica la paleta de colores oficial de la Junta de Andalucía según su Manual de Identidad Corporativa, eliminando badges estridentes y mejorando la UI.

## Cambios realizados

### 1. Dashboard
- ❌ **Eliminados badges de advertencia** (⚠️ warning, 🔴 danger)
  - Se mostrarán en formularios cuando se implementen, no en navegación
- ✅ **Badges de roles del usuario**: Gris Cool Gray 2 (`#e6e6e5`) con texto Cool Gray 11 (`#54585a`)

### 2. Tabla de Usuarios
- ✅ **Badges de roles**: Gris Cool Gray 2/11 (discretos, no distraen)
- ✅ **Badge "Activo"**: Verde corporativo JA (`#00695c`)
- ✅ Badge "Inactivo" sin cambios (`bg-secondary`)

## Colores aplicados (Manual Identidad Corporativa JA)
- Verde corporativo: `#00695c` (Pantone 356 C)
- Cool Gray 2: `#e6e6e5`
- Cool Gray 11: `#54585a`

## Resultado
- UI más limpia y profesional
- Badges discretos que no hieren la vista
- Cumplimiento con estándares oficiales JA

## Commits
- [35f80dc](https://github.com/genete/bddat/commit/35f80dc4bb2b274777270e9d795cfd8d8f874c88) - Eliminar badges advertencia del dashboard
- [db7b93d](https://github.com/genete/bddat/commit/db7b93d2e451f82826475f4d90f7a3a5527510d2) - Aplicar colores oficiales JA en dashboard
- [4b4ef2a](https://github.com/genete/bddat/commit/4b4ef2a9f66463a8e5945fc667eaa7697b714640) - Aplicar colores oficiales JA en tabla usuarios