### PR TITLE
feat(#93): Sistema metadata-driven + auto-discovery — Fase 4

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,10 +7,10 @@ Responsabilidades:
 - Configuración de Jinja2
 - Manejo de errores HTTP
 """
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 from app.config import config
 
 # Instancias de extensiones (sin vincular a app aún)
@@ -76,10 +76,21 @@ def create_app(config_name='development'):
     app.register_blueprint(vista3.bp)                       # usa 'bp'
     app.register_blueprint(api_entidades.api_entidades_bp)  # usa 'api_entidades_bp' — Issue #61
 
-    # Registrar módulos (app/modules/) — Fase 3: registro manual
-    # Los módulos con bp = None se omiten hasta completar su migración.
+    # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry
     ModuleRegistry.register_all(app)
+
+    # Context processor — inyecta navegación de módulos en todos los templates
+    @app.context_processor
+    def inject_module_nav():
+        user_roles = (
+            [r.nombre for r in current_user.roles]
+            if current_user.is_authenticated else []
+        )
+        return {
+            'module_nav':    ModuleRegistry.get_navigation(user_roles),
+            'active_module': request.blueprint,
+        }
 
     # Configuración de Jinja2
     app.jinja_env.trim_blocks = True

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -1,31 +1,102 @@
 """
 Registro de módulos de la aplicación.
 
-Fase 3: registro manual. Auto-discovery queda para Fase 4.
-
-El ModuleRegistry complementa el sistema de blueprints existente en app/routes/.
-Los módulos listados en MODULES se registran si su routes.py expone un blueprint 'bp'.
+Fase 4: auto-discovery por escaneo de directorio + sistema metadata-driven.
+Añadir un módulo nuevo = crear carpeta con routes.py y metadata.json,
+sin tocar código central.
 """
 import importlib
+import json
+from pathlib import Path
 
 
 class ModuleRegistry:
-    """Registro central de módulos de la aplicación."""
+    """
+    Registro central de módulos.
 
-    # Lista explícita de módulos. Fase 4 implementará auto-discovery.
-    MODULES = ['expedientes', 'entidades']
+    Descubre automáticamente los módulos en app/modules/,
+    carga sus metadatos y expone la navegación filtrada por rol.
+    """
+
+    _metadata_cache: dict = {}
 
     @classmethod
-    def register_all(cls, app):
+    def _discover_modules(cls) -> list[str]:
         """
-        Registra los blueprints de todos los módulos en la app Flask.
+        Escanea app/modules/ y devuelve los nombres de módulos válidos,
+        ordenados alfabéticamente.
+
+        Un directorio es un módulo válido si contiene routes.py.
+        Los directorios que empiezan por '_' (como __pycache__) se omiten.
+        """
+        modules_dir = Path(__file__).parent
+        return sorted([
+            d.name for d in modules_dir.iterdir()
+            if d.is_dir()
+            and not d.name.startswith('_')
+            and (d / 'routes.py').exists()
+        ])
+
+    @classmethod
+    def register_all(cls, app) -> None:
+        """
+        Registra los blueprints de todos los módulos descubiertos.
 
         Solo registra módulos cuyo routes.py exponga un blueprint 'bp' no nulo.
-        En Fase 3, mientras se produce la migración, un módulo puede estar
-        registrado tanto aquí como en app/routes/ — en ese caso routes.py
-        debe devolver bp = None para evitar el doble registro.
         """
-        for module_name in cls.MODULES:
+        for module_name in cls._discover_modules():
             module = importlib.import_module(f'app.modules.{module_name}.routes')
             if hasattr(module, 'bp') and module.bp is not None:
                 app.register_blueprint(module.bp)
+
+    @classmethod
+    def get_metadata(cls, module_name: str) -> dict | None:
+        """
+        Devuelve el metadata.json del módulo, con caché en memoria.
+        Retorna None si el fichero no existe.
+        """
+        if module_name not in cls._metadata_cache:
+            metadata_path = Path(__file__).parent / module_name / 'metadata.json'
+            if metadata_path.exists():
+                with open(metadata_path, encoding='utf-8') as f:
+                    cls._metadata_cache[module_name] = json.load(f)
+            else:
+                cls._metadata_cache[module_name] = None
+        return cls._metadata_cache[module_name]
+
+    @classmethod
+    def get_navigation(cls, user_roles: list[str] | None = None) -> list[dict]:
+        """
+        Devuelve los items de navegación ordenados por 'order',
+        filtrados por el permiso 'list' del módulo.
+
+        Args:
+            user_roles: Lista de nombres de rol del usuario actual.
+                        Si es None o vacía, no se aplica filtro de permisos.
+
+        Returns:
+            Lista de dicts con: label, route, icon, order, module.
+        """
+        nav_items = []
+
+        for module_name in cls._discover_modules():
+            metadata = cls.get_metadata(module_name)
+            if not metadata:
+                continue
+
+            # Filtrar por permiso 'list' si se proporcionan roles
+            if user_roles:
+                allowed_roles = metadata.get('permissions', {}).get('list', [])
+                if not any(r in allowed_roles for r in user_roles):
+                    continue
+
+            nav = metadata.get('navigation', {})
+            nav_items.append({
+                'label':  nav.get('label', module_name.capitalize()),
+                'route':  nav.get('route', ''),
+                'icon':   metadata.get('icon', 'fa-circle'),
+                'order':  metadata.get('order', 99),
+                'module': module_name,
+            })
+
+        return sorted(nav_items, key=lambda x: x['order'])

--- a/app/static/css/v2-layout.css
+++ b/app/static/css/v2-layout.css
@@ -228,3 +228,45 @@
     font-size: 1.25rem;
   }
 }
+
+/* ==========================================================================
+   Navegación de módulos (metadata-driven) — Fase 4 Issue #93
+   ========================================================================== */
+
+.app-header .module-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  margin-left: 0.75rem;
+}
+
+.app-header .module-nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.app-header .module-nav-link:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: var(--text-inverse);
+}
+
+.app-header .module-nav-link.active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: var(--text-inverse);
+  font-weight: 600;
+}
+
+/* Ocultar module-nav en mobile (demasiado estrecho) */
+@media (max-width: 767px) {
+  .app-header .module-nav {
+    display: none;
+  }
+}

--- a/app/templates/layout/base_acordeon.html
+++ b/app/templates/layout/base_acordeon.html
@@ -25,21 +25,38 @@
                 <i class="fas fa-bolt"></i>
                 BDDAT
             </a>
-            
+
+            {# Navegación de módulos — generada automáticamente desde metadata.json #}
+            {% if module_nav %}
+            <nav class="module-nav">
+                {% for item in module_nav %}
+                <a href="{{ url_for(item.route) }}"
+                   class="module-nav-link{% if active_module == item.module %} active{% endif %}">
+                    <i class="fas {{ item.icon }}"></i>
+                    {{ item.label }}
+                </a>
+                {% endfor %}
+            </nav>
+            {% endif %}
+
             <nav class="breadcrumb">
                 {% block breadcrumb %}
                 <a href="{{ url_for('dashboard.index') }}">Inicio</a>
-                <span>/</span>
-                <span>Tramitación</span>
+                {% for item in module_nav %}
+                    {% if active_module == item.module %}
+                    <span>›</span>
+                    <span>{{ item.label }}</span>
+                    {% endif %}
+                {% endfor %}
                 {% endblock %}
             </nav>
-            
+
             <!-- Spacer: empuja user-menu a la derecha -->
             <div class="spacer"></div>
-            
+
             <div class="user-menu">
                 {% if current_user.is_authenticated %}
-                    <span>👤 {{ current_user.nombre }} {{ current_user.apellido1 or '' }}</span>
+                    <span>{{ current_user.nombre }} {{ current_user.apellido1 or '' }}</span>
                     <a href="{{ url_for('auth.logout') }}">
                         <i class="fas fa-sign-out-alt"></i> Salir
                     </a>

--- a/app/templates/layout/header.html
+++ b/app/templates/layout/header.html
@@ -3,19 +3,39 @@
         <i class="fas fa-bolt"></i>
         BDDAT
     </a>
-    
+
+    {# Navegación de módulos — generada automáticamente desde metadata.json #}
+    {% if module_nav %}
+    <nav class="module-nav">
+        {% for item in module_nav %}
+        <a href="{{ url_for(item.route) }}"
+           class="module-nav-link{% if active_module == item.module %} active{% endif %}">
+            <i class="fas {{ item.icon }}"></i>
+            {{ item.label }}
+        </a>
+        {% endfor %}
+    </nav>
+    {% endif %}
+
+    {# Breadcrumb — auto desde metadata si hay módulo activo; overrideable por template #}
     <nav class="breadcrumb">
         {% block breadcrumb %}
         <a href="{{ url_for('dashboard.index') }}">Inicio</a>
+        {% for item in module_nav %}
+            {% if active_module == item.module %}
+            <span>›</span>
+            <span>{{ item.label }}</span>
+            {% endif %}
+        {% endfor %}
         {% endblock %}
     </nav>
-    
+
     <!-- Spacer: empuja user-menu a la derecha -->
     <div class="spacer"></div>
-    
+
     <div class="user-menu">
         {% if current_user.is_authenticated %}
-            <span>👤 {{ current_user.nombre }} {{ current_user.apellidos }}</span>
+            <span>{{ current_user.nombre }} {{ current_user.apellidos }}</span>
             <a href="{{ url_for('auth.logout') }}">
                 <i class="fas fa-sign-out-alt"></i> Salir
             </a>


### PR DESCRIPTION
## Resumen

Implementa el sistema metadata-driven que cierra el Epic #93. A partir de ahora, añadir un módulo al sistema = crear una carpeta en `app/modules/` con `routes.py` y `metadata.json`, sin tocar código central.

## Cambios

- **`ModuleRegistry`** (auto-discovery): escanea `app/modules/` en lugar de mantener una lista manual. Expone `get_metadata()` con caché y `get_navigation(user_roles)` con filtrado por permisos.
- **Context processor** (`app/__init__.py`): inyecta `module_nav` y `active_module` en todos los templates automáticamente.
- **`header.html` + `base_acordeon.html`**: nav de módulos generado desde metadata; breadcrumb automático `Inicio › [Módulo]` según `request.blueprint`.
- **`v2-layout.css`**: estilos `.module-nav` / `.module-nav-link` (hover + active).

## Comportamiento

- **Dashboard**: muestra todos los módulos en el nav (ninguno activo).
- **`/expedientes/*`**: link "Expedientes" resaltado + breadcrumb `Inicio › Expedientes`.
- **`/entidades/*`**: link "Entidades" resaltado + breadcrumb `Inicio › Entidades`.
- **Templates legacy** (`base.html`): sin module-nav, comportamiento esperado hasta que se actualicen.

## Test plan

- [x] Auto-discovery detecta `expedientes` y `entidades` ordenados por `order`
- [x] Playwright 6/6 OK: login, dashboard, listado-v2, entidades/, tramitacion_v3, detalle
- [x] Link activo correcto en cada módulo
- [x] Breadcrumb automático funciona en `base_fullwidth.html` y `base_acordeon.html`
- [x] Sin errores 500 en ninguna ruta

🤖 Generated with [Claude Code](https://claude.com/claude-code)