### PR TITLE
Documentar carga de 785 municipios de Andalucía

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Repositorio:** https://github.com/genete/bddat  
 **Historial completo:** [Ver Pull Requests cerrados](https://github.com/genete/bddat/pulls?q=is%3Apr+is%3Aclosed)  
-**Última actualización:** 24 de enero de 2026
+**Última actualización:** 25 de enero de 2026
 
 ---
 
@@ -15,6 +15,40 @@ Este archivo mantiene un **resumen de los últimos 5 PRs mergeados** para consul
 ---
 
 ## Últimos Cambios
+
+### 2026-01-25 - Carga Inicial de Municipios de Andalucía
+
+**Objetivo:** Poblar tabla `estructura.municipios` con catálogo completo de municipios andaluces basado en datos oficiales del INE.
+
+**Cambios principales:**
+- ✅ **785 municipios cargados** en `estructura.municipios` (8 provincias andaluzas)
+- ✅ **Fuente oficial:** INE - Fichero 25codmun.xlsx a 1 de enero de 2025
+- ✅ **COMMENT añadido** a la tabla documentando fuente, fecha y trazabilidad
+- ✅ **Secuencia actualizada:** `estructura.municipios_id_seq` → 785
+- ✅ **datos_estructurales.sql regenerado** con pg_dump (commit c9de403)
+
+**Distribución por provincia:**
+- Almería (04): 103 municipios | Cádiz (11): 45 municipios
+- Córdoba (14): 77 municipios | Granada (18): 174 municipios  
+- Huelva (21): 80 municipios | Jaén (23): 97 municipios
+- Málaga (29): 103 municipios | Sevilla (41): 106 municipios
+
+**Utilidad:**
+- Códigos INE de 5 dígitos (CPRO + CMUN) para identificación única
+- Detección de proyectos interprovinciales: `LEFT(codigo, 2)` extrae provincia
+- Validación de datos de localización en expedientes
+- Integración con sistemas externos que usen códigos INE
+
+**Proceso de carga:**
+1. Extracción de Excel oficial INE
+2. Generación de script SQL con 785 INSERT
+3. Ejecución en PostgreSQL local
+4. Regeneración automática con `utils/update_datos_estructurales.bat`
+5. Commit y subida a GitHub
+
+**Documentación:** [25codmun.xlsx](https://www.ine.es/daco/daco42/codmun/25codmun.xlsx)
+
+---
 
 ### 2026-01-24 - [PR #20: Agregar 11 Tablas Faltantes](https://github.com/genete/bddat/pull/20)
 
@@ -67,21 +101,6 @@ Este archivo mantiene un **resumen de los últimos 5 PRs mergeados** para consul
 - ✅ Visualización heredado: solo muestra check verde cuando aplica
 
 **Archivos:** nuevo.html, editar.html, detalle.html
-
----
-
-### 2026-01-21 - Feature: Unificación Listado Expedientes
-
-**Objetivo:** Vista unificada de expedientes con filtrado opcional por responsable.
-
-**Cambios principales:**
-- ✅ Ruta index() unificada con parámetro `?mis_expedientes=1`
-- ✅ Estadísticas en parte superior (sin scroll)
-- ✅ Cabeceras multilinea, elipsis en textos largos
-- ✅ Columna Heredado simplificada (solo check verde cuando aplica)
-- ✅ Redirección desde `/mis_expedientes` a `/expedientes/?mis_expedientes=1`
-
-**Template eliminado:** dashboard/mis_expedientes.html (ya no necesario)
 
 ---
 


### PR DESCRIPTION
## 📋 Resumen

Documentación en CHANGELOG de la carga inicial de la tabla `estructura.municipios` con el catálogo completo de municipios andaluces.

## ✅ Cambios realizados

- **785 municipios cargados** de 8 provincias andaluzas
- **Fuente oficial:** INE - Fichero 25codmun.xlsx (1 enero 2025)
- **COMMENT añadido** a la tabla con trazabilidad completa
- **datos_estructurales.sql** regenerado automáticamente
- **Secuencia actualizada** a 785

## 📊 Distribución por provincia

| Provincia | Código | Municipios |
|-----------|--------|------------|
| Almería   | 04     | 103        |
| Cádiz     | 11     | 45         |
| Córdoba   | 14     | 77         |
| Granada   | 18     | 174        |
| Huelva    | 21     | 80         |
| Jaén      | 23     | 97         |
| Málaga    | 29     | 103        |
| Sevilla   | 41     | 106        |

## 🎯 Utilidad

- Códigos INE de 5 dígitos para identificación única de municipios
- Detección de proyectos interprovinciales: `LEFT(codigo, 2)` extrae código de provincia
- Validación de datos de localización en expedientes
- Integración con sistemas externos que usen códigos INE

## 📁 Archivos modificados

- `docs/CHANGELOG.md` - Nueva entrada con documentación completa

## 🔗 Enlaces

- **Commit de datos:** [c9de403](https://github.com/genete/bddat/commit/c9de4032d5b674c9c3b94faba63f0172c0a783d3)
- **Fuente INE:** [25codmun.xlsx](https://www.ine.es/daco/daco42/codmun/25codmun.xlsx)

## ✓ Checklist

- [x] CHANGELOG actualizado con formato correcto
- [x] Última actualización modificada a 25 de enero de 2026
- [x] Entrada más antigua eliminada (mantener solo 5 últimos)
- [x] Commit con prefijo `[CHANGELOG]`
- [x] Documentación completa de fuente y proceso