### PR TITLE
[STYLE] #132 Migrar Bootstrap al CDN oficial de la Junta de Andalucía v1.2.5

### DIFF
--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -208,20 +208,6 @@
   color: var(--text-inverse);
 }
 
-/* Botón outline primario (corporativo Junta) */
-.btn-outline-primary {
-  color: var(--primary);
-  border-color: var(--primary);
-}
-
-.btn-outline-primary:hover,
-.btn-outline-primary:active,
-.btn-outline-primary.active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: var(--text-inverse);
-}
-
 /* Botón secundario */
 .btn-secondary {
   background: var(--gris-principal);

--- a/app/static/css/v2-theme.css
+++ b/app/static/css/v2-theme.css
@@ -63,10 +63,12 @@
   --focus-ring: rgba(8, 112, 33, 0.25); /* Verde corporativo con transparencia */
 
   /* ===== INTEGRACIÓN BOOTSTRAP 5 ===== */
-  /* Alias --bs-* que apuntan a la fuente de verdad --primary          */
-  /* v2-theme carga DESPUÉS de Bootstrap, por lo que estas definiciones */
-  /* sobreescriben las variables azules por defecto de Bootstrap 5.     */
-  /* Para cambiar el color corporativo basta con modificar --primary.   */
+  /* Alias --bs-* que apuntan a la fuente de verdad --primary.          */
+  /* El CDN Junta ya define --bs-primary:#087021 a nivel de componente  */
+  /* (btn-primary, btn-outline-primary, etc.). Estas definiciones        */
+  /* complementan las clases utilitarias (:root) para .text-primary,    */
+  /* .bg-primary, acordeón, etc. Para cambiar el color basta con        */
+  /* modificar --primary.                                               */
   --bs-primary: var(--primary);
   --bs-primary-rgb: 8, 112, 33;                                    /* RGB de #087021 - CSS no convierte hex a RGB automáticamente */
   --bs-primary-bg-subtle: var(--primary-light);

--- a/app/templates/layout/base_acordeon.html
+++ b/app/templates/layout/base_acordeon.html
@@ -5,15 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Tramitación - BDDAT{% endblock %}</title>
     
-    <!-- Bootstrap 5 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    
+    <!-- CDN oficial Junta de Andalucía v1.2.5 (Bootstrap 5.3.3 + FA 6.5.1 + tipografía) Ref: #132 -->
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/fonts.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/all.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/custom-jda-bootstrap.css" rel="stylesheet">
+
     <!-- CSS v2 base (reutilización header/footer) -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
-    
-    <!-- Font Awesome (iconos) -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     
     {% block extra_css %}{% endblock %}
 </head>
@@ -81,8 +80,8 @@
         {% include 'layout/footer.html' %}
     </div>
     
-    <!-- Bootstrap 5 JS Bundle -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Bootstrap JS bundle del CDN Junta (Bootstrap 5.3.3) Ref: #132 -->
+    <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
     
     {% block extra_js %}{% endblock %}
 </body>

--- a/app/templates/layout/base_fullwidth.html
+++ b/app/templates/layout/base_fullwidth.html
@@ -6,18 +6,19 @@
     <title>{% block title %}BDDAT{% endblock %} - Junta de Andalucía</title>
     <link rel="icon" href="data:,">
 
-    {# Bootstrap 5 + Bootstrap Icons PRIMERO (sus variables --bs-* se definen aquí) #}
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
-          crossorigin="anonymous">
+    {# CDN oficial Junta de Andalucía v1.2.5
+         - fonts.css: tipografía corporativa
+         - all.css: Font Awesome 6.5.1
+         - custom-jda-bootstrap.css: Bootstrap 5.3.3 precompilado con --bs-primary #087021
+         Ref: #132 #}
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/fonts.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/all.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/custom-jda-bootstrap.css" rel="stylesheet">
+    {# Bootstrap Icons (no incluido en el CDN de la Junta) #}
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
-    {# Font Awesome (iconos legacy de la app) #}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-
-    {# CSS núcleo v2 DESPUÉS de Bootstrap: sobreescribe --bs-* con colores corporativos Junta #}
+    {# CSS núcleo v2 DESPUÉS del CDN Junta: añade variables --primary y app-específicas #}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-components.css') }}">
@@ -77,10 +78,8 @@
         {% endwith %}
     </div>
 
-    {# Bootstrap JS bundle para componentes interactivos (accordion, dropdowns, etc.) #}
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-            integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-            crossorigin="anonymous"></script>
+    {# Bootstrap JS bundle del CDN Junta (Bootstrap 5.3.3) #}
+    <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
 
     <script>
         // Auto-inicializar toasts al cargar la página (patrón del PR #44)

--- a/app/templates/layout/base_login.html
+++ b/app/templates/layout/base_login.html
@@ -6,14 +6,16 @@
     <title>{% block title %}BDDAT{% endblock %} - Junta de Andalucía</title>
     <link rel="icon" href="data:,">
 
+    <!-- CDN oficial Junta de Andalucía v1.2.5 (Bootstrap 5.3.3 + FA 6.5.1 + tipografía) Ref: #132 -->
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/fonts.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/all.css" rel="stylesheet">
+    <link href="https://cdn.juntadeandalucia.es/components/sass/1.2.5/css/custom-jda-bootstrap.css" rel="stylesheet">
+
     <!-- CSS v2 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-components.css') }}">
-    
-    <!-- Font Awesome (iconos) -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    
+
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -40,6 +42,9 @@
     </div>
     <!-- Fin A -->
     
+    <!-- Bootstrap JS bundle del CDN Junta (Bootstrap 5.3.3) Ref: #132 -->
+    <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
+
     {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Resumen

Sustituye el CDN de jsdelivr (Bootstrap estándar, azul) por el CDN oficial de la Junta de Andalucía v1.2.5, que incluye Bootstrap 5.3.3 precompilado con los colores corporativos verdes (`--bs-primary: #087021`) a nivel de componente Sass.

## Motivación

Con Bootstrap estándar, los colores de los componentes (`.btn-primary`, `.btn-outline-primary`, etc.) se hardcodean en azul durante la compilación Sass. Para corregirlos había que añadir overrides manuales en `v2-components.css` uno a uno. El CDN de la Junta compila Bootstrap directamente con el verde corporativo, eliminando esa fricción de raíz.

## Cambios

- `base_fullwidth.html`, `base_acordeon.html`, `base_login.html`: reemplazados CDNs de Bootstrap y Font Awesome por equivalentes del CDN Junta (`fonts.css`, `all.css`, `custom-jda-bootstrap.css`, `bootstrap.bundle.min.js`)
- `base_login.html`: también se añade el Bootstrap JS bundle, que estaba ausente
- `v2-components.css`: eliminado override `.btn-outline-primary` (ahora nativo en el CDN)
- `v2-theme.css`: actualizado comentario del bloque de integración Bootstrap

## Versión fijada

Se usa `/1.2.5/` en lugar de `/latest/` para control de versión explícito. Migración a versiones futuras será una decisión consciente.

## Test

Verificado visualmente con Playwright en: login, dashboard, listado expedientes, detalle expediente (V4), vista tramitación (V3).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)