### PR TITLE
Unificar actualización de changelog en rama de feature/bugfix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,33 @@ Este archivo mantiene un **resumen de los últimos 5 PRs mergeados** para consul
 
 **Fuente de verdad:** Los Pull Requests cerrados en GitHub contienen toda la información histórica del proyecto.
 
+**Actualización del changelog:** Se realiza **en la misma rama de desarrollo** (feature/bugfix/etc.) antes de crear el PR, no en rama separada. Esto reduce overhead de ramas/PRs/acciones.
+
 ---
 
 ## Últimos Cambios
+
+### 2026-01-25 - Unificar Actualización de Changelog en Rama de Feature
+
+**Objetivo:** Simplificar workflow eliminando ramas y PRs separados para actualizar el changelog.
+
+**Cambios principales:**
+- ✅ **Workflow simplificado**: Changelog se actualiza en la misma rama de desarrollo
+- ✅ **Menos overhead**: Elimina rama/PR/acciones separadas solo para changelog
+- ✅ **REGLAS_DESARROLLO.md actualizado**: Documenta nueva secuencia de trabajo
+- ✅ **ACCESO_RAPIDO_PROYECTO.md actualizado**: Añade regla en sección de workflow
+- ✅ **Aplicación inmediata**: Este mismo PR aplica la nueva regla
+
+**Workflow anterior:**
+1. Rama feature → commits → PR → merge
+2. Rama docs/changelog → commit changelog → PR → merge
+
+**Workflow nuevo:**
+1. Rama feature → commits + commit changelog → PR → merge
+
+**Archivos:** docs/fuentesIA/REGLAS_DESARROLLO.md, docs/fuentesIA/ACCESO_RAPIDO_PROYECTO.md, docs/CHANGELOG.md
+
+---
 
 ### 2026-01-25 - [PR #24: Detección de Proyectos Interprovinciales](https://github.com/genete/bddat/pull/24)
 
@@ -90,20 +114,6 @@ provincias = proyecto.provincias_afectadas  # ['Almería', 'Granada']
 - ✅ Incorporación normativa: RDL 7/2025 (AAE provisional/definitiva), RADNE Andalucía, RAIPEE renovables
 
 **Tipo:** Solo documentación (sin cambios en código)
-
----
-
-### 2026-01-22 - [PR #18: Fix Email Duplicado en Usuarios](https://github.com/genete/bddat/pull/18)
-
-**Objetivo:** Resolver error UNIQUE constraint cuando múltiples usuarios tienen email vacío.
-
-**Cambios principales:**
-- ✅ Modelo usuarios.py: Email convertido a property con setter que transforma '' → NULL
-- ✅ Rutas: Captura específica de IntegrityError con feedback visual
-- ✅ Templates: Validación Bootstrap con mensaje inline
-- ✅ Preservación de datos en formulario cuando hay error
-
-**Issues resueltos:** #12, #13
 
 ---
 

--- a/docs/fuentesIA/ACCESO_RAPIDO_PROYECTO.md
+++ b/docs/fuentesIA/ACCESO_RAPIDO_PROYECTO.md
@@ -44,7 +44,7 @@
 
 **Ubicación:** `docs/CHANGELOG.md`
 - Registro cronológico de cambios
-- Actualizado tras cada merge de PR a `main`
+- **Actualizado en la misma rama de desarrollo** antes del PR
 - Formato: fecha, PR, issue, cambios por categoría
 
 ---
@@ -74,9 +74,9 @@
 2. Prepara cambios con descripción detallada
 3. **Espera aprobación explícita del usuario** antes de cada commit
 4. Hace commit y push remoto tras OK
-5. Crea Pull Request tras pruebas del usuario
-6. Hace merge del PR
-7. Actualiza `docs/CHANGELOG.md` en commit separado
+5. **Actualiza `docs/CHANGELOG.md` en la misma rama** antes del PR
+6. Crea Pull Request (incluye changelog)
+7. Hace merge del PR
 
 **Usuario:**
 1. Ejecuta `git pull` para traer cambios
@@ -106,6 +106,7 @@
 [BD] Añadir tabla expedientes_auditoría
 [MODELO] Crear modelo Solicitud con validaciones
 [RUTA] Implementar endpoint GET /expedientes/<id>
+[CHANGELOG] Documentar detección de proyectos interprovinciales
 [DOCS] Actualizar documentación tablas maestras
 ```
 
@@ -140,6 +141,7 @@ bddat/
 3. **No hacer commits remotos sin OK explícito** del usuario
 4. **Consultar `REGLAS_DESARROLLO.md`** para detalles completos del workflow
 5. **Mantener `snake_case` estricto** en todo el código (excepto clases de modelos)
+6. **Actualizar changelog en la misma rama** de desarrollo (no rama separada)
 
 ---
 
@@ -177,7 +179,10 @@ flask db upgrade
 **Pregunta rápida:** ¿Puedo hacer commits remotos directamente?  
 **Respuesta:** NO. Siempre esperar aprobación explícita del usuario.
 
+**Pregunta rápida:** ¿Cómo actualizo el changelog?  
+**Respuesta:** En la misma rama de desarrollo antes del PR, no en rama separada.
+
 ---
 
-**Última actualización:** 22 de enero de 2026, 18:52 CET  
-**Versión:** 1.1
+**Última actualización:** 25 de enero de 2026, 08:00 CET  
+**Versión:** 1.2

--- a/docs/fuentesIA/REGLAS_DESARROLLO.md
+++ b/docs/fuentesIA/REGLAS_DESARROLLO.md
@@ -5,8 +5,8 @@
 **Repositorio:** https://github.com/genete/bddat  
 **Rama principal:** main  
 **Documento creado:** 17 de enero de 2026  
-**Última actualización:** 24 de enero de 2026  
-**Versión:** 2.1
+**Última actualización:** 25 de enero de 2026  
+**Versión:** 2.2
 
 ---
 
@@ -33,7 +33,7 @@
   - Ejemplo: "OK, adelante con la migración" o "Perfecto, haz el commit"
   - No hago commits "a sorpresa": siempre espero tu revisión previa
 - Tras tus pruebas funcionales y tu OK, creo el Pull Request de la rama a `main`
-- Tras el merge del PR, genero el changelog correspondiente y lo subo a `docs/CHANGELOG.md` en commit separado
+- **Actualizo `docs/CHANGELOG.md` en la misma rama de desarrollo** antes del PR
 - Mantengo coherencia con documentación existente
 
 #### Usuario (Tú)
@@ -85,15 +85,16 @@
 - Confirmación de que todo funciona como se esperaba
 - Si hay ajustes inevitables, los realizas y haces `git push`
 
-#### Fase 3.1: Pull Request y Changelog (por IA)
+#### Fase 4: Pull Request y Changelog (por IA)
 
-- Finalmente, tras las pruebas funcionales y el OK del usuario, creo el Pull Request de esa rama a la rama `main`
-- Cuando el desarrollo responde a un issue, se indica en el commit y el changelog
-- Tras el merge del PR a `main`, genero el changelog correspondiente
-- Actualizo `docs/CHANGELOG.md` con la nueva entrada en **commit separado**
-- Formato del changelog: entrada con fecha, PR, issue relacionado, cambios por categoría
+- **Actualizo `docs/CHANGELOG.md` en la misma rama de desarrollo** con la nueva entrada
+- Genero commit del changelog: `[CHANGELOG] Documentar [descripción del cambio]`
+- Tras tu OK final, creo el Pull Request de la rama a `main`
+- Cuando el desarrollo responde a un issue, se indica en el PR
+- Hago merge del PR a `main`
+- **No se requiere rama/PR separado para el changelog** (ya va incluido en la rama de la feature/bugfix)
 
-#### Fase 4: Actualización de Documentación
+#### Fase 5: Actualización de Documentación
 
 - Se procurará que los documentos de referencia (como este) se subirán al repositorio en `docs/fuentesIA/`
 - Intentaremos que los documentos directos en las fuentes de conocimiento sean los estrictamente esenciales
@@ -113,6 +114,7 @@
 5. **Aprobación previa:** No hay commits remotos sin tu OK
 6. **Responsabilidad compartida:** Cada rol tiene tareas claras y no solapadas
 7. **Repositorio como fuente de verdad:** Documentos en `docs/fuentesIA/` prevalecen sobre otras fuentes
+8. **Changelog unificado:** Se actualiza en la misma rama de desarrollo, no en rama separada
 
 ---
 
@@ -336,7 +338,7 @@ bddat/
 - Actualización de requirements.txt
 - Cambios de configuración
 - Cambios en .gitignore u otros archivos de configuración
-- **Actualización de `docs/CHANGELOG.md`** tras merge de PR
+- **Actualización de `docs/CHANGELOG.md` en la misma rama de desarrollo**
 
 **Proceso:**
 
@@ -345,8 +347,9 @@ bddat/
 3. Te muestro exactamente qué archivos se tocan
 4. **Espero tu aprobación explícita para cada commit**
 5. Una vez apruebes, hago: `git add [archivos]` → `git commit -m "..."` → `git push`
-6. Tras tus pruebas y tu OK final, creo el Pull Request a `main`
-7. Tras el merge, actualizo el changelog en commit separado
+6. **Actualizo `docs/CHANGELOG.md` en la misma rama antes del PR**
+7. Tras tus pruebas y tu OK final, creo el Pull Request a `main`
+8. Hago merge del PR (el changelog ya va incluido)
 
 ---
 
@@ -399,7 +402,7 @@ bddat/
 [MIGA] Actualizar estructura de migraciones
 [TEST] Pruebas locales de flujo expediente
 [DOCS] Actualizar documentación tablas maestras
-[CHANGELOG] Añadir entrada PR #18 fix email duplicado
+[CHANGELOG] Documentar detección de proyectos interprovinciales
 [MERGE] Merge feature/nueva-funcionalidad a main
 ```
 
@@ -417,6 +420,7 @@ bddat/
 - [ ] No hay archivos innecesarios
 - [ ] Mensaje de commit es descriptivo con categoría correcta entre `[]`
 - [ ] He consultado `schema.sql` para cambios de BD
+- [ ] **Changelog actualizado en la misma rama** (si aplica)
 
 ---
 
@@ -444,7 +448,7 @@ bddat/
 - Contiene **solo los últimos 5 PRs** mergeados
 - Cada entrada incluye: fecha, enlace al PR, objetivo y cambios principales
 - Para detalles completos (commits, archivos, diffs): consultar el PR en GitHub
-- Se actualiza **tras cada merge de PR a main** en commit separado con categoría `[CHANGELOG]`
+- **Se actualiza en la misma rama de desarrollo** antes de crear el PR
 
 **Ventajas de esta estrategia:**
 - ✅ No duplica información (DRY principle)
@@ -452,17 +456,20 @@ bddat/
 - ✅ El changelog es manejable y no crece infinitamente
 - ✅ La IA puede consultar rápidamente contexto reciente
 - ✅ Historial completo siempre accesible en GitHub
+- ✅ **No requiere rama/PR separado** para actualizar el changelog
 
 ### 7.2 Actualización del Changelog
 
-**Cuándo:** Tras cada merge de PR a `main`
+**Cuándo:** En la misma rama de desarrollo, antes de crear el PR
 
 **Proceso:**
-1. Identificar el PR mergeado (número, título, fecha)
-2. Extraer información clave del PR: objetivo, cambios principales, issues relacionados
+1. Completar los cambios funcionales de la feature/bugfix
+2. Identificar la información clave: objetivo, cambios principales
 3. Añadir entrada al inicio de `docs/CHANGELOG.md` (orden cronológico inverso)
 4. Mantener solo últimos 5 PRs (eliminar el más antiguo si hay más de 5)
-5. Commit separado con mensaje `[CHANGELOG] Añadir entrada PR #XX`
+5. Commit en la misma rama: `[CHANGELOG] Documentar [descripción del cambio]`
+6. Crear PR que incluye tanto los cambios funcionales como el changelog
+7. Hacer merge del PR (todo en uno)
 
 **Formato de entrada:**
 
@@ -479,6 +486,11 @@ bddat/
 **Issues resueltos:** #XX, #YY (si aplica)
 **Tipo:** Feature/Bugfix/Docs/Refactor (si aplica)
 ```
+
+**Nota importante:** El número de PR aún no existe al actualizar el changelog (se genera al crear el PR). Por tanto:
+- Se puede dejar como `[PR #XX: Título]` temporalmente
+- O usar formato `### YYYY-MM-DD - [Título]` sin número de PR
+- El usuario puede actualizar el número de PR tras el merge si lo desea
 
 ### 7.3 Consulta de Historial Antiguo
 
@@ -553,10 +565,10 @@ Si hay conflictos en `git pull`:
 1. IA crea rama de desarrollo
 2. IA hace commits en la rama (con aprobación usuario)
 3. Usuario prueba localmente
-4. Usuario da OK final
-5. IA crea Pull Request a `main`
-6. IA hace merge del PR
-7. IA actualiza changelog en commit separado
+4. **IA actualiza changelog en la misma rama**
+5. Usuario da OK final
+6. IA crea Pull Request a `main` (incluye changelog)
+7. IA hace merge del PR
 
 ---
 
@@ -635,9 +647,9 @@ git status
 | Consultar schema.sql para cambios BD | ✅ | |
 | Esperar aprobación previa | ✅ | |
 | Hacer commits remotos (tras OK) | ✅ | |
+| **Actualizar changelog en misma rama** | ✅ | |
 | Crear Pull Requests | ✅ | |
 | Hacer merge de PRs | ✅ | |
-| Actualizar changelogs | ✅ | |
 | Actualizar documentación en docs/fuentesIA/ | ✅ | |
 | Hacer git pull | | ✅ |
 | Generar schema.sql y subirlo | | ✅ |
@@ -656,10 +668,11 @@ git status
 **Sincronización:** Después de cada sesión de desarrollo  
 **Documentación:** Actualizada en `docs/fuentesIA/` y `docs/CHANGELOG.md`  
 **Aprobación de cambios:** Explícita y previa a commits remotos  
+**Changelog:** Actualizado en la misma rama de desarrollo, no en rama separada
 
 ---
 
 **Documento creado:** 17 de enero de 2026, 21:24 CET  
-**Última actualización:** 24 de enero de 2026, 10:38 CET  
-**Versión:** 2.1  
+**Última actualización:** 25 de enero de 2026, 08:00 CET  
+**Versión:** 2.2  
 **Referencia:** Repositorio oficial genete/bddat en GitHub


### PR DESCRIPTION
## 🎯 Objetivo

Simplificar el workflow de desarrollo eliminando la necesidad de crear ramas y PRs separados para actualizar el changelog.

## ✅ Cambios realizados

### Documentación actualizada

- **REGLAS_DESARROLLO.md** (v2.1 → v2.2)
  - Sección 2.1: IA actualiza changelog en misma rama de desarrollo
  - Sección 2.2: Fase 4 reorganizada (changelog antes de PR)
  - Sección 2.3: Añadido principio #8 "Changelog unificado"
  - Sección 5.1: Workflow actualizado con changelog en misma rama
  - Sección 7.2: Proceso de actualización modificado
  - Sección 10: Tabla de responsabilidades actualizada

- **ACCESO_RAPIDO_PROYECTO.md** (v1.1 → v1.2)
  - Sección 3.2: Workflow IA actualizado (paso 5)
  - Sección 5: Añadida regla #6 sobre changelog
  - Sección 7: Añadida pregunta FAQ sobre changelog

- **CHANGELOG.md**
  - Estrategia actualizada: nota sobre actualización en misma rama
  - Nueva entrada documentando este cambio
  - Eliminada entrada PR #18 (mantener solo 5 últimos)

## 🔄 Comparación de workflows

### Workflow anterior (2 PRs)
```
1. feature/nueva-funcionalidad
   → commits funcionales
   → PR #X → merge

2. docs/update-changelog
   → commit changelog
   → PR #Y → merge
```

### Workflow nuevo (1 PR)
```
1. feature/nueva-funcionalidad
   → commits funcionales
   → commit changelog
   → PR #X → merge
```

## 🎉 Ventajas

- ✅ Menos ramas en el repositorio
- ✅ Menos PRs que revisar/mergear
- ✅ Menos acciones de GitHub que ejecutar
- ✅ Workflow más ágil y natural
- ✅ Changelog siempre sincronizado con el PR

## 📝 Meta-nota

**Este PR aplica la nueva regla sobre sí mismo**: contiene tanto los cambios de documentación como la actualización del changelog en una sola rama.