### PR TITLE
Permitir expedientes sin responsable asignado (huérfanos)

### DIFF
--- a/app/models/expedientes.py
+++ b/app/models/expedientes.py
@@ -17,7 +17,7 @@ class Expediente(db.Model):
     
     CARACTERÍSTICAS:
         - Único en toda la organización (identificado por NUMERO_AT)
-        - Asignado a un responsable (tramitador con permisos completos)
+        - Puede estar sin responsable (huérfano) hasta asignación por supervisor
         - Clasificado por tipo (determina procedimiento aplicable)
         - Puede ser heredado del sistema anterior (datos incompletos)
     
@@ -27,6 +27,11 @@ class Expediente(db.Model):
             - NO es el ID técnico, sino identificador administrativo
             - Único en la organización
             - Usado en referencias y búsquedas
+        
+        RESPONSABLE_ID:
+            - NULL permitido: expediente "huérfano" sin asignar
+            - Supervisor puede asignar según carga de trabajo o especialización
+            - Una vez asignado, el tramitador tiene permisos completos
         
         HEREDADO:
             - TRUE: Expediente migrado del sistema anterior
@@ -39,14 +44,14 @@ class Expediente(db.Model):
             - El proyecto evoluciona mediante documentos en DOCUMENTOS_PROYECTO
     
     RELACIONES:
-        - responsable → USUARIOS (tramitador asignado)
+        - responsable → USUARIOS (tramitador asignado, nullable)
         - tipo_expediente → TIPOS_EXPEDIENTES (clasificación normativa)
         - proyecto → PROYECTOS (relación 1:1, proyecto técnico único)
         - solicitudes ← SOLICITUDES (1:N, múltiples actos administrativos)
         - documentos ← DOCUMENTOS (1:N, pool de archivos del expediente)
     
     REGLAS DE NEGOCIO:
-        1. Cada expediente debe tener un responsable asignado
+        1. Expediente puede crearse sin responsable (huérfano)
         2. NUMERO_AT debe ser único en la organización
         3. PROYECTO_ID es obligatorio y único (relación 1:1)
         4. El tipo de expediente determina:
@@ -58,6 +63,7 @@ class Expediente(db.Model):
     NOTAS DE VERSIÓN:
         v3.0: Añadido PROYECTO_ID (relación 1:1). Antes el proyecto
               apuntaba al expediente, ahora es inverso para mayor claridad.
+        v3.1: RESPONSABLE_ID ahora nullable para permitir expedientes huérfanos.
     """
     __tablename__ = 'expedientes'
     __table_args__ = (
@@ -85,8 +91,8 @@ class Expediente(db.Model):
     responsable_id = db.Column(
         db.Integer,
         db.ForeignKey('public.usuarios.id'),
-        nullable=False,
-        comment='FK a USUARIOS. Tramitador asignado con permisos de gestión completa'
+        nullable=True,  # ← CAMBIO: permite NULL para expedientes huérfanos
+        comment='FK a USUARIOS. Tramitador asignado con permisos de gestión completa. NULL = huérfano sin asignar'
     )
     
     tipo_expediente_id = db.Column(

--- a/app/routes/expedientes.py
+++ b/app/routes/expedientes.py
@@ -95,9 +95,11 @@ def nuevo():
             numero_at = ultimo_numero + 1
             
             # Crear EXPEDIENTE vinculado al proyecto
+            # responsable_id puede ser None (expediente huérfano sin asignar)
+            responsable_id = request.form.get('responsable_id')
             nuevo_expediente = Expediente(
                 numero_at=numero_at,
-                responsable_id=request.form.get('responsable_id') or current_user.id,
+                responsable_id=int(responsable_id) if responsable_id else None,
                 tipo_expediente_id=request.form.get('tipo_expediente_id') or None,
                 heredado=request.form.get('heredado') == 'on',
                 proyecto_id=nuevo_proyecto.id
@@ -157,10 +159,10 @@ def editar(id):
             expediente.heredado = request.form.get('heredado') == 'on'
             
             # Solo ADMIN/SUPERVISOR puede cambiar responsable (usando utilidad)
+            # Permitir establecer None (expediente huérfano) explícitamente
             if puede_cambiar_responsable():
                 nuevo_responsable_id = request.form.get('responsable_id')
-                if nuevo_responsable_id:
-                    expediente.responsable_id = nuevo_responsable_id
+                expediente.responsable_id = int(nuevo_responsable_id) if nuevo_responsable_id else None
             
             # Actualizar PROYECTO - PostgreSQL mantiene defaults si vienen None
             proyecto = expediente.proyecto

--- a/app/templates/expedientes/detalle.html
+++ b/app/templates/expedientes/detalle.html
@@ -48,8 +48,12 @@
                 <div class="mb-3">
                     <div class="text-muted small mb-1" style="white-space: nowrap;">Responsable:</div>
                     <div>
-                        <strong>{{ expediente.responsable.siglas }}</strong> - 
-                        {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
+                        {% if expediente.responsable %}
+                            <strong>{{ expediente.responsable.siglas }}</strong> - 
+                            {{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}
+                        {% else %}
+                            <span class="badge bg-warning text-dark">Sin asignar (huérfano)</span>
+                        {% endif %}
                     </div>
                 </div>
                 

--- a/app/templates/expedientes/editar.html
+++ b/app/templates/expedientes/editar.html
@@ -47,6 +47,9 @@
                         <label for="responsable_id" class="form-label">Responsable</label>
                         <select class="form-select" id="responsable_id" name="responsable_id" 
                                 {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}disabled{% endif %}>
+                            <option value="" {% if not expediente.responsable_id %}selected{% endif %}>
+                                -- Sin asignar (huérfano) --
+                            </option>
                             {% for usuario in usuarios %}
                                 <option value="{{ usuario.id }}" 
                                         {% if expediente.responsable_id == usuario.id %}selected{% endif %}>
@@ -56,6 +59,8 @@
                         </select>
                         {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}
                             <small class="form-text text-muted">Solo ADMIN/SUPERVISOR puede cambiar responsable</small>
+                        {% else %}
+                            <small class="form-text text-muted">Dejar sin asignar para gestión posterior por supervisor</small>
                         {% endif %}
                     </div>
                     

--- a/app/templates/expedientes/index.html
+++ b/app/templates/expedientes/index.html
@@ -87,11 +87,15 @@
                         
                         <!-- Responsable -->
                         <td class="d-none d-lg-table-cell">
-                            <span title="{{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}">
-                                {{ expediente.responsable.siglas }}
-                            </span>
-                            {% if expediente.responsable_id == current_user.id %}
-                                <span class="badge bg-primary ms-1">Tú</span>
+                            {% if expediente.responsable %}
+                                <span title="{{ expediente.responsable.nombre }} {{ expediente.responsable.apellido1 }}">
+                                    {{ expediente.responsable.siglas }}
+                                </span>
+                                {% if expediente.responsable_id == current_user.id %}
+                                    <span class="badge bg-primary ms-1">Tú</span>
+                                {% endif %}
+                            {% else %}
+                                <span class="badge bg-warning text-dark">Sin asignar</span>
                             {% endif %}
                         </td>
                         

--- a/app/templates/expedientes/nuevo.html
+++ b/app/templates/expedientes/nuevo.html
@@ -41,13 +41,14 @@
                     <div class="mb-3">
                         <label for="responsable_id" class="form-label">Responsable</label>
                         <select class="form-select" id="responsable_id" name="responsable_id">
+                            <option value="">-- Sin asignar (huérfano) --</option>
                             {% for usuario in usuarios %}
                                 <option value="{{ usuario.id }}" {% if usuario.id == current_user.id %}selected{% endif %}>
                                     {{ usuario.siglas }} - {{ usuario.nombre }} {{ usuario.apellido1 }}
                                 </option>
                             {% endfor %}
                         </select>
-                        <small class="form-text text-muted">Por defecto: tú</small>
+                        <small class="form-text text-muted">Dejar sin asignar para posterior gestión por supervisor</small>
                     </div>
                     
                     <!-- Heredado -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Repositorio:** https://github.com/genete/bddat  
 **Historial completo:** [Ver Pull Requests cerrados](https://github.com/genete/bddat/pulls?q=is%3Apr+is%3Aclosed)  
-**Última actualización:** 27 de enero de 2026
+**Última actualización:** 28 de enero de 2026
 
 ---
 
@@ -17,6 +17,29 @@ Este archivo mantiene un **resumen de los últimos 5 PRs mergeados** para consul
 ---
 
 ## Últimos Cambios
+
+### 2026-01-28 - [PR #TBD: Permitir expedientes sin responsable asignado (huérfanos)](https://github.com/genete/bddat/pull/TBD)
+
+**Objetivo:** Modificar el modelo Expediente para permitir `responsable_id = NULL`, habilitando la creación de expedientes huérfanos que posteriormente pueden ser asignados por un supervisor según carga de trabajo o especialización.
+
+**Cambios principales:**
+- ✅ **Modelo expedientes.py**: `responsable_id` ahora acepta NULL
+- ✅ **Migración Alembic**: `ALTER TABLE expedientes ALTER COLUMN responsable_id DROP NOT NULL`
+- ✅ **Rutas expedientes.py**: Permitir crear y editar expedientes con `responsable_id = None`
+- ✅ **Templates nuevo.html/editar.html**: Opción "-- Sin asignar (huérfano) --" en select de responsable
+- ✅ **Templates detalle.html/index.html**: Badge visual "Sin asignar" cuando expediente sin responsable
+- ✅ **Documentación**: Actualizada docstring del modelo con reglas de negocio de expedientes huérfanos
+
+**Casos de uso:**
+- Supervisor crea expediente para posterior asignación según disponibilidad
+- Redistribución de carga: dejar expediente sin asignar temporalmente
+- Gestión flexible de recursos humanos
+
+**Issues resueltos:** #46  
+**Milestone:** 1.3 - Expedientes básicos (MVP)  
+**Archivos:** app/models/expedientes.py, migrations/versions/51fcf34d6955_*.py, app/routes/expedientes.py, app/templates/expedientes/*.html
+
+---
 
 ### 2026-01-27 - [PR #TBD: Mejorar Diseño de Mensajes Informativos](https://github.com/genete/bddat/pull/TBD)
 
@@ -104,20 +127,6 @@ provincias = proyecto.provincias_afectadas  # ['Almería', 'Granada']
 - Integración con sistemas externos que usen códigos INE
 
 **Documentación:** [25codmun.xlsx](https://www.ine.es/daco/daco42/codmun/25codmun.xlsx)
-
----
-
-### 2026-01-24 - [PR #20: Agregar 11 Tablas Faltantes](https://github.com/genete/bddat/pull/20)
-
-**Objetivo:** Completar la base de datos con las 11 tablas faltantes según diseño v3.0.
-
-**Cambios principales:**
-- ✅ 4 tablas maestras nuevas en schema `estructura`: municipios, tipos_resultados_fases, tipos_tareas, tipos_tramites
-- ✅ 7 tablas operacionales nuevas en schema `public`: documentos, solicitudes, fases, tramites, tareas, documentos_proyecto, municipios_proyecto
-- ✅ Correcciones en modelos: fases.py, tramites.py, tareas.py
-- ✅ Actualizado schema.sql con 16 tablas totales
-
-**Estado final:** 16 tablas (9 en estructura + 14 en public)
 
 ---
 

--- a/migrations/versions/51fcf34d6955_allow_null_responsable_id_in_expedientes.py
+++ b/migrations/versions/51fcf34d6955_allow_null_responsable_id_in_expedientes.py
@@ -1,0 +1,30 @@
+"""allow_null_responsable_id_in_expedientes
+
+Revision ID: 51fcf34d6955
+Revises: 3daee4b13400
+Create Date: 2026-01-28 19:58:55.258731
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '51fcf34d6955'
+down_revision = '3daee4b13400'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('expedientes', 'responsable_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=True,
+                    schema='public')
+
+
+def downgrade():
+    op.alter_column('expedientes', 'responsable_id',
+                    existing_type=sa.INTEGER(),
+                    nullable=False,
+                    schema='public')


### PR DESCRIPTION
## 🎯 Objetivo
Modificar el modelo Expediente para permitir `responsable_id = NULL`, habilitando la creación de expedientes huérfanos que posteriormente pueden ser asignados por un supervisor según carga de trabajo o especialización.

## ✅ Cambios implementados
- [x] Modelo `expedientes.py`: `responsable_id` acepta NULL
- [x] Migración Alembic para ALTER COLUMN
- [x] Rutas: permitir crear/editar con responsable None
- [x] Templates formularios: opción "Sin asignar (huérfano)"
- [x] Templates vistas: badge visual "Sin asignar"
- [x] CHANGELOG actualizado

## 🧪 Testing
- [x] Crear expediente sin responsable
- [x] Editar y asignar responsable
- [x] Editar y quitar responsable (volver a huérfano)
- [x] Ver listado con expedientes sin asignar
- [x] Ver detalle de expediente sin asignar

## 📋 Checklist
- [x] Código probado en local
- [x] Migraciones aplicadas correctamente
- [x] UI/UX validado
- [x] CHANGELOG actualizado

Closes #46