### PR TITLE
#61 Fase 3 — Navegación contextual (issues #70 #71 #72 #73)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/detalle.html
+++ b/app/modules/expedientes/templates/expedientes/detalle.html
@@ -1,8 +1,19 @@
-{% extends 'base.html' %}
+{% extends 'layout/base_fullwidth.html' %}
 
 {% block title %}Expediente AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
 
+{% block page_breadcrumb %}
+<nav aria-label="breadcrumb" class="px-4 py-2 bg-light border-bottom">
+    <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><a href="{{ url_for('dashboard.index') }}">Inicio</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a></li>
+        <li class="breadcrumb-item active" aria-current="page">AT-{{ expediente.numero_at }}</li>
+    </ol>
+</nav>
+{% endblock %}
+
 {% block content %}
+<div class="p-4">
 <div class="row mb-3">
     <div class="col-md-8">
         <h2>
@@ -13,6 +24,9 @@
     <div class="col-md-4 text-end">
         <a href="{{ url_for('expedientes.listado_v2') }}" class="btn btn-secondary me-2">
             <i class="fas fa-arrow-left me-1"></i> Volver
+        </a>
+        <a href="{{ url_for('expedientes.tramitacion_v3', id=expediente.id) }}" class="btn btn-success me-2">
+            <i class="fas fa-tasks me-1"></i> Tramitar
         </a>
         <a href="{{ url_for('expedientes.editar', id=expediente.id) }}" class="btn btn-primary">
             <i class="fas fa-edit me-1"></i> Editar
@@ -28,6 +42,16 @@
                 <h5 class="mb-0"><i class="fas fa-info-circle me-2"></i>Información General</h5>
             </div>
             <div class="card-body">
+                <!-- Titular -->
+                <div class="mb-2">
+                    <span class="text-muted small" style="white-space: nowrap;">Titular:</span>
+                    {% if expediente.titular %}
+                        <strong class="ms-2">{{ expediente.titular.nombre_completo }}</strong>
+                    {% else %}
+                        <span class="badge bg-secondary ms-2">Sin titular</span>
+                    {% endif %}
+                </div>
+
                 <!-- Número AT -->
                 <div class="mb-2">
                     <span class="text-muted small" style="white-space: nowrap;">Número AT:</span>
@@ -181,4 +205,5 @@
         </div>
     </div>
 </div>
+</div>{# /p-4 #}
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/listado_v2.html
+++ b/app/modules/expedientes/templates/expedientes/listado_v2.html
@@ -28,6 +28,8 @@
 <th>Titular</th>
 <th>Tipo</th>
 <th>Responsable</th>
+<th>Solicitudes</th>
+<th>Estado</th>
 <th></th>
 {% endblock %}
 
@@ -40,11 +42,50 @@
         entityLabel: 'expedientes',
         detailUrl:   id => `/expedientes/${id}/tramitacion_v3`,
         columns: [
-            { key: 'codigo',          label: 'N° Expediente', type: 'text'     },
-            { key: 'titular',         label: 'Titular',       type: 'text'     },
-            { key: 'tipo_expediente', label: 'Tipo',          type: 'text'     },
-            { key: 'responsable',     label: 'Responsable',   type: 'text'     },
-            { key: '_acciones',       label: '',              type: 'acciones' }
+            { key: 'codigo',          label: 'N° Expediente', type: 'text' },
+            { key: 'titular',         label: 'Titular',       type: 'text' },
+            { key: 'tipo_expediente', label: 'Tipo',          type: 'text' },
+            { key: 'responsable',     label: 'Responsable',   type: 'text' },
+            {
+                key: 'num_solicitudes',
+                label: 'Solicitudes',
+                type: 'custom',
+                renderFn: (val, item) => {
+                    const total = item.num_solicitudes || 0;
+                    const activas = item.num_activas || 0;
+                    if (total === 0) return '<span class="text-muted">—</span>';
+                    const badge = activas > 0
+                        ? `<span class="badge bg-primary ms-1">${activas} activa${activas !== 1 ? 's' : ''}</span>`
+                        : '';
+                    return `${total}${badge}`;
+                }
+            },
+            {
+                key: 'estado_tramitacion',
+                label: 'Estado',
+                type: 'custom',
+                renderFn: (val) => {
+                    const mapa = {
+                        'SIN_SOLICITUDES': ['secondary', 'Sin solicitudes'],
+                        'EN_TRAMITE':      ['primary',   'En trámite'],
+                        'RESUELTO':        ['success',   'Resuelto']
+                    };
+                    const [cls, label] = mapa[val] || ['secondary', val || '—'];
+                    return `<span class="badge bg-${cls}">${label}</span>`;
+                }
+            },
+            {
+                key: '_acciones',
+                label: '',
+                type: 'custom',
+                renderFn: (val, item) =>
+                    `<a href="/expedientes/${item.id}" class="btn btn-sm btn-outline-secondary me-1">
+                        <i class="fas fa-info-circle"></i> Detalle
+                     </a>
+                     <a href="${item.url_tramitacion}" class="btn btn-sm btn-primary">
+                        <i class="fas fa-tasks"></i> Tramitar
+                     </a>`
+            }
         ]
     });
 

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -10,7 +10,7 @@ CAMBIOS v2.1: Añadido campo 'codigo' ("AT-{numero_at}") a serialización del li
               para compatibilidad con ScrollInfinito genérico (Opción B, Issue #61).
 """
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, url_for
 from flask_login import login_required
 from sqlalchemy.orm import joinedload
 from sqlalchemy import func, or_
@@ -160,6 +160,23 @@ def listar_expedientes():
     next_cursor = expedientes[-1].id if expedientes else cursor
 
     # ==========================================================================
+    # PASO 5b: Obtener estadísticas de solicitudes para los IDs de esta página
+    # Una sola query adicional evita N+1 y no modifica el query principal
+    # ==========================================================================
+
+    ids_pagina = [e.id for e in expedientes]
+    sol_stats = {}
+    if ids_pagina:
+        rows = db.session.query(
+            Solicitud.expediente_id,
+            func.count(Solicitud.id).label('total'),
+            func.count(Solicitud.id).filter(Solicitud.estado == 'EN_TRAMITE').label('activas')
+        ).filter(
+            Solicitud.expediente_id.in_(ids_pagina)
+        ).group_by(Solicitud.expediente_id).all()
+        sol_stats = {row.expediente_id: row for row in rows}
+
+    # ==========================================================================
     # PASO 6: Calcular total (solo si hay filtros)
     # ==========================================================================
 
@@ -198,14 +215,30 @@ def listar_expedientes():
         else:
             nombre_responsable = 'Sin asignar'
 
+        # Datos de solicitudes de esta página
+        stats = sol_stats.get(exp.id)
+        num_solicitudes = stats.total if stats else 0
+        num_activas = stats.activas if stats else 0
+        if num_solicitudes == 0:
+            estado_tramitacion = 'SIN_SOLICITUDES'
+        elif num_activas > 0:
+            estado_tramitacion = 'EN_TRAMITE'
+        else:
+            estado_tramitacion = 'RESUELTO'
+
         expediente_dict = {
-            'id':             exp.id,
-            'codigo':         f'AT-{exp.numero_at}',   # Opción B Issue #61
-            'numero_at':      exp.numero_at,
-            'titular':        exp.titular.nombre_completo if exp.titular else 'Sin titular',
-            'tipo_expediente': exp.tipo_expediente.tipo if exp.tipo_expediente else 'Sin tipo',
-            'responsable':    nombre_responsable,
-            'heredado':       exp.heredado if exp.heredado is not None else False
+            'id':                  exp.id,
+            'codigo':              f'AT-{exp.numero_at}',   # Opción B Issue #61
+            'numero_at':           exp.numero_at,
+            'titular':             exp.titular.nombre_completo if exp.titular else 'Sin titular',
+            'tipo_expediente':     exp.tipo_expediente.tipo if exp.tipo_expediente else 'Sin tipo',
+            'responsable':         nombre_responsable,
+            'heredado':            exp.heredado if exp.heredado is not None else False,
+            # Campos SFTT (#70)
+            'num_solicitudes':     num_solicitudes,
+            'num_activas':         num_activas,
+            'estado_tramitacion':  estado_tramitacion,
+            'url_tramitacion':     url_for('expedientes.tramitacion_v3', id=exp.id)
         }
         data.append(expediente_dict)
 

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -124,16 +124,52 @@
    DETALLES Y METADATOS
    ============================================================================= */
 
-.detalle-solicitud {
+.detalle-solicitud,
+.detalle-fase,
+.detalle-tramite,
+.detalle-tarea {
     background-color: #f8f9fa;
     border: 1px solid #dee2e6;
     border-radius: 6px;
     padding: 1rem;
 }
 
-.detalle-solicitud p {
+.detalle-solicitud p,
+.detalle-fase p,
+.detalle-tramite p,
+.detalle-tarea p {
     margin-bottom: 0.5rem;
     font-size: 0.95rem;
+}
+
+/* =============================================================================
+   TABS DENTRO DE ACORDEONES (Issues #71 + #72)
+   ============================================================================= */
+
+/* El accordion-body tiene p-0 cuando contiene tabs; los tabs aportan su propio padding */
+.vista3-level-2 .accordion-body,
+.vista3-level-3 .accordion-body,
+.vista3-level-4 .accordion-body,
+.vista3-level-5 .accordion-body {
+    padding: 0;
+}
+
+/* Borde inferior de nav-tabs alineado con el borde del acordeón */
+.vista3-level-2 .nav-tabs,
+.vista3-level-3 .nav-tabs,
+.vista3-level-4 .nav-tabs,
+.vista3-level-5 .nav-tabs {
+    border-bottom: 1px solid #dee2e6;
+    background-color: #f8f9fa;
+}
+
+/* Tab activo dentro de acordeón: fondo blanco para distinguirlo */
+.vista3-level-2 .nav-tabs .nav-link.active,
+.vista3-level-3 .nav-tabs .nav-link.active,
+.vista3-level-4 .nav-tabs .nav-link.active,
+.vista3-level-5 .nav-tabs .nav-link.active {
+    background-color: #fff;
+    border-bottom-color: #fff;
 }
 
 /* =============================================================================

--- a/app/static/js/v2-scroll-infinito.js
+++ b/app/static/js/v2-scroll-infinito.js
@@ -198,6 +198,11 @@ class ScrollInfinito {
                         ? '<i class="fas fa-check-circle text-success"></i>'
                         : '';
                     break;
+                case 'custom': {
+                    const val = item[col.key];
+                    td.innerHTML = col.renderFn ? col.renderFn(val, item) : (val ?? '-');
+                    break;
+                }
                 case 'acciones': {
                     const btn = document.createElement('button');
                     btn.className = 'btn btn-sm btn-primary';

--- a/app/templates/layout/base_fullwidth.html
+++ b/app/templates/layout/base_fullwidth.html
@@ -34,11 +34,10 @@
         <!-- B.1: Header (sticky) -->
         {% include 'layout/header.html' %}
 
-        <!-- Breadcrumb de página (overrideable por templates hijo) -->
-        {% block page_breadcrumb %}{% endblock %}
-
         <!-- B.2: Main Content (scrollable si C.1+C.2+C.3 > espacio) -->
         <main class="app-main">
+            <!-- Breadcrumb de página opcional (overrideable por templates hijo) -->
+            {% block page_breadcrumb %}{% endblock %}
             {% block content %}{% endblock %}
         </main>
         <!-- Fin B.2 -->

--- a/app/templates/layout/base_fullwidth.html
+++ b/app/templates/layout/base_fullwidth.html
@@ -34,6 +34,9 @@
         <!-- B.1: Header (sticky) -->
         {% include 'layout/header.html' %}
 
+        <!-- Breadcrumb de página (overrideable por templates hijo) -->
+        {% block page_breadcrumb %}{% endblock %}
+
         <!-- B.2: Main Content (scrollable si C.1+C.2+C.3 > espacio) -->
         <main class="app-main">
             {% block content %}{% endblock %}

--- a/app/templates/vistas/vista3/_fase_accordion.html
+++ b/app/templates/vistas/vista3/_fase_accordion.html
@@ -1,73 +1,125 @@
 {# Acordeón de Fase específica - Nivel 3 #}
 <div class="accordion-item vista3-level-3" data-level-type="fase" data-level-id="{{ fase.id }}">
     <h2 class="accordion-header" id="heading-fase-{{ fase.id }}">
-        <button class="accordion-button" 
+        <button class="accordion-button"
                 type="button"
                 onclick="navigateToLevel({{ level_index }})">
             <i class="bi bi-list-task"></i>
             &nbsp;Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else 'Fase ' ~ fase.id }}
         </button>
     </h2>
-    <div class="accordion-collapse collapse show" 
+    <div class="accordion-collapse collapse show"
          aria-labelledby="heading-fase-{{ fase.id }}">
-        <div class="accordion-body">
-            {# Cuerpo fijo de la fase - SIEMPRE VISIBLE #}
-            <div class="detalle-fase mb-3">
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="mb-1"><strong>Inicio:</strong> {{ fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else 'Pendiente' }}</p>
-                        <p class="mb-1"><strong>Fin:</strong> {{ fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else 'En curso' }}</p>
-                    </div>
-                    <div class="col-md-6">
-                        {% if fase.resultado_fase %}
-                        <p class="mb-1"><strong>Resultado:</strong> {{ fase.resultado_fase.nombre }}</p>
+        <div class="accordion-body p-0">
+
+            {# --- Tabs de navegación --- #}
+            <ul class="nav nav-tabs px-3 pt-2" id="tabs-fase-{{ fase.id }}" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tab-fase-{{ fase.id }}-datos-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-fase-{{ fase.id }}-datos"
+                            type="button" role="tab">
+                        <i class="bi bi-info-circle me-1"></i>Datos
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-fase-{{ fase.id }}-tramites-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-fase-{{ fase.id }}-tramites"
+                            type="button" role="tab">
+                        <i class="bi bi-card-checklist me-1"></i>Trámites
+                        {% if tramites %}
+                        <span class="badge bg-secondary ms-1">{{ tramites|length }}</span>
                         {% endif %}
-                        {% if fase.observaciones %}
-                        <p class="mb-1"><strong>Obs:</strong> {{ fase.observaciones[:100] }}</p>
-                        {% endif %}
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-fase-{{ fase.id }}-docs-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-fase-{{ fase.id }}-docs"
+                            type="button" role="tab">
+                        <i class="bi bi-file-earmark me-1"></i>Documentos
+                    </button>
+                </li>
+            </ul>
+
+            {# --- Contenido de tabs --- #}
+            <div class="tab-content px-3 pb-3 pt-3">
+
+                {# Tab Datos #}
+                <div class="tab-pane fade show active"
+                     id="tab-fase-{{ fase.id }}-datos"
+                     role="tabpanel">
+                    <div class="detalle-fase">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p class="mb-1"><strong>Inicio:</strong> {{ fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else 'Pendiente' }}</p>
+                                <p class="mb-1"><strong>Fin:</strong> {{ fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else 'En curso' }}</p>
+                            </div>
+                            <div class="col-md-6">
+                                {% if fase.resultado_fase %}
+                                <p class="mb-1"><strong>Resultado:</strong> {{ fase.resultado_fase.nombre }}</p>
+                                {% endif %}
+                                {% if fase.observaciones %}
+                                <p class="mb-1"><strong>Obs:</strong> {{ fase.observaciones[:100] }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
+                {# Tab Trámites #}
+                <div class="tab-pane fade"
+                     id="tab-fase-{{ fase.id }}-tramites"
+                     role="tabpanel">
+                    {% if tramites %}
+                    <table class="table table-sm table-hover">
+                        <thead class="table-success">
+                            <tr>
+                                <th>Trámite</th>
+                                <th>Estado</th>
+                                <th>Tareas</th>
+                                <th>Fechas</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for tramite_data in tramites %}
+                            <tr>
+                                <td>{{ tramite_data.nombre }}</td>
+                                <td><span class="badge bg-primary">{{ tramite_data.estado }}</span></td>
+                                <td>{{ tramite_data.tareas_completadas }}/{{ tramite_data.total_tareas }}</td>
+                                <td class="small">
+                                    {{ tramite_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tramite_data.obj.fecha_inicio else '-' }}
+                                    {% if tramite_data.obj.fecha_fin %}
+                                    → {{ tramite_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if is_active %}
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            onclick="drillDown('tramite', {{ tramite_data.obj.id }})">
+                                        [...]
+                                    </button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted mb-0">No hay trámites en esta fase.</p>
+                    {% endif %}
+                </div>
+
+                {# Tab Documentos #}
+                <div class="tab-pane fade"
+                     id="tab-fase-{{ fase.id }}-docs"
+                     role="tabpanel">
+                    <p class="text-muted mb-0">Sin documentos registrados.</p>
+                </div>
+
             </div>
-            
-            {# Listado de trámites - SOLO SI ES NIVEL ACTIVO #}
-            {% if is_active and tramites %}
-            <hr>
-            <h6>Trámites de esta fase</h6>
-            <table class="table table-sm table-hover">
-                <thead class="table-success">
-                    <tr>
-                        <th>Trámite</th>
-                        <th>Estado</th>
-                        <th>Tareas</th>
-                        <th>Fechas</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for tramite_data in tramites %}
-                    <tr>
-                        <td>{{ tramite_data.nombre }}</td>
-                        <td><span class="badge bg-primary">{{ tramite_data.estado }}</span></td>
-                        <td>{{ tramite_data.tareas_completadas }}/{{ tramite_data.total_tareas }}</td>
-                        <td class="small">
-                            {{ tramite_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tramite_data.obj.fecha_inicio else '-' }}
-                            {% if tramite_data.obj.fecha_fin %}
-                            → {{ tramite_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <button class="btn btn-sm btn-outline-primary" 
-                                    onclick="drillDown('tramite', {{ tramite_data.obj.id }})">
-                                [...]
-                            </button>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% elif is_active %}
-            <p class="text-muted">No hay trámites en esta fase.</p>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/app/templates/vistas/vista3/_solicitud_accordion.html
+++ b/app/templates/vistas/vista3/_solicitud_accordion.html
@@ -1,72 +1,124 @@
 {# Acordeón de Solicitud específica - Nivel 2 #}
 <div class="accordion-item vista3-level-2" data-level-type="solicitud" data-level-id="{{ solicitud.id }}">
     <h2 class="accordion-header" id="heading-solicitud-{{ solicitud.id }}">
-        <button class="accordion-button" 
+        <button class="accordion-button"
                 type="button"
                 onclick="navigateToLevel({{ level_index }})">
             <i class="bi bi-file-earmark-check"></i>
             &nbsp;Solicitud {{ solicitud.id }} {{ tipos_str }}
         </button>
     </h2>
-    <div class="accordion-collapse collapse show" 
+    <div class="accordion-collapse collapse show"
          aria-labelledby="heading-solicitud-{{ solicitud.id }}">
-        <div class="accordion-body">
-            {# Cuerpo fijo de la solicitud - SIEMPRE VISIBLE #}
-            <div class="detalle-solicitud mb-3">
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="mb-1"><strong>Tipos:</strong> <span class="badge bg-secondary">{{ tipos_str }}</span></p>
-                        <p class="mb-1"><strong>Fecha:</strong> {{ solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '-' }}</p>
-                        <p class="mb-1"><strong>Estado:</strong> <span class="badge bg-info">{{ solicitud.estado }}</span></p>
-                    </div>
-                    <div class="col-md-6">
-                        <p class="mb-1"><strong>Solicitante:</strong> {{ solicitud.entidad.nombre_completo if solicitud.entidad else '-' }}</p>
-                        {% if solicitud.observaciones %}
-                        <p class="mb-1"><strong>Obs:</strong> {{ solicitud.observaciones[:100] }}</p>
+        <div class="accordion-body p-0">
+
+            {# --- Tabs de navegación --- #}
+            <ul class="nav nav-tabs px-3 pt-2" id="tabs-solicitud-{{ solicitud.id }}" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tab-sol-{{ solicitud.id }}-datos-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-sol-{{ solicitud.id }}-datos"
+                            type="button" role="tab">
+                        <i class="bi bi-info-circle me-1"></i>Datos
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-sol-{{ solicitud.id }}-fases-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-sol-{{ solicitud.id }}-fases"
+                            type="button" role="tab">
+                        <i class="bi bi-list-task me-1"></i>Fases
+                        {% if fases %}
+                        <span class="badge bg-secondary ms-1">{{ fases|length }}</span>
                         {% endif %}
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-sol-{{ solicitud.id }}-docs-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-sol-{{ solicitud.id }}-docs"
+                            type="button" role="tab">
+                        <i class="bi bi-file-earmark me-1"></i>Documentos
+                    </button>
+                </li>
+            </ul>
+
+            {# --- Contenido de tabs --- #}
+            <div class="tab-content px-3 pb-3 pt-3">
+
+                {# Tab Datos #}
+                <div class="tab-pane fade show active"
+                     id="tab-sol-{{ solicitud.id }}-datos"
+                     role="tabpanel">
+                    <div class="detalle-solicitud">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p class="mb-1"><strong>Tipos:</strong> <span class="badge bg-secondary">{{ tipos_str }}</span></p>
+                                <p class="mb-1"><strong>Fecha:</strong> {{ solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '-' }}</p>
+                                <p class="mb-1"><strong>Estado:</strong> <span class="badge bg-info">{{ solicitud.estado }}</span></p>
+                            </div>
+                            <div class="col-md-6">
+                                <p class="mb-1"><strong>Solicitante:</strong> {{ solicitud.entidad.nombre_completo if solicitud.entidad else '-' }}</p>
+                                {% if solicitud.observaciones %}
+                                <p class="mb-1"><strong>Obs:</strong> {{ solicitud.observaciones[:100] }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
+                {# Tab Fases #}
+                <div class="tab-pane fade"
+                     id="tab-sol-{{ solicitud.id }}-fases"
+                     role="tabpanel">
+                    {% if fases %}
+                    <table class="table table-sm table-hover">
+                        <thead class="table-success">
+                            <tr>
+                                <th>Fase</th>
+                                <th>Estado</th>
+                                <th>Trámites</th>
+                                <th>Fechas</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for fase_data in fases %}
+                            <tr>
+                                <td>{{ fase_data.nombre }}</td>
+                                <td><span class="badge bg-warning">{{ fase_data.estado }}</span></td>
+                                <td>{{ fase_data.tramites_completados }}/{{ fase_data.total_tramites }}</td>
+                                <td class="small">
+                                    {{ fase_data.obj.fecha_inicio.strftime('%d/%m/%Y') if fase_data.obj.fecha_inicio else '-' }}
+                                    {% if fase_data.obj.fecha_fin %}
+                                    → {{ fase_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if is_active %}
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            onclick="drillDown('fase', {{ fase_data.obj.id }})">
+                                        [...]
+                                    </button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted mb-0">No hay fases en esta solicitud.</p>
+                    {% endif %}
+                </div>
+
+                {# Tab Documentos #}
+                <div class="tab-pane fade"
+                     id="tab-sol-{{ solicitud.id }}-docs"
+                     role="tabpanel">
+                    <p class="text-muted mb-0">Sin documentos registrados.</p>
+                </div>
+
             </div>
-            
-            {# Listado de fases - SOLO SI ES NIVEL ACTIVO #}
-            {% if is_active and fases %}
-            <hr>
-            <h6>Fases de esta solicitud</h6>
-            <table class="table table-sm table-hover">
-                <thead class="table-success">
-                    <tr>
-                        <th>Fase</th>
-                        <th>Estado</th>
-                        <th>Trámites</th>
-                        <th>Fechas</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for fase_data in fases %}
-                    <tr>
-                        <td>{{ fase_data.nombre }}</td>
-                        <td><span class="badge bg-warning">{{ fase_data.estado }}</span></td>
-                        <td>{{ fase_data.tramites_completados }}/{{ fase_data.total_tramites }}</td>
-                        <td class="small">
-                            {{ fase_data.obj.fecha_inicio.strftime('%d/%m/%Y') if fase_data.obj.fecha_inicio else '-' }}
-                            {% if fase_data.obj.fecha_fin %}
-                            → {{ fase_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <button class="btn btn-sm btn-outline-primary" 
-                                    onclick="drillDown('fase', {{ fase_data.obj.id }})">
-                                [...]
-                            </button>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% elif is_active %}
-            <p class="text-muted">No hay fases en esta solicitud.</p>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/app/templates/vistas/vista3/_tarea_accordion.html
+++ b/app/templates/vistas/vista3/_tarea_accordion.html
@@ -1,69 +1,104 @@
 {# Acordeón de Tarea específica - Nivel 5 (final) #}
 <div class="accordion-item vista3-level-5" data-level-type="tarea" data-level-id="{{ tarea.id }}">
     <h2 class="accordion-header" id="heading-tarea-{{ tarea.id }}">
-        <button class="accordion-button" 
+        <button class="accordion-button"
                 type="button"
                 onclick="navigateToLevel({{ level_index }})">
             <i class="bi bi-check2-square"></i>
             &nbsp;Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else 'Tarea ' ~ tarea.id }}
         </button>
     </h2>
-    <div class="accordion-collapse collapse show" 
+    <div class="accordion-collapse collapse show"
          aria-labelledby="heading-tarea-{{ tarea.id }}">
-        <div class="accordion-body">
-            {# Cuerpo fijo de la tarea - SIEMPRE VISIBLE #}
-            <div class="detalle-tarea mb-3">
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="mb-1"><strong>Inicio:</strong> {{ tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else 'Pendiente' }}</p>
-                        <p class="mb-1"><strong>Fin:</strong> {{ tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else 'En curso' }}</p>
-                    </div>
-                    <div class="col-md-6">
-                        {% if tarea.responsable %}
-                        <p class="mb-1"><strong>Responsable:</strong> {{ tarea.responsable.siglas }}</p>
+        <div class="accordion-body p-0">
+
+            {# --- Tabs de navegación --- #}
+            <ul class="nav nav-tabs px-3 pt-2" id="tabs-tarea-{{ tarea.id }}" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tab-tarea-{{ tarea.id }}-datos-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-tarea-{{ tarea.id }}-datos"
+                            type="button" role="tab">
+                        <i class="bi bi-info-circle me-1"></i>Datos
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-tarea-{{ tarea.id }}-docs-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-tarea-{{ tarea.id }}-docs"
+                            type="button" role="tab">
+                        <i class="bi bi-file-earmark me-1"></i>Documentos
+                        {% if documentos %}
+                        <span class="badge bg-secondary ms-1">{{ documentos|length }}</span>
                         {% endif %}
-                        {% if tarea.observaciones %}
-                        <p class="mb-1"><strong>Obs:</strong> {{ tarea.observaciones[:100] }}</p>
-                        {% endif %}
+                    </button>
+                </li>
+            </ul>
+
+            {# --- Contenido de tabs --- #}
+            <div class="tab-content px-3 pb-3 pt-3">
+
+                {# Tab Datos #}
+                <div class="tab-pane fade show active"
+                     id="tab-tarea-{{ tarea.id }}-datos"
+                     role="tabpanel">
+                    <div class="detalle-tarea">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p class="mb-1"><strong>Inicio:</strong> {{ tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else 'Pendiente' }}</p>
+                                <p class="mb-1"><strong>Fin:</strong> {{ tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else 'En curso' }}</p>
+                            </div>
+                            <div class="col-md-6">
+                                {% if tarea.responsable %}
+                                <p class="mb-1"><strong>Responsable:</strong> {{ tarea.responsable.siglas }}</p>
+                                {% endif %}
+                                {% if tarea.observaciones %}
+                                <p class="mb-1"><strong>Obs:</strong> {{ tarea.observaciones[:100] }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
+                {# Tab Documentos #}
+                <div class="tab-pane fade"
+                     id="tab-tarea-{{ tarea.id }}-docs"
+                     role="tabpanel">
+                    {% if documentos %}
+                    <table class="table table-sm table-hover">
+                        <thead class="table-success">
+                            <tr>
+                                <th>Relación</th>
+                                <th>Documento</th>
+                                <th>Fecha</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for doc_data in documentos %}
+                            <tr>
+                                <td><span class="badge bg-secondary">{{ doc_data.tipo_relacion }}</span></td>
+                                <td>{{ doc_data.obj.nombre if doc_data.obj.nombre else 'Doc ' ~ doc_data.obj.id }}</td>
+                                <td class="small">{{ doc_data.obj.fecha_creacion.strftime('%d/%m/%Y') if doc_data.obj.fecha_creacion else '-' }}</td>
+                                <td>
+                                    {% if doc_data.obj.ruta %}
+                                    <a href="{{ url_for('static', filename='uploads/' ~ doc_data.obj.ruta) }}"
+                                       class="btn btn-sm btn-outline-secondary"
+                                       target="_blank">
+                                        <i class="bi bi-download"></i>
+                                    </a>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted mb-0">No hay documentos asociados a esta tarea.</p>
+                    {% endif %}
+                </div>
+
             </div>
-            
-            {# Listado de documentos - SIEMPRE VISIBLE (nivel final) #}
-            {% if documentos %}
-            <hr>
-            <h6>Documentos de esta tarea</h6>
-            <table class="table table-sm table-hover">
-                <thead class="table-success">
-                    <tr>
-                        <th>Relación</th>
-                        <th>Documento</th>
-                        <th>Fecha</th>
-                        <th>Acciones</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for doc_data in documentos %}
-                    <tr>
-                        <td><span class="badge bg-secondary">{{ doc_data.tipo_relacion }}</span></td>
-                        <td>{{ doc_data.obj.nombre if doc_data.obj.nombre else 'Doc ' ~ doc_data.obj.id }}</td>
-                        <td class="small">{{ doc_data.obj.fecha_creacion.strftime('%d/%m/%Y') if doc_data.obj.fecha_creacion else '-' }}</td>
-                        <td>
-                            {% if doc_data.obj.ruta %}
-                            <a href="{{ url_for('static', filename='uploads/' ~ doc_data.obj.ruta) }}" 
-                               class="btn btn-sm btn-outline-secondary" 
-                               target="_blank">
-                                <i class="bi bi-download"></i>
-                            </a>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% else %}
-            <p class="text-muted">No hay documentos asociados a esta tarea.</p>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/app/templates/vistas/vista3/_tramite_accordion.html
+++ b/app/templates/vistas/vista3/_tramite_accordion.html
@@ -1,73 +1,125 @@
 {# Acordeón de Trámite específico - Nivel 4 #}
 <div class="accordion-item vista3-level-4" data-level-type="tramite" data-level-id="{{ tramite.id }}">
     <h2 class="accordion-header" id="heading-tramite-{{ tramite.id }}">
-        <button class="accordion-button" 
+        <button class="accordion-button"
                 type="button"
                 onclick="navigateToLevel({{ level_index }})">
             <i class="bi bi-card-checklist"></i>
             &nbsp;Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else 'Trámite ' ~ tramite.id }}
         </button>
     </h2>
-    <div class="accordion-collapse collapse show" 
+    <div class="accordion-collapse collapse show"
          aria-labelledby="heading-tramite-{{ tramite.id }}">
-        <div class="accordion-body">
-            {# Cuerpo fijo del trámite - SIEMPRE VISIBLE #}
-            <div class="detalle-tramite mb-3">
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="mb-1"><strong>Inicio:</strong> {{ tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else 'Pendiente' }}</p>
-                        <p class="mb-1"><strong>Fin:</strong> {{ tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else 'En curso' }}</p>
-                    </div>
-                    <div class="col-md-6">
-                        {% if tramite.responsable %}
-                        <p class="mb-1"><strong>Responsable:</strong> {{ tramite.responsable.siglas }}</p>
+        <div class="accordion-body p-0">
+
+            {# --- Tabs de navegación --- #}
+            <ul class="nav nav-tabs px-3 pt-2" id="tabs-tramite-{{ tramite.id }}" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="tab-tramite-{{ tramite.id }}-datos-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-tramite-{{ tramite.id }}-datos"
+                            type="button" role="tab">
+                        <i class="bi bi-info-circle me-1"></i>Datos
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-tramite-{{ tramite.id }}-tareas-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-tramite-{{ tramite.id }}-tareas"
+                            type="button" role="tab">
+                        <i class="bi bi-check2-square me-1"></i>Tareas
+                        {% if tareas %}
+                        <span class="badge bg-secondary ms-1">{{ tareas|length }}</span>
                         {% endif %}
-                        {% if tramite.observaciones %}
-                        <p class="mb-1"><strong>Obs:</strong> {{ tramite.observaciones[:100] }}</p>
-                        {% endif %}
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="tab-tramite-{{ tramite.id }}-docs-btn"
+                            data-bs-toggle="tab"
+                            data-bs-target="#tab-tramite-{{ tramite.id }}-docs"
+                            type="button" role="tab">
+                        <i class="bi bi-file-earmark me-1"></i>Documentos
+                    </button>
+                </li>
+            </ul>
+
+            {# --- Contenido de tabs --- #}
+            <div class="tab-content px-3 pb-3 pt-3">
+
+                {# Tab Datos #}
+                <div class="tab-pane fade show active"
+                     id="tab-tramite-{{ tramite.id }}-datos"
+                     role="tabpanel">
+                    <div class="detalle-tramite">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p class="mb-1"><strong>Inicio:</strong> {{ tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else 'Pendiente' }}</p>
+                                <p class="mb-1"><strong>Fin:</strong> {{ tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else 'En curso' }}</p>
+                            </div>
+                            <div class="col-md-6">
+                                {% if tramite.responsable %}
+                                <p class="mb-1"><strong>Responsable:</strong> {{ tramite.responsable.siglas }}</p>
+                                {% endif %}
+                                {% if tramite.observaciones %}
+                                <p class="mb-1"><strong>Obs:</strong> {{ tramite.observaciones[:100] }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
+                {# Tab Tareas #}
+                <div class="tab-pane fade"
+                     id="tab-tramite-{{ tramite.id }}-tareas"
+                     role="tabpanel">
+                    {% if tareas %}
+                    <table class="table table-sm table-hover">
+                        <thead class="table-success">
+                            <tr>
+                                <th>Tarea</th>
+                                <th>Estado</th>
+                                <th>Documentos</th>
+                                <th>Fechas</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for tarea_data in tareas %}
+                            <tr>
+                                <td>{{ tarea_data.nombre }}</td>
+                                <td><span class="badge bg-dark">{{ tarea_data.estado }}</span></td>
+                                <td>{{ tarea_data.documentos_count }}</td>
+                                <td class="small">
+                                    {{ tarea_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tarea_data.obj.fecha_inicio else '-' }}
+                                    {% if tarea_data.obj.fecha_fin %}
+                                    → {{ tarea_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if is_active %}
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            onclick="drillDown('tarea', {{ tarea_data.obj.id }})">
+                                        [...]
+                                    </button>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% else %}
+                    <p class="text-muted mb-0">No hay tareas en este trámite.</p>
+                    {% endif %}
+                </div>
+
+                {# Tab Documentos #}
+                <div class="tab-pane fade"
+                     id="tab-tramite-{{ tramite.id }}-docs"
+                     role="tabpanel">
+                    <p class="text-muted mb-0">Sin documentos registrados.</p>
+                </div>
+
             </div>
-            
-            {# Listado de tareas - SOLO SI ES NIVEL ACTIVO #}
-            {% if is_active and tareas %}
-            <hr>
-            <h6>Tareas de este trámite</h6>
-            <table class="table table-sm table-hover">
-                <thead class="table-success">
-                    <tr>
-                        <th>Tarea</th>
-                        <th>Estado</th>
-                        <th>Documentos</th>
-                        <th>Fechas</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for tarea_data in tareas %}
-                    <tr>
-                        <td>{{ tarea_data.nombre }}</td>
-                        <td><span class="badge bg-dark">{{ tarea_data.estado }}</span></td>
-                        <td>{{ tarea_data.documentos_count }}</td>
-                        <td class="small">
-                            {{ tarea_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tarea_data.obj.fecha_inicio else '-' }}
-                            {% if tarea_data.obj.fecha_fin %}
-                            → {{ tarea_data.obj.fecha_fin.strftime('%d/%m/%Y') }}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <button class="btn btn-sm btn-outline-primary" 
-                                    onclick="drillDown('tarea', {{ tarea_data.obj.id }})">
-                                [...]
-                            </button>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            {% elif is_active %}
-            <p class="text-muted">No hay tareas en este trámite.</p>
-            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Resumen

Implementación completa de la Fase 3 del epic #61 (Interfaz Navegación Contextual).
Tres bloques independientes que enriquecen el flujo Listado → Detalle → Vista 3.

Closes #70
Closes #71
Closes #72
Closes #73

## Cambios incluidos

### Issue #70 — Enriquecer listado V2 con datos SFTT
- **API** (`api_expedientes.py`): subconsulta `COUNT FILTER` por IDs de página para obtener estadísticas de solicitudes (1 query adicional, sin tocar el query principal con cursor/paginación)
- Nuevos campos serializados: `num_solicitudes`, `num_activas`, `estado_tramitacion` (`SIN_SOLICITUDES` / `EN_TRAMITE` / `RESUELTO`), `url_tramitacion`
- **JS** (`v2-scroll-infinito.js`): nuevo tipo de columna `custom` con callback `renderFn`
- **Listado V2**: columna *Solicitudes* (count + badge de activas), columna *Estado* (badge semántico), botones *Detalle* y *Tramitar* separados en acciones

### Issues #71 + #72 — Tabs Bootstrap en acordeones Vista 3
- Los 4 parciales (`_solicitud`, `_fase`, `_tramite`, `_tarea`) ahora tienen tabs Bootstrap
- Tabs: **[Datos]** **[Fases/Trámites/Tareas]** **[Documentos]** con IDs únicos `tab-{tipo}-{id}` para evitar conflictos entre acordeones
- La tabla de hijos es siempre visible (se elimina la condición `is_active` del wrapper exterior); los botones `drillDown()` siguen condicionados a `is_active`
- `_tarea_accordion.html`: solo 2 tabs `[Datos]` `[Documentos]` (nivel final de la jerarquía)
- CSS ajustado en `v3-tramitacion.css`: `accordion-body p-0` + estilos `nav-tabs` dentro de acordeones anidados

### Issue #73 — Migrar detalle.html a base_fullwidth + breadcrumb
- `base_fullwidth.html`: añadido `{% block page_breadcrumb %}` dentro de `<main>` (overrideable por templates hijo sin romper el grid CSS de 3 filas)
- `detalle.html`: migrado de `base.html` (legacy Bootstrap navbar) a `layout/base_fullwidth.html`
- Breadcrumb 3 niveles: **Inicio › Expedientes › AT-{numero_at}**
- Botón **Tramitar** → `tramitacion_v3` añadido junto a Volver/Editar
- Campo **Titular** añadido en card Información General (maneja `NULL` con badge)

## Decisiones técnicas

- `titular_id` es `NULL` en los expedientes de prueba → mostrado como badge "Sin titular"
- `base.html` legacy no eliminado (lo usan auth, dashboard, proyectos)
- `fecha_limite` en `Tramite` omitida (pendiente issue #74 semáforos/alertas)

## Test plan

- [x] `/expedientes/listado-v2` — columnas *Solicitudes* y *Estado* visibles; botón *Tramitar* navega a Vista 3; botón *Detalle* navega a detalle
- [x] `/expedientes/104/tramitacion_v3` — tabs clicables en acordeones de solicitud, fase, trámite y tarea
- [x] `/expedientes/104` — breadcrumb "Inicio › Expedientes › AT-1" visible; botón *Tramitar* presente; layout correcto (sin zona en blanco)
- [x] Flujo completo: Listado → Tramitar → Vista 3 → breadcrumb dinámico navega atrás

🤖 Generated with [Claude Code](https://claude.com/claude-code)