### PR TITLE
Fix: Resolver errores de email duplicado en usuarios (Issues #12 y #13)

### DIFF
--- a/app/models/usuarios.py
+++ b/app/models/usuarios.py
@@ -29,7 +29,7 @@ class Usuario(UserMixin, db.Model):
     nombre = db.Column(db.String(100), nullable=False, default='Usuario')
     apellido1 = db.Column(db.String(50), nullable=False, default='no asignado')
     apellido2 = db.Column(db.String(50))
-    email = db.Column(db.String(120), unique=True, nullable=True)
+    _email = db.Column('email', db.String(120), unique=True, nullable=True)
     activo = db.Column(db.Boolean, default=True)
     
     # Seguridad y Roles
@@ -41,6 +41,19 @@ class Usuario(UserMixin, db.Model):
     
     # Relación M:N con Roles
     roles = db.relationship('Rol', secondary=usuarios_roles, backref=db.backref('usuarios', lazy='dynamic'))
+
+    # Property para email que convierte cadenas vacías a None
+    @property
+    def email(self):
+        return self._email
+    
+    @email.setter
+    def email(self, value):
+        """Convierte cadenas vacías a None para evitar violación de constraint UNIQUE"""
+        if value == '' or (isinstance(value, str) and value.strip() == ''):
+            self._email = None
+        else:
+            self._email = value
 
     # Flask-Login: sobrescribir is_active para usar nuestro campo activo
     @property

--- a/app/routes/usuarios.py
+++ b/app/routes/usuarios.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for
 from flask_login import login_required, current_user
+from sqlalchemy.exc import IntegrityError
 from app import db
 from app.models.usuarios import Usuario, Rol
 from app.decorators import role_required
@@ -26,6 +27,7 @@ def index():
     # Variable para controlar si mostrar modal y preservar datos
     form_data = None
     error_siglas = None
+    error_email = None
 
     if request.method == 'POST':
         # Lógica para crear usuario
@@ -34,6 +36,7 @@ def index():
             nombre = request.form['nombre']
             apellido1 = request.form['apellido1']
             apellido2 = request.form.get('apellido2')
+            email = request.form.get('email')
             
             password = request.form['password']
             confirm_password = request.form['confirm_password']
@@ -47,6 +50,7 @@ def index():
                 'nombre': nombre,
                 'apellido1': apellido1,
                 'apellido2': apellido2,
+                'email': email,
                 'roles_ids': roles_ids
             }
             
@@ -88,6 +92,9 @@ def index():
                 apellido2=apellido2
             )
             
+            # Asignar email (el setter del modelo convertirá '' a None)
+            nuevo_usuario.email = email
+            
             # Establecer contraseña (hash)
             nuevo_usuario.set_password(password)
             
@@ -103,6 +110,24 @@ def index():
             flash('Usuario creado correctamente con roles y contraseña', 'success')
             return redirect(url_for('usuarios.index'))
             
+        except IntegrityError as e:
+            db.session.rollback()
+            # Detectar si es error de email duplicado
+            if 'usuarios_email_key' in str(e.orig):
+                error_email = 'Este email ya está registrado por otro usuario. Usa uno diferente o déjalo vacío.'
+                return render_template('usuarios/index.html', 
+                                     usuarios=usuarios, 
+                                     roles=todos_los_roles,
+                                     form_data=form_data,
+                                     error_email=error_email,
+                                     show_modal=True)
+            else:
+                flash(f'Error de integridad al crear usuario: {str(e)}', 'danger')
+                return render_template('usuarios/index.html', 
+                                     usuarios=usuarios, 
+                                     roles=todos_los_roles,
+                                     form_data=form_data,
+                                     show_modal=True)
         except Exception as e:
             db.session.rollback()
             flash(f'Error al crear usuario: {str(e)}', 'danger')
@@ -128,8 +153,9 @@ def editar(id):
         flash('No tienes permisos para editar usuarios ADMIN', 'danger')
         return redirect(url_for('usuarios.index'))
     
-    # Variable para error de siglas
+    # Variables para errores
     error_siglas = None
+    error_email = None
     
     if request.method == 'POST':
         try:
@@ -211,7 +237,7 @@ def editar(id):
             usuario.nombre = request.form['nombre']
             usuario.apellido1 = request.form['apellido1']
             usuario.apellido2 = request.form.get('apellido2')
-            usuario.email = request.form.get('email')
+            usuario.email = request.form.get('email')  # El setter del modelo convertirá '' a None
             
             # Actualizar estado activo (sin mensaje flash - es reversible)
             usuario.activo = activo_nuevo
@@ -226,14 +252,49 @@ def editar(id):
             if nueva_password:
                 confirm_password = request.form.get('confirm_password')
                 if nueva_password != confirm_password:
+                    # Preparar form_data y mantener diálogo abierto
+                    form_data = {
+                        'siglas': nuevas_siglas,
+                        'nombre': request.form['nombre'],
+                        'apellido1': request.form['apellido1'],
+                        'apellido2': request.form.get('apellido2'),
+                        'email': request.form.get('email'),
+                        'activo': activo_nuevo,
+                        'roles_ids': roles_ids
+                    }
                     flash('Las contraseñas no coinciden', 'danger')
-                    return redirect(url_for('usuarios.editar', id=id))
+                    return render_template('usuarios/editar.html',
+                                         usuario=usuario,
+                                         roles=todos_los_roles,
+                                         form_data=form_data)
                 usuario.set_password(nueva_password)
             
             db.session.commit()
             flash(f'Usuario {usuario.siglas} actualizado correctamente', 'success')
             return redirect(url_for('usuarios.index'))
             
+        except IntegrityError as e:
+            db.session.rollback()
+            # Detectar si es error de email duplicado
+            if 'usuarios_email_key' in str(e.orig):
+                error_email = 'Este email ya está registrado por otro usuario. Usa uno diferente o déjalo vacío.'
+                # Preparar form_data para mantener los valores
+                form_data = {
+                    'siglas': request.form['siglas'],
+                    'nombre': request.form['nombre'],
+                    'apellido1': request.form['apellido1'],
+                    'apellido2': request.form.get('apellido2'),
+                    'email': request.form.get('email'),
+                    'activo': 'activo' in request.form,
+                    'roles_ids': request.form.getlist('roles')
+                }
+                return render_template('usuarios/editar.html', 
+                                     usuario=usuario, 
+                                     roles=todos_los_roles,
+                                     error_email=error_email,
+                                     form_data=form_data)
+            else:
+                flash(f'Error de integridad al actualizar usuario: {str(e)}', 'danger')
         except Exception as e:
             db.session.rollback()
             flash(f'Error al actualizar usuario: {str(e)}', 'danger')

--- a/app/templates/usuarios/editar.html
+++ b/app/templates/usuarios/editar.html
@@ -68,11 +68,16 @@
                         <div class="col-md-12">
                             <label for="email" class="form-label">Email</label>
                             <input type="email" 
-                                   class="form-control" 
+                                   class="form-control {% if error_email %}is-invalid{% endif %}" 
                                    id="email" 
                                    name="email" 
                                    value="{{ form_data.email if form_data else (usuario.email or '') }}" 
                                    placeholder="usuario@ejemplo.com">
+                            {% if error_email %}
+                            <div class="invalid-feedback">
+                                {{ error_email }}
+                            </div>
+                            {% endif %}
                         </div>
                     </div>
 

--- a/app/templates/usuarios/index.html
+++ b/app/templates/usuarios/index.html
@@ -147,6 +147,22 @@
                                    value="{{ form_data.apellido2 if form_data else '' }}">
                         </div>
                     </div>
+                    <div class="row mb-3">
+                        <div class="col-md-12">
+                            <label for="email" class="form-label">Email</label>
+                            <input type="email" 
+                                   class="form-control {% if error_email %}is-invalid{% endif %}" 
+                                   id="email" 
+                                   name="email" 
+                                   placeholder="usuario@ejemplo.com"
+                                   value="{{ form_data.email if form_data else '' }}">
+                            {% if error_email %}
+                            <div class="invalid-feedback">
+                                {{ error_email }}
+                            </div>
+                            {% endif %}
+                        </div>
+                    </div>
 
                     <!-- Seguridad -->
                     <h6 class="border-bottom pb-2 mb-3 mt-4">Seguridad y Acceso</h6>


### PR DESCRIPTION
## Resumen

Resuelve los issues #12 y #13 relacionados con errores de restricción de unicidad en el campo `email` de usuarios.

## Problema identificado

Ambos issues reportaban el siguiente error al editar usuarios:
```
llave duplicada viola restricción de unicidad «usuarios_email_key»
DETAIL: Ya existe la llave (email)=().
```

**Causa raíz**: La tabla `usuarios` tiene constraint `UNIQUE` en el campo `email`. Cuando múltiples usuarios tenían `email = ''` (cadena vacía), PostgreSQL detectaba duplicados al intentar actualizar.

## Solución implementada

### 1. **Modelo Usuario** (`app/models/usuarios.py`)
- Añadido **property setter** en campo `email` que convierte cadenas vacías `''` a `None`
- Esto aplica tanto en creación como en edición de usuarios
- PostgreSQL trata múltiples valores `NULL` como distintos (no viola UNIQUE)

### 2. **Rutas** (`app/routes/usuarios.py`)
- **Captura específica** de `IntegrityError` con detección de `usuarios_email_key`
- **Mantenimiento del diálogo abierto**: cuando hay error, se preservan todos los valores ingresados y se devuelve el template con `form_data`
- **Mensaje no intrusivo**: error se muestra en el campo responsable (email) sin cerrar el formulario
- Implementado tanto en **creación** (modal) como en **edición** (página)

### 3. **Templates**
- `app/templates/usuarios/editar.html`: Añadida validación visual con `is-invalid` y `invalid-feedback` en campo email
- `app/templates/usuarios/index.html`: Añadido campo email en modal de creación con validación visual
- Mensajes tipo tooltip (comportamiento Bootstrap) que desaparecen al editar el campo

## Comportamiento esperado

### Antes
- ❌ Error genérico al guardar
- ❌ Diálogo se cierra perdiendo datos ingresados
- ❌ Usuario no sabe qué campo causa el problema

### Después
- ✅ Email vacío se guarda como `NULL` (sin errores)
- ✅ Si hay email duplicado, se muestra mensaje claro en el campo responsable
- ✅ Diálogo permanece abierto con todos los datos preservados
- ✅ Solo se limpian campos de contraseña si aplica (issue #12)
- ✅ Mensaje desaparece al editar el campo (experiencia no intrusiva)

## Instrucciones SQL para limpiar datos existentes

Antes de hacer merge, **ejecutar en la base de datos**:
```sql
UPDATE usuarios SET email = NULL WHERE email = '';
```

Esto convierte emails vacíos existentes a `NULL` para evitar conflictos futuros.

## Testing

- [ ] Crear usuario sin email (campo vacío) → Debe guardarse correctamente
- [ ] Editar usuario y dejar email vacío → Debe guardarse como NULL
- [ ] Intentar crear dos usuarios con mismo email → Debe mostrar error en campo email sin cerrar modal
- [ ] Intentar editar usuario con email ya existente → Debe mostrar error en campo email sin cerrar formulario
- [ ] Verificar que otros campos se preservan cuando hay error de email

## Cierra

Closes #12
Closes #13