### PR TITLE
[FEAT] Wizard creación de expedientes en 3 pasos (#67)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -65,6 +65,11 @@ def create_app(config_name='development'):
     app.register_blueprint(perfil.bp)
     app.register_blueprint(entidades.bp)        # Issue #61
 
+    # Registrar blueprints - Wizards
+    from app.routes import wizard_expediente
+
+    app.register_blueprint(wizard_expediente.bp)  # Issue #67
+
     # Registrar blueprints - APIs
     from app.routes import api_expedientes, api_municipios, vista3, api_entidades
 

--- a/app/routes/api_entidades.py
+++ b/app/routes/api_entidades.py
@@ -4,10 +4,11 @@ ENDPOINTS:
     GET /api/entidades
         Modo scroll infinito : parámetros cursor + limit + search + activo
         Modo autocomplete    : parámetro ?q=texto (mín 2 chars, máx 10 resultados)
+                               Opcional: ?rol=titular|consultado|publicador
                                Devuelve {results: [{id, text}, ...]}
                                Pensado para selects de titular en wizard expediente.
 
-VERSIÓN: 1.0
+VERSIÓN: 1.1
 FECHA: 2026-02-19
 ISSUE: #61
 """
@@ -31,6 +32,12 @@ def listar_entidades():
         Activo cuando se pasa el parámetro 'q' (mín 2 chars).
         Devuelve máx. 10 resultados: [{"id": 1, "text": "Nombre (NIF)"}]
         Filtra solo entidades activas.
+
+        Parámetro opcional 'rol':
+            rol=titular    → solo entidades con rol_titular=True
+            rol=consultado → solo entidades con rol_consultado=True
+            rol=publicador → solo entidades con rol_publicador=True
+            (omitido o valor desconocido → sin filtro extra, retrocompatible)
 
     MODO SCROLL INFINITO (sin 'q'):
         Query Parameters:
@@ -69,19 +76,28 @@ def listar_entidades():
         if len(q) < 2:
             return jsonify({'results': []}), 200
 
-        entidades = (
+        rol = request.args.get('rol', '').strip().lower()
+
+        query = (
             Entidad.query
+            .filter(Entidad.activo == True)
             .filter(
                 or_(
                     func.lower(Entidad.nombre_completo).contains(func.lower(q)),
                     func.lower(Entidad.nif).contains(func.lower(q))
                 )
             )
-            .filter(Entidad.activo == True)
-            .order_by(Entidad.nombre_completo)
-            .limit(10)
-            .all()
         )
+
+        # Filtro opcional por rol (retrocompatible: sin rol = sin restricción)
+        if rol == 'titular':
+            query = query.filter(Entidad.rol_titular == True)
+        elif rol == 'consultado':
+            query = query.filter(Entidad.rol_consultado == True)
+        elif rol == 'publicador':
+            query = query.filter(Entidad.rol_publicador == True)
+
+        entidades = query.order_by(Entidad.nombre_completo).limit(10).all()
 
         results = []
         for e in entidades:

--- a/app/routes/wizard_expediente.py
+++ b/app/routes/wizard_expediente.py
@@ -1,0 +1,352 @@
+"""Wizard de creación de expediente + proyecto + solicitud.
+
+FLUJO:
+    Paso 1 → Datos básicos del expediente (tipo, responsable, heredado)
+    Paso 2 → Datos del proyecto técnico (título, descripción, municipios, etc.)
+    Paso 3 → Solicitud (entidad titular, fecha, tipos de solicitud)
+
+    Los datos de pasos 1 y 2 se guardan en sesión Flask (SESSION_KEY).
+    El commit transaccional completo ocurre al finalizar el paso 3.
+
+ISSUE: #67
+VERSÓN: 1.0
+FECHA: 2026-02-19
+"""
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash, session
+from flask_login import login_required
+from datetime import date
+from app import db
+from app.models.expedientes import Expediente
+from app.models.proyectos import Proyecto
+from app.models.usuarios import Usuario
+from app.models.tipos_expedientes import TipoExpediente
+from app.models.tipos_ia import TipoIA
+from app.models.municipios_proyecto import MunicipioProyecto
+from app.models.entidad import Entidad
+from app.models.solicitudes import Solicitud
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.solicitudes_tipos import SolicitudTipo
+
+bp = Blueprint('wizard_expediente', __name__, url_prefix='/expedientes/wizard')
+
+SESSION_KEY = 'wizard_expediente'
+
+
+# =============================================================================
+# HELPERS DE SESIÓN
+# =============================================================================
+
+def _get_wizard():
+    """Devuelve el dict de la sesión del wizard (o dict vacío)."""
+    return session.get(SESSION_KEY, {})
+
+
+def _save_wizard(data):
+    """Persiste el dict en sesión y marca como modificada."""
+    session[SESSION_KEY] = data
+    session.modified = True
+
+
+def _reset_wizard():
+    """Elimina el dict del wizard de la sesión."""
+    session.pop(SESSION_KEY, None)
+    session.modified = True
+
+
+# =============================================================================
+# RUTAS
+# =============================================================================
+
+@bp.route('/')
+@login_required
+def index():
+    """Redirige siempre al paso 1."""
+    return redirect(url_for('wizard_expediente.paso1'))
+
+
+@bp.route('/cancelar')
+@login_required
+def cancelar():
+    """Limpia la sesión del wizard y vuelve al listado."""
+    _reset_wizard()
+    flash('Creación de expediente cancelada.', 'info')
+    return redirect(url_for('expedientes.listado_v2'))
+
+
+@bp.route('/paso1', methods=['GET', 'POST'])
+@login_required
+def paso1():
+    """
+    Paso 1: Datos básicos del expediente.
+
+    Campos:
+        tipo_expediente_id  (obligatorio): Tipo normativo del expediente.
+        responsable_id      (opcional):    Tramitador asignado. NULL = huérfano.
+        heredado            (bool):        TRUE si proviene del sistema legacy.
+    """
+    data = _get_wizard()
+    paso1_data = data.get('paso1', {})
+
+    if request.method == 'POST':
+        tipo_expediente_id = request.form.get('tipo_expediente_id') or None
+        responsable_id = request.form.get('responsable_id') or None
+        heredado = request.form.get('heredado') == 'on'
+
+        if not tipo_expediente_id:
+            flash('Debe seleccionar un tipo de expediente.', 'danger')
+            return redirect(url_for('wizard_expediente.paso1'))
+
+        tipo = TipoExpediente.query.get(int(tipo_expediente_id))
+        if not tipo:
+            flash('El tipo de expediente seleccionado no es válido.', 'danger')
+            return redirect(url_for('wizard_expediente.paso1'))
+
+        data['paso1'] = {
+            'tipo_expediente_id': int(tipo_expediente_id),
+            'responsable_id': int(responsable_id) if responsable_id else None,
+            'heredado': heredado,
+        }
+        _save_wizard(data)
+        return redirect(url_for('wizard_expediente.paso2'))
+
+    tipos_expedientes = TipoExpediente.query.order_by(TipoExpediente.tipo).all()
+    usuarios = Usuario.query.filter_by(activo=True).order_by(
+        Usuario.apellido1, Usuario.nombre
+    ).all()
+
+    return render_template(
+        'expedientes/wizard_paso1.html',
+        tipos_expedientes=tipos_expedientes,
+        usuarios=usuarios,
+        paso1=paso1_data,
+    )
+
+
+@bp.route('/paso2', methods=['GET', 'POST'])
+@login_required
+def paso2():
+    """
+    Paso 2: Datos del proyecto técnico.
+
+    Campos:
+        titulo, descripcion, finalidad, emplazamiento  (obligatorios)
+        fecha        (obligatorio): Fecha técnica del proyecto (firma/visado).
+        ia_id        (opcional):   Instrumento ambiental aplicable.
+        municipios_ids[] (obligatorio, mín. 1): Municipios afectados.
+
+    Requiere paso 1 completado en sesión.
+    """
+    data = _get_wizard()
+    if 'paso1' not in data:
+        flash('Debe completar primero el paso 1.', 'warning')
+        return redirect(url_for('wizard_expediente.paso1'))
+
+    paso2_data = data.get('paso2', {})
+
+    if request.method == 'POST':
+        titulo = (request.form.get('titulo') or '').strip()
+        descripcion = (request.form.get('descripcion') or '').strip()
+        finalidad = (request.form.get('finalidad') or '').strip()
+        emplazamiento = (request.form.get('emplazamiento') or '').strip()
+        fecha_str = (request.form.get('fecha') or '').strip()
+        ia_id = request.form.get('ia_id') or None
+        municipios_ids = request.form.getlist('municipios_ids[]')
+
+        errores = []
+        if not titulo:
+            errores.append('El título del proyecto es obligatorio.')
+        if not descripcion:
+            errores.append('La descripción del proyecto es obligatoria.')
+        if not finalidad:
+            errores.append('La finalidad del proyecto es obligatoria.')
+        if not emplazamiento:
+            errores.append('El emplazamiento es obligatorio.')
+        if not municipios_ids:
+            errores.append('Debe añadir al menos un municipio afectado.')
+
+        try:
+            fecha = date.fromisoformat(fecha_str) if fecha_str else date.today()
+        except ValueError:
+            errores.append('Fecha de proyecto inválida (formato esperado: YYYY-MM-DD).')
+            fecha = date.today()
+
+        if errores:
+            for e in errores:
+                flash(e, 'danger')
+            return redirect(url_for('wizard_expediente.paso2'))
+
+        try:
+            municipios_ids = [int(mid) for mid in municipios_ids]
+        except ValueError:
+            flash('IDs de municipios inválidos.', 'danger')
+            return redirect(url_for('wizard_expediente.paso2'))
+
+        data['paso2'] = {
+            'titulo': titulo,
+            'descripcion': descripcion,
+            'finalidad': finalidad,
+            'emplazamiento': emplazamiento,
+            'fecha': fecha.isoformat(),
+            'ia_id': int(ia_id) if ia_id else None,
+            'municipios_ids': municipios_ids,
+        }
+        _save_wizard(data)
+        return redirect(url_for('wizard_expediente.paso3'))
+
+    tipos_ia = TipoIA.query.order_by(TipoIA.siglas).all()
+
+    return render_template(
+        'expedientes/wizard_paso2.html',
+        tipos_ia=tipos_ia,
+        paso2=paso2_data,
+    )
+
+
+@bp.route('/paso3', methods=['GET', 'POST'])
+@login_required
+def paso3():
+    """
+    Paso 3: Solicitud (entidad titular, fecha, tipos de solicitud).
+
+    Commit transaccional completo en este orden:
+        1) Proyecto
+        2) MunicipioProyecto x N
+        3) Expediente  (signal after_insert → histórico INICIAL automático)
+        4) Solicitud
+        5) SolicitudTipo x N
+
+    Requiere pasos 1 y 2 completados en sesión.
+    """
+    data = _get_wizard()
+    if 'paso1' not in data or 'paso2' not in data:
+        flash('Debe completar primero los pasos anteriores.', 'warning')
+        return redirect(url_for('wizard_expediente.paso1'))
+
+    if request.method == 'POST':
+        entidad_id = (request.form.get('entidad_id') or '').strip()
+        fecha_solicitud_str = (request.form.get('fecha_solicitud') or '').strip()
+        observaciones = (request.form.get('observaciones') or '').strip() or None
+        tipos_solicitud_ids = request.form.getlist('tipos_solicitud_ids[]')
+
+        # --- Validaciones ---
+        if not entidad_id:
+            flash('Debe seleccionar un titular/solicitante.', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        try:
+            entidad = Entidad.query.filter_by(
+                id=int(entidad_id), activo=True, rol_titular=True
+            ).first()
+        except ValueError:
+            entidad = None
+
+        if not entidad:
+            flash('La entidad seleccionada no es válida como titular.', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        try:
+            fecha_solicitud = date.fromisoformat(fecha_solicitud_str)
+        except ValueError:
+            flash('Fecha de solicitud inválida (formato esperado: YYYY-MM-DD).', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        if not tipos_solicitud_ids:
+            flash('Debe seleccionar al menos un tipo de solicitud.', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        try:
+            tipos_solicitud_ids = [int(tid) for tid in tipos_solicitud_ids]
+        except ValueError:
+            flash('Tipos de solicitud inválidos.', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        # Verificar que todos los tipos existen en la BD
+        tipos_validos = TipoSolicitud.query.filter(
+            TipoSolicitud.id.in_(tipos_solicitud_ids)
+        ).all()
+        if len(tipos_validos) != len(tipos_solicitud_ids):
+            flash('Algún tipo de solicitud seleccionado no es válido.', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+        # --- Transacción ---
+        try:
+            paso1 = data['paso1']
+            paso2 = data['paso2']
+
+            # 1) Proyecto
+            proyecto = Proyecto(
+                titulo=paso2['titulo'],
+                descripcion=paso2['descripcion'],
+                finalidad=paso2['finalidad'],
+                emplazamiento=paso2['emplazamiento'],
+                fecha=date.fromisoformat(paso2['fecha']),
+                ia_id=paso2['ia_id'],
+            )
+            db.session.add(proyecto)
+            db.session.flush()  # → proyecto.id disponible
+
+            # 2) Municipios del proyecto
+            for municipio_id in paso2['municipios_ids']:
+                mp = MunicipioProyecto(
+                    municipio_id=municipio_id,
+                    proyecto_id=proyecto.id,
+                )
+                db.session.add(mp)
+
+            # 3) numero_at = MAX(numero_at) + 1 dentro de la misma transacción
+            ultimo_numero = db.session.query(
+                db.func.max(Expediente.numero_at)
+            ).scalar() or 0
+            numero_at = ultimo_numero + 1
+
+            # 4) Expediente
+            #    El signal after_insert crea automáticamente el histórico INICIAL
+            expediente = Expediente(
+                numero_at=numero_at,
+                responsable_id=paso1['responsable_id'],
+                tipo_expediente_id=paso1['tipo_expediente_id'],
+                heredado=paso1['heredado'],
+                proyecto_id=proyecto.id,
+                titular_id=entidad.id,
+            )
+            db.session.add(expediente)
+            db.session.flush()  # → expediente.id disponible
+
+            # 5) Solicitud
+            solicitud = Solicitud(
+                expediente_id=expediente.id,
+                entidad_id=entidad.id,
+                fecha_solicitud=fecha_solicitud,
+                estado='EN_TRAMITE',
+                observaciones=observaciones,
+            )
+            db.session.add(solicitud)
+            db.session.flush()  # → solicitud.id disponible
+
+            # 6) Tipos de solicitud (tabla puente)
+            for tipo_id in tipos_solicitud_ids:
+                st = SolicitudTipo(
+                    solicitudid=solicitud.id,
+                    tiposolicitudid=tipo_id,
+                )
+                db.session.add(st)
+
+            db.session.commit()
+            _reset_wizard()
+
+            flash(f'Expediente AT-{numero_at} creado correctamente.', 'success')
+            return redirect(url_for('expedientes.listado_v2'))
+
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error al crear el expediente: {str(e)}', 'danger')
+            return redirect(url_for('wizard_expediente.paso3'))
+
+    # GET
+    tipos_solicitudes = TipoSolicitud.query.order_by(TipoSolicitud.siglas).all()
+
+    return render_template(
+        'expedientes/wizard_paso3.html',
+        tipos_solicitudes=tipos_solicitudes,
+    )

--- a/app/templates/dashboard/index_v1.html
+++ b/app/templates/dashboard/index_v1.html
@@ -76,9 +76,9 @@
     </a>
     {% endif %}
     
-    <!-- Card: Nuevo Expediente -->
+    <!-- Card: Nuevo Expediente — apunta al wizard (Issue #67) -->
     {% if 'TRAMITADOR' in user_roles or 'ADMINISTRATIVO' in user_roles or 'SUPERVISOR' in user_roles or 'ADMIN' in user_roles %}
-    <a href="{{ url_for('expedientes.nuevo') }}" class="dashboard-card">
+    <a href="{{ url_for('wizard_expediente.paso1') }}" class="dashboard-card">
         <div class="card-icon">
             <i class="fas fa-plus-circle"></i>
         </div>

--- a/app/templates/expedientes/listado_v2.html
+++ b/app/templates/expedientes/listado_v2.html
@@ -7,7 +7,7 @@
 
 {% block btn_nuevo %}
 <button class="btn btn-primary"
-        onclick="window.location.href='{{ url_for('expedientes.nuevo') }}'">
+        onclick="window.location.href='{{ url_for('wizard_expediente.paso1') }}'">
     <i class="fas fa-plus"></i> Nuevo Expediente
 </button>
 {% endblock %}

--- a/app/templates/expedientes/wizard_paso1.html
+++ b/app/templates/expedientes/wizard_paso1.html
@@ -1,13 +1,10 @@
-{% extends 'layout/base_full_width.html' %}
+{% extends 'layout/base_fullwidth.html' %}
 
 {% block title %}Nuevo Expediente &mdash; Paso 1{% endblock %}
 
 {% block content %}
 <div class="container-fluid py-4">
 
-    {# ------------------------------------------------------------------ #}
-    {# Migas de pan                                                         #}
-    {# ------------------------------------------------------------------ #}
     <nav aria-label="breadcrumb" class="mb-3">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
@@ -16,9 +13,6 @@
         </ol>
     </nav>
 
-    {# ------------------------------------------------------------------ #}
-    {# Título + indicador de pasos                                          #}
-    {# ------------------------------------------------------------------ #}
     <div class="d-flex align-items-center mb-4 gap-3">
         <h1 class="h3 mb-0">
             <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
@@ -26,16 +20,12 @@
         <span class="badge bg-primary fs-6">Paso 1 de 3</span>
     </div>
 
-    {# Indicador de progreso #}
     <div class="progress mb-4" style="height: 6px;">
         <div class="progress-bar bg-primary" style="width: 33%"
              role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100">
         </div>
     </div>
 
-    {# ------------------------------------------------------------------ #}
-    {# Mensajes flash                                                       #}
-    {# ------------------------------------------------------------------ #}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
@@ -47,9 +37,6 @@
         {% endif %}
     {% endwith %}
 
-    {# ------------------------------------------------------------------ #}
-    {# Formulario                                                           #}
-    {# ------------------------------------------------------------------ #}
     <div class="row justify-content-center">
         <div class="col-lg-7 col-md-10">
             <div class="card shadow-sm">
@@ -59,7 +46,6 @@
                 <div class="card-body">
                     <form method="post" action="{{ url_for('wizard_expediente.paso1') }}" novalidate>
 
-                        {# Tipo de expediente #}
                         <div class="mb-4">
                             <label for="tipo_expediente_id" class="form-label fw-semibold">
                                 Tipo de expediente <span class="text-danger">*</span>
@@ -80,7 +66,6 @@
                             <div class="form-text">Define el procedimiento normativo aplicable.</div>
                         </div>
 
-                        {# Responsable #}
                         <div class="mb-4">
                             <label for="responsable_id" class="form-label fw-semibold">Tramitador responsable</label>
                             <select id="responsable_id" name="responsable_id" class="form-select">
@@ -98,7 +83,6 @@
                             <div class="form-text">Opcional. Puede asignarse después.</div>
                         </div>
 
-                        {# Heredado #}
                         <div class="mb-4">
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox"
@@ -108,10 +92,9 @@
                                     Expediente heredado del sistema anterior
                                 </label>
                             </div>
-                            <div class="form-text ms-4">Marcar solo si proviene del sistema legacy (puede tener datos incompletos).</div>
+                            <div class="form-text ms-4">Marcar solo si proviene del sistema legacy.</div>
                         </div>
 
-                        {# Botones #}
                         <div class="d-flex justify-content-between pt-2">
                             <a href="{{ url_for('wizard_expediente.cancelar') }}"
                                class="btn btn-outline-secondary">

--- a/app/templates/expedientes/wizard_paso1.html
+++ b/app/templates/expedientes/wizard_paso1.html
@@ -1,0 +1,132 @@
+{% extends 'layout/base_full_width.html' %}
+
+{% block title %}Nuevo Expediente &mdash; Paso 1{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-4">
+
+    {# ------------------------------------------------------------------ #}
+    {# Migas de pan                                                         #}
+    {# ------------------------------------------------------------------ #}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a></li>
+            <li class="breadcrumb-item active">Nuevo &mdash; Paso 1 de 3</li>
+        </ol>
+    </nav>
+
+    {# ------------------------------------------------------------------ #}
+    {# Título + indicador de pasos                                          #}
+    {# ------------------------------------------------------------------ #}
+    <div class="d-flex align-items-center mb-4 gap-3">
+        <h1 class="h3 mb-0">
+            <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
+        </h1>
+        <span class="badge bg-primary fs-6">Paso 1 de 3</span>
+    </div>
+
+    {# Indicador de progreso #}
+    <div class="progress mb-4" style="height: 6px;">
+        <div class="progress-bar bg-primary" style="width: 33%"
+             role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100">
+        </div>
+    </div>
+
+    {# ------------------------------------------------------------------ #}
+    {# Mensajes flash                                                       #}
+    {# ------------------------------------------------------------------ #}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {# ------------------------------------------------------------------ #}
+    {# Formulario                                                           #}
+    {# ------------------------------------------------------------------ #}
+    <div class="row justify-content-center">
+        <div class="col-lg-7 col-md-10">
+            <div class="card shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="mb-0"><i class="fas fa-cog me-2 text-secondary"></i>Clasificación del expediente</h5>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ url_for('wizard_expediente.paso1') }}" novalidate>
+
+                        {# Tipo de expediente #}
+                        <div class="mb-4">
+                            <label for="tipo_expediente_id" class="form-label fw-semibold">
+                                Tipo de expediente <span class="text-danger">*</span>
+                            </label>
+                            <select id="tipo_expediente_id" name="tipo_expediente_id"
+                                    class="form-select" required>
+                                <option value="" disabled
+                                    {% if not paso1.get('tipo_expediente_id') %}selected{% endif %}>
+                                    &mdash; Seleccione un tipo &mdash;
+                                </option>
+                                {% for te in tipos_expedientes %}
+                                    <option value="{{ te.id }}"
+                                        {% if paso1.get('tipo_expediente_id') == te.id %}selected{% endif %}>
+                                        {{ te.tipo }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                            <div class="form-text">Define el procedimiento normativo aplicable.</div>
+                        </div>
+
+                        {# Responsable #}
+                        <div class="mb-4">
+                            <label for="responsable_id" class="form-label fw-semibold">Tramitador responsable</label>
+                            <select id="responsable_id" name="responsable_id" class="form-select">
+                                <option value=""
+                                    {% if not paso1.get('responsable_id') %}selected{% endif %}>
+                                    Sin asignar (huérfano)
+                                </option>
+                                {% for u in usuarios %}
+                                    <option value="{{ u.id }}"
+                                        {% if paso1.get('responsable_id') == u.id %}selected{% endif %}>
+                                        {{ u.apellido1 }}{% if u.apellido2 %} {{ u.apellido2 }}{% endif %}, {{ u.nombre }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                            <div class="form-text">Opcional. Puede asignarse después.</div>
+                        </div>
+
+                        {# Heredado #}
+                        <div class="mb-4">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox"
+                                       id="heredado" name="heredado"
+                                       {% if paso1.get('heredado') %}checked{% endif %}>
+                                <label class="form-check-label" for="heredado">
+                                    Expediente heredado del sistema anterior
+                                </label>
+                            </div>
+                            <div class="form-text ms-4">Marcar solo si proviene del sistema legacy (puede tener datos incompletos).</div>
+                        </div>
+
+                        {# Botones #}
+                        <div class="d-flex justify-content-between pt-2">
+                            <a href="{{ url_for('wizard_expediente.cancelar') }}"
+                               class="btn btn-outline-secondary">
+                                <i class="fas fa-times me-1"></i>Cancelar
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                Siguiente <i class="fas fa-arrow-right ms-1"></i>
+                            </button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/expedientes/wizard_paso1.html
+++ b/app/templates/expedientes/wizard_paso1.html
@@ -26,17 +26,6 @@
         </div>
     </div>
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <div class="row justify-content-center">
         <div class="col-lg-7 col-md-10">
             <div class="card shadow-sm">

--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base_full_width.html' %}
+{% extends 'layout/base_fullwidth.html' %}
 
 {% block title %}Nuevo Expediente &mdash; Paso 2{% endblock %}
 
@@ -61,7 +61,7 @@
                                 Descripción <span class="text-danger">*</span>
                             </label>
                             <textarea id="descripcion" name="descripcion"
-                                      class="form-control" rows="4"
+                                      class="form-control" rows="3"
                                       maxlength="10000" required>{{ paso2.get('descripcion', '') }}</textarea>
                         </div>
 
@@ -95,7 +95,7 @@
                                        class="form-control"
                                        value="{{ paso2.get('fecha', '') }}"
                                        required>
-                                <div class="form-text">Fecha de firma/visado (no administrativa).</div>
+                                <div class="form-text">Fecha de firma/visado.</div>
                             </div>
                             <div class="col-md-8 mb-3">
                                 <label for="ia_id" class="form-label fw-semibold">Instrumento ambiental</label>
@@ -114,57 +114,64 @@
                             </div>
                         </div>
 
-                        {# ============================================================ #}
-                        {# MUNICIPIOS AFECTADOS — selector dos pasos: provincia + muni  #}
-                        {# API: GET /api/provincias?q=   → ["Sevilla", ...]             #}
-                        {#      GET /api/municipios?provincia=X&q=Y                     #}
-                        {#           → [{id, nombre, codigo, provincia}]                #}
-                        {# ============================================================ #}
+                        {# ============================================================= #}
+                        {# MUNICIPIOS AFECTADOS                                          #}
+                        {# Paso A: provincia  →  GET /api/provincias?q=                  #}
+                        {#         respuesta: ["Sevilla", "Cádiz", ...]                   #}
+                        {# Paso B: municipio  →  GET /api/municipios?provincia=X&q=Y      #}
+                        {#         respuesta: [{id, nombre, codigo, provincia}]          #}
+                        {# ============================================================= #}
                         <div class="mb-4">
                             <label class="form-label fw-semibold">
                                 Municipios afectados <span class="text-danger">*</span>
                             </label>
 
-                            <div class="row g-2 align-items-start mb-2">
+                            <div class="card bg-light border-0 p-3">
 
-                                {# --- Columna 1: Provincia --- #}
-                                <div class="col-md-5" style="position: relative;">
-                                    <label for="provincia-search" class="form-label small text-muted mb-1">Provincia</label>
+                                {# Paso A: Provincia #}
+                                <div class="mb-3" style="position:relative;">
+                                    <label for="provincia-search" class="form-label small fw-semibold mb-1">
+                                        <span class="badge bg-secondary me-1">A</span> Provincia
+                                    </label>
                                     <input type="text" id="provincia-search"
-                                           class="form-control form-control-sm"
-                                           placeholder="Escriba la provincia..."
+                                           class="form-control"
+                                           placeholder="Escriba el nombre de la provincia..."
                                            autocomplete="off">
-                                    <ul id="provincia-suggestions"
-                                        class="list-group"
+                                    <ul id="provincia-suggestions" class="list-group shadow-sm"
                                         style="position:absolute; z-index:1050; width:100%;
-                                               max-height:180px; overflow-y:auto; display:none;">
+                                               max-height:200px; overflow-y:auto; display:none;">
                                     </ul>
                                 </div>
 
-                                {# --- Columna 2: Municipio (bloqueado hasta tener provincia) --- #}
-                                <div class="col-md-7" style="position: relative;">
-                                    <label for="municipio-search" class="form-label small text-muted mb-1">
+                                {# Paso B: Municipio (bloqueado hasta seleccionar provincia) #}
+                                <div class="mb-3" style="position:relative;">
+                                    <label for="municipio-search" class="form-label small fw-semibold mb-1">
+                                        <span class="badge bg-secondary me-1">B</span>
                                         Municipio
-                                        <span id="municipio-provincia-label" class="text-primary fw-semibold"></span>
+                                        <span id="municipio-provincia-label" class="text-primary fst-italic"></span>
                                     </label>
                                     <input type="text" id="municipio-search"
-                                           class="form-control form-control-sm"
+                                           class="form-control"
                                            placeholder="Seleccione primero una provincia..."
-                                           autocomplete="off"
-                                           disabled>
-                                    <ul id="municipio-suggestions"
-                                        class="list-group"
+                                           autocomplete="off" disabled>
+                                    <ul id="municipio-suggestions" class="list-group shadow-sm"
                                         style="position:absolute; z-index:1050; width:100%;
                                                max-height:220px; overflow-y:auto; display:none;">
                                     </ul>
                                 </div>
 
+                                {# Lista de municipios ya añadidos #}
+                                <div>
+                                    <p class="small text-muted mb-2">Municipios seleccionados:</p>
+                                    <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2">
+                                        <span class="text-muted small" id="municipios-placeholder">Ninguno añadido todavía.</span>
+                                    </div>
+                                </div>
+
                             </div>
 
-                            {# Municipios ya añadidos (badges) #}
-                            <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2 mb-1"></div>
                             <div id="municipios-error" class="text-danger small mt-1" style="display:none;">
-                                Debe añadir al menos un municipio.
+                                <i class="fas fa-exclamation-circle me-1"></i>Debe añadir al menos un municipio.
                             </div>
                             <div id="municipios-hidden-inputs"></div>
                         </div>
@@ -199,33 +206,26 @@
 (function () {
     'use strict';
 
-    // ================================================================
-    // Estado en memoria
-    // ================================================================
-    const municipiosSeleccionados = {};   // { id: 'Nombre (Provincia)' }
-    let provinciaActual = null;            // string nombre provincia seleccionada
+    const municipiosSeleccionados = {};  // { id: etiqueta }
+    let provinciaActual = null;
 
-    // ================================================================
-    // Referencias DOM
-    // ================================================================
-    const provinciaSearch    = document.getElementById('provincia-search');
-    const provinciaSugg      = document.getElementById('provincia-suggestions');
-    const municipioSearch    = document.getElementById('municipio-search');
-    const municipioSugg      = document.getElementById('municipio-suggestions');
-    const municipioLabel     = document.getElementById('municipio-provincia-label');
-    const badgesContainer    = document.getElementById('municipios-seleccionados');
-    const hiddenContainer    = document.getElementById('municipios-hidden-inputs');
-    const errorDiv           = document.getElementById('municipios-error');
+    const provinciaSearch = document.getElementById('provincia-search');
+    const provinciaSugg   = document.getElementById('provincia-suggestions');
+    const municipioSearch = document.getElementById('municipio-search');
+    const municipioSugg   = document.getElementById('municipio-suggestions');
+    const municipioLabel  = document.getElementById('municipio-provincia-label');
+    const badgesDiv       = document.getElementById('municipios-seleccionados');
+    const hiddenDiv       = document.getElementById('municipios-hidden-inputs');
+    const errorDiv        = document.getElementById('municipios-error');
 
-    let timerProvincia  = null;
-    let timerMunicipio  = null;
+    let tProv = null, tMuni = null;
 
-    // ================================================================
-    // PASO A: autocomplete de provincia  →  /api/provincias?q=
-    // ================================================================
+    // ------------------------------------------------------------------
+    // A) Autocomplete de provincia  →  /api/provincias?q=
+    // ------------------------------------------------------------------
     provinciaSearch.addEventListener('input', function () {
-        clearTimeout(timerProvincia);
-        // Al cambiar texto, desactivar municipio hasta nueva selección
+        clearTimeout(tProv);
+        // Reset municipio al cambiar provincia
         provinciaActual = null;
         municipioSearch.disabled = true;
         municipioSearch.value = '';
@@ -234,151 +234,145 @@
         municipioSugg.style.display = 'none';
 
         const q = this.value.trim();
-        if (q.length < 1) {
-            provinciaSugg.style.display = 'none';
-            return;
-        }
-        timerProvincia = setTimeout(() => buscarProvincias(q), 200);
-    });
+        if (!q) { provinciaSugg.style.display = 'none'; return; }
 
-    function buscarProvincias(q) {
-        fetch(`/api/provincias?q=${encodeURIComponent(q)}`)
-            .then(r => r.json())
-            .then(lista => {
-                provinciaSugg.innerHTML = '';
-                if (!lista.length) {
-                    provinciaSugg.style.display = 'none';
-                    return;
-                }
-                lista.forEach(nombre => {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item list-group-item-action py-1';
-                    li.textContent = nombre;
-                    li.addEventListener('click', () => seleccionarProvincia(nombre));
-                    provinciaSugg.appendChild(li);
-                });
-                provinciaSugg.style.display = 'block';
-            })
-            .catch(() => { provinciaSugg.style.display = 'none'; });
-    }
+        tProv = setTimeout(() => {
+            fetch(`/api/provincias?q=${encodeURIComponent(q)}`)
+                .then(r => r.json())
+                .then(lista => renderSugg(
+                    provinciaSugg,
+                    lista.map(n => ({ id: n, text: n })),
+                    item => seleccionarProvincia(item.text)
+                ))
+                .catch(() => { provinciaSugg.style.display = 'none'; });
+        }, 200);
+    });
 
     function seleccionarProvincia(nombre) {
         provinciaActual = nombre;
         provinciaSearch.value = nombre;
         provinciaSugg.style.display = 'none';
-        // Habilitar buscador de municipio
         municipioSearch.disabled = false;
-        municipioSearch.placeholder = 'Escriba el municipio...';
-        municipioLabel.textContent = ' (' + nombre + ')';
+        municipioSearch.placeholder = 'Escriba el nombre del municipio...';
+        municipioLabel.textContent = ' — ' + nombre;
         municipioSearch.focus();
     }
 
-    // ================================================================
-    // PASO B: autocomplete de municipio  →  /api/municipios?provincia=X&q=Y
-    // ================================================================
+    // ------------------------------------------------------------------
+    // B) Autocomplete de municipio  →  /api/municipios?provincia=X&q=Y
+    // ------------------------------------------------------------------
     municipioSearch.addEventListener('input', function () {
-        clearTimeout(timerMunicipio);
+        clearTimeout(tMuni);
         if (!provinciaActual) return;
         const q = this.value.trim();
-        if (q.length < 1) {
-            municipioSugg.style.display = 'none';
-            return;
-        }
-        timerMunicipio = setTimeout(() => buscarMunicipios(q), 200);
+        if (!q) { municipioSugg.style.display = 'none'; return; }
+
+        tMuni = setTimeout(() => {
+            const url = `/api/municipios?provincia=${encodeURIComponent(provinciaActual)}&q=${encodeURIComponent(q)}`;
+            fetch(url)
+                .then(r => r.json())
+                .then(lista => {
+                    if (!Array.isArray(lista)) lista = [];
+                    renderSugg(
+                        municipioSugg,
+                        lista.map(m => ({ id: m.id, text: m.nombre + ' (' + m.provincia + ')' })),
+                        item => { agregarMunicipio(item.id, item.text); municipioSearch.value = ''; }
+                    );
+                })
+                .catch(() => { municipioSugg.style.display = 'none'; });
+        }, 200);
     });
 
-    function buscarMunicipios(q) {
-        const url = `/api/municipios?provincia=${encodeURIComponent(provinciaActual)}&q=${encodeURIComponent(q)}`;
-        fetch(url)
-            .then(r => r.json())
-            .then(lista => {
-                municipioSugg.innerHTML = '';
-                if (!Array.isArray(lista) || !lista.length) {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item text-muted small py-1';
-                    li.textContent = 'Sin resultados';
-                    municipioSugg.appendChild(li);
-                    municipioSugg.style.display = 'block';
-                    return;
-                }
-                lista.forEach(m => {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item list-group-item-action py-1';
-                    li.textContent = m.nombre;
-                    li.addEventListener('click', () => {
-                        agregarMunicipio(m.id, m.nombre + ' (' + m.provincia + ')');
-                        municipioSearch.value = '';
-                        municipioSugg.style.display = 'none';
-                    });
-                    municipioSugg.appendChild(li);
+    // ------------------------------------------------------------------
+    // Render genérico de lista desplegable
+    // ------------------------------------------------------------------
+    function renderSugg(ul, items, onSelect) {
+        ul.innerHTML = '';
+        if (!items.length) {
+            const li = document.createElement('li');
+            li.className = 'list-group-item text-muted small py-2';
+            li.textContent = 'Sin resultados';
+            ul.appendChild(li);
+        } else {
+            items.forEach(item => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item list-group-item-action py-2';
+                li.textContent = item.text;
+                // mousedown en lugar de click para que se dispare antes del blur
+                li.addEventListener('mousedown', e => {
+                    e.preventDefault();
+                    onSelect(item);
+                    ul.style.display = 'none';
                 });
-                municipioSugg.style.display = 'block';
-            })
-            .catch(() => { municipioSugg.style.display = 'none'; });
+                ul.appendChild(li);
+            });
+        }
+        ul.style.display = 'block';
     }
 
-    // Cerrar dropdowns al clicar fuera
-    document.addEventListener('click', function (e) {
-        if (!provinciaSugg.contains(e.target) && e.target !== provinciaSearch) {
-            provinciaSugg.style.display = 'none';
-        }
-        if (!municipioSugg.contains(e.target) && e.target !== municipioSearch) {
-            municipioSugg.style.display = 'none';
-        }
+    // Cerrar al perder el foco (con delay para que mousedown del item se ejecute primero)
+    [provinciaSearch, municipioSearch].forEach(inp => {
+        inp.addEventListener('blur', () => {
+            setTimeout(() => {
+                provinciaSugg.style.display = 'none';
+                municipioSugg.style.display = 'none';
+            }, 150);
+        });
     });
 
-    // ================================================================
-    // Gestionar lista de municipios seleccionados
-    // ================================================================
+    // ------------------------------------------------------------------
+    // Gestión de municipios seleccionados
+    // ------------------------------------------------------------------
     function agregarMunicipio(id, etiqueta) {
-        if (municipiosSeleccionados[id]) return;
+        if (municipiosSeleccionados[id]) return; // ya está
         municipiosSeleccionados[id] = etiqueta;
-        renderizarMunicipios();
+        renderBadges();
         errorDiv.style.display = 'none';
     }
 
     function eliminarMunicipio(id) {
         delete municipiosSeleccionados[id];
-        renderizarMunicipios();
+        renderBadges();
     }
 
-    function renderizarMunicipios() {
-        badgesContainer.innerHTML = '';
-        hiddenContainer.innerHTML = '';
-        Object.entries(municipiosSeleccionados).forEach(([id, etiqueta]) => {
+    function renderBadges() {
+        badgesDiv.innerHTML = '';
+        hiddenDiv.innerHTML = '';
+        const ids = Object.keys(municipiosSeleccionados);
+        if (!ids.length) {
+            badgesDiv.innerHTML = '<span class="text-muted small">Ninguno añadido todavía.</span>';
+            return;
+        }
+        ids.forEach(id => {
+            const etiqueta = municipiosSeleccionados[id];
+
             const span = document.createElement('span');
-            span.className = 'badge bg-primary d-inline-flex align-items-center gap-1 me-1 mb-1';
-            span.style.fontSize = '0.85em';
+            span.className = 'badge bg-primary d-inline-flex align-items-center gap-1';
             span.innerHTML = escapeHtml(etiqueta) +
                 `<button type="button" class="btn-close btn-close-white ms-1"
-                         aria-label="Eliminar" style="font-size:0.55rem;"></button>`;
+                         aria-label="Eliminar" style="font-size:0.5rem;"></button>`;
             span.querySelector('button').addEventListener('click', () => eliminarMunicipio(id));
-            badgesContainer.appendChild(span);
+            badgesDiv.appendChild(span);
 
             const inp = document.createElement('input');
-            inp.type  = 'hidden';
-            inp.name  = 'municipios_ids[]';
-            inp.value = id;
-            hiddenContainer.appendChild(inp);
+            inp.type = 'hidden'; inp.name = 'municipios_ids[]'; inp.value = id;
+            hiddenDiv.appendChild(inp);
         });
     }
 
-    // ================================================================
+    // ------------------------------------------------------------------
     // Validación pre-submit
-    // ================================================================
+    // ------------------------------------------------------------------
     document.getElementById('form-paso2').addEventListener('submit', function (e) {
-        if (Object.keys(municipiosSeleccionados).length === 0) {
+        if (!Object.keys(municipiosSeleccionados).length) {
             e.preventDefault();
             errorDiv.style.display = 'block';
             provinciaSearch.focus();
         }
     });
 
-    // ================================================================
-    // Helpers
-    // ================================================================
-    function escapeHtml(str) {
-        return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    function escapeHtml(s) {
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
 }());

--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -5,9 +5,6 @@
 {% block content %}
 <div class="container-fluid py-4">
 
-    {# ------------------------------------------------------------------ #}
-    {# Migas de pan                                                         #}
-    {# ------------------------------------------------------------------ #}
     <nav aria-label="breadcrumb" class="mb-3">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
@@ -16,9 +13,6 @@
         </ol>
     </nav>
 
-    {# ------------------------------------------------------------------ #}
-    {# Título + indicador de pasos                                          #}
-    {# ------------------------------------------------------------------ #}
     <div class="d-flex align-items-center mb-4 gap-3">
         <h1 class="h3 mb-0">
             <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
@@ -32,9 +26,6 @@
         </div>
     </div>
 
-    {# ------------------------------------------------------------------ #}
-    {# Mensajes flash                                                       #}
-    {# ------------------------------------------------------------------ #}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
@@ -46,9 +37,6 @@
         {% endif %}
     {% endwith %}
 
-    {# ------------------------------------------------------------------ #}
-    {# Formulario                                                           #}
-    {# ------------------------------------------------------------------ #}
     <div class="row justify-content-center">
         <div class="col-lg-9 col-md-11">
             <div class="card shadow-sm">
@@ -58,7 +46,6 @@
                 <div class="card-body">
                     <form method="post" action="{{ url_for('wizard_expediente.paso2') }}" novalidate id="form-paso2">
 
-                        {# Título #}
                         <div class="mb-3">
                             <label for="titulo" class="form-label fw-semibold">
                                 Título del proyecto <span class="text-danger">*</span>
@@ -69,7 +56,6 @@
                                    maxlength="500" required>
                         </div>
 
-                        {# Descripción #}
                         <div class="mb-3">
                             <label for="descripcion" class="form-label fw-semibold">
                                 Descripción <span class="text-danger">*</span>
@@ -80,7 +66,6 @@
                         </div>
 
                         <div class="row">
-                            {# Finalidad #}
                             <div class="col-md-6 mb-3">
                                 <label for="finalidad" class="form-label fw-semibold">
                                     Finalidad <span class="text-danger">*</span>
@@ -90,8 +75,6 @@
                                        value="{{ paso2.get('finalidad', '') }}"
                                        maxlength="500" required>
                             </div>
-
-                            {# Emplazamiento #}
                             <div class="col-md-6 mb-3">
                                 <label for="emplazamiento" class="form-label fw-semibold">
                                     Emplazamiento <span class="text-danger">*</span>
@@ -104,7 +87,6 @@
                         </div>
 
                         <div class="row">
-                            {# Fecha técnica #}
                             <div class="col-md-4 mb-3">
                                 <label for="fecha" class="form-label fw-semibold">
                                     Fecha del proyecto <span class="text-danger">*</span>
@@ -115,8 +97,6 @@
                                        required>
                                 <div class="form-text">Fecha de firma/visado (no administrativa).</div>
                             </div>
-
-                            {# Instrumento ambiental #}
                             <div class="col-md-8 mb-3">
                                 <label for="ia_id" class="form-label fw-semibold">Instrumento ambiental</label>
                                 <select id="ia_id" name="ia_id" class="form-select">
@@ -134,42 +114,61 @@
                             </div>
                         </div>
 
-                        {# ------------------------------------------------------------------ #}
-                        {# Municipios afectados                                               #}
-                        {# ------------------------------------------------------------------ #}
+                        {# ============================================================ #}
+                        {# MUNICIPIOS AFECTADOS — selector dos pasos: provincia + muni  #}
+                        {# API: GET /api/provincias?q=   → ["Sevilla", ...]             #}
+                        {#      GET /api/municipios?provincia=X&q=Y                     #}
+                        {#           → [{id, nombre, codigo, provincia}]                #}
+                        {# ============================================================ #}
                         <div class="mb-4">
                             <label class="form-label fw-semibold">
                                 Municipios afectados <span class="text-danger">*</span>
                             </label>
 
-                            {# Buscador #}
-                            <div class="input-group mb-2">
-                                <span class="input-group-text"><i class="fas fa-search"></i></span>
-                                <input type="text" id="municipio-search"
-                                       class="form-control"
-                                       placeholder="Escriba nombre del municipio..."
-                                       autocomplete="off">
+                            <div class="row g-2 align-items-start mb-2">
+
+                                {# --- Columna 1: Provincia --- #}
+                                <div class="col-md-5" style="position: relative;">
+                                    <label for="provincia-search" class="form-label small text-muted mb-1">Provincia</label>
+                                    <input type="text" id="provincia-search"
+                                           class="form-control form-control-sm"
+                                           placeholder="Escriba la provincia..."
+                                           autocomplete="off">
+                                    <ul id="provincia-suggestions"
+                                        class="list-group"
+                                        style="position:absolute; z-index:1050; width:100%;
+                                               max-height:180px; overflow-y:auto; display:none;">
+                                    </ul>
+                                </div>
+
+                                {# --- Columna 2: Municipio (bloqueado hasta tener provincia) --- #}
+                                <div class="col-md-7" style="position: relative;">
+                                    <label for="municipio-search" class="form-label small text-muted mb-1">
+                                        Municipio
+                                        <span id="municipio-provincia-label" class="text-primary fw-semibold"></span>
+                                    </label>
+                                    <input type="text" id="municipio-search"
+                                           class="form-control form-control-sm"
+                                           placeholder="Seleccione primero una provincia..."
+                                           autocomplete="off"
+                                           disabled>
+                                    <ul id="municipio-suggestions"
+                                        class="list-group"
+                                        style="position:absolute; z-index:1050; width:100%;
+                                               max-height:220px; overflow-y:auto; display:none;">
+                                    </ul>
+                                </div>
+
                             </div>
 
-                            {# Lista de sugerencias #}
-                            <ul id="municipio-suggestions"
-                                class="list-group mb-2"
-                                style="max-height: 200px; overflow-y: auto; display: none;">
-                            </ul>
-
-                            {# Municipios seleccionados (badges) #}
-                            <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2 mb-1">
-                                {# Se rellenan por JS, y al cargar la página si hay datos en sesión #}
-                            </div>
-                            <div id="municipios-error" class="text-danger small" style="display:none;">
+                            {# Municipios ya añadidos (badges) #}
+                            <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2 mb-1"></div>
+                            <div id="municipios-error" class="text-danger small mt-1" style="display:none;">
                                 Debe añadir al menos un municipio.
                             </div>
-                            <div id="municipios-hidden-inputs">
-                                {# Los inputs hidden se generan por JS #}
-                            </div>
+                            <div id="municipios-hidden-inputs"></div>
                         </div>
 
-                        {# Botones #}
                         <div class="d-flex justify-content-between pt-2">
                             <div class="d-flex gap-2">
                                 <a href="{{ url_for('wizard_expediente.paso1') }}"
@@ -200,75 +199,140 @@
 (function () {
     'use strict';
 
-    // --- Municipios seleccionados en memoria ---
-    const municipiosSeleccionados = {}; // { id: nombre }
+    // ================================================================
+    // Estado en memoria
+    // ================================================================
+    const municipiosSeleccionados = {};   // { id: 'Nombre (Provincia)' }
+    let provinciaActual = null;            // string nombre provincia seleccionada
 
-    // Restaurar municipios de la sesión si los hay (pasados como data attribute)
-    // No procede en la primera visita; al volver del paso3 sí habría datos en sesión,
-    // pero el servidor no los re-envía en el GET (diseño simplificado).
+    // ================================================================
+    // Referencias DOM
+    // ================================================================
+    const provinciaSearch    = document.getElementById('provincia-search');
+    const provinciaSugg      = document.getElementById('provincia-suggestions');
+    const municipioSearch    = document.getElementById('municipio-search');
+    const municipioSugg      = document.getElementById('municipio-suggestions');
+    const municipioLabel     = document.getElementById('municipio-provincia-label');
+    const badgesContainer    = document.getElementById('municipios-seleccionados');
+    const hiddenContainer    = document.getElementById('municipios-hidden-inputs');
+    const errorDiv           = document.getElementById('municipios-error');
 
-    const searchInput    = document.getElementById('municipio-search');
-    const suggestions    = document.getElementById('municipio-suggestions');
-    const badgesContainer = document.getElementById('municipios-seleccionados');
-    const hiddenContainer = document.getElementById('municipios-hidden-inputs');
-    const errorDiv        = document.getElementById('municipios-error');
+    let timerProvincia  = null;
+    let timerMunicipio  = null;
 
-    let debounceTimer = null;
+    // ================================================================
+    // PASO A: autocomplete de provincia  →  /api/provincias?q=
+    // ================================================================
+    provinciaSearch.addEventListener('input', function () {
+        clearTimeout(timerProvincia);
+        // Al cambiar texto, desactivar municipio hasta nueva selección
+        provinciaActual = null;
+        municipioSearch.disabled = true;
+        municipioSearch.value = '';
+        municipioSearch.placeholder = 'Seleccione primero una provincia...';
+        municipioLabel.textContent = '';
+        municipioSugg.style.display = 'none';
 
-    // ----------------------------------------------------------------
-    // Buscar municipios en la API
-    // ----------------------------------------------------------------
-    searchInput.addEventListener('input', function () {
-        clearTimeout(debounceTimer);
         const q = this.value.trim();
-        if (q.length < 2) {
-            suggestions.style.display = 'none';
-            suggestions.innerHTML = '';
+        if (q.length < 1) {
+            provinciaSugg.style.display = 'none';
             return;
         }
-        debounceTimer = setTimeout(() => buscarMunicipios(q), 250);
+        timerProvincia = setTimeout(() => buscarProvincias(q), 200);
+    });
+
+    function buscarProvincias(q) {
+        fetch(`/api/provincias?q=${encodeURIComponent(q)}`)
+            .then(r => r.json())
+            .then(lista => {
+                provinciaSugg.innerHTML = '';
+                if (!lista.length) {
+                    provinciaSugg.style.display = 'none';
+                    return;
+                }
+                lista.forEach(nombre => {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item list-group-item-action py-1';
+                    li.textContent = nombre;
+                    li.addEventListener('click', () => seleccionarProvincia(nombre));
+                    provinciaSugg.appendChild(li);
+                });
+                provinciaSugg.style.display = 'block';
+            })
+            .catch(() => { provinciaSugg.style.display = 'none'; });
+    }
+
+    function seleccionarProvincia(nombre) {
+        provinciaActual = nombre;
+        provinciaSearch.value = nombre;
+        provinciaSugg.style.display = 'none';
+        // Habilitar buscador de municipio
+        municipioSearch.disabled = false;
+        municipioSearch.placeholder = 'Escriba el municipio...';
+        municipioLabel.textContent = ' (' + nombre + ')';
+        municipioSearch.focus();
+    }
+
+    // ================================================================
+    // PASO B: autocomplete de municipio  →  /api/municipios?provincia=X&q=Y
+    // ================================================================
+    municipioSearch.addEventListener('input', function () {
+        clearTimeout(timerMunicipio);
+        if (!provinciaActual) return;
+        const q = this.value.trim();
+        if (q.length < 1) {
+            municipioSugg.style.display = 'none';
+            return;
+        }
+        timerMunicipio = setTimeout(() => buscarMunicipios(q), 200);
     });
 
     function buscarMunicipios(q) {
-        fetch(`/api/municipios?q=${encodeURIComponent(q)}`)
+        const url = `/api/municipios?provincia=${encodeURIComponent(provinciaActual)}&q=${encodeURIComponent(q)}`;
+        fetch(url)
             .then(r => r.json())
-            .then(data => {
-                const resultados = data.results || data;
-                suggestions.innerHTML = '';
-                if (!resultados.length) {
-                    suggestions.style.display = 'none';
+            .then(lista => {
+                municipioSugg.innerHTML = '';
+                if (!Array.isArray(lista) || !lista.length) {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item text-muted small py-1';
+                    li.textContent = 'Sin resultados';
+                    municipioSugg.appendChild(li);
+                    municipioSugg.style.display = 'block';
                     return;
                 }
-                resultados.forEach(m => {
+                lista.forEach(m => {
                     const li = document.createElement('li');
-                    li.className = 'list-group-item list-group-item-action';
-                    li.textContent = m.text || m.nombre || m.nombre_completo;
-                    li.dataset.id = m.id;
+                    li.className = 'list-group-item list-group-item-action py-1';
+                    li.textContent = m.nombre;
                     li.addEventListener('click', () => {
-                        agregarMunicipio(m.id, li.textContent);
-                        suggestions.style.display = 'none';
-                        searchInput.value = '';
+                        agregarMunicipio(m.id, m.nombre + ' (' + m.provincia + ')');
+                        municipioSearch.value = '';
+                        municipioSugg.style.display = 'none';
                     });
-                    suggestions.appendChild(li);
+                    municipioSugg.appendChild(li);
                 });
-                suggestions.style.display = 'block';
+                municipioSugg.style.display = 'block';
             })
-            .catch(() => { suggestions.style.display = 'none'; });
+            .catch(() => { municipioSugg.style.display = 'none'; });
     }
 
-    // Cerrar sugerencias al hacer clic fuera
+    // Cerrar dropdowns al clicar fuera
     document.addEventListener('click', function (e) {
-        if (!suggestions.contains(e.target) && e.target !== searchInput) {
-            suggestions.style.display = 'none';
+        if (!provinciaSugg.contains(e.target) && e.target !== provinciaSearch) {
+            provinciaSugg.style.display = 'none';
+        }
+        if (!municipioSugg.contains(e.target) && e.target !== municipioSearch) {
+            municipioSugg.style.display = 'none';
         }
     });
 
-    // ----------------------------------------------------------------
-    // Agregar municipio a la selección
-    // ----------------------------------------------------------------
-    function agregarMunicipio(id, nombre) {
-        if (municipiosSeleccionados[id]) return; // ya está
-        municipiosSeleccionados[id] = nombre;
+    // ================================================================
+    // Gestionar lista de municipios seleccionados
+    // ================================================================
+    function agregarMunicipio(id, etiqueta) {
+        if (municipiosSeleccionados[id]) return;
+        municipiosSeleccionados[id] = etiqueta;
         renderizarMunicipios();
         errorDiv.style.display = 'none';
     }
@@ -281,41 +345,40 @@
     function renderizarMunicipios() {
         badgesContainer.innerHTML = '';
         hiddenContainer.innerHTML = '';
-        Object.entries(municipiosSeleccionados).forEach(([id, nombre]) => {
-            // Badge visible
+        Object.entries(municipiosSeleccionados).forEach(([id, etiqueta]) => {
             const span = document.createElement('span');
-            span.className = 'badge bg-primary d-flex align-items-center gap-1';
-            span.innerHTML = `${escapeHtml(nombre)}
-                <button type="button" class="btn-close btn-close-white btn-sm ms-1"
-                        aria-label="Eliminar" style="font-size:0.6rem;"></button>`;
+            span.className = 'badge bg-primary d-inline-flex align-items-center gap-1 me-1 mb-1';
+            span.style.fontSize = '0.85em';
+            span.innerHTML = escapeHtml(etiqueta) +
+                `<button type="button" class="btn-close btn-close-white ms-1"
+                         aria-label="Eliminar" style="font-size:0.55rem;"></button>`;
             span.querySelector('button').addEventListener('click', () => eliminarMunicipio(id));
             badgesContainer.appendChild(span);
 
-            // Input hidden para el POST
-            const input = document.createElement('input');
-            input.type  = 'hidden';
-            input.name  = 'municipios_ids[]';
-            input.value = id;
-            hiddenContainer.appendChild(input);
+            const inp = document.createElement('input');
+            inp.type  = 'hidden';
+            inp.name  = 'municipios_ids[]';
+            inp.value = id;
+            hiddenContainer.appendChild(inp);
         });
     }
 
-    // ----------------------------------------------------------------
-    // Validación antes de enviar
-    // ----------------------------------------------------------------
+    // ================================================================
+    // Validación pre-submit
+    // ================================================================
     document.getElementById('form-paso2').addEventListener('submit', function (e) {
         if (Object.keys(municipiosSeleccionados).length === 0) {
             e.preventDefault();
             errorDiv.style.display = 'block';
-            searchInput.focus();
+            provinciaSearch.focus();
         }
     });
 
-    // ----------------------------------------------------------------
+    // ================================================================
     // Helpers
-    // ----------------------------------------------------------------
+    // ================================================================
     function escapeHtml(str) {
-        return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
 }());

--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -1,0 +1,323 @@
+{% extends 'layout/base_full_width.html' %}
+
+{% block title %}Nuevo Expediente &mdash; Paso 2{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-4">
+
+    {# ------------------------------------------------------------------ #}
+    {# Migas de pan                                                         #}
+    {# ------------------------------------------------------------------ #}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a></li>
+            <li class="breadcrumb-item active">Nuevo &mdash; Paso 2 de 3</li>
+        </ol>
+    </nav>
+
+    {# ------------------------------------------------------------------ #}
+    {# Título + indicador de pasos                                          #}
+    {# ------------------------------------------------------------------ #}
+    <div class="d-flex align-items-center mb-4 gap-3">
+        <h1 class="h3 mb-0">
+            <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
+        </h1>
+        <span class="badge bg-primary fs-6">Paso 2 de 3</span>
+    </div>
+
+    <div class="progress mb-4" style="height: 6px;">
+        <div class="progress-bar bg-primary" style="width: 66%"
+             role="progressbar" aria-valuenow="66" aria-valuemin="0" aria-valuemax="100">
+        </div>
+    </div>
+
+    {# ------------------------------------------------------------------ #}
+    {# Mensajes flash                                                       #}
+    {# ------------------------------------------------------------------ #}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {# ------------------------------------------------------------------ #}
+    {# Formulario                                                           #}
+    {# ------------------------------------------------------------------ #}
+    <div class="row justify-content-center">
+        <div class="col-lg-9 col-md-11">
+            <div class="card shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="mb-0"><i class="fas fa-drafting-compass me-2 text-secondary"></i>Datos del proyecto técnico</h5>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ url_for('wizard_expediente.paso2') }}" novalidate id="form-paso2">
+
+                        {# Título #}
+                        <div class="mb-3">
+                            <label for="titulo" class="form-label fw-semibold">
+                                Título del proyecto <span class="text-danger">*</span>
+                            </label>
+                            <input type="text" id="titulo" name="titulo"
+                                   class="form-control"
+                                   value="{{ paso2.get('titulo', '') }}"
+                                   maxlength="500" required>
+                        </div>
+
+                        {# Descripción #}
+                        <div class="mb-3">
+                            <label for="descripcion" class="form-label fw-semibold">
+                                Descripción <span class="text-danger">*</span>
+                            </label>
+                            <textarea id="descripcion" name="descripcion"
+                                      class="form-control" rows="4"
+                                      maxlength="10000" required>{{ paso2.get('descripcion', '') }}</textarea>
+                        </div>
+
+                        <div class="row">
+                            {# Finalidad #}
+                            <div class="col-md-6 mb-3">
+                                <label for="finalidad" class="form-label fw-semibold">
+                                    Finalidad <span class="text-danger">*</span>
+                                </label>
+                                <input type="text" id="finalidad" name="finalidad"
+                                       class="form-control"
+                                       value="{{ paso2.get('finalidad', '') }}"
+                                       maxlength="500" required>
+                            </div>
+
+                            {# Emplazamiento #}
+                            <div class="col-md-6 mb-3">
+                                <label for="emplazamiento" class="form-label fw-semibold">
+                                    Emplazamiento <span class="text-danger">*</span>
+                                </label>
+                                <input type="text" id="emplazamiento" name="emplazamiento"
+                                       class="form-control"
+                                       value="{{ paso2.get('emplazamiento', '') }}"
+                                       maxlength="200" required>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            {# Fecha técnica #}
+                            <div class="col-md-4 mb-3">
+                                <label for="fecha" class="form-label fw-semibold">
+                                    Fecha del proyecto <span class="text-danger">*</span>
+                                </label>
+                                <input type="date" id="fecha" name="fecha"
+                                       class="form-control"
+                                       value="{{ paso2.get('fecha', '') }}"
+                                       required>
+                                <div class="form-text">Fecha de firma/visado (no administrativa).</div>
+                            </div>
+
+                            {# Instrumento ambiental #}
+                            <div class="col-md-8 mb-3">
+                                <label for="ia_id" class="form-label fw-semibold">Instrumento ambiental</label>
+                                <select id="ia_id" name="ia_id" class="form-select">
+                                    <option value=""
+                                        {% if not paso2.get('ia_id') %}selected{% endif %}>
+                                        Sin determinar
+                                    </option>
+                                    {% for ia in tipos_ia %}
+                                        <option value="{{ ia.id }}"
+                                            {% if paso2.get('ia_id') == ia.id %}selected{% endif %}>
+                                            {{ ia.siglas }}{% if ia.descripcion %} &mdash; {{ ia.descripcion }}{% endif %}
+                                        </option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        </div>
+
+                        {# ------------------------------------------------------------------ #}
+                        {# Municipios afectados                                               #}
+                        {# ------------------------------------------------------------------ #}
+                        <div class="mb-4">
+                            <label class="form-label fw-semibold">
+                                Municipios afectados <span class="text-danger">*</span>
+                            </label>
+
+                            {# Buscador #}
+                            <div class="input-group mb-2">
+                                <span class="input-group-text"><i class="fas fa-search"></i></span>
+                                <input type="text" id="municipio-search"
+                                       class="form-control"
+                                       placeholder="Escriba nombre del municipio..."
+                                       autocomplete="off">
+                            </div>
+
+                            {# Lista de sugerencias #}
+                            <ul id="municipio-suggestions"
+                                class="list-group mb-2"
+                                style="max-height: 200px; overflow-y: auto; display: none;">
+                            </ul>
+
+                            {# Municipios seleccionados (badges) #}
+                            <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2 mb-1">
+                                {# Se rellenan por JS, y al cargar la página si hay datos en sesión #}
+                            </div>
+                            <div id="municipios-error" class="text-danger small" style="display:none;">
+                                Debe añadir al menos un municipio.
+                            </div>
+                            <div id="municipios-hidden-inputs">
+                                {# Los inputs hidden se generan por JS #}
+                            </div>
+                        </div>
+
+                        {# Botones #}
+                        <div class="d-flex justify-content-between pt-2">
+                            <div class="d-flex gap-2">
+                                <a href="{{ url_for('wizard_expediente.paso1') }}"
+                                   class="btn btn-outline-secondary">
+                                    <i class="fas fa-arrow-left me-1"></i>Atrás
+                                </a>
+                                <a href="{{ url_for('wizard_expediente.cancelar') }}"
+                                   class="btn btn-outline-danger">
+                                    <i class="fas fa-times me-1"></i>Cancelar
+                                </a>
+                            </div>
+                            <button type="submit" class="btn btn-primary" id="btn-siguiente-paso2">
+                                Siguiente <i class="fas fa-arrow-right ms-1"></i>
+                            </button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+    'use strict';
+
+    // --- Municipios seleccionados en memoria ---
+    const municipiosSeleccionados = {}; // { id: nombre }
+
+    // Restaurar municipios de la sesión si los hay (pasados como data attribute)
+    // No procede en la primera visita; al volver del paso3 sí habría datos en sesión,
+    // pero el servidor no los re-envía en el GET (diseño simplificado).
+
+    const searchInput    = document.getElementById('municipio-search');
+    const suggestions    = document.getElementById('municipio-suggestions');
+    const badgesContainer = document.getElementById('municipios-seleccionados');
+    const hiddenContainer = document.getElementById('municipios-hidden-inputs');
+    const errorDiv        = document.getElementById('municipios-error');
+
+    let debounceTimer = null;
+
+    // ----------------------------------------------------------------
+    // Buscar municipios en la API
+    // ----------------------------------------------------------------
+    searchInput.addEventListener('input', function () {
+        clearTimeout(debounceTimer);
+        const q = this.value.trim();
+        if (q.length < 2) {
+            suggestions.style.display = 'none';
+            suggestions.innerHTML = '';
+            return;
+        }
+        debounceTimer = setTimeout(() => buscarMunicipios(q), 250);
+    });
+
+    function buscarMunicipios(q) {
+        fetch(`/api/municipios?q=${encodeURIComponent(q)}`)
+            .then(r => r.json())
+            .then(data => {
+                const resultados = data.results || data;
+                suggestions.innerHTML = '';
+                if (!resultados.length) {
+                    suggestions.style.display = 'none';
+                    return;
+                }
+                resultados.forEach(m => {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item list-group-item-action';
+                    li.textContent = m.text || m.nombre || m.nombre_completo;
+                    li.dataset.id = m.id;
+                    li.addEventListener('click', () => {
+                        agregarMunicipio(m.id, li.textContent);
+                        suggestions.style.display = 'none';
+                        searchInput.value = '';
+                    });
+                    suggestions.appendChild(li);
+                });
+                suggestions.style.display = 'block';
+            })
+            .catch(() => { suggestions.style.display = 'none'; });
+    }
+
+    // Cerrar sugerencias al hacer clic fuera
+    document.addEventListener('click', function (e) {
+        if (!suggestions.contains(e.target) && e.target !== searchInput) {
+            suggestions.style.display = 'none';
+        }
+    });
+
+    // ----------------------------------------------------------------
+    // Agregar municipio a la selección
+    // ----------------------------------------------------------------
+    function agregarMunicipio(id, nombre) {
+        if (municipiosSeleccionados[id]) return; // ya está
+        municipiosSeleccionados[id] = nombre;
+        renderizarMunicipios();
+        errorDiv.style.display = 'none';
+    }
+
+    function eliminarMunicipio(id) {
+        delete municipiosSeleccionados[id];
+        renderizarMunicipios();
+    }
+
+    function renderizarMunicipios() {
+        badgesContainer.innerHTML = '';
+        hiddenContainer.innerHTML = '';
+        Object.entries(municipiosSeleccionados).forEach(([id, nombre]) => {
+            // Badge visible
+            const span = document.createElement('span');
+            span.className = 'badge bg-primary d-flex align-items-center gap-1';
+            span.innerHTML = `${escapeHtml(nombre)}
+                <button type="button" class="btn-close btn-close-white btn-sm ms-1"
+                        aria-label="Eliminar" style="font-size:0.6rem;"></button>`;
+            span.querySelector('button').addEventListener('click', () => eliminarMunicipio(id));
+            badgesContainer.appendChild(span);
+
+            // Input hidden para el POST
+            const input = document.createElement('input');
+            input.type  = 'hidden';
+            input.name  = 'municipios_ids[]';
+            input.value = id;
+            hiddenContainer.appendChild(input);
+        });
+    }
+
+    // ----------------------------------------------------------------
+    // Validación antes de enviar
+    // ----------------------------------------------------------------
+    document.getElementById('form-paso2').addEventListener('submit', function (e) {
+        if (Object.keys(municipiosSeleccionados).length === 0) {
+            e.preventDefault();
+            errorDiv.style.display = 'block';
+            searchInput.focus();
+        }
+    });
+
+    // ----------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------
+    function escapeHtml(str) {
+        return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+}());
+</script>
+{% endblock %}

--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -26,17 +26,6 @@
         </div>
     </div>
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <div class="row justify-content-center">
         <div class="col-lg-9 col-md-11">
             <div class="card shadow-sm">
@@ -164,7 +153,7 @@
                                 <div>
                                     <p class="small text-muted mb-2">Municipios seleccionados:</p>
                                     <div id="municipios-seleccionados" class="d-flex flex-wrap gap-2">
-                                        <span class="text-muted small" id="municipios-placeholder">Ninguno añadido todavía.</span>
+                                        <span class="text-muted small">Ninguno añadido todavía.</span>
                                     </div>
                                 </div>
 
@@ -225,7 +214,6 @@
     // ------------------------------------------------------------------
     provinciaSearch.addEventListener('input', function () {
         clearTimeout(tProv);
-        // Reset municipio al cambiar provincia
         provinciaActual = null;
         municipioSearch.disabled = true;
         municipioSearch.value = '';
@@ -298,7 +286,6 @@
                 const li = document.createElement('li');
                 li.className = 'list-group-item list-group-item-action py-2';
                 li.textContent = item.text;
-                // mousedown en lugar de click para que se dispare antes del blur
                 li.addEventListener('mousedown', e => {
                     e.preventDefault();
                     onSelect(item);
@@ -310,7 +297,6 @@
         ul.style.display = 'block';
     }
 
-    // Cerrar al perder el foco (con delay para que mousedown del item se ejecute primero)
     [provinciaSearch, municipioSearch].forEach(inp => {
         inp.addEventListener('blur', () => {
             setTimeout(() => {
@@ -324,7 +310,7 @@
     // Gestión de municipios seleccionados
     // ------------------------------------------------------------------
     function agregarMunicipio(id, etiqueta) {
-        if (municipiosSeleccionados[id]) return; // ya está
+        if (municipiosSeleccionados[id]) return;
         municipiosSeleccionados[id] = etiqueta;
         renderBadges();
         errorDiv.style.display = 'none';
@@ -345,7 +331,6 @@
         }
         ids.forEach(id => {
             const etiqueta = municipiosSeleccionados[id];
-
             const span = document.createElement('span');
             span.className = 'badge bg-primary d-inline-flex align-items-center gap-1';
             span.innerHTML = escapeHtml(etiqueta) +

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -26,17 +26,6 @@
         </div>
     </div>
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                    {{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    {% endwith %}
-
     <div class="row justify-content-center">
         <div class="col-lg-8 col-md-11">
             <div class="card shadow-sm">

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -1,0 +1,285 @@
+{% extends 'layout/base_full_width.html' %}
+
+{% block title %}Nuevo Expediente &mdash; Paso 3{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-4">
+
+    {# ------------------------------------------------------------------ #}
+    {# Migas de pan                                                         #}
+    {# ------------------------------------------------------------------ #}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a></li>
+            <li class="breadcrumb-item active">Nuevo &mdash; Paso 3 de 3</li>
+        </ol>
+    </nav>
+
+    {# ------------------------------------------------------------------ #}
+    {# Título + indicador de pasos                                          #}
+    {# ------------------------------------------------------------------ #}
+    <div class="d-flex align-items-center mb-4 gap-3">
+        <h1 class="h3 mb-0">
+            <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
+        </h1>
+        <span class="badge bg-primary fs-6">Paso 3 de 3</span>
+    </div>
+
+    <div class="progress mb-4" style="height: 6px;">
+        <div class="progress-bar bg-primary" style="width: 100%"
+             role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">
+        </div>
+    </div>
+
+    {# ------------------------------------------------------------------ #}
+    {# Mensajes flash                                                       #}
+    {# ------------------------------------------------------------------ #}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {# ------------------------------------------------------------------ #}
+    {# Formulario                                                           #}
+    {# ------------------------------------------------------------------ #}
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-md-11">
+            <div class="card shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="mb-0"><i class="fas fa-file-alt me-2 text-secondary"></i>Datos de la solicitud</h5>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ url_for('wizard_expediente.paso3') }}" novalidate>
+
+                        {# ------------------------------------------------------------------ #}
+                        {# Titular / solicitante (autocomplete)                               #}
+                        {# ------------------------------------------------------------------ #}
+                        <div class="mb-4">
+                            <label for="entidad-search" class="form-label fw-semibold">
+                                Titular / Solicitante <span class="text-danger">*</span>
+                            </label>
+
+                            {# Input oculto que envía el ID al servidor #}
+                            <input type="hidden" id="entidad_id" name="entidad_id">
+
+                            {# Input de búsqueda visible #}
+                            <div class="input-group">
+                                <span class="input-group-text"><i class="fas fa-search"></i></span>
+                                <input type="text" id="entidad-search"
+                                       class="form-control"
+                                       placeholder="Escriba nombre o NIF (mín. 2 caracteres)..."
+                                       autocomplete="off">
+                                <button type="button" class="btn btn-outline-secondary"
+                                        id="btn-limpiar-entidad" title="Limpiar" style="display:none;">
+                                    <i class="fas fa-times"></i>
+                                </button>
+                            </div>
+
+                            {# Lista de sugerencias #}
+                            <ul id="entidad-suggestions"
+                                class="list-group mt-1"
+                                style="max-height: 220px; overflow-y: auto;
+                                       position: absolute; z-index: 1050;
+                                       width: calc(100% - 2rem); display: none;">
+                            </ul>
+
+                            <div class="form-text">Solo entidades activas con rol Titular. Si no aparece, créela primero en el catálogo.</div>
+                            <div id="entidad-error" class="text-danger small mt-1" style="display:none;">
+                                Debe seleccionar un titular/solicitante.
+                            </div>
+                        </div>
+
+                        {# Fecha de solicitud #}
+                        <div class="mb-4">
+                            <label for="fecha_solicitud" class="form-label fw-semibold">
+                                Fecha de solicitud <span class="text-danger">*</span>
+                            </label>
+                            <input type="date" id="fecha_solicitud" name="fecha_solicitud"
+                                   class="form-control w-auto"
+                                   required>
+                            <div class="form-text">Fecha oficial de presentación de la solicitud.</div>
+                        </div>
+
+                        {# Tipos de solicitud (checkboxes) #}
+                        <div class="mb-4">
+                            <label class="form-label fw-semibold">
+                                Tipo(s) de solicitud <span class="text-danger">*</span>
+                            </label>
+                            <div id="tipos-solicitud-error" class="text-danger small mb-1" style="display:none;">
+                                Debe seleccionar al menos un tipo.
+                            </div>
+                            <div class="row row-cols-1 row-cols-md-2 g-2">
+                                {% for ts in tipos_solicitudes %}
+                                    <div class="col">
+                                        <div class="form-check border rounded p-2 h-100">
+                                            <input class="form-check-input tipo-solicitud-check"
+                                                   type="checkbox"
+                                                   name="tipos_solicitud_ids[]"
+                                                   id="ts_{{ ts.id }}"
+                                                   value="{{ ts.id }}">
+                                            <label class="form-check-label" for="ts_{{ ts.id }}">
+                                                <span class="badge bg-secondary me-1">{{ ts.siglas }}</span>
+                                                {{ ts.descripcion }}
+                                            </label>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        {# Observaciones #}
+                        <div class="mb-4">
+                            <label for="observaciones" class="form-label fw-semibold">Observaciones</label>
+                            <textarea id="observaciones" name="observaciones"
+                                      class="form-control" rows="3"
+                                      maxlength="2000"
+                                      placeholder="Notas adicionales (opcional)"></textarea>
+                        </div>
+
+                        {# Botones #}
+                        <div class="d-flex justify-content-between pt-2">
+                            <div class="d-flex gap-2">
+                                <a href="{{ url_for('wizard_expediente.paso2') }}"
+                                   class="btn btn-outline-secondary">
+                                    <i class="fas fa-arrow-left me-1"></i>Atrás
+                                </a>
+                                <a href="{{ url_for('wizard_expediente.cancelar') }}"
+                                   class="btn btn-outline-danger">
+                                    <i class="fas fa-times me-1"></i>Cancelar
+                                </a>
+                            </div>
+                            <button type="submit" class="btn btn-success" id="btn-finalizar">
+                                <i class="fas fa-check me-1"></i>Crear expediente
+                            </button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+    'use strict';
+
+    // ================================================================
+    // Autocomplete entidad (solo activas con rol_titular=True)
+    // ================================================================
+    const entidadSearch     = document.getElementById('entidad-search');
+    const entidadIdInput    = document.getElementById('entidad_id');
+    const entidadSuggestions = document.getElementById('entidad-suggestions');
+    const btnLimpiarEntidad = document.getElementById('btn-limpiar-entidad');
+    const entidadError      = document.getElementById('entidad-error');
+
+    let debounceEntidad = null;
+
+    entidadSearch.addEventListener('input', function () {
+        clearTimeout(debounceEntidad);
+        const q = this.value.trim();
+        entidadIdInput.value = '';          // limpiar selección previa
+        btnLimpiarEntidad.style.display = 'none';
+        if (q.length < 2) {
+            entidadSuggestions.style.display = 'none';
+            entidadSuggestions.innerHTML = '';
+            return;
+        }
+        debounceEntidad = setTimeout(() => buscarEntidades(q), 250);
+    });
+
+    function buscarEntidades(q) {
+        fetch(`/api/entidades?q=${encodeURIComponent(q)}&rol=titular`)
+            .then(r => r.json())
+            .then(data => {
+                const resultados = data.results || [];
+                entidadSuggestions.innerHTML = '';
+                if (!resultados.length) {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item text-muted small';
+                    li.textContent = 'No se encontraron entidades con rol Titular.';
+                    entidadSuggestions.appendChild(li);
+                    entidadSuggestions.style.display = 'block';
+                    return;
+                }
+                resultados.forEach(e => {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item list-group-item-action';
+                    li.textContent = e.text;
+                    li.addEventListener('click', () => {
+                        seleccionarEntidad(e.id, e.text);
+                    });
+                    entidadSuggestions.appendChild(li);
+                });
+                entidadSuggestions.style.display = 'block';
+            })
+            .catch(() => { entidadSuggestions.style.display = 'none'; });
+    }
+
+    function seleccionarEntidad(id, texto) {
+        entidadIdInput.value    = id;
+        entidadSearch.value     = texto;
+        entidadSuggestions.style.display = 'none';
+        btnLimpiarEntidad.style.display  = 'inline-block';
+        entidadError.style.display = 'none';
+    }
+
+    btnLimpiarEntidad.addEventListener('click', function () {
+        entidadIdInput.value   = '';
+        entidadSearch.value    = '';
+        this.style.display     = 'none';
+        entidadSuggestions.style.display = 'none';
+    });
+
+    // Cerrar sugerencias al clicar fuera
+    document.addEventListener('click', function (e) {
+        if (!entidadSuggestions.contains(e.target) && e.target !== entidadSearch) {
+            entidadSuggestions.style.display = 'none';
+        }
+    });
+
+    // ================================================================
+    // Validación antes de enviar
+    // ================================================================
+    document.querySelector('form').addEventListener('submit', function (e) {
+        let valido = true;
+
+        // Titular
+        if (!entidadIdInput.value) {
+            entidadError.style.display = 'block';
+            valido = false;
+        }
+
+        // Tipos de solicitud
+        const tiposChecked = document.querySelectorAll('.tipo-solicitud-check:checked');
+        const tiposError   = document.getElementById('tipos-solicitud-error');
+        if (tiposChecked.length === 0) {
+            tiposError.style.display = 'block';
+            valido = false;
+        } else {
+            tiposError.style.display = 'none';
+        }
+
+        if (!valido) {
+            e.preventDefault();
+        } else {
+            // Deshabilitar botón para evitar doble envío
+            document.getElementById('btn-finalizar').disabled = true;
+            document.getElementById('btn-finalizar').innerHTML =
+                '<i class="fas fa-spinner fa-spin me-1"></i>Creando...';
+        }
+    });
+
+}());
+</script>
+{% endblock %}

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -1,13 +1,10 @@
-{% extends 'layout/base_full_width.html' %}
+{% extends 'layout/base_fullwidth.html' %}
 
 {% block title %}Nuevo Expediente &mdash; Paso 3{% endblock %}
 
 {% block content %}
 <div class="container-fluid py-4">
 
-    {# ------------------------------------------------------------------ #}
-    {# Migas de pan                                                         #}
-    {# ------------------------------------------------------------------ #}
     <nav aria-label="breadcrumb" class="mb-3">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
@@ -16,9 +13,6 @@
         </ol>
     </nav>
 
-    {# ------------------------------------------------------------------ #}
-    {# Título + indicador de pasos                                          #}
-    {# ------------------------------------------------------------------ #}
     <div class="d-flex align-items-center mb-4 gap-3">
         <h1 class="h3 mb-0">
             <i class="fas fa-folder-plus me-2 text-primary"></i>Nuevo Expediente
@@ -32,9 +26,6 @@
         </div>
     </div>
 
-    {# ------------------------------------------------------------------ #}
-    {# Mensajes flash                                                       #}
-    {# ------------------------------------------------------------------ #}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
             {% for category, message in messages %}
@@ -46,9 +37,6 @@
         {% endif %}
     {% endwith %}
 
-    {# ------------------------------------------------------------------ #}
-    {# Formulario                                                           #}
-    {# ------------------------------------------------------------------ #}
     <div class="row justify-content-center">
         <div class="col-lg-8 col-md-11">
             <div class="card shadow-sm">
@@ -58,62 +46,51 @@
                 <div class="card-body">
                     <form method="post" action="{{ url_for('wizard_expediente.paso3') }}" novalidate>
 
-                        {# ------------------------------------------------------------------ #}
-                        {# Titular / solicitante (autocomplete)                               #}
-                        {# ------------------------------------------------------------------ #}
-                        <div class="mb-4">
-                            <label for="entidad-search" class="form-label fw-semibold">
+                        {# --- Titular / solicitante --- #}
+                        <div class="mb-4" style="position:relative;">
+                            <label class="form-label fw-semibold">
                                 Titular / Solicitante <span class="text-danger">*</span>
                             </label>
-
-                            {# Input oculto que envía el ID al servidor #}
                             <input type="hidden" id="entidad_id" name="entidad_id">
-
-                            {# Input de búsqueda visible #}
                             <div class="input-group">
                                 <span class="input-group-text"><i class="fas fa-search"></i></span>
                                 <input type="text" id="entidad-search"
                                        class="form-control"
-                                       placeholder="Escriba nombre o NIF (mín. 2 caracteres)..."
+                                       placeholder="Nombre o NIF (mín. 2 caracteres)..."
                                        autocomplete="off">
                                 <button type="button" class="btn btn-outline-secondary"
                                         id="btn-limpiar-entidad" title="Limpiar" style="display:none;">
                                     <i class="fas fa-times"></i>
                                 </button>
                             </div>
-
-                            {# Lista de sugerencias #}
-                            <ul id="entidad-suggestions"
-                                class="list-group mt-1"
-                                style="max-height: 220px; overflow-y: auto;
-                                       position: absolute; z-index: 1050;
-                                       width: calc(100% - 2rem); display: none;">
+                            <ul id="entidad-suggestions" class="list-group shadow-sm"
+                                style="position:absolute; z-index:1050;
+                                       width:calc(100% - var(--bs-gutter-x, 0px));
+                                       max-height:220px; overflow-y:auto; display:none;">
                             </ul>
-
-                            <div class="form-text">Solo entidades activas con rol Titular. Si no aparece, créela primero en el catálogo.</div>
+                            <div class="form-text">Solo entidades activas con rol Titular.</div>
                             <div id="entidad-error" class="text-danger small mt-1" style="display:none;">
-                                Debe seleccionar un titular/solicitante.
+                                <i class="fas fa-exclamation-circle me-1"></i>Debe seleccionar un titular.
                             </div>
                         </div>
 
-                        {# Fecha de solicitud #}
+                        {# --- Fecha solicitud --- #}
                         <div class="mb-4">
                             <label for="fecha_solicitud" class="form-label fw-semibold">
                                 Fecha de solicitud <span class="text-danger">*</span>
                             </label>
                             <input type="date" id="fecha_solicitud" name="fecha_solicitud"
-                                   class="form-control w-auto"
-                                   required>
-                            <div class="form-text">Fecha oficial de presentación de la solicitud.</div>
+                                   class="form-control w-auto" required>
+                            <div class="form-text">Fecha oficial de presentación.</div>
                         </div>
 
-                        {# Tipos de solicitud (checkboxes) #}
+                        {# --- Tipos de solicitud --- #}
                         <div class="mb-4">
                             <label class="form-label fw-semibold">
                                 Tipo(s) de solicitud <span class="text-danger">*</span>
                             </label>
-                            <div id="tipos-solicitud-error" class="text-danger small mb-1" style="display:none;">
-                                Debe seleccionar al menos un tipo.
+                            <div id="tipos-solicitud-error" class="text-danger small mb-2" style="display:none;">
+                                <i class="fas fa-exclamation-circle me-1"></i>Debe seleccionar al menos un tipo.
                             </div>
                             <div class="row row-cols-1 row-cols-md-2 g-2">
                                 {% for ts in tipos_solicitudes %}
@@ -134,7 +111,7 @@
                             </div>
                         </div>
 
-                        {# Observaciones #}
+                        {# --- Observaciones --- #}
                         <div class="mb-4">
                             <label for="observaciones" class="form-label fw-semibold">Observaciones</label>
                             <textarea id="observaciones" name="observaciones"
@@ -143,7 +120,6 @@
                                       placeholder="Notas adicionales (opcional)"></textarea>
                         </div>
 
-                        {# Botones #}
                         <div class="d-flex justify-content-between pt-2">
                             <div class="d-flex gap-2">
                                 <a href="{{ url_for('wizard_expediente.paso2') }}"
@@ -174,109 +150,82 @@
 (function () {
     'use strict';
 
-    // ================================================================
-    // Autocomplete entidad (solo activas con rol_titular=True)
-    // ================================================================
-    const entidadSearch     = document.getElementById('entidad-search');
-    const entidadIdInput    = document.getElementById('entidad_id');
-    const entidadSuggestions = document.getElementById('entidad-suggestions');
-    const btnLimpiarEntidad = document.getElementById('btn-limpiar-entidad');
-    const entidadError      = document.getElementById('entidad-error');
+    const entidadSearch  = document.getElementById('entidad-search');
+    const entidadIdInput = document.getElementById('entidad_id');
+    const entidadSugg    = document.getElementById('entidad-suggestions');
+    const btnLimpiar     = document.getElementById('btn-limpiar-entidad');
+    const entidadError   = document.getElementById('entidad-error');
 
-    let debounceEntidad = null;
+    let timer = null;
 
     entidadSearch.addEventListener('input', function () {
-        clearTimeout(debounceEntidad);
+        clearTimeout(timer);
+        entidadIdInput.value = '';
+        btnLimpiar.style.display = 'none';
         const q = this.value.trim();
-        entidadIdInput.value = '';          // limpiar selección previa
-        btnLimpiarEntidad.style.display = 'none';
-        if (q.length < 2) {
-            entidadSuggestions.style.display = 'none';
-            entidadSuggestions.innerHTML = '';
-            return;
-        }
-        debounceEntidad = setTimeout(() => buscarEntidades(q), 250);
+        if (q.length < 2) { entidadSugg.style.display = 'none'; return; }
+        timer = setTimeout(() => {
+            fetch(`/api/entidades?q=${encodeURIComponent(q)}&rol=titular`)
+                .then(r => r.json())
+                .then(data => {
+                    const lista = data.results || [];
+                    entidadSugg.innerHTML = '';
+                    if (!lista.length) {
+                        const li = document.createElement('li');
+                        li.className = 'list-group-item text-muted small py-2';
+                        li.textContent = 'Sin resultados con rol Titular.';
+                        entidadSugg.appendChild(li);
+                    } else {
+                        lista.forEach(e => {
+                            const li = document.createElement('li');
+                            li.className = 'list-group-item list-group-item-action py-2';
+                            li.textContent = e.text;
+                            li.addEventListener('mousedown', ev => {
+                                ev.preventDefault();
+                                entidadIdInput.value = e.id;
+                                entidadSearch.value  = e.text;
+                                entidadSugg.style.display = 'none';
+                                btnLimpiar.style.display  = 'inline-block';
+                                entidadError.style.display = 'none';
+                            });
+                            entidadSugg.appendChild(li);
+                        });
+                    }
+                    entidadSugg.style.display = 'block';
+                })
+                .catch(() => { entidadSugg.style.display = 'none'; });
+        }, 250);
     });
 
-    function buscarEntidades(q) {
-        fetch(`/api/entidades?q=${encodeURIComponent(q)}&rol=titular`)
-            .then(r => r.json())
-            .then(data => {
-                const resultados = data.results || [];
-                entidadSuggestions.innerHTML = '';
-                if (!resultados.length) {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item text-muted small';
-                    li.textContent = 'No se encontraron entidades con rol Titular.';
-                    entidadSuggestions.appendChild(li);
-                    entidadSuggestions.style.display = 'block';
-                    return;
-                }
-                resultados.forEach(e => {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item list-group-item-action';
-                    li.textContent = e.text;
-                    li.addEventListener('click', () => {
-                        seleccionarEntidad(e.id, e.text);
-                    });
-                    entidadSuggestions.appendChild(li);
-                });
-                entidadSuggestions.style.display = 'block';
-            })
-            .catch(() => { entidadSuggestions.style.display = 'none'; });
-    }
-
-    function seleccionarEntidad(id, texto) {
-        entidadIdInput.value    = id;
-        entidadSearch.value     = texto;
-        entidadSuggestions.style.display = 'none';
-        btnLimpiarEntidad.style.display  = 'inline-block';
-        entidadError.style.display = 'none';
-    }
-
-    btnLimpiarEntidad.addEventListener('click', function () {
-        entidadIdInput.value   = '';
-        entidadSearch.value    = '';
-        this.style.display     = 'none';
-        entidadSuggestions.style.display = 'none';
+    entidadSearch.addEventListener('blur', () => {
+        setTimeout(() => { entidadSugg.style.display = 'none'; }, 150);
     });
 
-    // Cerrar sugerencias al clicar fuera
-    document.addEventListener('click', function (e) {
-        if (!entidadSuggestions.contains(e.target) && e.target !== entidadSearch) {
-            entidadSuggestions.style.display = 'none';
-        }
+    btnLimpiar.addEventListener('click', () => {
+        entidadIdInput.value = '';
+        entidadSearch.value  = '';
+        btnLimpiar.style.display = 'none';
+        entidadSugg.style.display = 'none';
     });
 
-    // ================================================================
-    // Validación antes de enviar
-    // ================================================================
     document.querySelector('form').addEventListener('submit', function (e) {
-        let valido = true;
-
-        // Titular
+        let ok = true;
         if (!entidadIdInput.value) {
-            entidadError.style.display = 'block';
-            valido = false;
+            entidadError.style.display = 'block'; ok = false;
         }
-
-        // Tipos de solicitud
-        const tiposChecked = document.querySelectorAll('.tipo-solicitud-check:checked');
-        const tiposError   = document.getElementById('tipos-solicitud-error');
-        if (tiposChecked.length === 0) {
-            tiposError.style.display = 'block';
-            valido = false;
+        const checked  = document.querySelectorAll('.tipo-solicitud-check:checked');
+        const tiposErr = document.getElementById('tipos-solicitud-error');
+        if (!checked.length) {
+            tiposErr.style.display = 'block'; ok = false;
         } else {
-            tiposError.style.display = 'none';
+            tiposErr.style.display = 'none';
         }
-
-        if (!valido) {
+        if (!ok) {
             e.preventDefault();
         } else {
-            // Deshabilitar botón para evitar doble envío
-            document.getElementById('btn-finalizar').disabled = true;
-            document.getElementById('btn-finalizar').innerHTML =
-                '<i class="fas fa-spinner fa-spin me-1"></i>Creando...';
+            const btn = document.getElementById('btn-finalizar');
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Creando...';
         }
     });
 

--- a/app/templates/layout/base_fullwidth.html
+++ b/app/templates/layout/base_fullwidth.html
@@ -21,6 +21,9 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-components.css') }}">
 
+    {# Estilos del sistema de notificaciones (toasts) definidos en PR #44 #}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -42,10 +45,58 @@
     </div>
     <!-- Fin A -->
 
+    <!-- Sistema de notificaciones toast (flash messages de Flask) -->
+    <div class="toast-container position-fixed bottom-0 p-3">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                <div class="toast toast-{{ category }}" role="alert"
+                     aria-live="assertive" aria-atomic="true"
+                     data-bs-autohide="true" data-bs-delay="8000">
+                    <div class="d-flex align-items-center p-3">
+                        <div class="flex-grow-1">
+                            {% if category == 'success' %}
+                                <i class="fas fa-check-circle me-2"></i><strong>Correcto:</strong> {{ message }}
+                            {% elif category == 'danger' %}
+                                <i class="fas fa-exclamation-circle me-2"></i><strong>Error:</strong> {{ message }}
+                            {% elif category == 'warning' %}
+                                <i class="fas fa-exclamation-triangle me-2"></i><strong>Atención:</strong> {{ message }}
+                            {% elif category == 'info' %}
+                                <i class="fas fa-info-circle me-2"></i><strong>Información:</strong> {{ message }}
+                            {% endif %}
+                        </div>
+                        <button type="button" class="btn-close ms-3"
+                                data-bs-dismiss="toast" aria-label="Cerrar"></button>
+                    </div>
+                </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+    </div>
+
     {# Bootstrap JS bundle para componentes interactivos (accordion, dropdowns, etc.) #}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
             crossorigin="anonymous"></script>
+
+    <script>
+        // Auto-inicializar toasts al cargar la página (patrón del PR #44)
+        document.addEventListener('DOMContentLoaded', function() {
+            var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+            toastElList.forEach(function(toastEl) {
+                toastEl.classList.add('showing');
+                var toast = new bootstrap.Toast(toastEl);
+                toast.show();
+                setTimeout(function() { toastEl.classList.remove('showing'); }, 300);
+                toastEl.addEventListener('hide.bs.toast', function() {
+                    toastEl.classList.add('hide');
+                });
+                toastEl.addEventListener('click', function(e) {
+                    if (!e.target.closest('.btn-close')) { toast.hide(); }
+                });
+            });
+        });
+    </script>
 
     {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
## Resumen

Implementa el wizard de creación de expedientes en 3 pasos, sustituyendo el antiguo formulario único `expedientes.nuevo`. Cierra #67.

---

## Cambios introducidos

### Nuevas rutas — `app/routes/wizard_expediente.py`
- Blueprint `wizard_expediente` con 4 endpoints: `paso1`, `paso2`, `paso3`, `cancelar`
- Datos de cada paso se persisten en `session['wizard_expediente']` entre requests
- Paso 3 ejecuta la creación en una **única transacción** (expediente + proyecto + solicitud + municipios + tipos de solicitud)
- Registrado en `app/__init__.py`

### Nuevas vistas — `app/templates/expedientes/`
- `wizard_paso1.html` — Clasificación: tipo de expediente, responsable, heredado
- `wizard_paso2.html` — Proyecto técnico: título, descripción, finalidad, emplazamiento, fecha, instrumento ambiental, municipios afectados
- `wizard_paso3.html` — Solicitud: titular (autocomplete), fecha solicitud, tipos de solicitud, observaciones

> ⚠️ **Nota sobre estilos de las vistas:** Los tres templates del wizard utilizan clases Bootstrap 5 estándar y la estructura correcta, pero **requieren revisión y mejora visual** (espaciados, adaptación al tema corporativo Junta de Andalucía, responsividad). Estas mejoras visuales se realizarán en un issue/PR independiente para no bloquear la entrega de la estructura funcional.

### Nueva API — `app/routes/api_geo.py`
- `GET /api/provincias?q=` — Autocomplete de provincias
- `GET /api/municipios?provincia=X&q=Y` — Autocomplete de municipios filtrado por provincia (parámetro obligatorio)

### Template base — `app/templates/layout/base_fullwidth.html`
- Añadido sistema de **toasts flash** (patrón PR #44): `custom.css` + contenedor HTML + JS de inicialización
- Beneficia a todos los templates v2 que extienden este base

### Dashboard — `app/templates/dashboard/index_v1.html`
- Card "Nuevo Expediente" apunta a `wizard_expediente.paso1` en lugar de `expedientes.nuevo`

### Listado de expedientes — `app/templates/expedientes/listado_v2.html`
- Botón "Nuevo Expediente" apunta a `wizard_expediente.paso1`

---

## Fixes incluidos

| Fix | Descripción |
|---|---|
| Base template | Corregido uso de `base_full_width.html` (sin Bootstrap CDN) → `base_fullwidth.html` (correcto) |
| Municipios API | Selector dos pasos A→B (provincia primero, municipio después) acorde con la API real |
| Toasts wizard | Eliminados `{% with messages %}` inline; ahora los gestiona `base_fullwidth.html` |

---

## Testing manual

- [x] Paso 1 → Paso 2 → Paso 3 → expediente creado y visible en listado
- [x] Botón "Atrás" recupera datos ya introducidos (session)
- [x] "Cancelar" limpia la sesión y vuelve al listado
- [x] Validación frontend: municipio obligatorio (paso 2), titular y tipo de solicitud (paso 3)
- [x] Toast de confirmación al crear expediente
- [x] Card dashboard apunta al wizard
- [x] Header y footer correctos (template v2 real)
