### PR TITLE
feat #119: Separación titular/solicitante en wizard paso 3

### DIFF
--- a/app/models/autorizados_titular.py
+++ b/app/models/autorizados_titular.py
@@ -134,41 +134,25 @@ class AutorizadoTitular(db.Model):
         }
     
     @validates('titular_entidad_id')
-    def validate_titular_es_administrado(self, key, titular_id):
-        """
-        Valida que el titular sea un administrado (tenga entrada en entidades_administrados).
-        """
+    def validate_titular(self, key, titular_id):
+        """Valida que el titular exista y esté activo."""
         from app.models.entidad import Entidad
-        
-        titular = Entidad.query.get(titular_id)
-        if not titular:
-            raise ValueError(f"Entidad {titular_id} no existe")
-        
-        if not titular.datos_administrado:
-            raise ValueError(
-                f"{titular.nombre_completo} (ID {titular_id}) no es un administrado. "
-                f"Debe tener entrada en entidades_administrados"
-            )
-        
+        entidad = Entidad.query.get(titular_id)
+        if not entidad:
+            raise ValueError(f"Entidad titular {titular_id} no existe")
+        if not entidad.activo:
+            raise ValueError(f"{entidad.nombre_completo} (ID {titular_id}) no está activa")
         return titular_id
-    
+
     @validates('autorizado_entidad_id')
-    def validate_autorizado_es_administrado(self, key, autorizado_id):
-        """
-        Valida que el autorizado sea un administrado (tenga entrada en entidades_administrados).
-        """
+    def validate_autorizado(self, key, autorizado_id):
+        """Valida que el autorizado exista y esté activo."""
         from app.models.entidad import Entidad
-        
-        autorizado = Entidad.query.get(autorizado_id)
-        if not autorizado:
-            raise ValueError(f"Entidad {autorizado_id} no existe")
-        
-        if not autorizado.datos_administrado:
-            raise ValueError(
-                f"{autorizado.nombre_completo} (ID {autorizado_id}) no es un administrado. "
-                f"Debe tener entrada en entidades_administrados"
-            )
-        
+        entidad = Entidad.query.get(autorizado_id)
+        if not entidad:
+            raise ValueError(f"Entidad autorizada {autorizado_id} no existe")
+        if not entidad.activo:
+            raise ValueError(f"{entidad.nombre_completo} (ID {autorizado_id}) no está activa")
         return autorizado_id
     
     def revocar(self, motivo=None):

--- a/app/routes/api_entidades.py
+++ b/app/routes/api_entidades.py
@@ -18,6 +18,7 @@ from flask_login import login_required
 from sqlalchemy import func, or_
 from app import db
 from app.models.entidad import Entidad
+from app.models.autorizados_titular import AutorizadoTitular
 
 api_entidades_bp = Blueprint('api_entidades', __name__, url_prefix='/api')
 
@@ -210,3 +211,38 @@ def listar_entidades():
         response['total'] = total
 
     return jsonify(response), 200
+
+
+@api_entidades_bp.route('/entidades/<int:titular_id>/autorizados', methods=['GET'])
+@login_required
+def listar_autorizados(titular_id):
+    """
+    GET /api/entidades/<titular_id>/autorizados
+
+    Devuelve los autorizados vigentes de un titular, incluyendo al propio titular
+    como primera opción (autoautorización implícita).
+
+    Respuesta JSON:
+        { "data": [{"id": 1, "text": "Nombre (NIF)"}, ...] }
+
+    Returns:
+        200 OK  con lista de autorizados (puede ser solo el titular si no hay más).
+        404 Not Found si el titular no existe o no tiene rol_titular=True.
+    """
+    titular = Entidad.query.get(titular_id)
+    if not titular or not titular.rol_titular:
+        return jsonify({'error': 'Titular no encontrado'}), 404
+
+    # Siempre incluir al propio titular como primera opción
+    def _label(e):
+        return f'{e.nombre_completo} ({e.nif})' if e.nif else e.nombre_completo
+
+    data = [{'id': titular.id, 'text': _label(titular)}]
+
+    # Añadir autorizados vigentes (distintos del titular)
+    autorizaciones = AutorizadoTitular.obtener_autorizados_de_titular(titular_id, solo_activos=True)
+    for aut in autorizaciones:
+        if aut.autorizado:
+            data.append({'id': aut.autorizado.id, 'text': _label(aut.autorizado)})
+
+    return jsonify({'data': data}), 200

--- a/app/routes/wizard_expediente.py
+++ b/app/routes/wizard_expediente.py
@@ -27,6 +27,7 @@ from app.models.entidad import Entidad
 from app.models.solicitudes import Solicitud
 from app.models.tipos_solicitudes import TipoSolicitud
 from app.models.solicitudes_tipos import SolicitudTipo
+from app.models.autorizados_titular import AutorizadoTitular
 
 bp = Blueprint('wizard_expediente', __name__, url_prefix='/expedientes/wizard')
 
@@ -252,6 +253,24 @@ def paso3():
             flash('La entidad seleccionada no es válida como titular.', 'danger')
             return redirect(url_for('wizard_expediente.paso3'))
 
+        # --- Solicitante (puede ser el titular o un tercero autorizado) ---
+        solicitante_id_raw = (request.form.get('solicitante_id') or '').strip()
+        try:
+            solicitante_id = int(solicitante_id_raw) if solicitante_id_raw else entidad.id
+        except ValueError:
+            solicitante_id = entidad.id
+
+        if solicitante_id != entidad.id:
+            if not AutorizadoTitular.puede_actuar_como(solicitante_id, entidad.id):
+                flash('El solicitante no tiene autorización vigente para actuar en nombre de este titular.', 'danger')
+                return redirect(url_for('wizard_expediente.paso3'))
+            solicitante = Entidad.query.get(solicitante_id)
+            if not solicitante:
+                flash('Solicitante no encontrado.', 'danger')
+                return redirect(url_for('wizard_expediente.paso3'))
+        else:
+            solicitante = entidad
+
         try:
             fecha_solicitud = date.fromisoformat(fecha_solicitud_str)
         except ValueError:
@@ -322,10 +341,10 @@ def paso3():
             db.session.add(expediente)
             db.session.flush()  # → expediente.id disponible
 
-            # 5) Solicitud
+            # 5) Solicitud (entidad_id = solicitante, que puede ser distinto del titular)
             solicitud = Solicitud(
                 expediente_id=expediente.id,
-                entidad_id=entidad.id,
+                entidad_id=solicitante.id,
                 fecha_solicitud=fecha_solicitud,
                 estado='EN_TRAMITE',
                 observaciones=observaciones,

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -199,7 +199,7 @@
                 // Resetear sección solicitante al cambiar titular
                 chkDistinto.checked = false;
                 solicitanteSection.style.display = 'none';
-                solicitanteSel.limpiar();
+                solicitanteSel.clear();
                 avisoSinAut.style.display = 'none';
             }
         }
@@ -224,7 +224,10 @@
             .then(r => r.json())
             .then(json => {
                 // Filtrar el propio titular (ya está elegido arriba)
-                const opciones = (json.data || []).filter(o => o.id !== parseInt(titular_id, 10));
+                // Convertir {id, text} → {v, t} que espera SelectorBusqueda
+                const opciones = (json.data || [])
+                    .filter(o => o.id !== parseInt(titular_id, 10))
+                    .map(o => ({ v: String(o.id), t: o.text }));
                 if (!opciones.length) {
                     // Sin autorizados: mostrar aviso y revertir toggle
                     avisoSinAut.style.display = '';
@@ -250,12 +253,12 @@
             const tid = entidadSel.getValue();
             if (!tid) { this.checked = false; return; }
             solicitanteSection.style.display = '';
-            solicitanteSel.limpiar();
+            solicitanteSel.clear();
             solicitanteHidden.value = '';
             cargarAutorizados(tid);
         } else {
             solicitanteSection.style.display = 'none';
-            solicitanteSel.limpiar();
+            solicitanteSel.clear();
             avisoSinAut.style.display = 'none';
             // Solicitante vuelve a ser el titular
             solicitanteHidden.value = entidadSel.getValue() || '';

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -35,10 +35,10 @@
                 <div class="card-body">
                     <form method="post" action="{{ url_for('wizard_expediente.paso3') }}" novalidate>
 
-                        {# --- Titular / solicitante --- #}
-                        <div class="mb-4">
+                        {# --- Titular --- #}
+                        <div class="mb-3">
                             <label class="form-label fw-semibold">
-                                Titular / Solicitante <span class="text-danger">*</span>
+                                Titular <span class="text-danger">*</span>
                             </label>
                             <div id="sb-titular"></div>
                             <div class="form-text">Solo entidades activas con rol Titular.</div>
@@ -46,6 +46,35 @@
                                 <i class="fas fa-exclamation-circle me-1"></i>Debe seleccionar un titular.
                             </div>
                         </div>
+
+                        {# --- Toggle: solicitante distinto del titular --- #}
+                        <div id="toggle-solicitante-section" class="mb-3" style="display:none;">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="chk-solicitante-distinto">
+                                <label class="form-check-label" for="chk-solicitante-distinto">
+                                    El solicitante es distinto del titular
+                                </label>
+                            </div>
+                        </div>
+
+                        {# --- Selector de solicitante (solo si es distinto) --- #}
+                        <div id="solicitante-section" class="mb-4" style="display:none;">
+                            <label class="form-label fw-semibold">
+                                Solicitante <span class="text-danger">*</span>
+                            </label>
+                            <div id="sb-solicitante"></div>
+                            <div class="form-text">Solo entidades con autorización vigente para este titular.</div>
+                            <div id="aviso-sin-autorizados" class="alert alert-warning py-2 mt-2" style="display:none;">
+                                <i class="fas fa-exclamation-triangle me-1"></i>
+                                Este titular no tiene autorizados vigentes. Cree la autorización antes de continuar.
+                            </div>
+                            <div id="solicitante-error" class="text-danger small mt-1" style="display:none;">
+                                <i class="fas fa-exclamation-circle me-1"></i>Debe seleccionar un solicitante.
+                            </div>
+                        </div>
+
+                        {# Input hidden: solicitante final (titular o autorizado elegido) #}
+                        <input type="hidden" name="solicitante_id" id="solicitante-id-hidden">
 
                         {# --- Fecha solicitud --- #}
                         <div class="mb-4">
@@ -141,21 +170,97 @@
     'use strict';
 
     // ------------------------------------------------------------------
-    // A) SelectorBusqueda para titular / entidad
+    // A) Selectores de titular y solicitante
     // ------------------------------------------------------------------
-    const entidadError = document.getElementById('entidad-error');
+    const entidadError      = document.getElementById('entidad-error');
+    const toggleSection     = document.getElementById('toggle-solicitante-section');
+    const chkDistinto       = document.getElementById('chk-solicitante-distinto');
+    const solicitanteSection = document.getElementById('solicitante-section');
+    const avisoSinAut       = document.getElementById('aviso-sin-autorizados');
+    const solicitanteError  = document.getElementById('solicitante-error');
+    const solicitanteHidden = document.getElementById('solicitante-id-hidden');
 
     const entidadSel = new SelectorBusqueda(
         '#sb-titular',
         {{ entidades_opts | tojson }},
         {
-            placeholder: '— Seleccione titular/solicitante —',
+            placeholder: '— Seleccione titular —',
             name: 'entidad_id',
             onChange: (v) => {
-                if (v) entidadError.style.display = 'none';
+                if (v) {
+                    entidadError.style.display = 'none';
+                    // Mostrar toggle y sincronizar solicitante_id con el titular por defecto
+                    toggleSection.style.display = '';
+                    solicitanteHidden.value = v;
+                } else {
+                    toggleSection.style.display = 'none';
+                    solicitanteHidden.value = '';
+                }
+                // Resetear sección solicitante al cambiar titular
+                chkDistinto.checked = false;
+                solicitanteSection.style.display = 'none';
+                solicitanteSel.limpiar();
+                avisoSinAut.style.display = 'none';
             }
         }
     );
+
+    const solicitanteSel = new SelectorBusqueda(
+        '#sb-solicitante',
+        [],
+        {
+            placeholder: '— Seleccione solicitante —',
+            name: '_solicitante_display',   // no se envía al servidor; usa el hidden
+            onChange: (v) => {
+                solicitanteHidden.value = v || '';
+                if (v) solicitanteError.style.display = 'none';
+            }
+        }
+    );
+
+    /** Carga autorizados vigentes del titular desde la API y rellena el selector. */
+    function cargarAutorizados(titular_id) {
+        fetch(`/api/entidades/${titular_id}/autorizados`)
+            .then(r => r.json())
+            .then(json => {
+                // Filtrar el propio titular (ya está elegido arriba)
+                const opciones = (json.data || []).filter(o => o.id !== parseInt(titular_id, 10));
+                if (!opciones.length) {
+                    // Sin autorizados: mostrar aviso y revertir toggle
+                    avisoSinAut.style.display = '';
+                    chkDistinto.checked = false;
+                    solicitanteSection.style.display = 'none';
+                    // Restaurar solicitante_id al titular
+                    solicitanteHidden.value = titular_id;
+                } else {
+                    avisoSinAut.style.display = 'none';
+                    solicitanteSel.setOpciones(opciones);
+                }
+            })
+            .catch(() => {
+                // Error de red: revertir toggle
+                chkDistinto.checked = false;
+                solicitanteSection.style.display = 'none';
+                solicitanteHidden.value = entidadSel.getValue() || '';
+            });
+    }
+
+    chkDistinto.addEventListener('change', function () {
+        if (this.checked) {
+            const tid = entidadSel.getValue();
+            if (!tid) { this.checked = false; return; }
+            solicitanteSection.style.display = '';
+            solicitanteSel.limpiar();
+            solicitanteHidden.value = '';
+            cargarAutorizados(tid);
+        } else {
+            solicitanteSection.style.display = 'none';
+            solicitanteSel.limpiar();
+            avisoSinAut.style.display = 'none';
+            // Solicitante vuelve a ser el titular
+            solicitanteHidden.value = entidadSel.getValue() || '';
+        }
+    });
 
     // ------------------------------------------------------------------
     // B) Selector de tipos de solicitud con badges acumulables
@@ -251,6 +356,14 @@
             ok = false;
         } else {
             entidadError.style.display = 'none';
+        }
+
+        // Validar solicitante si el toggle está activo
+        if (chkDistinto.checked && !solicitanteSel.getValue()) {
+            solicitanteError.style.display = 'block';
+            ok = false;
+        } else {
+            solicitanteError.style.display = 'none';
         }
 
         // Validar al menos un tipo seleccionado


### PR DESCRIPTION
## Resumen

Implementa la separación entre **titular** y **solicitante** en el paso 3 del wizard de creación de expedientes (issue #119), y corrige un bug relacionado en el modelo `AutorizadoTitular` (issue #130).

## Cambios

- **Nuevo endpoint** `GET /api/entidades/<titular_id>/autorizados` — devuelve los autorizados vigentes de un titular (incluyendo al propio titular como primera opción)
- **Wizard paso 3** — toggle «El solicitante es distinto del titular», oculto hasta elegir titular; al activarlo carga autorizados vía API; aviso si no hay autorizados vigentes
- **Backend wizard** — valida `AutorizadoTitular.puede_actuar_como()` antes del commit; `Solicitud.entidad_id` puede diferir de `Expediente.titular_id`
- **Fix #130** — validators de `AutorizadoTitular` reescritos; eliminadas referencias a `datos_administrado` (backref de tabla eliminada en #103)

## Sin migraciones

El modelo de datos ya soportaba `titular_id ≠ Solicitud.entidad_id`. Solo era un problema de UI.

## Verificado

- Toggle invisible hasta elegir titular ✅
- Selector carga solo autorizados (titular excluido) ✅
- Expediente AT-17 creado con `titular_id=6 ≠ solicitante_id=8` confirmado en BD ✅
- Caso sin autorizados: aviso + toggle revertido ✅
- Validación servidor rechaza solicitante sin autorización ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)