### PR TITLE
[MODELO][RUTA] Motor de reglas — evaluador de acciones ESFTT (#152)

### DIFF
--- a/app/models/fases.py
+++ b/app/models/fases.py
@@ -142,3 +142,29 @@ class Fase(db.Model):
     def __str__(self):
         """Representación legible para interfaz."""
         return f'Fase {self.id} - {self.tipo_fase.nombre if self.tipo_fase else "Sin tipo"}'
+
+    # --- Estados deducibles (vocabulario CREAR/INICIAR/FINALIZAR/BORRAR) ---
+
+    @property
+    def planificada(self):
+        """True si la fase existe pero aún no se ha iniciado (fecha_inicio IS NULL)."""
+        return self.fecha_inicio is None
+
+    @property
+    def en_curso(self):
+        """True si la fase ha sido iniciada pero no finalizada."""
+        return self.fecha_inicio is not None and self.fecha_fin is None
+
+    @property
+    def finalizada(self):
+        """True si la fase ha sido finalizada (fecha_fin IS NOT NULL)."""
+        return self.fecha_fin is not None
+
+    @property
+    def finalizada_favorable(self):
+        """True si la fase está finalizada con resultado favorable o favorable condicionado."""
+        return (
+            self.fecha_fin is not None
+            and self.resultado_fase_id is not None
+            and self.resultado_fase.codigo in ('FAVORABLE', 'FAVORABLE_CONDICIONADO')
+        )

--- a/app/models/motor_reglas.py
+++ b/app/models/motor_reglas.py
@@ -54,7 +54,7 @@ class ReglaMotor(db.Model):
     """
     __tablename__ = 'reglas_motor'
     __table_args__ = (
-        db.CheckConstraint("evento IN ('CREAR','CERRAR','BORRAR')", name='ck_reglas_motor_evento'),
+        db.CheckConstraint("evento IN ('CREAR','INICIAR','FINALIZAR','BORRAR')", name='ck_reglas_motor_evento'),
         db.CheckConstraint(
             "entidad IN ('SOLICITUD','FASE','TRAMITE','TAREA','EXPEDIENTE')",
             name='ck_reglas_motor_entidad'

--- a/app/models/proyectos.py
+++ b/app/models/proyectos.py
@@ -128,10 +128,17 @@ class Proyecto(db.Model):
     )
     
     ia_id = db.Column(
-        db.Integer, 
-        db.ForeignKey('tipos_ia.id'), 
+        db.Integer,
+        db.ForeignKey('tipos_ia.id'),
         nullable=True,
         comment='FK a TIPOS_IA. Instrumento ambiental aplicable (AAI, AAU, AAUS, CA, EXENTO)'
+    )
+
+    es_modificacion = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        comment='True si el proyecto tramita modificación de instalaciones existentes (afecta tramitación ambiental AAU/AAUS)'
     )
     
     # Relación con TipoIA

--- a/app/models/tareas.py
+++ b/app/models/tareas.py
@@ -155,3 +155,25 @@ class Tarea(db.Model):
     def __str__(self):
         """Representación legible para interfaz."""
         return f'Tarea {self.id} - {self.tipo_tarea.nombre if self.tipo_tarea else "Sin tipo"}'
+
+    # --- Estados deducibles (vocabulario CREAR/INICIAR/FINALIZAR/BORRAR) ---
+
+    @property
+    def planificada(self):
+        """True si la tarea existe pero aún no se ha iniciado (fecha_inicio IS NULL)."""
+        return self.fecha_inicio is None
+
+    @property
+    def en_curso(self):
+        """True si la tarea ha sido iniciada pero no finalizada."""
+        return self.fecha_inicio is not None and self.fecha_fin is None
+
+    @property
+    def ejecutada(self):
+        """True si la tarea ha sido finalizada (fecha_fin IS NOT NULL)."""
+        return self.fecha_fin is not None
+
+    @property
+    def ejecutada_con_doc(self):
+        """True si la tarea está finalizada y ha producido un documento."""
+        return self.fecha_fin is not None and self.documento_producido_id is not None

--- a/app/models/tramites.py
+++ b/app/models/tramites.py
@@ -112,3 +112,20 @@ class Tramite(db.Model):
     def __str__(self):
         """Representación legible para interfaz."""
         return f'Trámite {self.id} - {self.tipo_tramite.nombre if self.tipo_tramite else "Sin tipo"}'
+
+    # --- Estados deducibles (vocabulario CREAR/INICIAR/FINALIZAR/BORRAR) ---
+
+    @property
+    def planificado(self):
+        """True si el trámite existe pero aún no se ha iniciado (fecha_inicio IS NULL)."""
+        return self.fecha_inicio is None
+
+    @property
+    def en_curso(self):
+        """True si el trámite ha sido iniciado pero no finalizado."""
+        return self.fecha_inicio is not None and self.fecha_fin is None
+
+    @property
+    def finalizado(self):
+        """True si el trámite ha sido finalizado (fecha_fin IS NOT NULL)."""
+        return self.fecha_fin is not None

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -21,7 +21,11 @@ from app.models.documentos import Documento
 from app.models.tipos_solicitudes import TipoSolicitud
 from app.models.solicitudes_tipos import SolicitudTipo
 from app.models.tipos_resultados_fases import TipoResultadoFase
+from app.models.tipos_fases import TipoFase
+from app.models.tipos_tramites import TipoTramite
+from app.models.tipos_tareas import TipoTarea
 from app.utils.permisos import verificar_acceso_expediente
+from app.services.motor_reglas import evaluar
 
 bp = Blueprint('vista3', __name__, url_prefix='/api/vista3')
 
@@ -268,8 +272,18 @@ def editar_solicitud(sol_id):
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
     try:
-        sol.fecha_solicitud = date.fromisoformat(request.form['fecha_solicitud']) if request.form.get('fecha_solicitud') else None
-        sol.fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+        nueva_fecha_solicitud = date.fromisoformat(request.form['fecha_solicitud']) if request.form.get('fecha_solicitud') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        # Hook FINALIZAR (fecha_fin: None → valor)
+        res_eval = None
+        if sol.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        sol.fecha_solicitud = nueva_fecha_solicitud
+        sol.fecha_fin = nueva_fecha_fin
         if request.form.get('estado'):
             sol.estado = request.form['estado']
         sol.observaciones = request.form.get('observaciones') or None
@@ -278,7 +292,8 @@ def editar_solicitud(sol_id):
         result = _get_solicitudes_con_stats(sol.expediente_id)
         sol_data = next((s for s in result if s['obj'].id == sol_id), None)
         html = render_template('vistas/vista3/_acordeon_solicitud.html', sol_data=sol_data) if sol_data else ''
-        return jsonify({'ok': True, 'html': html})
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500
@@ -294,8 +309,24 @@ def editar_fase(fase_id):
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
     try:
-        fase.fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
-        fase.fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        # Hook INICIAR (fecha_inicio: None → valor)
+        res_eval = None
+        if fase.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        # Hook FINALIZAR (fecha_fin: None → valor)
+        if fase.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        fase.fecha_inicio = nueva_fecha_inicio
+        fase.fecha_fin = nueva_fecha_fin
         resultado_id = request.form.get('resultado_fase_id')
         fase.resultado_fase_id = int(resultado_id) if resultado_id else None
         fase.observaciones = request.form.get('observaciones') or None
@@ -306,7 +337,8 @@ def editar_fase(fase_id):
         resultados_fase = TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
         html = render_template('vistas/vista3/_acordeon_fase.html', fase_data=fase_data,
                                resultados_fase=resultados_fase) if fase_data else ''
-        return jsonify({'ok': True, 'html': html})
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500
@@ -322,15 +354,32 @@ def editar_tramite(tram_id):
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
     try:
-        tramite.fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
-        tramite.fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        # Hook INICIAR (fecha_inicio: None → valor)
+        res_eval = None
+        if tramite.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        # Hook FINALIZAR (fecha_fin: None → valor)
+        if tramite.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        tramite.fecha_inicio = nueva_fecha_inicio
+        tramite.fecha_fin = nueva_fecha_fin
         tramite.observaciones = request.form.get('observaciones') or None
         db.session.commit()
         # Re-renderizar el acordeón para actualizar el DOM sin recargar
         result = _get_tramites_con_stats(tramite.fase_id)
         tramite_data = next((t for t in result if t['obj'].id == tram_id), None)
         html = render_template('vistas/vista3/_acordeon_tramite.html', tramite_data=tramite_data) if tramite_data else ''
-        return jsonify({'ok': True, 'html': html})
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500
@@ -346,8 +395,24 @@ def editar_tarea(tarea_id):
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
     try:
-        tarea.fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
-        tarea.fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        # Hook INICIAR (fecha_inicio: None → valor)
+        res_eval = None
+        if tarea.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        # Hook FINALIZAR (fecha_fin: None → valor)
+        if tarea.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        tarea.fecha_inicio = nueva_fecha_inicio
+        tarea.fecha_fin = nueva_fecha_fin
         tarea.notas = request.form.get('notas') or None
         db.session.commit()
         # Re-renderizar el acordeón para actualizar el DOM sin recargar
@@ -356,7 +421,151 @@ def editar_tarea(tarea_id):
         documentos = _get_documentos_tarea(tarea_id)
         html = render_template('vistas/vista3/_acordeon_tarea.html', tarea_data=tarea_data,
                                documentos=documentos) if tarea_data else ''
-        return jsonify({'ok': True, 'html': html})
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+# ============================================
+# ENDPOINTS POST — CREAR entidades
+# ============================================
+
+@bp.route('/solicitud/<int:sol_id>/fases/nueva', methods=['POST'])
+@login_required
+def crear_fase(sol_id):
+    """Crea una nueva fase en la solicitud indicada."""
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_fase_id = request.form.get('tipo_fase_id', type=int)
+    if not tipo_fase_id:
+        return jsonify({'ok': False, 'error': 'tipo_fase_id es obligatorio'}), 400
+    if not TipoFase.query.get(tipo_fase_id):
+        return jsonify({'ok': False, 'error': 'Tipo de fase no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'FASE', tipo_id=tipo_fase_id, padre_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
+    db.session.add(fase)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': fase.id, 'advertencia': advertencia})
+
+
+@bp.route('/fase/<int:fase_id>/tramites/nuevo', methods=['POST'])
+@login_required
+def crear_tramite(fase_id):
+    """Crea un nuevo trámite en la fase indicada."""
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_tramite_id = request.form.get('tipo_tramite_id', type=int)
+    if not tipo_tramite_id:
+        return jsonify({'ok': False, 'error': 'tipo_tramite_id es obligatorio'}), 400
+    if not TipoTramite.query.get(tipo_tramite_id):
+        return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'TRAMITE', tipo_id=tipo_tramite_id, padre_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
+    db.session.add(tramite)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': tramite.id, 'advertencia': advertencia})
+
+
+@bp.route('/tramite/<int:tram_id>/tareas/nueva', methods=['POST'])
+@login_required
+def crear_tarea(tram_id):
+    """Crea una nueva tarea en el trámite indicado."""
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_tarea_id = request.form.get('tipo_tarea_id', type=int)
+    if not tipo_tarea_id:
+        return jsonify({'ok': False, 'error': 'tipo_tarea_id es obligatorio'}), 400
+    if not TipoTarea.query.get(tipo_tarea_id):
+        return jsonify({'ok': False, 'error': 'Tipo de tarea no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'TAREA', tipo_id=tipo_tarea_id, padre_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea = Tarea(tramite_id=tram_id, tipo_tarea_id=tipo_tarea_id)
+    db.session.add(tarea)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': tarea.id, 'advertencia': advertencia})
+
+
+# ============================================
+# ENDPOINTS POST — BORRAR entidades
+# ============================================
+
+@bp.route('/fase/<int:fase_id>/borrar', methods=['POST'])
+@login_required
+def borrar_fase(fase_id):
+    """Elimina una fase si el motor de reglas lo permite."""
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    db.session.delete(fase)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/tramite/<int:tram_id>/borrar', methods=['POST'])
+@login_required
+def borrar_tramite(tram_id):
+    """Elimina un trámite si el motor de reglas lo permite."""
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    db.session.delete(tramite)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/tarea/<int:tarea_id>/borrar', methods=['POST'])
+@login_required
+def borrar_tarea(tarea_id):
+    """Elimina una tarea si el motor de reglas lo permite."""
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    db.session.delete(tarea)
+    db.session.commit()
+    return jsonify({'ok': True})

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -1,0 +1,597 @@
+"""
+Motor de reglas — Evaluador de acciones sobre entidades ESFTT.
+
+Principio rector: todo está PERMITIDO excepto lo expresamente prohibido.
+Flujo de evaluación:
+  1. Construir contexto jerárquico (sube hasta Expediente/Proyecto)
+  2. Ejecutar checks estructurales hardcoded (invariantes de negocio)
+  3. Consultar reglas en BD y evaluar condiciones configurables
+  4. BLOQUEAR tiene prioridad sobre ADVERTIR
+
+Uso:
+    from app.services.motor_reglas import evaluar
+
+    # Crear una fase (tipo_fase_id=8) dentro de la solicitud 23
+    res = evaluar('CREAR', 'FASE', tipo_id=8, padre_id=23)
+
+    # Iniciar la fase 45
+    res = evaluar('INICIAR', 'FASE', entidad_id=45)
+
+    # Borrar la tarea 12
+    res = evaluar('BORRAR', 'TAREA', entidad_id=12)
+
+    if not res.permitido:
+        return jsonify({'ok': False, 'error': res.mensaje, 'norma': res.norma}), 422
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from app import db
+from app.models.expedientes import Expediente
+from app.models.solicitudes import Solicitud
+from app.models.fases import Fase
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+from app.models.tipos_fases import TipoFase
+from app.models.tipos_tramites import TipoTramite
+from app.models.tipos_tareas import TipoTarea
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.solicitudes_tipos import SolicitudTipo
+from app.models.motor_reglas import ReglaMotor, CondicionRegla
+
+
+# ---------------------------------------------------------------------------
+# Resultado público
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvaluacionResult:
+    permitido: bool
+    nivel: str     # 'BLOQUEAR' | 'ADVERTIR' | ''
+    mensaje: str
+    norma: str
+
+
+# Resultado singleton para "todo ok"
+PERMITIDO = EvaluacionResult(permitido=True, nivel='', mensaje='', norma='')
+
+
+# ---------------------------------------------------------------------------
+# Contexto jerárquico (privado)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Contexto:
+    """Snapshot del árbol ESFTT necesario para evaluar una regla."""
+    entidad: str
+    tarea:      Optional[Tarea]      = field(default=None)
+    tramite:    Optional[Tramite]    = field(default=None)
+    fase:       Optional[Fase]       = field(default=None)
+    solicitud:  Optional[Solicitud]  = field(default=None)
+    expediente: Optional[Expediente] = field(default=None)
+    proyecto:   Optional[object]     = field(default=None)  # Proyecto
+
+
+def _construir_contexto(evento: str, entidad: str,
+                        entidad_id: Optional[int],
+                        padre_id: Optional[int]) -> _Contexto:
+    """
+    Sube el árbol jerárquico desde el objeto indicado hasta Expediente/Proyecto.
+
+    Para CREAR, padre_id es el ID del contenedor (solicitud, fase o tramite).
+    Para INICIAR/FINALIZAR/BORRAR, entidad_id es el ID del objeto en cuestión.
+    """
+    ctx = _Contexto(entidad=entidad)
+
+    if evento == 'CREAR':
+        _ctx_crear(entidad, padre_id, ctx)
+    else:
+        _ctx_operar(entidad, entidad_id, ctx)
+
+    return ctx
+
+
+def _ctx_crear(entidad: str, padre_id: Optional[int], ctx: _Contexto) -> None:
+    """Construye contexto para evento CREAR (padre_id = contenedor)."""
+    if entidad == 'SOLICITUD':
+        # padre_id = expediente_id
+        if padre_id:
+            ctx.expediente = Expediente.query.get(padre_id)
+            if ctx.expediente:
+                ctx.proyecto = ctx.expediente.proyecto
+
+    elif entidad == 'FASE':
+        # padre_id = solicitud_id
+        if padre_id:
+            ctx.solicitud = Solicitud.query.get(padre_id)
+            if ctx.solicitud:
+                ctx.expediente = ctx.solicitud.expediente
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'TRAMITE':
+        # padre_id = fase_id
+        if padre_id:
+            ctx.fase = Fase.query.get(padre_id)
+            if ctx.fase:
+                ctx.solicitud = ctx.fase.solicitud
+                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'TAREA':
+        # padre_id = tramite_id
+        if padre_id:
+            ctx.tramite = Tramite.query.get(padre_id)
+            if ctx.tramite:
+                ctx.fase = ctx.tramite.fase
+                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
+                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+
+def _ctx_operar(entidad: str, entidad_id: Optional[int], ctx: _Contexto) -> None:
+    """Construye contexto para INICIAR/FINALIZAR/BORRAR."""
+    if entidad == 'TAREA':
+        if entidad_id:
+            ctx.tarea = Tarea.query.get(entidad_id)
+            if ctx.tarea:
+                ctx.tramite = ctx.tarea.tramite
+                ctx.fase = ctx.tramite.fase if ctx.tramite else None
+                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
+                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'TRAMITE':
+        if entidad_id:
+            ctx.tramite = Tramite.query.get(entidad_id)
+            if ctx.tramite:
+                ctx.fase = ctx.tramite.fase
+                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
+                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'FASE':
+        if entidad_id:
+            ctx.fase = Fase.query.get(entidad_id)
+            if ctx.fase:
+                ctx.solicitud = ctx.fase.solicitud
+                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'SOLICITUD':
+        if entidad_id:
+            ctx.solicitud = Solicitud.query.get(entidad_id)
+            if ctx.solicitud:
+                ctx.expediente = ctx.solicitud.expediente
+                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
+
+    elif entidad == 'EXPEDIENTE':
+        if entidad_id:
+            ctx.expediente = Expediente.query.get(entidad_id)
+            if ctx.expediente:
+                ctx.proyecto = ctx.expediente.proyecto
+
+
+# ---------------------------------------------------------------------------
+# Checks estructurales hardcoded
+# ---------------------------------------------------------------------------
+
+def _checks_hardcoded(evento: str, entidad: str,
+                      ctx: _Contexto) -> Optional[EvaluacionResult]:
+    """
+    Invariantes de negocio no configurables en BD.
+    Retorna EvaluacionResult(BLOQUEAR) si se viola una regla, None si todo OK.
+    """
+    if evento == 'BORRAR':
+        return _check_borrar(entidad, ctx)
+    elif evento == 'FINALIZAR':
+        return _check_finalizar(entidad, ctx)
+    return None
+
+
+def _check_borrar(entidad: str, ctx: _Contexto) -> Optional[EvaluacionResult]:
+    if entidad in ('FASE', 'TRAMITE', 'TAREA'):
+        obj = ctx.fase or ctx.tramite or ctx.tarea
+        if obj and obj.fecha_inicio is not None:
+            return EvaluacionResult(
+                permitido=False,
+                nivel='BLOQUEAR',
+                mensaje='No se puede eliminar una entidad ya iniciada.',
+                norma=''
+            )
+
+    elif entidad == 'SOLICITUD':
+        if ctx.solicitud:
+            tiene_fase_iniciada = db.session.query(Fase).filter(
+                Fase.solicitud_id == ctx.solicitud.id,
+                Fase.fecha_inicio.isnot(None)
+            ).first()
+            if tiene_fase_iniciada:
+                return EvaluacionResult(
+                    permitido=False,
+                    nivel='BLOQUEAR',
+                    mensaje='No se puede eliminar una solicitud con fases ya iniciadas.',
+                    norma=''
+                )
+    return None
+
+
+def _check_finalizar(entidad: str, ctx: _Contexto) -> Optional[EvaluacionResult]:
+    if entidad == 'SOLICITUD':
+        if ctx.solicitud:
+            fase_abierta = db.session.query(Fase).filter(
+                Fase.solicitud_id == ctx.solicitud.id,
+                Fase.fecha_fin.is_(None)
+            ).first()
+            if fase_abierta:
+                return EvaluacionResult(
+                    permitido=False,
+                    nivel='BLOQUEAR',
+                    mensaje='Hay fases sin cerrar. Finalice todas las fases antes de cerrar la solicitud.',
+                    norma=''
+                )
+
+    elif entidad == 'FASE':
+        if ctx.fase:
+            tramite_abierto = db.session.query(Tramite).filter(
+                Tramite.fase_id == ctx.fase.id,
+                Tramite.fecha_fin.is_(None)
+            ).first()
+            if tramite_abierto:
+                return EvaluacionResult(
+                    permitido=False,
+                    nivel='BLOQUEAR',
+                    mensaje='Hay trámites sin cerrar. Finalice todos los trámites antes de cerrar la fase.',
+                    norma=''
+                )
+
+    elif entidad == 'TRAMITE':
+        if ctx.tramite:
+            tarea_abierta = db.session.query(Tarea).filter(
+                Tarea.tramite_id == ctx.tramite.id,
+                Tarea.fecha_fin.is_(None)
+            ).first()
+            if tarea_abierta:
+                return EvaluacionResult(
+                    permitido=False,
+                    nivel='BLOQUEAR',
+                    mensaje='Hay tareas sin ejecutar. Finalice todas las tareas antes de cerrar el trámite.',
+                    norma=''
+                )
+
+    elif entidad == 'TAREA':
+        return _check_finalizar_tarea(ctx)
+
+    return None
+
+
+# Tipos de tarea que requieren documento producido al finalizar
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+
+# Tipos de tarea que requieren documento de entrada al finalizar
+_TIPOS_REQUIEREN_DOC_USADO = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+
+
+def _check_finalizar_tarea(ctx: _Contexto) -> Optional[EvaluacionResult]:
+    tarea = ctx.tarea
+    if not tarea or not tarea.tipo_tarea:
+        return None
+
+    codigo = tarea.tipo_tarea.codigo
+
+    if codigo in _TIPOS_REQUIEREN_DOC_PRODUCIDO and tarea.documento_producido_id is None:
+        return EvaluacionResult(
+            permitido=False,
+            nivel='BLOQUEAR',
+            mensaje='Falta el documento producido. Asócielo antes de finalizar la tarea.',
+            norma=''
+        )
+
+    if codigo in _TIPOS_REQUIEREN_DOC_USADO and tarea.documento_usado_id is None:
+        return EvaluacionResult(
+            permitido=False,
+            nivel='BLOQUEAR',
+            mensaje='Falta el documento de entrada. Asócielo antes de finalizar la tarea.',
+            norma=''
+        )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Evaluadores de criterio
+# ---------------------------------------------------------------------------
+
+def _evaluar_criterio(tipo_criterio: str, parametros: dict,
+                      ctx: _Contexto, params: dict) -> bool:
+    """
+    Despacha al evaluador específico según el tipo_criterio.
+    Devuelve True si la condición se cumple.
+    """
+    evaluadores = {
+        'EXISTE_FASE_CERRADA':      _criterio_existe_fase_cerrada,
+        'EXISTE_FASE_CON_RESULTADO': _criterio_existe_fase_con_resultado,
+        'VARIABLE_EXPEDIENTE':      _criterio_variable_expediente,
+        'VARIABLE_PROYECTO':        _criterio_variable_proyecto,
+        'TIPO_FASE_PADRE_ES':       _criterio_tipo_fase_padre_es,
+        'EXISTE_TAREA_TIPO':        _criterio_existe_tarea_tipo,
+        'EXISTE_TRAMITE_TIPO':      _criterio_existe_tramite_tipo,
+        'ESTADO_SOLICITUD':         _criterio_estado_solicitud,
+        'EXISTE_TIPO_SOLICITUD':    _criterio_existe_tipo_solicitud,
+        # Stubs — requieren modelo Documento (pendiente)
+        'EXISTE_DOCUMENTO_TIPO':    lambda p, c, ps: False,
+        'EXISTE_DOC_ORGANISMO':     lambda p, c, ps: False,
+    }
+    fn = evaluadores.get(tipo_criterio)
+    if fn is None:
+        # Criterio desconocido: por seguridad, se considera no cumplido
+        return False
+    return fn(parametros, ctx, params)
+
+
+def _criterio_existe_fase_cerrada(p: dict, ctx: _Contexto, params: dict) -> bool:
+    """¿Existe una fase cerrada del tipo indicado en la solicitud?"""
+    if not ctx.solicitud:
+        return False
+    tipo_fase_codigo = p.get('tipo_fase_codigo')
+    q = db.session.query(Fase).join(TipoFase, Fase.tipo_fase_id == TipoFase.id).filter(
+        Fase.solicitud_id == ctx.solicitud.id,
+        Fase.fecha_fin.isnot(None)
+    )
+    if tipo_fase_codigo:
+        q = q.filter(TipoFase.codigo == tipo_fase_codigo)
+    return q.first() is not None
+
+
+def _criterio_existe_fase_con_resultado(p: dict, ctx: _Contexto, params: dict) -> bool:
+    """¿Existe una fase del tipo indicado con alguno de los resultados especificados?"""
+    if not ctx.solicitud:
+        return False
+    from app.models.tipos_resultados_fases import TipoResultadoFase
+    tipo_fase_codigo  = p.get('tipo_fase_codigo')
+    resultado_codigos = p.get('resultado_codigos', [])
+    q = (db.session.query(Fase)
+         .join(TipoFase, Fase.tipo_fase_id == TipoFase.id)
+         .join(TipoResultadoFase, Fase.resultado_fase_id == TipoResultadoFase.id)
+         .filter(Fase.solicitud_id == ctx.solicitud.id))
+    if tipo_fase_codigo:
+        q = q.filter(TipoFase.codigo == tipo_fase_codigo)
+    if resultado_codigos:
+        q = q.filter(TipoResultadoFase.codigo.in_(resultado_codigos))
+    return q.first() is not None
+
+
+def _navegar_dot(obj, ruta: str):
+    """Navega una ruta dot-notation ('campo.subcampo') sobre un objeto."""
+    for parte in ruta.split('.'):
+        if obj is None:
+            return None
+        obj = getattr(obj, parte, None)
+    return obj
+
+
+_OPERADORES = {
+    'EQ':      lambda v, ref: v == ref,
+    'NEQ':     lambda v, ref: v != ref,
+    'IN':      lambda v, ref: v in (ref if isinstance(ref, list) else [ref]),
+    'NOT_IN':  lambda v, ref: v not in (ref if isinstance(ref, list) else [ref]),
+    'IS_NULL': lambda v, _: v is None,
+    'NOT_NULL': lambda v, _: v is not None,
+}
+
+
+def _criterio_variable_expediente(p: dict, ctx: _Contexto, params: dict) -> bool:
+    if not ctx.expediente:
+        return False
+    valor = _navegar_dot(ctx.expediente, p['campo'])
+    op_fn = _OPERADORES.get(p.get('operador', 'EQ'))
+    return op_fn(valor, p.get('valor')) if op_fn else False
+
+
+def _criterio_variable_proyecto(p: dict, ctx: _Contexto, params: dict) -> bool:
+    if not ctx.proyecto:
+        return False
+    valor = _navegar_dot(ctx.proyecto, p['campo'])
+    op_fn = _OPERADORES.get(p.get('operador', 'EQ'))
+    return op_fn(valor, p.get('valor')) if op_fn else False
+
+
+def _criterio_tipo_fase_padre_es(p: dict, ctx: _Contexto, params: dict) -> bool:
+    if not ctx.fase or not ctx.fase.tipo_fase:
+        return False
+    return ctx.fase.tipo_fase.codigo == p.get('tipo_fase_codigo')
+
+
+def _criterio_existe_tarea_tipo(p: dict, ctx: _Contexto, params: dict) -> bool:
+    """¿Existe una tarea del tipo indicado en el trámite actual?"""
+    if not ctx.tramite:
+        return False
+    codigo = p.get('tipo_tarea_codigo')
+    cerrada = p.get('cerrada', False)
+    requiere_doc_producido = p.get('requiere_doc_producido', False)
+
+    q = (db.session.query(Tarea)
+         .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
+         .filter(Tarea.tramite_id == ctx.tramite.id))
+    if codigo:
+        q = q.filter(TipoTarea.codigo == codigo)
+    if cerrada:
+        q = q.filter(Tarea.fecha_fin.isnot(None))
+    if requiere_doc_producido:
+        q = q.filter(Tarea.documento_producido_id.isnot(None))
+    return q.first() is not None
+
+
+def _criterio_existe_tramite_tipo(p: dict, ctx: _Contexto, params: dict) -> bool:
+    """¿Existe un trámite del tipo indicado en la fase actual?"""
+    if not ctx.fase:
+        return False
+    codigo = p.get('tipo_tramite_codigo')
+    cerrado = p.get('cerrado', False)
+    requiere_doc_producido = p.get('requiere_doc_producido', False)
+
+    q = (db.session.query(Tramite)
+         .join(TipoTramite, Tramite.tipo_tramite_id == TipoTramite.id)
+         .filter(Tramite.fase_id == ctx.fase.id))
+    if codigo:
+        q = q.filter(TipoTramite.codigo == codigo)
+    if cerrado:
+        q = q.filter(Tramite.fecha_fin.isnot(None))
+    if requiere_doc_producido:
+        # Existe al menos una tarea en ese trámite con documento producido
+        q = q.filter(
+            db.session.query(Tarea)
+            .filter(Tarea.tramite_id == Tramite.id,
+                    Tarea.documento_producido_id.isnot(None))
+            .exists()
+        )
+    return q.first() is not None
+
+
+def _criterio_estado_solicitud(p: dict, ctx: _Contexto, params: dict) -> bool:
+    if not ctx.solicitud:
+        return False
+    return ctx.solicitud.estado == p.get('estado')
+
+
+def _criterio_existe_tipo_solicitud(p: dict, ctx: _Contexto, params: dict) -> bool:
+    if not ctx.solicitud:
+        return False
+    siglas = p.get('tipo_solicitud_codigo')
+    resultado = (db.session.query(SolicitudTipo)
+                 .join(TipoSolicitud, SolicitudTipo.tiposolicitudid == TipoSolicitud.id)
+                 .filter(SolicitudTipo.solicitudid == ctx.solicitud.id,
+                         TipoSolicitud.siglas == siglas)
+                 .first())
+    return resultado is not None
+
+
+# ---------------------------------------------------------------------------
+# Evaluación de condiciones de una regla
+# ---------------------------------------------------------------------------
+
+def _evaluar_regla(regla: ReglaMotor, ctx: _Contexto, params: dict) -> bool:
+    """
+    Evalúa todas las condiciones de una regla.
+    Sin condiciones → regla siempre dispara (True).
+    Combina condiciones izq→dcha usando operador_siguiente[i].
+    """
+    condiciones = sorted(regla.condiciones, key=lambda c: c.orden)
+    if not condiciones:
+        return True
+
+    resultados = []
+    for cond in condiciones:
+        val = _evaluar_criterio(cond.tipo_criterio, cond.parametros or {}, ctx, params)
+        if cond.negacion:
+            val = not val
+        resultados.append((val, cond.operador_siguiente))
+
+    # Combinar usando el operador_siguiente de cada condición con la siguiente
+    acumulado = resultados[0][0]
+    for i in range(1, len(resultados)):
+        operador = resultados[i - 1][1]  # operador entre i-1 e i
+        siguiente = resultados[i][0]
+        if operador == 'OR':
+            acumulado = acumulado or siguiente
+        else:  # AND (por defecto)
+            acumulado = acumulado and siguiente
+
+    return acumulado
+
+
+# ---------------------------------------------------------------------------
+# Función pública principal
+# ---------------------------------------------------------------------------
+
+def evaluar(
+    evento:     str,
+    entidad:    str,
+    tipo_id:    Optional[int] = None,
+    entidad_id: Optional[int] = None,
+    padre_id:   Optional[int] = None,
+    params:     Optional[dict] = None
+) -> EvaluacionResult:
+    """
+    Evalúa si un evento sobre una entidad está permitido.
+
+    Args:
+        evento:     'CREAR' | 'INICIAR' | 'FINALIZAR' | 'BORRAR'
+        entidad:    'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA' | 'EXPEDIENTE'
+        tipo_id:    ID en la tabla tipos_* correspondiente. Para CREAR, es obligatorio.
+                    Para INICIAR/FINALIZAR/BORRAR se deduce del objeto si no se pasa.
+        entidad_id: ID del objeto existente (INICIAR/FINALIZAR/BORRAR).
+        padre_id:   ID del contenedor (CREAR).
+        params:     Parámetros adicionales para evaluadores (ej: organismo_id).
+
+    Returns:
+        EvaluacionResult con permitido=True o False.
+    """
+    if params is None:
+        params = {}
+
+    # --- Construir contexto ---
+    ctx = _construir_contexto(evento, entidad, entidad_id, padre_id)
+
+    # --- Para INICIAR/FINALIZAR/BORRAR, deducir tipo_id si no se pasó ---
+    if tipo_id is None and evento != 'CREAR':
+        tipo_id = _deducir_tipo_id(entidad, ctx)
+
+    # --- Checks estructurales hardcoded ---
+    bloqueo = _checks_hardcoded(evento, entidad, ctx)
+    if bloqueo:
+        return bloqueo
+
+    # --- Consultar reglas en BD ---
+    q = ReglaMotor.query.filter_by(evento=evento, entidad=entidad, activa=True)
+    if tipo_id is not None:
+        # Reglas específicas del tipo O genéricas (tipo_id NULL)
+        q = q.filter(
+            db.or_(ReglaMotor.tipo_id == tipo_id, ReglaMotor.tipo_id.is_(None))
+        )
+    else:
+        # Sin tipo_id conocido: solo reglas genéricas
+        q = q.filter(ReglaMotor.tipo_id.is_(None))
+
+    reglas = q.all()
+
+    # --- Evaluar reglas: primero BLOQUEAR, luego ADVERTIR ---
+    resultado_advertir = None
+
+    for regla in reglas:
+        if _evaluar_regla(regla, ctx, params):
+            if regla.accion == 'BLOQUEAR':
+                return EvaluacionResult(
+                    permitido=False,
+                    nivel='BLOQUEAR',
+                    mensaje=regla.mensaje,
+                    norma=regla.norma or ''
+                )
+            elif regla.accion == 'ADVERTIR' and resultado_advertir is None:
+                # Guardamos la primera advertencia; seguimos buscando BLOQUEARs
+                resultado_advertir = EvaluacionResult(
+                    permitido=True,
+                    nivel='ADVERTIR',
+                    mensaje=regla.mensaje,
+                    norma=regla.norma or ''
+                )
+
+    if resultado_advertir:
+        return resultado_advertir
+
+    return PERMITIDO
+
+
+def _deducir_tipo_id(entidad: str, ctx: _Contexto) -> Optional[int]:
+    """Obtiene el tipo_id del objeto en contexto."""
+    if entidad == 'TAREA'    and ctx.tarea:
+        return ctx.tarea.tipo_tarea_id
+    if entidad == 'TRAMITE'  and ctx.tramite:
+        return ctx.tramite.tipo_tramite_id
+    if entidad == 'FASE'     and ctx.fase:
+        return ctx.fase.tipo_fase_id
+    if entidad == 'SOLICITUD' and ctx.solicitud:
+        # La solicitud puede tener múltiples tipos — no hay un único tipo_id
+        return None
+    return None

--- a/docs/fuentesIA/GuiaGeneralNueva.md
+++ b/docs/fuentesIA/GuiaGeneralNueva.md
@@ -328,15 +328,15 @@ Una fase es un conjunto de trámites para obtener un requisito para alcanzar el 
 
 - `ID` de fase, `ID` de solicitud, tipo de fase, fecha de inicio, fecha de fin, observaciones.
 - **Fecha de fin:** se define como la última fecha de finalización de todos los trámites asociados.
-- **EXITO:** Es el valor booleano del resultado exitoso de la fase. Si es `SI`, la fase ha concluido exitosamente respecto a su tipo. Por ejemplo si la fase es "INFORME MINISTERIO" entonces se ha obtenido el informe favorable. Ese informe estará en el trámite/tarea correspondiente.
+- **RESULTADO_FASE_ID:** FK a `tipos_resultados_fases`. Registra el resultado al cerrar la fase. Valores del catálogo: `FAVORABLE`, `FAVORABLE_CONDICIONADO`, `DESFAVORABLE`, `NO_PROCEDE`, `DESISTIDA`, `ARCHIVADA`. Una fase "exitosa" ≡ `resultado_fase.codigo IN ('FAVORABLE', 'FAVORABLE_CONDICIONADO')`. NULL = fase en curso o pendiente de cierre.
 - **DOCUMENTO_RESULTADO_ID:** posible vínculo al documento oficial generado. Posiblemente desaparezca.
 
 **Rellenado y flujo:**
 
 - La fecha fin de la fase debe ser rellenada **manualmente por el usuario**. En fases posteriores del desarrollo, se podrá añadir una sugerencia automática basada en la fecha del último trámite cerrado, pero nunca será obligatoria ni se aplicará automáticamente.
-- El éxito o no de la fase debe ser registrado **manualmente por el usuario** una vez analizada la documentación oficial correspondiente.
-- Si `EXITO` es nulo, la fase está en curso o pendiente de cierre administrativo.
-- Al tener el valor de éxito relleno (SÍ/NO) la fase se considera concluida y se puede permitir la creación o activación de fases sucesivas según reglas de negocio.
+- El resultado de la fase debe ser registrado **manualmente por el usuario** una vez analizada la documentación oficial correspondiente, eligiendo uno de los valores del catálogo `tipos_resultados_fases`.
+- Si `RESULTADO_FASE_ID` es nulo, la fase está en curso o pendiente de cierre administrativo.
+- Al tener `RESULTADO_FASE_ID` relleno, la fase se considera concluida y se puede permitir la creación o activación de fases sucesivas según reglas de negocio. Las reglas que requieren "fase exitosa" evalúan `resultado_fase.codigo IN ('FAVORABLE', 'FAVORABLE_CONDICIONADO')`.
 
 **Reglas de negocio y validación:**
 

--- a/docs/fuentesIA/MOTOR_REGLAS_arquitectura.md
+++ b/docs/fuentesIA/MOTOR_REGLAS_arquitectura.md
@@ -1,19 +1,18 @@
 # MOTOR_REGLAS — Arquitectura de diseño
 
-> **Fecha:** 2026-02-27
-> Documento derivado del análisis de dos ejemplos reales de tramitación AT en Andalucía.
+> **Última revisión:** 2026-02-28
+> Documento derivado del análisis de dos ejemplos reales de tramitación AT en Andalucía
+> y revisión exhaustiva en sesión con el técnico del servicio.
 
 ---
 
 ## Decisión de partida
 
-Se abandona la investigación legislativa exhaustiva (Perplexity) como prerequisito.
-Motivo: el diseño del mecanismo de evaluación es más urgente que tener todas las reglas.
+Se abandona la investigación legislativa exhaustiva como prerequisito.
 Las reglas se irán añadiendo progresivamente en producción — una, probarla, iterar.
 
-Lo que sí se hace ahora (Fase 2): colocar hooks en las rutas y modelos ESFTT
-con la firma definitiva del evaluador, devolviendo siempre PERMITIDO hasta que
-el motor esté implementado en Fase 3.
+**Fase 2 (actual):** Hooks en rutas y modelos ESFTT con la firma definitiva del evaluador,
+devolviendo siempre PERMITIDO hasta que el motor esté implementado en Fase 3.
 
 ---
 
@@ -24,33 +23,61 @@ el motor esté implementado en Fase 3.
 El motor no define qué está permitido — define qué está prohibido en cada momento.
 La iniciativa es siempre del técnico tramitador; el motor valida o informa.
 El motor no genera el flujo automáticamente; responde a la pregunta:
-"¿Está esto prohibido ahora mismo en estas circunstancias?"
+«¿Está esto prohibido ahora mismo en estas circunstancias?»
+
+---
+
+## Vocabulario de eventos del motor
+
+El motor distingue cuatro eventos en el ciclo de vida de cualquier entidad ESFTT:
+
+| Evento | Semántica | Tipo de acción habitual |
+|--------|-----------|------------------------|
+| **CREAR** | ¿Es conceptualmente válido planificar esto en este contexto? | ADVERTIR (absurdo pero no imposible) o BLOQUEAR (imposible) |
+| **INICIAR** | ¿Están cumplidos los prerequisitos para comenzar a ejecutar? | BLOQUEAR (restricción dura) |
+| **FINALIZAR** | ¿Pueden cerrarse sus hijos? ¿Tiene documento requerido? | BLOQUEAR |
+| **BORRAR** | ¿Ha sido ya iniciada la entidad? | BLOQUEAR si `fecha_inicio IS NOT NULL` |
+
+**Distinción CREAR vs INICIAR:**
+- CREAR corresponde al momento de insertar el registro, que puede ser sin `fecha_inicio` (planificación). Valida coherencia conceptual con el contexto.
+- INICIAR corresponde al momento de poner `fecha_inicio` por primera vez (puede ocurrir en el mismo formulario de creación o en una edición posterior). Valida que los prerequisitos estén cumplidos.
+
+**SOLICITUD** no tiene `fecha_inicio` — se crea siempre activa con `fecha_solicitud` (NOT NULL).
+Solo tiene CREAR, FINALIZAR y BORRAR.
+
+**Sobre el borrado:**
+Una entidad iniciada (`fecha_inicio IS NOT NULL`) implica actividad administrativa con posible rastro externo (documentos en servidor de archivos, notificaciones enviadas). El criterio es binario: si se ha iniciado, no se borra — se finaliza ordenadamente incluso si hay incumplimiento de otras reglas, dejando rastro justificado. Si una entidad finalizada impide crear una nueva por reglas, la solución es revisar las reglas, no permitir el borrado.
 
 ---
 
 ## Arquitectura: un solo evaluador, no múltiples motores
 
 Un único evaluador con reglas etiquetadas por evento y entidad.
-La diferencia entre "motor de creación" y "motor de cierre" es solo un filtro
-`WHERE evento='CREAR'` — no código separado.
+La diferencia entre «motor de creación» y «motor de cierre» es solo un filtro
+`WHERE evento='INICIAR'` — no código separado.
 
 ---
 
 ## Firma del evaluador
 
-Asimetría necesaria entre CREAR y CERRAR/BORRAR:
+Asimetría necesaria entre CREAR/INICIAR y FINALIZAR/BORRAR:
 
 ```python
 # CREAR: la entidad aún no existe
 evaluar(evento='CREAR', entidad='FASE', tipo_id=8, padre_id=23, params={})
 
-# CERRAR / BORRAR: la entidad ya existe; el motor lee el tipo desde la BD
-evaluar(evento='CERRAR', entidad='FASE', entidad_id=45, params={})
+# INICIAR: la entidad ya existe (está planificada); el motor lee el tipo desde la BD
+evaluar(evento='INICIAR', entidad='FASE', entidad_id=45, params={})
+
+# FINALIZAR / BORRAR: la entidad ya existe
+evaluar(evento='FINALIZAR', entidad='FASE', entidad_id=45, params={})
+evaluar(evento='BORRAR',    entidad='FASE', entidad_id=45, params={})
 ```
 
 Retorna: `EvaluacionResult(permitido: bool, nivel: str, mensaje: str, norma: str)`
 
-`params` solo es necesario en un caso conocido: `organismo_id` para SEPARATAS.
+`params` solo es necesario en casos especiales actualmente no confirmados tras la
+revisión del patrón SEPARATAS (ver sección «Zona gris — consultas a organismos»).
 
 ---
 
@@ -59,21 +86,37 @@ Retorna: `EvaluacionResult(permitido: bool, nivel: str, mensaje: str, norma: str
 | Código | Qué evalúa |
 |--------|-----------|
 | EXISTE_DOCUMENTO_TIPO | ¿Hay documento de tipo X (ej: DR_NO_DUP) en esta solicitud/expediente? |
-| VARIABLE_EXPEDIENTE | ¿Campo Y del expediente tiene valor Z? (ej: figura_ambiental = CA) |
-| EXISTE_FASE_EXITO | ¿Hay fase de tipo X cerrada con éxito en esta solicitud? |
+| VARIABLE_EXPEDIENTE | ¿Campo Y del expediente tiene valor Z? (ej: tipo_expediente_id = 1) |
+| VARIABLE_PROYECTO | ¿Campo Y del proyecto tiene valor Z? (ej: ia.siglas = CA, es_modificacion = true) |
+| EXISTE_FASE_EXITO | ¿Hay fase de tipo X cerrada con resultado favorable en esta solicitud? |
 | EXISTE_DOC_ORGANISMO | ¿Hay DR de tipo X para organismo concreto? |
 
 El motor hace los JOINs internamente subiendo el árbol jerárquico:
-TAREA → TRAMITE → FASE → SOLICITUD → EXPEDIENTE.
+TAREA → TRAMITE → FASE → SOLICITUD → EXPEDIENTE → PROYECTO.
+
+`VARIABLE_PROYECTO` accede a `expediente.proyecto` (relación 1:1 garantizada).
 
 ---
 
-## Declaraciones responsables (DRs)
+## Campos en Proyecto necesarios para el motor
 
-Son documentos incorporados por el técnico como documentos tipificados individuales.
-No se ocultan en zips. El motor las localiza por tipo de documento.
-Se integran en el modelo documental existente mediante tabla secundaria
-(patrón análogo a DocumentoProyecto), pendiente de definir.
+### `proyecto.ia_id` — ya implementado
+FK a tabla `tipos_ia`. Instrumento ambiental del proyecto.
+
+| id | siglas | Descripción |
+|----|--------|-------------|
+| 1 | AAI | Autorización Ambiental Integrada |
+| 2 | AAU | Autorización Ambiental Unificada |
+| 3 | AAUS | Autorización Ambiental Unificada Simplificada |
+| 4 | CA | Calificación Ambiental |
+| 5 | EXENTO | Exento de instrumento ambiental |
+
+El motor accede como `proyecto.ia.siglas` (criterio `VARIABLE_PROYECTO`).
+
+### `proyecto.es_modificacion` — **pendiente de implementar**
+`Boolean`, default `False`. Indica si el expediente tramita una modificación de
+instalaciones existentes (frente a instalación nueva).
+Afecta directamente a las reglas de tramitación ambiental (ver mapa de reglas).
 
 ---
 
@@ -94,33 +137,55 @@ Si es **FALSE → operación permitida** (principio de todo permitido excepto pr
 | CREAR | RENUNCIA | NOT EXISTS solicitud resuelta favorablemente en este expediente | BLOQUEAR |
 | CREAR | RECURSO | NOT EXISTS resolución emitida en este expediente | BLOQUEAR |
 | CREAR | RAIPEE_DEFINITIVA | NOT EXISTS RAIPEE_PREVIA resuelta en este expediente | ADVERTIR |
-| CERRAR | cualquiera | NOT EXISTS fase RESOLUCION con fecha_fin not null AND exito=true en esta solicitud | BLOQUEAR |
-| BORRAR | cualquiera | EXISTS tarea tipo NOTIFICAR o PUBLICAR con fecha_fin not null en esta solicitud | BLOQUEAR |
+| FINALIZAR | cualquiera | NOT EXISTS fase RESOLUCION con `fecha_fin IS NOT NULL` en esta solicitud | BLOQUEAR |
+| BORRAR | cualquiera | EXISTS fase con `fecha_inicio IS NOT NULL` en esta solicitud | BLOQUEAR |
+
+**Nota FINALIZAR:** Solo se requiere que exista una fase RESOLUCION completada.
+El resultado de la resolución (favorable o desfavorable) es irrelevante para el cierre
+de la solicitud — una resolución denegatoria es el mecanismo ordinario de finalización.
+
+---
 
 ### FASE — padre_id: solicitud_id
 
 | evento | tipo (codigo) | Condición (si TRUE → acción) | Acción |
 |--------|--------------|------------------------------|--------|
-| CREAR | INFORMACION_PUBLICA | EXISTS documento tipo DR_NO_DUP en esta solicitud AND figura_ambiental NOT IN {AAU, AAUs} | BLOQUEAR |
-| CREAR | FIGURA_AMBIENTAL_EXTERNA | figura_ambiental NOT IN {CA} | BLOQUEAR |
-| CREAR | AAU_AAUS_INTEGRADA | figura_ambiental NOT IN {AAU, AAUs} | BLOQUEAR |
-| CREAR | RESOLUCION | figura_ambiental = CA AND NOT EXISTS fase FIGURA_AMBIENTAL_EXTERNA con exito=true | BLOQUEAR |
-| CREAR | RESOLUCION | NOT EXISTS fase ANALISIS_TECNICO con fecha_fin not null (regla interna del servicio) | BLOQUEAR |
-| CREAR | CONSULTA_MINISTERIO | tipo_expediente NOT IN {competencia compartida con Ministerio} | BLOQUEAR |
-| CREAR | ADMISION_TRAMITE | tipo_expediente NOT IN {generación renovable} | BLOQUEAR |
-| CERRAR | cualquiera | EXISTS trámite con fecha_fin IS NULL en esta fase | BLOQUEAR |
-| BORRAR | cualquiera | EXISTS tarea con fecha_fin IS NOT NULL en algún trámite de esta fase | BLOQUEAR |
+| CREAR | CONSULTA_MINISTERIO | `expediente.tipo_expediente_id` NOT IN {1} (Transporte) | BLOQUEAR |
+| CREAR | ADMISION_TRAMITE | `expediente.tipo_expediente_id` NOT IN {4} (Renovable) | BLOQUEAR |
+| INICIAR | INFORMACION_PUBLICA | EXISTS documento tipo DR_NO_DUP en esta solicitud AND `proyecto.ia.siglas` NOT IN {AAU, AAUS} | BLOQUEAR |
+| INICIAR | FIGURA_AMBIENTAL_EXTERNA | `proyecto.ia.siglas` NOT IN {CA, AAI} AND NOT (`proyecto.ia.siglas` IN {AAU, AAUS} AND `proyecto.es_modificacion` = true) | BLOQUEAR |
+| INICIAR | AAU_AAUS_INTEGRADA | `proyecto.ia.siglas` NOT IN {AAU, AAUS} OR `proyecto.es_modificacion` = true | BLOQUEAR |
+| INICIAR | RESOLUCION | (`proyecto.ia.siglas` IN {CA, AAI} OR (`proyecto.ia.siglas` IN {AAU, AAUS} AND `proyecto.es_modificacion` = true)) AND NOT EXISTS fase FIGURA_AMBIENTAL_EXTERNA con `cerrada_favorable` = true | BLOQUEAR |
+| INICIAR | RESOLUCION | NOT EXISTS fase ANALISIS_TECNICO con `fecha_fin IS NOT NULL` (regla interna del servicio) | BLOQUEAR |
+| FINALIZAR | cualquiera | EXISTS trámite con `fecha_fin IS NULL` en esta fase | BLOQUEAR |
+| BORRAR | cualquiera | `fecha_inicio IS NOT NULL` | BLOQUEAR |
+
+**Notas sobre tramitación ambiental:**
+- **CA:** siempre se tramita externamente (FIGURA_AMBIENTAL_EXTERNA)
+- **AAI:** siempre se tramita externamente (FIGURA_AMBIENTAL_EXTERNA)
+- **AAU/AAUS + instalación nueva:** se tramita integrada (AAU_AAUS_INTEGRADA)
+- **AAU/AAUS + modificación (`es_modificacion=true`):** se tramita externamente (FIGURA_AMBIENTAL_EXTERNA)
+- La existencia de FIGURA_AMBIENTAL_EXTERNA favorable es prerequisito de INICIAR RESOLUCION para CA, AAI y AAU/AAUS en modificaciones
+
+**Tipos de expediente en BD** (tabla `tipos_expedientes`):
+`1=Transporte, 2=Distribución, 3=Distribución cedida, 4=Renovable, 5=Autoconsumo, 6=LineaDirecta, 7=Convencional, 8=Otros`
+
+---
 
 ### TRÁMITE — padre_id: fase_id
 
-| evento | tipo (codigo) | Condición (si TRUE → acción) | Acción | params |
-|--------|--------------|------------------------------|--------|--------|
-| CREAR | SEPARATAS | EXISTS documento tipo DR_ORGANISMO para organismo_id en esta solicitud | BLOQUEAR | organismo_id |
-| CREAR | ANUNCIO_BOE / ANUNCIO_BOP / ANUNCIO_PRENSA | tipo de la fase padre NOT IN {INFORMACION_PUBLICA} | BLOQUEAR | — |
-| CREAR | PUBLICACION_RESOLUCION | NOT EXISTS trámite ELABORACION_RESOLUCION con fecha_fin not null AND doc_producido_id not null | BLOQUEAR | — |
-| CREAR | NOTIFICACION_RESOLUCION | NOT EXISTS trámite ELABORACION_RESOLUCION con fecha_fin not null AND doc_producido_id not null | BLOQUEAR | — |
-| CERRAR | cualquiera | EXISTS tarea con fecha_fin IS NULL en este trámite | BLOQUEAR | — |
-| BORRAR | cualquiera | EXISTS tarea con fecha_fin IS NOT NULL en este trámite | BLOQUEAR | — |
+| evento | tipo (codigo) | Condición (si TRUE → acción) | Acción |
+|--------|--------------|------------------------------|--------|
+| CREAR | ANUNCIO_BOE / ANUNCIO_BOP / ANUNCIO_PRENSA | tipo de la fase padre NOT IN {INFORMACION_PUBLICA} | BLOQUEAR |
+| INICIAR | PUBLICACION_RESOLUCION | NOT EXISTS trámite ELABORACION_RESOLUCION con `fecha_fin IS NOT NULL` AND `doc_producido_id IS NOT NULL` | BLOQUEAR |
+| INICIAR | NOTIFICACION_RESOLUCION | NOT EXISTS trámite ELABORACION_RESOLUCION con `fecha_fin IS NOT NULL` AND `doc_producido_id IS NOT NULL` | BLOQUEAR |
+| FINALIZAR | cualquiera | EXISTS tarea con `fecha_fin IS NULL` en este trámite | BLOQUEAR |
+| BORRAR | cualquiera | `fecha_inicio IS NOT NULL` | BLOQUEAR |
+
+**Nota SEPARATAS:** Eliminada de las reglas conocidas. Requiere diseño previo de
+la tabla `entidades_consultadas`. Ver sección «Zona gris — consultas a organismos».
+
+---
 
 ### TAREA — padre_id: tramite_id
 
@@ -129,52 +194,54 @@ Las tareas tienen solo 7 tipos genéricos. Sus reglas son de secuencia interna
 
 | evento | tipo (codigo) | Condición (si TRUE → acción) | Acción |
 |--------|--------------|------------------------------|--------|
-| CREAR | FIRMAR | NOT EXISTS tarea REDACTAR con fecha_fin not null AND doc_producido_id not null en este trámite | BLOQUEAR |
-| CREAR | NOTIFICAR | NOT EXISTS tarea FIRMAR con fecha_fin not null AND doc_producido_id not null en este trámite | BLOQUEAR |
-| CREAR | PUBLICAR | NOT EXISTS tarea FIRMAR con fecha_fin not null AND doc_producido_id not null en este trámite | BLOQUEAR |
-| CERRAR | REDACTAR / FIRMAR / INCORPORAR | doc_producido_id IS NULL | BLOQUEAR |
-| CERRAR | NOTIFICAR / PUBLICAR | doc_usado_id IS NULL | BLOQUEAR |
-| BORRAR | cualquiera | fecha_fin IS NOT NULL | BLOQUEAR |
+| INICIAR | FIRMAR | NOT EXISTS tarea REDACTAR con `fecha_fin IS NOT NULL` AND `doc_producido_id IS NOT NULL` en este trámite | BLOQUEAR |
+| INICIAR | NOTIFICAR | NOT EXISTS tarea FIRMAR con `fecha_fin IS NOT NULL` AND `doc_producido_id IS NOT NULL` en este trámite | BLOQUEAR |
+| INICIAR | PUBLICAR | NOT EXISTS tarea FIRMAR con `fecha_fin IS NOT NULL` AND `doc_producido_id IS NOT NULL` en este trámite | BLOQUEAR |
+| FINALIZAR | REDACTAR / FIRMAR / INCORPORAR | `doc_producido_id IS NULL` | BLOQUEAR |
+| FINALIZAR | NOTIFICAR / PUBLICAR | `doc_usado_id IS NULL` | BLOQUEAR |
+| BORRAR | cualquiera | `fecha_inicio IS NOT NULL` | BLOQUEAR |
 
 ---
 
-## Observaciones clave
+## Zona gris — consultas a organismos
 
-1. **TAREAS primero:** Sus reglas son las más mecánicas y universales.
-   Mejor candidato para implementar en primera iteración del motor.
+**Estado:** Pendiente de diseño. Issue draft creado para refinamiento con el técnico.
 
-2. **FASES son el nivel más legislativo:** Aquí viven las excepciones
-   de los decretos de simplificación. Requieren el contexto más rico.
+Este patrón afecta al trámite SEPARATAS (y posiblemente a LISTA — informe de incidencia
+territorial por Ley de Sostenibilidad de Andalucía — y a otras consultas externas).
 
-3. **El motor sube el árbol:** Una regla de TAREA puede necesitar
-   el tipo del TRAMITE padre o el tipo de FASE abuelo. El motor hace
-   los JOINs — no se necesita pasar contexto completo en la llamada.
+**Principio de diseño:** Este mecanismo NO debe implementarse de forma ad-hoc en
+el HTML de un trámite concreto. Debe elevarse al nivel expediente/proyecto para que
+sea reutilizable y no genere variaciones hardcodeadas en plantillas.
 
-4. **SEPARATAS es el único caso especial:** Es el único donde `params`
-   es necesario (organismo_id). Todos los demás casos funcionan
-   con (evento, entidad, tipo_id, padre_id/entidad_id) sin extras.
+**Diseño tentativo:**
+- Tabla `entidades_consultadas` (solicitud_id FK, entidad_id FK → entidades). Lista de organismos a consultar en esta solicitud concreta.
+- **Al añadir entidad a la lista:** si EXISTS DR_ORGANISMO para esa entidad en esta solicitud → BLOQUEAR (el organismo ya declaró responsablemente, no hay que consultarle).
+- **Al incorporar un documento DR_ORGANISMO** para entidad que ya está en `entidades_consultadas` → ADVERTIR (contradicción — la entidad fue incluida en consulta y ahora aporta DR; el técnico decide).
+- **Trámite SEPARATAS:** la tarea REDACTAR usa plantilla de generación múltiple basada en toda la lista `entidades_consultadas`. Si una entidad está en la lista es porque el técnico la incluyó conscientemente.
+
+**Otros tramites de consulta:**
+- LISTA (Ley de Sostenibilidad): cubre mediante nuevos tipos en `tipos_fases` / `tipos_tramites`. No requiere tabla especial.
+- Las separatas en sí (SEPARATAS) son documentos individuales por organismo — el diseño de la plantilla múltiple está pendiente.
 
 ---
 
 ## Compatibilidad de tipos en una solicitud
 
 Una solicitud puede tener múltiples tipos simultáneamente (N:M via `solicitudes_tipos`),
-pero no todas las combinaciones son válidas. Ejemplos:
-
-- `AAP + AAE` → PROHIBIDO: AAE implica instalación construida; AAP es anterior a la construcción
-- `DUP + CIERRE` → PROHIBIDO: DUP implica que no se pudo construir; CIERRE implica instalación existente
-- `AAP + AAC` → PERMITIDO: tramitación conjunta estándar
-- `AAP + AAC + DUP` → PERMITIDO: procedimiento estándar para instalaciones que requieren utilidad pública
+pero no todas las combinaciones son válidas.
 
 **Decisión de diseño: whitelist (pares permitidos), no blacklist.**
 
-Excepción justificada al principio "todo permitido excepto prohibido":
-- Con 17 tipos hay 136 pares posibles; la mayoría son absurdos por definición
-- Definir los prohibidos requeriría listar ~120 pares para dejar ~16 válidos
-- Un tipo nuevo añadido sin actualizar la tabla quedaría compatible con todo por omisión
-- Con whitelist, lo nuevo es inválido hasta definición explícita — más seguro
+Con 17 tipos hay 136 pares posibles; la mayoría son absurdos por definición.
+Un tipo nuevo añadido sin actualizar la tabla quedaría compatible con todo por omisión.
+Con whitelist, lo nuevo es inválido hasta definición explícita — más seguro.
 
-**Tabla independiente de REGLAS_MOTOR** (restricción estructural estática, sin contexto):
+Ejemplos:
+- `AAP + AAE` → PROHIBIDO (AAE implica instalación construida; AAP es anterior)
+- `DUP + CIERRE` → PROHIBIDO (DUP implica que no se pudo construir; CIERRE implica existente)
+- `AAP + AAC` → PERMITIDO (tramitación conjunta estándar)
+- `AAP + AAC + DUP` → PERMITIDO (procedimiento estándar con utilidad pública)
 
 ```
 TIPOS_SOLICITUDES_COMPATIBLES
@@ -190,41 +257,51 @@ comprobar que ninguno de los tipos ya presentes es incompatible con el nuevo.
 
 ---
 
-## Tablas del motor (pendiente de diseñar en detalle)
+## Tablas del motor
 
 ```
 REGLAS_MOTOR
-  id, evento, entidad, tipo_id (nullable=aplica a todos),
-  accion (BLOQUEAR|ADVERTIR), mensaje, norma, activa
+  id, evento (CREAR|INICIAR|FINALIZAR|BORRAR), entidad (SOLICITUD|FASE|TRAMITE|TAREA|EXPEDIENTE),
+  tipo_id (nullable = aplica a todos), accion (BLOQUEAR|ADVERTIR),
+  mensaje, norma, activa
 
 CONDICIONES_REGLA  (1:N con REGLAS_MOTOR)
   id, regla_id, tipo_criterio, parametros (JSON),
-  negacion (bool), operador_con_siguiente (AND|OR)
+  negacion (bool), orden (int), operador_siguiente (AND|OR)
 ```
+
+**Tipos de criterio en `CONDICIONES_REGLA.tipo_criterio`:**
+- `EXISTE_DOCUMENTO_TIPO` — params: `{tipo_doc_codigo, ambito}`
+- `EXISTE_DOC_ORGANISMO` — params: `{tipo_doc_codigo}` + organismo via params_extra
+- `EXISTE_FASE_CERRADA` — params: `{tipo_fase_codigo}`
+- `EXISTE_FASE_CON_RESULTADO` — params: `{tipo_fase_codigo, resultado_codigos: []}`
+- `VARIABLE_EXPEDIENTE` — params: `{campo, operador, valor}`
+- `VARIABLE_PROYECTO` — params: `{campo, operador, valor}` (accede via expediente.proyecto)
+- `TIPO_FASE_PADRE_ES` — params: `{tipo_fase_codigo}`
+- `EXISTE_TAREA_TIPO` — params: `{tipo_tarea_codigo, cerrada, requiere_doc_producido}`
+- `EXISTE_TRAMITE_TIPO` — params: `{tipo_tramite_codigo, cerrado, requiere_doc_producido}`
+- `ESTADO_SOLICITUD` — params: `{estado}`
+- `EXISTE_TIPO_SOLICITUD` — params: `{tipo_solicitud_codigo}`
 
 ---
 
-## Estados de ESFTT — auditoría de modelos Python
+## Estados ESFTT — auditoría de modelos Python
 
-> Revisado contra modelos .py reales, no contra esquema de BD.
+> Revisado contra modelos .py reales.
 > Distinción clave: campo persistido vs. @property calculada al vuelo.
 
 ### EXPEDIENTE
 Sin campo `estado`, sin `fecha_inicio`/`fecha_fin`. Sin `@property` de estado.
 Estado completamente derivado de sus solicitudes — no implementado aún.
-El expediente vive mientras tenga solicitudes activas.
 
 **Ciclo de vida:**
-El expediente vive junto con el proyecto; su producto son las instalaciones en servicio.
-Los expedientes con tramitaciones fallidas se finalizan con resoluciones desestimatorias.
-Una vez archivado no tiene sentido en sí mismo — cualquier solicitud nueva tras el archivo
-crea un nuevo expediente.
+El expediente vive junto con el proyecto. Los expedientes con tramitaciones fallidas
+se finalizan con resoluciones desestimatorias. Una vez archivado, cualquier solicitud
+nueva tras el archivo crea un nuevo expediente.
 
 **Instalaciones (mundo aparte):**
-Nacen con el proyecto pero una vez en servicio se independizan de él. Tienen vida propia:
-cambian de estado por otros expedientes/proyectos posteriores. Sus estados
-(solicitada, autorizada, en servicio, cerrada, desmantelada) referencian el
-expediente/proyecto/solicitud/resolución que las dejó en ese estado.
+Nacen con el proyecto pero una vez en servicio se independizan de él. Sus estados
+referencian el expediente/proyecto/solicitud/resolución que las dejó en ese estado.
 No afectan al modelo ESFTT actual.
 
 ### SOLICITUD
@@ -233,44 +310,39 @@ Valores: `EN_TRAMITE`, `RESUELTA`, `DESISTIDA`, `ARCHIVADA`.
 
 **@property ya implementadas:**
 - `activa` → `estado == 'EN_TRAMITE'`
-- `es_desistimiento_o_renuncia` → `solicitud_afectada_id is not None` *(temporal, ver TODO en modelo)*
+- `es_desistimiento_o_renuncia` → `solicitud_afectada_id is not None` *(temporal — ver TODO en modelo)*
 
 **Tipos de solicitud — relación N:M deliberada:**
-No hay `tipo_solicitud_id` directo. Los tipos se gestionan en tabla puente `SolicitudTipo`
-(modelo `solicitudes_tipos.py`), permitiendo múltiples tipos simultáneos en una sola
-solicitud (ej: AAP+AAC+DUP = 3 registros en `solicitudes_tipos`).
-El motor de reglas evalúa cada tipo individualmente — diseño ya previsto en el modelo.
+No hay `tipo_solicitud_id` directo. Los tipos se gestionan en tabla puente `SolicitudTipo`.
 
 **Limitación del campo `estado`:** `RESUELTA` no distingue favorable de desfavorable.
 Para reglas que necesiten esa distinción, el motor debe consultar `resultado_fase_id`
 de la fase RESOLUCION asociada.
 
 ### FASE
-`resultado_fase_id` es FK a `tipos_resultados_fases` (no boolean).
+`resultado_fase_id` es FK a `tipos_resultados_fases` (NO boolean — GuiaGeneralNueva
+desactualizada; el modelo Python ya usa FK).
 Valores: `FAVORABLE`, `FAVORABLE_CONDICIONADO`, `DESFAVORABLE`, `NO_PROCEDE`, `DESISTIDA`, `ARCHIVADA`.
 
-**Estados deducibles** (descritos en docstring, sin `@property` implementada aún):
-- `PENDIENTE`: `fecha_inicio IS NULL`
+**Estados deducibles** (sin `@property` implementada aún):
+- `PLANIFICADA`: `fecha_inicio IS NULL`
 - `EN_CURSO`: `fecha_inicio IS NOT NULL AND fecha_fin IS NULL`
-- `COMPLETADA`: `fecha_fin IS NOT NULL`
-- `EXITOSA`: `fecha_fin IS NOT NULL AND resultado_fase_id` indica resultado favorable
+- `FINALIZADA`: `fecha_fin IS NOT NULL`
+- `FINALIZADA_FAVORABLE`: `fecha_fin IS NOT NULL AND resultado_fase.codigo IN ('FAVORABLE','FAVORABLE_CONDICIONADO')`
 
 ### TRÁMITE
 Sin campo de resultado — solo fechas. Sin `@property` implementada.
 
-**Estados deducibles** (descritos en docstring):
-- `PENDIENTE`: `fecha_inicio IS NULL`
+**Estados deducibles:**
+- `PLANIFICADO`: `fecha_inicio IS NULL`
 - `EN_CURSO`: `fecha_inicio IS NOT NULL AND fecha_fin IS NULL`
-- `COMPLETADO`: `fecha_fin IS NOT NULL`
-
-No distingue entre cierre exitoso y no exitoso. Pendiente de decidir si necesita
-`resultado_tramite_id` análogo al de FASE.
+- `FINALIZADO`: `fecha_fin IS NOT NULL`
 
 ### TAREA
-Sin `@property` implementada. Semántica por tipo documentada en docstring del modelo.
+Sin `@property` implementada.
 
 **Estados deducibles:**
-- `PENDIENTE`: `fecha_inicio IS NULL`
+- `PLANIFICADA`: `fecha_inicio IS NULL`
 - `EN_CURSO`: `fecha_inicio IS NOT NULL AND fecha_fin IS NULL`
 - `EJECUTADA`: `fecha_fin IS NOT NULL`
 - `EJECUTADA_CON_DOC`: `fecha_fin IS NOT NULL AND documento_producido_id IS NOT NULL`
@@ -290,11 +362,12 @@ Solo `Solicitud.activa` existe hoy — el resto está pendiente.
 | Solicitud | `resuelta_favorable` ⬜ | `estado == 'RESUELTA'` AND fase RESOLUCION con resultado favorable |
 | Fase | `planificada` ⬜ | `fecha_inicio is None` |
 | Fase | `en_curso` ⬜ | `fecha_inicio is not None and fecha_fin is None` |
-| Fase | `cerrada` ⬜ | `fecha_fin is not None` |
+| Fase | `finalizada` ⬜ | `fecha_fin is not None` |
 | Fase | `cerrada_favorable` ⬜ | `fecha_fin is not None and resultado_fase.codigo in ('FAVORABLE','FAVORABLE_CONDICIONADO')` |
-| Tramite | `en_curso` ⬜ | `fecha_fin is None` |
-| Tramite | `cerrado` ⬜ | `fecha_fin is not None` |
-| Tarea | `pendiente` ⬜ | `fecha_inicio is None` |
+| Tramite | `planificado` ⬜ | `fecha_inicio is None` |
+| Tramite | `en_curso` ⬜ | `fecha_fin is None and fecha_inicio is not None` |
+| Tramite | `finalizado` ⬜ | `fecha_fin is not None` |
+| Tarea | `planificada` ⬜ | `fecha_inicio is None` |
 | Tarea | `en_curso` ⬜ | `fecha_inicio is not None and fecha_fin is None` |
 | Tarea | `ejecutada` ⬜ | `fecha_fin is not None` |
 | Tarea | `ejecutada_con_doc` ⬜ | `fecha_fin is not None and documento_producido_id is not None` |
@@ -303,12 +376,40 @@ Solo `Solicitud.activa` existe hoy — el resto está pendiente.
 
 ---
 
-## Pendiente de sesión
+## Observaciones clave
 
-- Actualizar GuiaGeneralNueva: `exito` (bool) → `resultado_fase_id` (FK a tipos_resultados_fases)
-- Decidir si TRÁMITE necesita `resultado_tramite_id` análogo al de FASE
-- Decidir si EXPEDIENTE necesita `@property estado` explícito o derivado de solicitudes
-- Añadir `@property` de estado a FASE, TRÁMITE y TAREA antes de implementar el motor
-- Definir tabla secundaria para tipificar documentos (DRs y otros)
-- Diseño detallado de REGLAS_MOTOR y CONDICIONES_REGLA con ejemplos concretos
-- Decidir dónde vive `figura_ambiental` en el modelo (expediente, solicitud o proyecto)
+1. **TAREAS primero:** Sus reglas son las más mecánicas y universales.
+   Mejor candidato para implementar en primera iteración del motor.
+
+2. **FASES son el nivel más legislativo:** Aquí viven las excepciones
+   de los decretos de simplificación. Requieren el contexto más rico.
+
+3. **El motor sube el árbol:** Una regla de TAREA puede necesitar
+   el tipo del TRAMITE padre o el tipo de FASE abuelo. El motor hace
+   los JOINs — no se necesita pasar contexto completo en la llamada.
+   El árbol completo es: TAREA → TRAMITE → FASE → SOLICITUD → EXPEDIENTE → PROYECTO.
+
+4. **CREAR valida coherencia conceptual; INICIAR valida prerequisitos:**
+   Una fase puede planificarse aunque sus prerequisitos no estén cumplidos.
+   El motor bloquea el inicio, no la planificación. Esto permite al técnico
+   preparar el expediente con antelación sin violar reglas de negocio.
+
+5. **Consultas a organismos elevadas a nivel expediente/proyecto:**
+   El patrón de «lista de organismos consultados» no debe implementarse
+   ad-hoc en el HTML de un trámite concreto. Está pendiente de diseño
+   general reutilizable (issue draft separatas).
+
+---
+
+## Pendientes de sesión
+
+- ⬜ Implementar campo `proyecto.es_modificacion` (Boolean, default=False) + migración
+- ⬜ Cambiar CHECK constraint `reglas_motor.evento` de `('CREAR','CERRAR','BORRAR')` a `('CREAR','INICIAR','FINALIZAR','BORRAR')`
+- ⬜ Actualizar GuiaGeneralNueva: sección FASE — `exito` (bool) → `resultado_fase_id` (FK a tipos_resultados_fases)
+- ⬜ Añadir `@property` de estado a FASE, TRÁMITE y TAREA antes de implementar el motor
+- ⬜ Definir tabla `entidades_consultadas` y su integración con SEPARATAS (issue draft)
+- ⬜ Diseño detallado de evaluador con handlers por entidad (TAREA → TRÁMITE → FASE → SOLICITUD → EXPEDIENTE → PROYECTO)
+- ⬜ Poblar `reglas_motor` + `condiciones_regla` con las reglas del mapa anterior
+- ⬜ Definir pares compatibles en `tipos_solicitudes_compatibles` (con el técnico del servicio)
+- ⬜ Decidir si TRÁMITE necesita `resultado_tramite_id` análogo al de FASE
+- ⬜ Decidir si EXPEDIENTE necesita `@property estado` explícito o derivado de solicitudes

--- a/migrations/versions/cae8e6d884af_proyecto_añadir_es_modificacion.py
+++ b/migrations/versions/cae8e6d884af_proyecto_añadir_es_modificacion.py
@@ -1,0 +1,28 @@
+"""Proyecto — añadir es_modificacion
+
+Revision ID: cae8e6d884af
+Revises: 20e383031811
+Create Date: 2026-02-28 08:58:19.383819
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cae8e6d884af'
+down_revision = '20e383031811'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'proyectos',
+        sa.Column('es_modificacion', sa.Boolean(), nullable=False, server_default='false'),
+        schema='public'
+    )
+
+
+def downgrade():
+    op.drop_column('proyectos', 'es_modificacion', schema='public')

--- a/migrations/versions/f0d0988bb956_motor_reglas_evento_cerrar_a_finalizar_.py
+++ b/migrations/versions/f0d0988bb956_motor_reglas_evento_cerrar_a_finalizar_.py
@@ -1,0 +1,37 @@
+"""Motor reglas — evento CERRAR a FINALIZAR añadir INICIAR
+
+Revision ID: f0d0988bb956
+Revises: cae8e6d884af
+Create Date: 2026-02-28 08:59:04.925762
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f0d0988bb956'
+down_revision = 'cae8e6d884af'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Las tablas están vacías — migración limpia sin datos
+    op.drop_constraint('ck_reglas_motor_evento', 'reglas_motor', schema='public', type_='check')
+    op.create_check_constraint(
+        'ck_reglas_motor_evento',
+        'reglas_motor',
+        "evento IN ('CREAR','INICIAR','FINALIZAR','BORRAR')",
+        schema='public'
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_reglas_motor_evento', 'reglas_motor', schema='public', type_='check')
+    op.create_check_constraint(
+        'ck_reglas_motor_evento',
+        'reglas_motor',
+        "evento IN ('CREAR','CERRAR','BORRAR')",
+        schema='public'
+    )


### PR DESCRIPTION
## Resumen

- Implementa `app/services/motor_reglas.py`: función pública `evaluar(evento, entidad, ...)` con contexto jerárquico `_Contexto`, checks estructurales hardcoded (BORRAR/FINALIZAR) y 11 evaluadores de criterio configurables en BD.
- Añade `app/services/__init__.py` (módulo).
- Modifica `app/routes/vista3.py`: hooks INICIAR/FINALIZAR en las 4 rutas editar existentes (solicitud/fase/tramite/tarea) + 6 nuevas rutas POST (crear_fase, crear_tramite, crear_tarea, borrar_fase, borrar_tramite, borrar_tarea).
- Corrige CHECK constraint en `app/models/motor_reglas.py` para que refleje la BD real (`CREAR/INICIAR/FINALIZAR/BORRAR`).

## Comportamiento

- Tablas `reglas_motor` vacías → **PERMITIDO** (correcto para Fase 2).
- Checks hardcoded activos desde el primer momento:
  - BORRAR fase/tramite/tarea con `fecha_inicio` → **BLOQUEAR**
  - FINALIZAR fase con trámites abiertos → **BLOQUEAR**
  - FINALIZAR trámite con tareas abiertas → **BLOQUEAR**
  - FINALIZAR tarea sin doc requerido → **BLOQUEAR**

## Plan de pruebas

- [ ] `python run.py` → Flask arranca sin errores
- [ ] `evaluar('BORRAR','FASE', entidad_id=X)` con fase iniciada → BLOQUEAR
- [ ] `evaluar('BORRAR','FASE', entidad_id=X)` con fase no iniciada → PERMITIDO
- [ ] Editar fecha_fin de una fase con trámites abiertos → error 422 en frontend
- [ ] Crear fase vía `POST /api/vista3/solicitud/<id>/fases/nueva` → 200 OK

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)