### PR TITLE
Corrección modelo solicitudes - Añadir entidad_id y fecha_fin (#65)

### DIFF
--- a/app/models/solicitudes.py
+++ b/app/models/solicitudes.py
@@ -66,6 +66,7 @@ class Solicitud(db.Model):
               AÑADIDO solicitud_afectada_id.
         v3.1: AÑADIDO entidad_id (solicitante).
               AÑADIDO fecha_fin (finalización real).
+              AÑADIDO properties: activa, es_desistimiento_o_renuncia.
     """
     __tablename__ = 'solicitudes'
     __table_args__ = (
@@ -133,6 +134,38 @@ class Solicitud(db.Model):
     expediente = db.relationship('Expediente', backref='solicitudes')
     entidad = db.relationship('Entidad', backref='solicitudes')
     solicitud_afectada = db.relationship('Solicitud', remote_side=[id], backref='solicitudes_dependientes')
+    
+    # Properties
+    @property
+    def activa(self):
+        """
+        Determina si la solicitud está activa (en curso).
+        
+        Returns:
+            bool: True si estado es EN_TRAMITE, False en caso contrario.
+        
+        Uso:
+            if solicitud.activa:
+                # Solicitud aún en procedimiento
+        """
+        return self.estado == 'EN_TRAMITE'
+    
+    @property
+    def es_desistimiento_o_renuncia(self):
+        """
+        Determina si esta solicitud es un desistimiento o renuncia.
+        
+        Returns:
+            bool: True si tiene solicitud_afectada_id (referencia a otra solicitud).
+        
+        Regla de negocio:
+            Solo solicitudes de DESISTIMIENTO/RENUNCIA tienen solicitud_afectada_id.
+        
+        Uso:
+            if solicitud.es_desistimiento_o_renuncia:
+                solicitud_original = solicitud.solicitud_afectada
+        """
+        return self.solicitud_afectada_id is not None
     
     def __repr__(self):
         """Representación técnica para debugging."""

--- a/app/models/solicitudes.py
+++ b/app/models/solicitudes.py
@@ -10,7 +10,7 @@ class Solicitud(db.Model):
         solicitud con su estado propio, independiente del expediente global.
     
     FILOSOFÍA:
-        - Una solicitud puede tener MÚLTIPLES TIPOS simultáneamente (vía SOLICITUDES_TIPOS)
+        - Una solicitud puede tener MÚTIPLES TIPOS simultáneamente (vía SOLICITUDES_TIPOS)
         - Motor de reglas aplica lógica sobre tipos individuales, no combinaciones
         - Cada solicitud es una instancia independiente con estado y trazabilidad propios
         - Permite secuencias temporales (MOD requiere AAC previa)
@@ -18,6 +18,12 @@ class Solicitud(db.Model):
     CAMPO EXPEDIENTE_ID:
         - NOT NULL: Toda solicitud pertenece a un expediente
         - FK a EXPEDIENTES (public schema)
+    
+    CAMPO ENTIDAD_ID:
+        - NOT NULL: Identifica al solicitante (promotor/titular)
+        - FK a ENTIDADES (public schema)
+        - Puede diferir del titular del expediente (cambios de titularidad)
+        - Permite rastrear quién solicitó cada acto administrativo
     
     CAMPO SOLICITUD_AFECTADA_ID:
         - NULLABLE: Solo para DESISTIMIENTO o RENUNCIA
@@ -29,6 +35,13 @@ class Solicitud(db.Model):
         - Determina plazos de resolución
         - Fecha administrativa con efectos jurídicos
     
+    CAMPO FECHA_FIN:
+        - NULLABLE: Fecha real de finalización de la solicitud
+        - Puede ser rellenada manualmente o automáticamente por el sistema
+        - Fuente de verdad alternativa vs. "todas las fases finalizadas"
+        - Protección contra confusiones: solicitud cerrada con fases pendientes
+        - Si NULL: solicitud aún en curso
+    
     CAMPO ESTADO:
         - EN_TRAMITE: Solicitud activa en procedimiento
         - RESUELTA: Resolución firme emitida
@@ -37,22 +50,27 @@ class Solicitud(db.Model):
     
     RELACIONES:
         - expediente → EXPEDIENTES.id (FK, expediente contenedor)
+        - entidad → ENTIDADES.id (FK, solicitante)
         - solicitud_afectada → SOLICITUDES.id (FK self-referencia, para DESISTIMIENTO/RENUNCIA)
-        - solicitudes_tipos ← SOLICITUDES_TIPOS.solicitudid (tipos de la solicitud)
+        - solicitudes_tipos ← SOLICITUDES_TIPOS.solicitud_id (tipos de la solicitud)
     
     REGLAS DE NEGOCIO:
         - Tipos múltiples: Gestionados en tabla puente SOLICITUDES_TIPOS
         - DESISTIMIENTO/RENUNCIA: Requiere SOLICITUD_AFECTADA_ID NOT NULL
         - MOD: Debe existir AAC previa en el expediente (validar en interfaz)
         - Estado RESUELTA: Debe existir resolución asociada (validar)
+        - FECHA_FIN: Si estado = RESUELTA/DESISTIDA/ARCHIVADA, debería tener fecha_fin
     
     NOTAS DE VERSIÓN:
         v3.0: ELIMINADO tipo_solicitud_id (movido a SOLICITUDES_TIPOS N:M).
               AÑADIDO solicitud_afectada_id.
+        v3.1: AÑADIDO entidad_id (solicitante).
+              AÑADIDO fecha_fin (finalización real).
     """
     __tablename__ = 'solicitudes'
     __table_args__ = (
         db.Index('idx_solicitudes_expediente', 'expediente_id'),
+        db.Index('idx_solicitudes_entidad', 'entidad_id'),
         db.Index('idx_solicitudes_fecha', 'fecha_solicitud'),
         db.Index('idx_solicitudes_estado', 'estado'),
         {'schema': 'public'}
@@ -72,6 +90,13 @@ class Solicitud(db.Model):
         comment='FK a EXPEDIENTES. Expediente al que pertenece la solicitud'
     )
     
+    entidad_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.entidades.id', use_alter=True, name='fk_solicitudes_entidad'),
+        nullable=False,
+        comment='FK a ENTIDADES. Solicitante (promotor/titular) de la solicitud'
+    )
+    
     solicitud_afectada_id = db.Column(
         db.Integer,
         db.ForeignKey('public.solicitudes.id'),
@@ -83,6 +108,12 @@ class Solicitud(db.Model):
         db.Date,
         nullable=False,
         comment='Fecha oficial de presentación de la solicitud'
+    )
+    
+    fecha_fin = db.Column(
+        db.Date,
+        nullable=True,
+        comment='Fecha real de finalización de la solicitud. NULL si aún en curso'
     )
     
     estado = db.Column(
@@ -100,11 +131,12 @@ class Solicitud(db.Model):
     
     # Relaciones
     expediente = db.relationship('Expediente', backref='solicitudes')
+    entidad = db.relationship('Entidad', backref='solicitudes')
     solicitud_afectada = db.relationship('Solicitud', remote_side=[id], backref='solicitudes_dependientes')
     
     def __repr__(self):
         """Representación técnica para debugging."""
-        return f'<Solicitud id={self.id} expediente={self.expediente_id} estado={self.estado}>'
+        return f'<Solicitud id={self.id} expediente={self.expediente_id} entidad={self.entidad_id} estado={self.estado}>'
     
     def __str__(self):
         """Representación legible para interfaz."""

--- a/app/models/solicitudes.py
+++ b/app/models/solicitudes.py
@@ -10,7 +10,7 @@ class Solicitud(db.Model):
         solicitud con su estado propio, independiente del expediente global.
     
     FILOSOFÍA:
-        - Una solicitud puede tener MÚTIPLES TIPOS simultáneamente (vía SOLICITUDES_TIPOS)
+        - Una solicitud puede tener MÚLTIPLES TIPOS simultáneamente (vía SOLICITUDES_TIPOS)
         - Motor de reglas aplica lógica sobre tipos individuales, no combinaciones
         - Cada solicitud es una instancia independiente con estado y trazabilidad propios
         - Permite secuencias temporales (MOD requiere AAC previa)
@@ -153,15 +153,29 @@ class Solicitud(db.Model):
     @property
     def es_desistimiento_o_renuncia(self):
         """
-        Determina si esta solicitud es un desistimiento o renuncia.
+        IMPLEMENTACIÓN TEMPORAL - Fase "TODO VALE"
+        
+        Heurística simple: Si tiene solicitud_afectada_id, probablemente sea
+        desistimiento o renuncia de otra solicitud previa.
         
         Returns:
             bool: True si tiene solicitud_afectada_id (referencia a otra solicitud).
         
-        Regla de negocio:
-            Solo solicitudes de DESISTIMIENTO/RENUNCIA tienen solicitud_afectada_id.
+        LIMITACIÓN ACTUAL:
+            No verifica los tipos reales en solicitudes_tipos. Puede generar
+            falsos positivos si en el futuro hay otros tipos de solicitud
+            que también referencien otra solicitud (ej: MODIFICACIÓN, AMPLIACIÓN).
         
-        Uso:
+        Regla de negocio real (no implementada aún):
+            - Consultar solicitudes_tipos → obtener códigos de tipos
+            - Verificar si algún código IN ['DESISTIMIENTO', 'RENUNCIA']
+            - Validar que solicitud_afectada_id NOT NULL si aplica
+        
+        TODO (Fase Motor de Reglas):
+            Implementar verificación real consultando tipos asociados
+            cuando exista motor de validaciones configurables por tablas.
+        
+        Uso actual:
             if solicitud.es_desistimiento_o_renuncia:
                 solicitud_original = solicitud.solicitud_afectada
         """

--- a/migrations/versions/4a972bf8399a_anadir_entidad_id_y_fecha_fin_a.py
+++ b/migrations/versions/4a972bf8399a_anadir_entidad_id_y_fecha_fin_a.py
@@ -1,0 +1,68 @@
+"""Añadir entidad_id y fecha_fin a solicitudes - Issue 65
+
+Revision ID: 4a972bf8399a
+Revises: 0d6742443660
+Create Date: 2026-02-07 15:13:02.298254
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4a972bf8399a'
+down_revision = '0d6742443660'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    MIGRACIÓN MANUAL LIMPIA - Issue #65
+    
+    SOLO añade campos entidad_id y fecha_fin a tabla solicitudes.
+    
+    NO toca FKs existentes (Alembic los detecta erróneamente como cambios).
+    """
+    # Añadir campos nuevos a solicitudes
+    with op.batch_alter_table('solicitudes', schema='public') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'entidad_id', 
+                sa.Integer(), 
+                nullable=False, 
+                comment='FK a ENTIDADES. Solicitante (promotor/titular) de la solicitud'
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                'fecha_fin', 
+                sa.Date(), 
+                nullable=True, 
+                comment='Fecha real de finalización de la solicitud. NULL si aún en curso'
+            )
+        )
+        
+        # Crear índice para entidad_id
+        batch_op.create_index('idx_solicitudes_entidad', ['entidad_id'], unique=False)
+        
+        # Crear FK para entidad_id
+        batch_op.create_foreign_key(
+            'fk_solicitudes_entidad', 
+            'entidades', 
+            ['entidad_id'], 
+            ['id'], 
+            referent_schema='public',
+            use_alter=True
+        )
+
+
+def downgrade():
+    """
+    Revierte cambios: elimina entidad_id y fecha_fin de solicitudes.
+    """
+    with op.batch_alter_table('solicitudes', schema='public') as batch_op:
+        batch_op.drop_constraint('fk_solicitudes_entidad', type_='foreignkey')
+        batch_op.drop_index('idx_solicitudes_entidad')
+        batch_op.drop_column('fecha_fin')
+        batch_op.drop_column('entidad_id')


### PR DESCRIPTION
## 🎯 Objetivo

Corregir el modelo `Solicitud` añadiendo campos faltantes: `entidad_id` (solicitante) y `fecha_fin` (cierre).

**Closes #65**

---

## 📊 Cambios Realizados

### Modelo SQLAlchemy (`app/models/solicitudes.py`)

#### Nuevos Campos
- ✅ **`entidad_id`** (INTEGER, NOT NULL, FK a `entidades.id`)
  - Identifica al solicitante (promotor/titular)
  - Permite rastrear quién solicitó cada acto administrativo
  - Puede diferir del titular del expediente (cambios de titularidad)
  
- ✅ **`fecha_fin`** (DATE, NULLABLE)
  - Fecha real de finalización de la solicitud
  - NULL si aún en curso
  - Fuente de verdad alternativa vs. "todas las fases finalizadas"
  - Protección contra confusiones (solicitud cerrada con fases pendientes)

#### Nuevas Properties
- ✅ **`activa`**: Returns `True` si `estado == 'EN_TRAMITE'`
- ✅ **`es_desistimiento_o_renuncia`**: Heurística simple (verifica `solicitud_afectada_id`)
  - **Implementación temporal** documentada como "TODO VALE"
  - No verifica tipos reales en `solicitudes_tipos` (pendiente fase Motor de Reglas)

#### Índices
- ✅ `idx_solicitudes_entidad` (nuevo)
- ✅ Mantiene índices existentes: `expediente`, `fecha`, `estado`

#### Relaciones
- ✅ `entidad` → relationship a `Entidad` con backref `solicitudes`

---

### Migración Alembic

**Archivo:** `migrations/versions/4a972bf8399a_anadir_entidad_id_y_fecha_fin_a.py`

#### Operaciones
```sql
ALTER TABLE solicitudes 
  ADD COLUMN entidad_id INTEGER NOT NULL,
  ADD COLUMN fecha_fin DATE;

CREATE INDEX idx_solicitudes_entidad ON solicitudes(entidad_id);

ALTER TABLE solicitudes 
  ADD CONSTRAINT fk_solicitudes_entidad 
  FOREIGN KEY (entidad_id) REFERENCES entidades(id);
```

- ✅ Migración **limpia** (solo cambios necesarios)
- ✅ No toca FKs existentes (Alembic los detectó erróneamente)
- ✅ Downgrade implementado correctamente

---

## 📝 Commits

1. **`d315474`** - MODEL: Añadir entidad_id y fecha_fin a Solicitud
2. **`e0823e6`** - [MIGA] Añadir entidad_id y fecha_fin a solicitudes
3. **`4e25f70`** - MODEL: Añadir properties activa y es_desistimiento_o_renuncia
4. **`dd0189e`** - [DOCS] Documentar limitación temporal property es_desistimiento_o_renuncia

---

## ✅ Verificación

### Tests Realizados
- ✅ `flask db upgrade` ejecutado exitosamente
- ✅ `flask run` sin errores
- ✅ Modelo carga correctamente en Flask shell

### Pendiente (Issue #66)
- ⏳ Tests unitarios de properties
- ⏳ Validaciones de reglas de negocio
- ⏳ Poblar datos de prueba

---

## 🔗 Dependencias

- **Requiere**: #62 (tabla `entidades`), #64 (histórico titulares) ✅ completados
- **Bloqueante para**: #67 (wizard creación)

---

## 💡 Notas Técnicas

### Campo `entidad_id` vs `solicitante_id`
- Issue #65 menciona `solicitante_id` referenciando tabla `administrados`
- **Implementado como `entidad_id`** referenciando tabla `entidades`
- Razón: Tabla `entidades` ya existe y contiene todos los administrados
- Equivalencia semántica: `entidad_id` = solicitante

### Property `es_desistimiento_o_renuncia`
- **Implementación actual**: Verifica `solicitud_afectada_id IS NOT NULL`
- **Limitación conocida**: No consulta tipos reales en `solicitudes_tipos`
- **Fase actual**: "TODO VALE" (sin validaciones estrictas)
- **Futuro**: Implementar cuando exista Motor de Reglas configurables

### Migración Limpia
- Alembic autogeneró migración con **muchos cambios en FKs existentes**
- **Limpiada manualmente**: Solo operaciones necesarias (`entidad_id`, `fecha_fin`)
- Evita reescritura innecesaria de constraints

---

## 🚀 Próximos Pasos

1. Merge a `develop`
2. Poblar datos de prueba en BD
3. Issue #66: Tests + migraciones pendientes
4. Issue #67: Wizard creación expediente+solicitud

---

**Epic:** #61 - Sistema Navegación Modular  
**Milestone:** MS-3 - Alineación Administrativa