### PR TITLE
V3 Tabs anidados — fixes, colores, iconos y UX (#150)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,38 +99,35 @@ def create_app(config_name='development'):
     # Filtros Jinja2 para iconos/colores en V3 tabs (issue #150)
     def _icono_solicitud(estado):
         return {
-            'EN_TRAMITE': 'fa-solid fa-file-contract',
-            'RESUELTA':   'fa-solid fa-file-circle-check',
-            'DESISTIDA':  'fa-solid fa-file-circle-xmark',
-            'ARCHIVADA':  'fa-regular fa-file',
-        }.get(estado, 'fa-regular fa-file')
+            'EN_TRAMITE': 'bi bi-file-earmark-text',
+            'RESUELTA':   'bi bi-file-earmark-check',
+            'DESISTIDA':  'bi bi-file-earmark-x',
+            'ARCHIVADA':  'bi bi-file-earmark',
+        }.get(estado, 'bi bi-file-earmark')
 
     def _color_solicitud(estado):
-        return {'EN_TRAMITE': 'text-warning', 'RESUELTA': 'text-success'}.get(estado, 'text-secondary')
+        return {'EN_TRAMITE': 'text-primary', 'RESUELTA': 'text-success', 'DESISTIDA': 'text-danger'}.get(estado, 'text-secondary')
 
     def _icono_fase(estado):
-        return {
-            'En curso':   'fa-solid fa-sitemap',
-            'Finalizada': 'fa-solid fa-sitemap',
-        }.get(estado, 'fa-solid fa-sitemap')
+        return 'bi bi-bar-chart-steps'
 
     def _color_fase(estado):
         return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
 
     def _icono_tramite(estado):
         return {
-            'En curso':   'fa-solid fa-clipboard-list',
-            'Finalizado': 'fa-solid fa-clipboard-check',
-        }.get(estado, 'fa-regular fa-clipboard')
+            'En curso':   'bi bi-clipboard-pulse',
+            'Finalizado': 'bi bi-clipboard-check',
+        }.get(estado, 'bi bi-clipboard')
 
     def _color_tramite(estado):
         return {'En curso': 'text-warning', 'Finalizado': 'text-success'}.get(estado, 'text-secondary')
 
     def _icono_tarea(estado):
         return {
-            'En curso':   'fa-solid fa-pen-to-square',
-            'Finalizada': 'fa-solid fa-square-check',
-        }.get(estado, 'fa-regular fa-square')
+            'En curso':   'bi bi-pencil-square',
+            'Finalizada': 'bi bi-check-square',
+        }.get(estado, 'bi bi-square')
 
     def _color_tarea(estado):
         return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,6 +96,52 @@ def create_app(config_name='development'):
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
 
+    # Filtros Jinja2 para iconos/colores en V3 tabs (issue #150)
+    def _icono_solicitud(estado):
+        return {
+            'EN_TRAMITE': 'fa-solid fa-file-contract',
+            'RESUELTA':   'fa-solid fa-file-circle-check',
+            'DESISTIDA':  'fa-solid fa-file-circle-xmark',
+            'ARCHIVADA':  'fa-regular fa-file',
+        }.get(estado, 'fa-regular fa-file')
+
+    def _color_solicitud(estado):
+        return {'EN_TRAMITE': 'text-warning', 'RESUELTA': 'text-success'}.get(estado, 'text-secondary')
+
+    def _icono_fase(estado):
+        return {
+            'En curso':   'fa-solid fa-sitemap',
+            'Finalizada': 'fa-solid fa-sitemap',
+        }.get(estado, 'fa-solid fa-sitemap')
+
+    def _color_fase(estado):
+        return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
+
+    def _icono_tramite(estado):
+        return {
+            'En curso':   'fa-solid fa-clipboard-list',
+            'Finalizado': 'fa-solid fa-clipboard-check',
+        }.get(estado, 'fa-regular fa-clipboard')
+
+    def _color_tramite(estado):
+        return {'En curso': 'text-warning', 'Finalizado': 'text-success'}.get(estado, 'text-secondary')
+
+    def _icono_tarea(estado):
+        return {
+            'En curso':   'fa-solid fa-pen-to-square',
+            'Finalizada': 'fa-solid fa-square-check',
+        }.get(estado, 'fa-regular fa-square')
+
+    def _color_tarea(estado):
+        return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
+
+    app.jinja_env.filters.update({
+        'icono_solicitud': _icono_solicitud, 'color_solicitud': _color_solicitud,
+        'icono_fase':      _icono_fase,      'color_fase':      _color_fase,
+        'icono_tramite':   _icono_tramite,   'color_tramite':   _color_tramite,
+        'icono_tarea':     _icono_tarea,     'color_tarea':     _color_tarea,
+    })
+
     # Manejadores de errores HTTP
     @app.errorhandler(404)
     def not_found_error(error):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -145,8 +145,8 @@ def create_app(config_name='development'):
         return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
 
     def _formato_codigo(s):
-        """ADMISIBILIDAD_TECNICA → Admisibilidad Tecnica (para labels de tab)."""
-        return s.replace('_', ' ').title() if s else ''
+        """ADMISIBILIDAD_TECNICA → ADMISIBILIDAD TECNICA (para labels de tab)."""
+        return s.replace('_', ' ') if s else ''
 
     app.jinja_env.filters.update({
         'icono_solicitud':  _icono_solicitud,  'color_solicitud': _color_solicitud,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -109,7 +109,7 @@ def create_app(config_name='development'):
         return {'EN_TRAMITE': 'text-primary', 'RESUELTA': 'text-success', 'DESISTIDA': 'text-danger'}.get(estado, 'text-secondary')
 
     def _icono_fase(estado):
-        return 'bi bi-bar-chart-steps'
+        return 'bi bi-diagram-3-fill' if estado == 'En curso' else 'bi bi-diagram-3'
 
     def _color_fase(estado):
         return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
@@ -129,14 +129,32 @@ def create_app(config_name='development'):
             'Finalizada': 'bi bi-check-square',
         }.get(estado, 'bi bi-square')
 
+    def _icono_tarea_tipo(codigo):
+        """Icono semántico por tipo de tarea (mockup icons_ESFTT)."""
+        return {
+            'ANALISIS':     'bi bi-person-gear',
+            'REDACTAR':     'bi bi-pencil',
+            'FIRMAR':       'bi bi-pen',
+            'NOTIFICAR':    'bi bi-send',
+            'PUBLICAR':     'bi bi-megaphone',
+            'ESPERAR_PLAZO':'bi bi-hourglass-split',
+            'INCORPORAR':   'bi bi-box-arrow-in-down',
+        }.get(codigo, 'bi bi-square')
+
     def _color_tarea(estado):
         return {'En curso': 'text-warning', 'Finalizada': 'text-success'}.get(estado, 'text-secondary')
 
+    def _formato_codigo(s):
+        """ADMISIBILIDAD_TECNICA → Admisibilidad Tecnica (para labels de tab)."""
+        return s.replace('_', ' ').title() if s else ''
+
     app.jinja_env.filters.update({
-        'icono_solicitud': _icono_solicitud, 'color_solicitud': _color_solicitud,
-        'icono_fase':      _icono_fase,      'color_fase':      _color_fase,
-        'icono_tramite':   _icono_tramite,   'color_tramite':   _color_tramite,
-        'icono_tarea':     _icono_tarea,     'color_tarea':     _color_tarea,
+        'icono_solicitud':  _icono_solicitud,  'color_solicitud': _color_solicitud,
+        'icono_fase':       _icono_fase,       'color_fase':      _color_fase,
+        'icono_tramite':    _icono_tramite,    'color_tramite':   _color_tramite,
+        'icono_tarea':      _icono_tarea,      'color_tarea':     _color_tarea,
+        'icono_tarea_tipo': _icono_tarea_tipo,
+        'formato_codigo':   _formato_codigo,
     })
 
     # Manejadores de errores HTTP

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -12,12 +12,17 @@ from flask import Blueprint, render_template, request, flash, redirect, url_for
 from flask_login import login_required
 from app import db
 from app.models.expedientes import Expediente
-from app.routes.vista3 import _get_solicitudes_con_stats
+from app.routes.vista3 import _get_solicitudes_con_stats, _construir_arbol
 from app.models.proyectos import Proyecto
 from app.models.usuarios import Usuario
 from app.models.tipos_expedientes import TipoExpediente
 from app.models.tipos_ia import TipoIA
 from app.models.municipios_proyecto import MunicipioProyecto
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.tipos_fases import TipoFase
+from app.models.tipos_tramites import TipoTramite
+from app.models.tipos_tareas import TipoTarea
+from app.models.tipos_resultados_fases import TipoResultadoFase
 from app.decorators import role_required
 from app.utils.permisos import (
     puede_cambiar_responsable,
@@ -56,24 +61,18 @@ def listado_v2():
 @login_required
 def tramitacion_v3(id):
     """
-    Vista V3 - Tramitación con Sidebar Acordeón (Fase 1).
+    Vista V3 - Tramitación con Tabs Anidados (4 niveles) — issue #150.
 
-    Patrón de vista para navegación jerárquica dentro de UN expediente:
-    - Sidebar acordeón: Expediente > Solicitudes > Fases > Trámites > Tareas
-    - Panel detalle: Tabs [Datos] [Documentos] [Historial]
-    - Contexto fijo: Expediente/Proyecto siempre visible
-    - Paneles de hijos directos con listados (grupo C2.D de Vista 2)
-
-    Fase 1 (actual): Mockup estático con estructura completa
-    Fase 2+: JavaScript funcional + APIs backend
-
-    Referencias:
-    - Epic #93 - Sistema de Navegación UI Modular
-    - docs/arquitectura/PATRONES_UI.md - Patrón Vista 3
+    Reemplaza el acordeón lazy-loading por tabs renderizados en servidor:
+    - Nivel 1: Solicitudes (tabs horizontales)
+    - Nivel 2: Fases (tabs anidados dentro de cada solicitud)
+    - Nivel 3: Trámites (tabs anidados dentro de cada fase)
+    - Nivel 4: Tareas (tabs anidados dentro de cada trámite)
+    - Edición inline V4 (toggle ver/editar sin modal)
+    - Creación de entidades hijas via modal Bootstrap
     """
     expediente = Expediente.query.get_or_404(id)
 
-    # Verificación de acceso
     resultado = verificar_acceso_expediente(expediente, 'ver')
     if resultado:
         return resultado
@@ -81,7 +80,12 @@ def tramitacion_v3(id):
     return render_template(
         'expedientes/tramitacion_v3.html',
         expediente=expediente,
-        solicitudes=_get_solicitudes_con_stats(expediente.id)
+        solicitudes_arbol=_construir_arbol(expediente.id),
+        tipos_solicitud=TipoSolicitud.query.order_by(TipoSolicitud.nombre).all(),
+        tipos_fase=TipoFase.query.order_by(TipoFase.nombre).all(),
+        tipos_tramite=TipoTramite.query.order_by(TipoTramite.nombre).all(),
+        tipos_tarea=TipoTarea.query.order_by(TipoTarea.nombre).all(),
+        resultados_fase=TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all(),
     )
 
 

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -81,7 +81,7 @@ def tramitacion_v3(id):
         'expedientes/tramitacion_v3.html',
         expediente=expediente,
         solicitudes_arbol=_construir_arbol(expediente.id),
-        tipos_solicitud=TipoSolicitud.query.order_by(TipoSolicitud.nombre).all(),
+        tipos_solicitud=TipoSolicitud.query.order_by(TipoSolicitud.siglas).all(),
         tipos_fase=TipoFase.query.order_by(TipoFase.nombre).all(),
         tipos_tramite=TipoTramite.query.order_by(TipoTramite.nombre).all(),
         tipos_tarea=TipoTarea.query.order_by(TipoTarea.nombre).all(),

--- a/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
@@ -2,6 +2,10 @@
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-tramitacion.css') }}">
+{% endblock %}
+
 {% block breadcrumb %}
 <a href="{{ url_for('dashboard.index') }}">Inicio</a>
 <span>›</span>
@@ -13,47 +17,32 @@
 {% endblock %}
 
 {% block content %}
-{# C.1: Cabecera fija — no scrollea #}
+{# C.1: Cabecera fija — expediente + título #}
 <div class="lista-cabecera px-3 pt-3">
     <div class="d-flex align-items-center justify-content-between mb-2">
         <h2 class="mb-0">Tramitación AT-{{ expediente.numero_at }}</h2>
-        <div class="d-flex gap-2">
-            <button id="btn-expandir-todo" type="button" class="btn btn-sm btn-outline-primary">
-                <i class="fas fa-expand-alt me-1"></i> Expandir todo
-            </button>
-            <button id="btn-colapsar-todo" type="button" class="btn btn-sm btn-outline-primary">
-                <i class="fas fa-compress-alt me-1"></i> Colapsar todo
-            </button>
-            <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-               class="btn btn-sm btn-outline-secondary">
-                <i class="fas fa-arrow-left me-1"></i> Volver al detalle
-            </a>
-        </div>
+        <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+           class="btn btn-sm btn-outline-secondary">
+            <i class="fa-solid fa-arrow-left me-1"></i> Volver al detalle
+        </a>
     </div>
-    {# Bloque del expediente — siempre visible, fijo sobre los acordeones #}
     {% include 'vistas/vista3/_expediente_body.html' %}
 </div>
 
-{# C.2: Acordeones con scroll propio #}
-<div class="lista-scroll-container">
-    <div id="tramitacion-container"
-         class="accordion vista3-acordeon p-3"
-         data-expediente-id="{{ expediente.id }}">
-        {% for sol_data in solicitudes %}
-            {% include 'vistas/vista3/_acordeon_solicitud.html' %}
-        {% else %}
-            <div class="alert alert-info mt-2">
-                <i class="fas fa-info-circle me-2"></i>
-                Este expediente no tiene solicitudes registradas.
-            </div>
-        {% endfor %}
+{# C.2: Contenido con scroll — tabs 4 niveles #}
+<div class="lista-scroll-container p-3">
+    <div data-tabs-nivel="solicitud" data-parent-id="{{ expediente.id }}">
+        {% include 'vistas/vista3/_tabs_solicitudes.html' %}
     </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/acordeon_lazy.js') }}"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    initAcordeonLazy('tramitacion-container');
-});
-</script>
+{# Modales de creación (uno por nivel) #}
+{% include 'vistas/vista3/_modal_nueva_solicitud.html' %}
+{% include 'vistas/vista3/_modal_nueva_fase.html' %}
+{% include 'vistas/vista3/_modal_nuevo_tramite.html' %}
+{% include 'vistas/vista3/_modal_nueva_tarea.html' %}
+{% endblock %}
+
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/v3-tabs-main.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
@@ -31,7 +31,7 @@
 
 {# C.2: Contenido con scroll — tabs 4 niveles #}
 <div class="lista-scroll-container p-3">
-    <div data-tabs-nivel="solicitud" data-parent-id="{{ expediente.id }}">
+    <div class="tabs-nivel-1" data-tabs-nivel="solicitud" data-parent-id="{{ expediente.id }}">
         {% include 'vistas/vista3/_tabs_solicitudes.html' %}
     </div>
 </div>

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -96,22 +96,7 @@ def get_arbol(exp_id):
     if resultado:
         return jsonify({'error': 'Acceso denegado'}), 403
 
-    # Construir estructura anidada completa
-    solicitudes_arbol = []
-    for sol_data in _get_solicitudes_con_stats(exp_id):
-        fases_arbol = []
-        for fase_data in _get_fases_con_stats(sol_data['obj'].id):
-            tramites_arbol = []
-            for tramite_data in _get_tramites_con_stats(fase_data['obj'].id):
-                tareas = _get_tareas_con_stats(tramite_data['obj'].id)
-                tareas_con_docs = [
-                    {**t, 'documentos': _get_documentos_tarea(t['obj'].id)}
-                    for t in tareas
-                ]
-                tramites_arbol.append({**tramite_data, 'tareas': tareas_con_docs})
-            fases_arbol.append({**fase_data, 'tramites': tramites_arbol})
-        solicitudes_arbol.append({**sol_data, 'fases': fases_arbol})
-
+    solicitudes_arbol = _construir_arbol(exp_id)
     resultados_fase = TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
     html = render_template(
         'vistas/vista3/_arbol_completo.html',
@@ -119,6 +104,25 @@ def get_arbol(exp_id):
         resultados_fase=resultados_fase
     )
     return jsonify({'html': html, 'count': len(solicitudes_arbol)})
+
+
+def _construir_arbol(expediente_id):
+    """Construye árbol completo anidado de todos los niveles (para V3 tabs y acordeón)."""
+    solicitudes_arbol = []
+    for sol_data in _get_solicitudes_con_stats(expediente_id):
+        fases_arbol = []
+        for fase_data in _get_fases_con_stats(sol_data['obj'].id):
+            tramites_arbol = []
+            for tram_data in _get_tramites_con_stats(fase_data['obj'].id):
+                tareas = _get_tareas_con_stats(tram_data['obj'].id)
+                tareas_con_docs = [
+                    {**t, 'documentos': _get_documentos_tarea(t['obj'].id)}
+                    for t in tareas
+                ]
+                tramites_arbol.append({**tram_data, 'tareas': tareas_con_docs})
+            fases_arbol.append({**fase_data, 'tramites': tramites_arbol})
+        solicitudes_arbol.append({**sol_data, 'fases': fases_arbol})
+    return solicitudes_arbol
 
 
 # ============================================
@@ -431,6 +435,57 @@ def editar_tarea(tarea_id):
 # ============================================
 # ENDPOINTS POST — CREAR entidades
 # ============================================
+
+@bp.route('/expediente/<int:exp_id>/solicitudes/nueva', methods=['POST'])
+@login_required
+def crear_solicitud(exp_id):
+    """Crea una nueva solicitud en el expediente indicado."""
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_ids = request.form.getlist('tipo_solicitud_id[]', type=int)
+    fecha_str = request.form.get('fecha_solicitud')
+    entidad_id = request.form.get('entidad_id', type=int) or expediente.titular_id
+    if not tipo_ids or not fecha_str:
+        return jsonify({'ok': False, 'error': 'tipo y fecha son obligatorios'}), 400
+
+    try:
+        fecha = date.fromisoformat(fecha_str)
+    except ValueError:
+        return jsonify({'ok': False, 'error': 'Fecha inválida'}), 400
+
+    sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
+                    fecha_solicitud=fecha, estado='EN_TRAMITE')
+    db.session.add(sol)
+    db.session.flush()
+    for tipo_id in tipo_ids:
+        db.session.add(SolicitudTipo(solicitud_id=sol.id, tiposolicitudid=tipo_id))
+    db.session.commit()
+
+    tipos_objs = TipoSolicitud.query.filter(TipoSolicitud.id.in_(tipo_ids)).all()
+    tipos_str = '+'.join(t.siglas for t in tipos_objs) if tipos_objs else 'Nueva'
+    return jsonify({'ok': True, 'id': sol.id, 'tipos_str': tipos_str})
+
+
+@bp.route('/solicitud/<int:sol_id>/borrar', methods=['POST'])
+@login_required
+def borrar_solicitud(sol_id):
+    """Elimina una solicitud si el motor de reglas lo permite."""
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    db.session.delete(sol)
+    db.session.commit()
+    return jsonify({'ok': True})
+
 
 @bp.route('/solicitud/<int:sol_id>/fases/nueva', methods=['POST'])
 @login_required

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -482,6 +482,14 @@ def borrar_solicitud(sol_id):
     if not res_eval.permitido:
         return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
 
+    fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol_id).all()]
+    if fase_ids:
+        tram_ids = [t.id for t in Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).all()]
+        if tram_ids:
+            Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+        Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).delete()
+    Fase.query.filter_by(solicitud_id=sol_id).delete()
+    SolicitudTipo.query.filter_by(solicitudid=sol_id).delete()
     db.session.delete(sol)
     db.session.commit()
     return jsonify({'ok': True})
@@ -585,6 +593,10 @@ def borrar_fase(fase_id):
     if not res_eval.permitido:
         return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
 
+    tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase_id).all()]
+    if tram_ids:
+        Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+    Tramite.query.filter_by(fase_id=fase_id).delete()
     db.session.delete(fase)
     db.session.commit()
     return jsonify({'ok': True})
@@ -603,6 +615,7 @@ def borrar_tramite(tram_id):
     if not res_eval.permitido:
         return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
 
+    Tarea.query.filter_by(tramite_id=tram_id).delete()
     db.session.delete(tramite)
     db.session.commit()
     return jsonify({'ok': True})

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -461,7 +461,7 @@ def crear_solicitud(exp_id):
     db.session.add(sol)
     db.session.flush()
     for tipo_id in tipo_ids:
-        db.session.add(SolicitudTipo(solicitud_id=sol.id, tiposolicitudid=tipo_id))
+        db.session.add(SolicitudTipo(solicitudid=sol.id, tiposolicitudid=tipo_id))
     db.session.commit()
 
     tipos_objs = TipoSolicitud.query.filter(TipoSolicitud.id.in_(tipo_ids)).all()

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -188,6 +188,7 @@ def _get_fases_con_stats(solicitud_id):
         result.append({
             'obj': fase,
             'nombre': fase.tipo_fase.nombre if fase.tipo_fase else f'Fase {fase.id}',
+            'codigo': fase.tipo_fase.codigo if fase.tipo_fase else '',
             'tramites_completados': tramites_completados,
             'total_tramites': total_tramites,
             'estado': 'Finalizada' if fase.fecha_fin else 'En curso' if fase.fecha_inicio else 'Pendiente'
@@ -210,6 +211,7 @@ def _get_tramites_con_stats(fase_id):
         result.append({
             'obj': tramite,
             'nombre': tramite.tipo_tramite.nombre if tramite.tipo_tramite else f'Trámite {tramite.id}',
+            'codigo': tramite.tipo_tramite.codigo if tramite.tipo_tramite else '',
             'tareas_completadas': tareas_completadas,
             'total_tareas': total_tareas,
             'estado': 'Finalizado' if tramite.fecha_fin else 'En curso' if tramite.fecha_inicio else 'Pendiente'
@@ -234,6 +236,7 @@ def _get_tareas_con_stats(tramite_id):
         result.append({
             'obj': tarea,
             'nombre': tarea.tipo_tarea.nombre if tarea.tipo_tarea else f'Tarea {tarea.id}',
+            'codigo': tarea.tipo_tarea.codigo if tarea.tipo_tarea else '',
             'documentos_count': docs_count,
             'estado': 'Finalizada' if tarea.fecha_fin else 'En curso' if tarea.fecha_inicio else 'Pendiente'
         })

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -192,7 +192,7 @@ def _checks_hardcoded(evento: str, entidad: str,
 
 def _check_borrar(entidad: str, ctx: _Contexto) -> Optional[EvaluacionResult]:
     if entidad in ('FASE', 'TRAMITE', 'TAREA'):
-        obj = ctx.fase or ctx.tramite or ctx.tarea
+        obj = {'FASE': ctx.fase, 'TRAMITE': ctx.tramite, 'TAREA': ctx.tarea}[entidad]
         if obj and obj.fecha_inicio is not None:
             return EvaluacionResult(
                 permitido=False,

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -328,3 +328,6 @@
 .tabs-nivel-2 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #0d6efd; }
 .tabs-nivel-3 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #fd7e14; }
 .tabs-nivel-4 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #6f42c1; }
+
+/* === Tamaño icono en tabs (C3) === */
+.tramitacion-tabs .nav-link .tab-icon i { font-size: 1.1rem; }

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -314,16 +314,22 @@
 /* Tab pendiente — recién creado sin fechas */
 .tab-pendiente { font-style: italic; color: #6c757d; }
 
-/* === Colores por nivel (C1) === */
-.card-header-fase    { background-color: #0d6efd; color: #fff; }
-.card-header-tramite { background-color: #fd7e14; color: #fff; }
-.card-header-tarea   { background-color: #6f42c1; color: #fff; }
+/* === Colores por nivel (C1 revisado — headers y tabs pálidos) === */
 
-.tabs-nivel-1 .nav-link.active { background-color: #087021; color: #fff; font-weight: 700; border-color: #087021; }
-.tabs-nivel-2 .nav-link.active { background-color: #0d6efd; color: #fff; font-weight: 700; border-color: #0d6efd; }
-.tabs-nivel-3 .nav-link.active { background-color: #fd7e14; color: #fff; font-weight: 700; border-color: #fd7e14; }
-.tabs-nivel-4 .nav-link.active { background-color: #6f42c1; color: #fff; font-weight: 700; border-color: #6f42c1; }
+/* Fase: azul pálido (#cfe2ff) / texto azul oscuro */
+.card-header-fase    { background-color: #cfe2ff; color: #084298; }
+/* Trámite: naranja pálido (#fde8d1) / texto naranja oscuro */
+.card-header-tramite { background-color: #fde8d1; color: #8b4500; }
+/* Tarea: morado pálido (#e8d5f5) / texto morado oscuro */
+.card-header-tarea   { background-color: #e8d5f5; color: #4a1d8a; }
 
+/* Tabs activos: mismo pálido que el header, texto en color oscuro del nivel */
+.tabs-nivel-1 .nav-link.active { background-color: #c4ddca; color: #055218; font-weight: 700; border-color: #b0cdb7; border-bottom-color: #c4ddca; }
+.tabs-nivel-2 .nav-link.active { background-color: #cfe2ff; color: #084298; font-weight: 700; border-color: #9ec5fe; border-bottom-color: #cfe2ff; }
+.tabs-nivel-3 .nav-link.active { background-color: #fde8d1; color: #8b4500; font-weight: 700; border-color: #ffc69e; border-bottom-color: #fde8d1; }
+.tabs-nivel-4 .nav-link.active { background-color: #e8d5f5; color: #4a1d8a; font-weight: 700; border-color: #c9a8f0; border-bottom-color: #e8d5f5; }
+
+/* Tabs inactivos: texto en color saturado del nivel, en negrita */
 .tabs-nivel-1 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #087021; }
 .tabs-nivel-2 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #0d6efd; }
 .tabs-nivel-3 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #fd7e14; }

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -337,3 +337,9 @@
 
 /* === Tamaño icono en tabs (C3) === */
 .tramitacion-tabs .nav-link .tab-icon i { font-size: 1.1rem; }
+
+/* === Visibilidad icono en tab activo (C4) ===
+   El icono hereda el color de texto del nav-link activo (ya tiene
+   buen contraste con el fondo pálido del nivel), evitando que
+   text-warning/text-success queden invisibles sobre fondos coloreados. */
+.tramitacion-tabs .nav-link.active .tab-icon i { color: inherit !important; }

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -231,28 +231,85 @@
         position: relative;
         top: auto;
     }
-    
+
     .expediente-info h2 {
         font-size: 1.25rem;
     }
-    
+
     .proyecto-info h3 {
         font-size: 1rem;
     }
-    
+
     #accordionSolicitudes .accordion-button {
         font-size: 0.9rem;
         padding: 0.75rem;
     }
-    
+
     .accordion-anidado {
         margin-left: 0;
         border-left-width: 2px;
         padding-left: 0.5rem;
     }
-    
+
     /* Ocultar algunos badges en móvil para ahorrar espacio */
     .badge {
         font-size: 0.7rem;
     }
 }
+
+/* ===== TABS V3 — issue #150 ===== */
+
+.tramitacion-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-bottom: 1px solid #dee2e6;
+    scrollbar-width: thin;
+}
+
+.tramitacion-tabs .nav-link {
+    max-width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+}
+
+.tramitacion-tabs .nav-link .tab-icon { flex-shrink: 0; }
+.tramitacion-tabs .nav-link .tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 130px;
+}
+
+.tramitacion-tabs .btn-nueva-entidad {
+    color: #6c757d;
+    border: none;
+    background: none;
+    flex-shrink: 0;
+}
+.tramitacion-tabs .btn-nueva-entidad:hover { color: var(--bs-primary); }
+
+/* Indentación visual por nivel */
+.tabs-nivel-2 {
+    margin-top: 1rem;
+    border-top: 2px solid #dee2e6;
+    padding-top: 0.75rem;
+}
+.tabs-nivel-3 {
+    margin-top: 0.75rem;
+    border-top: 1px solid #e9ecef;
+    padding-top: 0.5rem;
+    margin-left: 0.5rem;
+}
+.tabs-nivel-4 {
+    margin-top: 0.5rem;
+    margin-left: 1rem;
+}
+
+/* Tab pendiente — recién creado sin fechas */
+.tab-pendiente { font-style: italic; color: #6c757d; }

--- a/app/static/css/v3-tramitacion.css
+++ b/app/static/css/v3-tramitacion.css
@@ -313,3 +313,18 @@
 
 /* Tab pendiente — recién creado sin fechas */
 .tab-pendiente { font-style: italic; color: #6c757d; }
+
+/* === Colores por nivel (C1) === */
+.card-header-fase    { background-color: #0d6efd; color: #fff; }
+.card-header-tramite { background-color: #fd7e14; color: #fff; }
+.card-header-tarea   { background-color: #6f42c1; color: #fff; }
+
+.tabs-nivel-1 .nav-link.active { background-color: #087021; color: #fff; font-weight: 700; border-color: #087021; }
+.tabs-nivel-2 .nav-link.active { background-color: #0d6efd; color: #fff; font-weight: 700; border-color: #0d6efd; }
+.tabs-nivel-3 .nav-link.active { background-color: #fd7e14; color: #fff; font-weight: 700; border-color: #fd7e14; }
+.tabs-nivel-4 .nav-link.active { background-color: #6f42c1; color: #fff; font-weight: 700; border-color: #6f42c1; }
+
+.tabs-nivel-1 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #087021; }
+.tabs-nivel-2 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #0d6efd; }
+.tabs-nivel-3 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #fd7e14; }
+.tabs-nivel-4 .nav-link:not(.active):not(.btn-nueva-entidad) { font-weight: 700; color: #6f42c1; }

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -216,12 +216,27 @@ function _actualizarTabIcon(nivel, id, panel) {
             'ARCHIVADA':  ['bi bi-file-earmark',       'text-secondary'],
         };
         [icono, color] = map[est] || map['EN_TRAMITE'];
+    } else if (nivel === 'tarea') {
+        // Icono por tipo (semántico), color por estado
+        const tipoCodigo = tabBtn.dataset.tipoCodigo || '';
+        const tipoIconos = {
+            'ANALISIS':      'bi bi-person-gear',
+            'REDACTAR':      'bi bi-pencil',
+            'FIRMAR':        'bi bi-pen',
+            'NOTIFICAR':     'bi bi-send',
+            'PUBLICAR':      'bi bi-megaphone',
+            'ESPERAR_PLAZO': 'bi bi-hourglass-split',
+            'INCORPORAR':    'bi bi-box-arrow-in-down',
+        };
+        icono = tipoIconos[tipoCodigo] || 'bi bi-square';
+        if (fechaFinEl?.value)    color = 'text-success';
+        else if (fechaInicioEl?.value) color = 'text-warning';
     } else {
         const tieneFin    = fechaFinEl?.value;
         const tieneInicio = fechaInicioEl?.value;
-        const finIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard-check', tarea: 'bi bi-check-square' };
-        const curIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard-pulse',  tarea: 'bi bi-pencil-square' };
-        const penIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard',        tarea: 'bi bi-square' };
+        const finIcons = { fase: 'bi bi-diagram-3',      tramite: 'bi bi-clipboard-check' };
+        const curIcons = { fase: 'bi bi-diagram-3-fill', tramite: 'bi bi-clipboard-pulse' };
+        const penIcons = { fase: 'bi bi-diagram-3',      tramite: 'bi bi-clipboard' };
         if (tieneFin) {
             icono = finIcons[nivel] || 'bi bi-file-earmark'; color = 'text-success';
         } else if (tieneInicio) {

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -78,8 +78,13 @@ document.addEventListener('submit', async (e) => {
         // Cerrar modal y recargar la página para mostrar el nuevo elemento
         bootstrap.Modal.getInstance(modalEl)?.hide();
         if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
-        const tabActivo = document.querySelector('.tramitacion-tabs .nav-link.active');
-        if (tabActivo) sessionStorage.setItem('v3_tab_activo', tabActivo.id);
+        // Guardar todos los tabs activos + el nuevo elemento para restaurar tras reload
+        const tabsPadres = [...document.querySelectorAll('.tramitacion-tabs .nav-link.active')]
+            .map(btn => btn.id).filter(id => id);
+        sessionStorage.setItem('v3_tabs_restaurar', JSON.stringify({
+            padres: tabsPadres,
+            nuevo: `tab-${nivel}-${data.id}`,
+        }));
         location.reload();
     } catch (err) {
         mostrarError('Error de red: ' + err.message);
@@ -285,13 +290,20 @@ function _buildCrearEndpoint(nivel, parentId) {
     return map[nivel] || null;
 }
 
-// Inicializar tooltips y restaurar tab activo tras reload
+// Inicializar tooltips y restaurar tabs activos tras crear elemento
 document.addEventListener('DOMContentLoaded', () => {
-    const tabId = sessionStorage.getItem('v3_tab_activo');
-    if (tabId) {
-        sessionStorage.removeItem('v3_tab_activo');
-        const btn = document.getElementById(tabId);
-        if (btn) new bootstrap.Tab(btn).show();
+    const restaurarStr = sessionStorage.getItem('v3_tabs_restaurar');
+    if (restaurarStr) {
+        sessionStorage.removeItem('v3_tabs_restaurar');
+        const { padres, nuevo } = JSON.parse(restaurarStr);
+        // Restaurar tabs padre en orden (nivel 1 → 4) para que los paneles estén visibles
+        padres.forEach(id => {
+            const btn = document.getElementById(id);
+            if (btn) new bootstrap.Tab(btn).show();
+        });
+        // Activar el tab del elemento recién creado
+        const btnNuevo = document.getElementById(nuevo);
+        if (btnNuevo) new bootstrap.Tab(btnNuevo).show();
     }
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
         new bootstrap.Tooltip(el);

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -78,11 +78,9 @@ document.addEventListener('submit', async (e) => {
         // Cerrar modal y recargar la página para mostrar el nuevo elemento
         bootstrap.Modal.getInstance(modalEl)?.hide();
         if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
-        // Guardar todos los tabs activos + el nuevo elemento para restaurar tras reload
-        const tabsPadres = [...document.querySelectorAll('.tramitacion-tabs .nav-link.active')]
-            .map(btn => btn.id).filter(id => id);
+        // Guardar la cadena de tabs visibles + el nuevo elemento para restaurar tras reload
         sessionStorage.setItem('v3_tabs_restaurar', JSON.stringify({
-            padres: tabsPadres,
+            padres: _getCadenaTabsActivos(),
             nuevo: `tab-${nivel}-${data.id}`,
         }));
         location.reload();
@@ -279,6 +277,27 @@ document.addEventListener('click', async (e) => {
 
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Devuelve los IDs de los tabs activos en la cadena visible (nivel 1→4),
+ * recorriendo los paneles activos de forma descendente para evitar incluir
+ * tabs activos de paneles ocultos.
+ */
+function _getCadenaTabsActivos() {
+    const cadena = [];
+    // Nivel 1 — solicitud
+    let btn = document.querySelector('.tabs-nivel-1 .tramitacion-tabs .nav-link.active:not(.btn-nueva-entidad)');
+    if (!btn?.id) return cadena;
+    cadena.push(btn.id);
+    // Niveles 2, 3, 4 — desciende por el panel activo de cada nivel
+    for (let i = 0; i < 3; i++) {
+        const panel = document.querySelector(btn.dataset.bsTarget);
+        btn = panel?.querySelector('.tramitacion-tabs .nav-link.active:not(.btn-nueva-entidad)');
+        if (!btn?.id) break;
+        cadena.push(btn.id);
+    }
+    return cadena;
+}
 
 function _buildCrearEndpoint(nivel, parentId) {
     const map = {

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -47,6 +47,13 @@ document.addEventListener('click', (e) => {
     const modalEl  = document.getElementById(`modal-nueva-${nivel}`);
     if (!modalEl) return;
     modalEl.dataset.parentId = parentId;
+    // Resetear form y re-habilitar submit por si quedó disabled de una apertura anterior
+    const form = modalEl.querySelector('.form-nueva-entidad');
+    if (form) {
+        form.reset();
+        const btnSubmit = form.querySelector('[type=submit]');
+        if (btnSubmit) btnSubmit.disabled = false;
+    }
     bootstrap.Modal.getOrCreateInstance(modalEl).show();
 });
 

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -196,24 +196,24 @@ function _actualizarTabIcon(nivel, id, panel) {
     if (nivel === 'solicitud') {
         const est = estadoEl?.value || 'EN_TRAMITE';
         const map = {
-            'EN_TRAMITE': ['fa-solid fa-file-contract',      'text-warning'],
-            'RESUELTA':   ['fa-solid fa-file-circle-check',  'text-success'],
-            'DESISTIDA':  ['fa-solid fa-file-circle-xmark',  'text-secondary'],
-            'ARCHIVADA':  ['fa-regular fa-file',             'text-secondary'],
+            'EN_TRAMITE': ['bi bi-file-earmark-text',  'text-primary'],
+            'RESUELTA':   ['bi bi-file-earmark-check', 'text-success'],
+            'DESISTIDA':  ['bi bi-file-earmark-x',     'text-danger'],
+            'ARCHIVADA':  ['bi bi-file-earmark',       'text-secondary'],
         };
         [icono, color] = map[est] || map['EN_TRAMITE'];
     } else {
         const tieneFin    = fechaFinEl?.value;
         const tieneInicio = fechaInicioEl?.value;
-        const finIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-solid fa-clipboard-check', tarea: 'fa-solid fa-square-check' };
-        const curIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-solid fa-clipboard-list',  tarea: 'fa-solid fa-pen-to-square' };
-        const penIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-regular fa-clipboard',     tarea: 'fa-regular fa-square' };
+        const finIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard-check', tarea: 'bi bi-check-square' };
+        const curIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard-pulse',  tarea: 'bi bi-pencil-square' };
+        const penIcons   = { fase: 'bi bi-bar-chart-steps', tramite: 'bi bi-clipboard',        tarea: 'bi bi-square' };
         if (tieneFin) {
-            icono = finIcons[nivel] || 'fa-regular fa-file'; color = 'text-success';
+            icono = finIcons[nivel] || 'bi bi-file-earmark'; color = 'text-success';
         } else if (tieneInicio) {
-            icono = curIcons[nivel] || 'fa-regular fa-file'; color = 'text-warning';
+            icono = curIcons[nivel] || 'bi bi-file-earmark'; color = 'text-warning';
         } else {
-            icono = penIcons[nivel] || 'fa-regular fa-file';
+            icono = penIcons[nivel] || 'bi bi-file-earmark';
         }
     }
     iconEl.className = `${icono} ${color}`;

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -50,7 +50,7 @@ document.addEventListener('click', (e) => {
     bootstrap.Modal.getOrCreateInstance(modalEl).show();
 });
 
-// Submit de formulario de creación → POST → location.reload()
+// Submit de formulario de creación → POST → inyección dinámica en DOM
 document.addEventListener('submit', async (e) => {
     if (!e.target.classList.contains('form-nueva-entidad')) return;
     e.preventDefault();
@@ -75,15 +75,9 @@ document.addEventListener('submit', async (e) => {
             if (btnSubmit) btnSubmit.disabled = false;
             return;
         }
-        // Cerrar modal y recargar la página para mostrar el nuevo elemento
         bootstrap.Modal.getInstance(modalEl)?.hide();
         if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
-        // Guardar la cadena de tabs visibles + el nuevo elemento para restaurar tras reload
-        sessionStorage.setItem('v3_tabs_restaurar', JSON.stringify({
-            padres: _getCadenaTabsActivos(),
-            nuevo: `tab-${nivel}-${data.id}`,
-        }));
-        location.reload();
+        await _insertarNuevoTab(nivel, data.id, parentId);
     } catch (err) {
         mostrarError('Error de red: ' + err.message);
         if (btnSubmit) btnSubmit.disabled = false;
@@ -278,27 +272,6 @@ document.addEventListener('click', async (e) => {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/**
- * Devuelve los IDs de los tabs activos en la cadena visible (nivel 1→4),
- * recorriendo los paneles activos de forma descendente para evitar incluir
- * tabs activos de paneles ocultos.
- */
-function _getCadenaTabsActivos() {
-    const cadena = [];
-    // Nivel 1 — solicitud
-    let btn = document.querySelector('.tabs-nivel-1 .tramitacion-tabs .nav-link.active:not(.btn-nueva-entidad)');
-    if (!btn?.id) return cadena;
-    cadena.push(btn.id);
-    // Niveles 2, 3, 4 — desciende por el panel activo de cada nivel
-    for (let i = 0; i < 3; i++) {
-        const panel = document.querySelector(btn.dataset.bsTarget);
-        btn = panel?.querySelector('.tramitacion-tabs .nav-link.active:not(.btn-nueva-entidad)');
-        if (!btn?.id) break;
-        cadena.push(btn.id);
-    }
-    return cadena;
-}
-
 function _buildCrearEndpoint(nivel, parentId) {
     const map = {
         solicitud: `/api/vista3/expediente/${parentId}/solicitudes/nueva`,
@@ -309,24 +282,60 @@ function _buildCrearEndpoint(nivel, parentId) {
     return map[nivel] || null;
 }
 
-// Inicializar tooltips y restaurar tabs activos tras crear elemento
-document.addEventListener('DOMContentLoaded', () => {
-    const restaurarStr = sessionStorage.getItem('v3_tabs_restaurar');
-    if (restaurarStr) {
-        sessionStorage.removeItem('v3_tabs_restaurar');
-        const { padres, nuevo } = JSON.parse(restaurarStr);
-        // Restaurar tabs padre en orden (nivel 1 → 4) para que los paneles estén visibles
-        padres.forEach(id => {
-            const btn = document.getElementById(id);
-            if (btn) new bootstrap.Tab(btn).show();
-        });
-        // Activar el tab del elemento recién creado y hacer scroll hasta él
-        const btnNuevo = document.getElementById(nuevo);
-        if (btnNuevo) {
-            new bootstrap.Tab(btnNuevo).show();
-            btnNuevo.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }
+/** Localiza el tabList y tabContent del contenedor padre según nivel y parentId. */
+function _encontrarContenedorTab(nivel, parentId) {
+    const parentNivelMap = { solicitud: null, fase: 'solicitud', tramite: 'fase', tarea: 'tramite' };
+    const parentNivel = parentNivelMap[nivel];
+    const container = parentNivel
+        ? document.getElementById(`panel-${parentNivel}-${parentId}`)
+        : document.querySelector('.tabs-nivel-1');
+    if (!container) return {};
+    return {
+        tabList:    container.querySelector('.tramitacion-tabs'),
+        tabContent: container.querySelector('.tab-content'),
+    };
+}
+
+/**
+ * Hace fetch de la página, extrae el tab+panel del nuevo elemento
+ * e los inyecta en el DOM sin recargar la página.
+ */
+async function _insertarNuevoTab(nivel, id, parentId) {
+    const respHtml = await fetch(location.href);
+    const html = await respHtml.text();
+    const tempDoc = new DOMParser().parseFromString(html, 'text/html');
+
+    const newLi    = tempDoc.getElementById(`tab-${nivel}-${id}`)?.closest('li');
+    const newPanel = tempDoc.getElementById(`panel-${nivel}-${id}`);
+    if (!newLi || !newPanel) { location.reload(); return; }
+
+    // Quitar active/show: se activará manualmente
+    newLi.querySelector('.nav-link')?.classList.remove('active');
+    newPanel.classList.remove('active', 'show');
+
+    const { tabList, tabContent } = _encontrarContenedorTab(nivel, parentId);
+    if (!tabList || !tabContent) { location.reload(); return; }
+
+    // Insertar antes del botón "+"
+    const plusLi = tabList.querySelector('.btn-nueva-entidad')?.closest('li');
+    tabList.insertBefore(document.adoptNode(newLi), plusLi || null);
+    tabContent.appendChild(document.adoptNode(newPanel));
+
+    // Activar el nuevo tab y desplazar hasta él
+    const newBtn = document.getElementById(`tab-${nivel}-${id}`);
+    if (newBtn) {
+        new bootstrap.Tab(newBtn).show();
+        newBtn.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
+
+    // Re-inicializar tooltips en el nuevo panel
+    document.getElementById(`panel-${nivel}-${id}`)
+        ?.querySelectorAll('[data-bs-toggle="tooltip"]')
+        .forEach(el => new bootstrap.Tooltip(el));
+}
+
+// Inicializar tooltips al cargar
+document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
         new bootstrap.Tooltip(el);
     });

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -320,9 +320,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const btn = document.getElementById(id);
             if (btn) new bootstrap.Tab(btn).show();
         });
-        // Activar el tab del elemento recién creado
+        // Activar el tab del elemento recién creado y hacer scroll hasta él
         const btnNuevo = document.getElementById(nuevo);
-        if (btnNuevo) new bootstrap.Tab(btnNuevo).show();
+        if (btnNuevo) {
+            new bootstrap.Tab(btnNuevo).show();
+            btnNuevo.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
     }
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
         new bootstrap.Tooltip(el);

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -78,6 +78,8 @@ document.addEventListener('submit', async (e) => {
         // Cerrar modal y recargar la página para mostrar el nuevo elemento
         bootstrap.Modal.getInstance(modalEl)?.hide();
         if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
+        const tabActivo = document.querySelector('.tramitacion-tabs .nav-link.active');
+        if (tabActivo) sessionStorage.setItem('v3_tab_activo', tabActivo.id);
         location.reload();
     } catch (err) {
         mostrarError('Error de red: ' + err.message);
@@ -266,8 +268,14 @@ function _buildCrearEndpoint(nivel, parentId) {
     return map[nivel] || null;
 }
 
-// Inicializar tooltips de Bootstrap en toda la página
+// Inicializar tooltips y restaurar tab activo tras reload
 document.addEventListener('DOMContentLoaded', () => {
+    const tabId = sessionStorage.getItem('v3_tab_activo');
+    if (tabId) {
+        sessionStorage.removeItem('v3_tab_activo');
+        const btn = document.getElementById(tabId);
+        if (btn) new bootstrap.Tab(btn).show();
+    }
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
         new bootstrap.Tooltip(el);
     });

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -1,0 +1,270 @@
+/**
+ * v3-tabs-main.js — Tabs dinámicos V3 (issue #150)
+ *
+ * Responsabilidades:
+ *   - Creación de entidad hija via modal → reload
+ *   - Edición inline (toggle ver/editar) → actualización DOM
+ *   - Borrado → eliminación DOM (tab + panel)
+ *   - Toasts de error/advertencia
+ */
+
+'use strict';
+
+// ── Helpers toast ─────────────────────────────────────────────────────────────
+
+function mostrarToast(mensaje, tipo) {
+    const contenedor = document.querySelector('.toast-container');
+    if (!contenedor) { alert(mensaje); return; }
+    const el = document.createElement('div');
+    el.className = `toast toast-${tipo}`;
+    el.setAttribute('role', 'alert');
+    el.setAttribute('data-bs-autohide', 'true');
+    el.setAttribute('data-bs-delay', '8000');
+    el.innerHTML = `
+        <div class="d-flex align-items-center p-3">
+            <div class="flex-grow-1">
+                <i class="fas fa-exclamation-circle me-2"></i>${mensaje}
+            </div>
+            <button type="button" class="btn-close ms-3" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+        </div>`;
+    contenedor.appendChild(el);
+    new bootstrap.Toast(el).show();
+    el.addEventListener('hidden.bs.toast', () => el.remove());
+}
+
+function mostrarError(msg)       { mostrarToast(msg, 'danger'); }
+function mostrarAdvertencia(msg) { mostrarToast(msg, 'warning'); }
+
+
+// ── Creación de entidad hija ──────────────────────────────────────────────────
+//    Clic en .btn-nueva-entidad → actualiza data-parent-id del modal y lo abre
+
+document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.btn-nueva-entidad');
+    if (!btn) return;
+    const nivel    = btn.dataset.nivel;
+    const parentId = btn.dataset.parentId;
+    const modalEl  = document.getElementById(`modal-nueva-${nivel}`);
+    if (!modalEl) return;
+    modalEl.dataset.parentId = parentId;
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+});
+
+// Submit de formulario de creación → POST → location.reload()
+document.addEventListener('submit', async (e) => {
+    if (!e.target.classList.contains('form-nueva-entidad')) return;
+    e.preventDefault();
+    const form     = e.target;
+    const nivel    = form.dataset.nivel;
+    const modalEl  = form.closest('.modal');
+    const parentId = modalEl.dataset.parentId;
+    const endpoint = _buildCrearEndpoint(nivel, parentId);
+    if (!endpoint) return;
+
+    const btnSubmit = form.querySelector('[type=submit]');
+    if (btnSubmit) btnSubmit.disabled = true;
+
+    try {
+        const resp = await fetch(endpoint, {
+            method: 'POST',
+            body: new FormData(form),
+        });
+        const data = await resp.json();
+        if (!data.ok) {
+            mostrarError(data.error || 'Error al crear');
+            if (btnSubmit) btnSubmit.disabled = false;
+            return;
+        }
+        // Cerrar modal y recargar la página para mostrar el nuevo elemento
+        bootstrap.Modal.getInstance(modalEl)?.hide();
+        if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
+        location.reload();
+    } catch (err) {
+        mostrarError('Error de red: ' + err.message);
+        if (btnSubmit) btnSubmit.disabled = false;
+    }
+});
+
+
+// ── Toggle edición inline ─────────────────────────────────────────────────────
+
+document.addEventListener('click', (e) => {
+    if (e.target.closest('.btn-editar-entidad')) {
+        const panel = e.target.closest('.tab-pane');
+        if (panel) _toggleModoEditar(panel, true);
+    }
+    if (e.target.closest('.btn-cancelar-edicion')) {
+        const panel = e.target.closest('.tab-pane');
+        if (panel) _toggleModoEditar(panel, false);
+    }
+});
+
+function _toggleModoEditar(panel, editar) {
+    panel.querySelectorAll('[data-modo-ver]').forEach(el =>
+        el.classList.toggle('d-none', editar));
+    panel.querySelectorAll('[data-modo-editar]').forEach(el =>
+        el.classList.toggle('d-none', !editar));
+    // Campos sin wrapper data-modo-* (textareas compartidas)
+    panel.querySelectorAll(
+        'textarea:not([data-modo-ver]):not([data-modo-editar])'
+    ).forEach(el => {
+        if (!el.dataset.siempreDeshabilitado) el.readOnly = !editar;
+    });
+}
+
+
+// ── Guardar edición inline ────────────────────────────────────────────────────
+
+document.addEventListener('submit', async (e) => {
+    if (!e.target.classList.contains('form-editar-entidad')) return;
+    e.preventDefault();
+    const form      = e.target;
+    const nivel     = form.dataset.nivel;
+    const entidadId = form.dataset.entidadId;
+    const endpoint  = `/api/vista3/${nivel}/${entidadId}/editar`;
+
+    const btnSubmit = form.querySelector('[type=submit]');
+    if (btnSubmit) btnSubmit.disabled = true;
+
+    try {
+        const resp = await fetch(endpoint, {
+            method: 'POST',
+            body: new FormData(form),
+        });
+        const data = await resp.json();
+        if (!data.ok) {
+            mostrarError(data.error || 'Error al guardar');
+            if (btnSubmit) btnSubmit.disabled = false;
+            return;
+        }
+        // Actualizar campos de vista y volver a modo ver
+        const panel = form.closest('.tab-pane');
+        _aplicarCambiosAVista(panel);
+        _toggleModoEditar(panel, false);
+        _actualizarTabIcon(nivel, entidadId, panel);
+        if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
+    } catch (err) {
+        mostrarError('Error de red: ' + err.message);
+    } finally {
+        if (btnSubmit) btnSubmit.disabled = false;
+    }
+});
+
+/** Copia los valores de los campos de edición a los campos de visualización. */
+function _aplicarCambiosAVista(panel) {
+    panel.querySelectorAll('[data-display-for]').forEach(displayEl => {
+        const nombre  = displayEl.dataset.displayFor;
+        const editEl  = panel.querySelector(`[name="${nombre}"]`);
+        if (!editEl) return;
+
+        if (editEl.tagName === 'SELECT') {
+            const sel = editEl.options[editEl.selectedIndex];
+            displayEl.value = sel ? sel.text : '';
+        } else if (editEl.type === 'date' && editEl.value) {
+            const [y, m, d] = editEl.value.split('-');
+            displayEl.value = d ? `${d}/${m}/${y}` : '';
+        } else {
+            displayEl.value = editEl.value;
+        }
+    });
+    // Textareas con data-display-for (observaciones, notas)
+    panel.querySelectorAll('textarea[data-display-for]').forEach(displayEl => {
+        const editEl = panel.querySelector(`[name="${displayEl.dataset.displayFor}"]`);
+        if (editEl) displayEl.value = editEl.value;
+    });
+}
+
+/** Actualiza el icono del tab según el estado derivado de los campos del panel. */
+function _actualizarTabIcon(nivel, id, panel) {
+    const tabBtn = document.getElementById(`tab-${nivel}-${id}`);
+    if (!tabBtn) return;
+    const iconEl = tabBtn.querySelector('.tab-icon i');
+    if (!iconEl) return;
+
+    const fechaInicioEl = panel?.querySelector('[name="fecha_inicio"]');
+    const fechaFinEl    = panel?.querySelector('[name="fecha_fin"]');
+    const estadoEl      = panel?.querySelector('[name="estado"]');
+
+    let icono = '', color = 'text-secondary';
+
+    if (nivel === 'solicitud') {
+        const est = estadoEl?.value || 'EN_TRAMITE';
+        const map = {
+            'EN_TRAMITE': ['fa-solid fa-file-contract',      'text-warning'],
+            'RESUELTA':   ['fa-solid fa-file-circle-check',  'text-success'],
+            'DESISTIDA':  ['fa-solid fa-file-circle-xmark',  'text-secondary'],
+            'ARCHIVADA':  ['fa-regular fa-file',             'text-secondary'],
+        };
+        [icono, color] = map[est] || map['EN_TRAMITE'];
+    } else {
+        const tieneFin    = fechaFinEl?.value;
+        const tieneInicio = fechaInicioEl?.value;
+        const finIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-solid fa-clipboard-check', tarea: 'fa-solid fa-square-check' };
+        const curIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-solid fa-clipboard-list',  tarea: 'fa-solid fa-pen-to-square' };
+        const penIcons   = { fase: 'fa-solid fa-sitemap',       tramite: 'fa-regular fa-clipboard',     tarea: 'fa-regular fa-square' };
+        if (tieneFin) {
+            icono = finIcons[nivel] || 'fa-regular fa-file'; color = 'text-success';
+        } else if (tieneInicio) {
+            icono = curIcons[nivel] || 'fa-regular fa-file'; color = 'text-warning';
+        } else {
+            icono = penIcons[nivel] || 'fa-regular fa-file';
+        }
+    }
+    iconEl.className = `${icono} ${color}`;
+}
+
+
+// ── Borrado ───────────────────────────────────────────────────────────────────
+
+document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.btn-borrar-entidad');
+    if (!btn) return;
+    if (!confirm('¿Eliminar este elemento? Esta acción no se puede deshacer.')) return;
+
+    const nivel = btn.dataset.nivel;
+    const id    = btn.dataset.id;
+
+    try {
+        const resp = await fetch(`/api/vista3/${nivel}/${id}/borrar`, {
+            method: 'POST',
+        });
+        const data = await resp.json();
+        if (!data.ok) {
+            mostrarError(data.error || 'No se pudo eliminar');
+            return;
+        }
+        // Activar tab anterior o siguiente antes de eliminar
+        const tabBtn  = document.getElementById(`tab-${nivel}-${id}`);
+        const panelEl = document.getElementById(`panel-${nivel}-${id}`);
+        const liEl    = tabBtn?.closest('li');
+        const prevLi  = liEl?.previousElementSibling;
+        const nextLi  = liEl?.nextElementSibling;
+        const targetBtn = prevLi?.querySelector('button.nav-link:not(.btn-nueva-entidad)')
+                       || nextLi?.querySelector('button.nav-link:not(.btn-nueva-entidad)');
+        if (targetBtn) new bootstrap.Tab(targetBtn).show();
+        liEl?.remove();
+        panelEl?.remove();
+    } catch (err) {
+        mostrarError('Error de red: ' + err.message);
+    }
+});
+
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function _buildCrearEndpoint(nivel, parentId) {
+    const map = {
+        solicitud: `/api/vista3/expediente/${parentId}/solicitudes/nueva`,
+        fase:      `/api/vista3/solicitud/${parentId}/fases/nueva`,
+        tramite:   `/api/vista3/fase/${parentId}/tramites/nuevo`,
+        tarea:     `/api/vista3/tramite/${parentId}/tareas/nueva`,
+    };
+    return map[nivel] || null;
+}
+
+// Inicializar tooltips de Bootstrap en toda la página
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el);
+    });
+});

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -88,6 +88,23 @@ document.addEventListener('submit', async (e) => {
 });
 
 
+// ── Cancelar edición al cambiar de tab ────────────────────────────────────────
+
+document.addEventListener('hide.bs.tab', (e) => {
+    const panelId = e.target.dataset.bsTarget;
+    if (!panelId) return;
+    const panel = document.querySelector(panelId);
+    if (!panel) return;
+    panel.querySelectorAll('.card').forEach(card => {
+        if (card.querySelector('[data-modo-editar]:not(.d-none)')) {
+            const form = card.querySelector('form');
+            if (form) form.reset();
+            _toggleModoEditar(card, false);
+        }
+    });
+});
+
+
 // ── Toggle edición inline ─────────────────────────────────────────────────────
 
 document.addEventListener('click', (e) => {

--- a/app/static/js/v3-tabs-main.js
+++ b/app/static/js/v3-tabs-main.js
@@ -90,12 +90,16 @@ document.addEventListener('submit', async (e) => {
 
 document.addEventListener('click', (e) => {
     if (e.target.closest('.btn-editar-entidad')) {
-        const panel = e.target.closest('.tab-pane');
-        if (panel) _toggleModoEditar(panel, true);
+        const card = e.target.closest('.card');
+        if (card) _toggleModoEditar(card, true);
     }
     if (e.target.closest('.btn-cancelar-edicion')) {
-        const panel = e.target.closest('.tab-pane');
-        if (panel) _toggleModoEditar(panel, false);
+        const card = e.target.closest('.card');
+        if (card) {
+            const form = card.querySelector('form');
+            if (form) form.reset();
+            _toggleModoEditar(card, false);
+        }
     }
 });
 
@@ -138,10 +142,10 @@ document.addEventListener('submit', async (e) => {
             return;
         }
         // Actualizar campos de vista y volver a modo ver
-        const panel = form.closest('.tab-pane');
-        _aplicarCambiosAVista(panel);
-        _toggleModoEditar(panel, false);
-        _actualizarTabIcon(nivel, entidadId, panel);
+        const card = form.closest('.card');
+        _aplicarCambiosAVista(card);
+        _toggleModoEditar(card, false);
+        _actualizarTabIcon(nivel, entidadId, card);
         if (data.advertencia) mostrarAdvertencia(data.advertencia.mensaje);
     } catch (err) {
         mostrarError('Error de red: ' + err.message);

--- a/app/templates/vistas/vista3/_cuerpo_fase.html
+++ b/app/templates/vistas/vista3/_cuerpo_fase.html
@@ -1,0 +1,83 @@
+{# Cuerpo de fase — patrón V4 (ver/editar inline)
+   Contexto: fase_data, resultados_fase
+#}
+<div class="card mb-3">
+    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-sitemap me-1"></i> {{ fase_data.nombre }}</span>
+        <div>
+            <div data-modo-ver>
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                    <i class="fa-solid fa-pen"></i> Editar
+                </button>
+            </div>
+            <div data-modo-editar class="d-none d-flex gap-1">
+                <button type="submit" form="form-fase-{{ fase_data.obj.id }}"
+                        class="btn btn-sm btn-success">
+                    <i class="fa-solid fa-save"></i> Guardar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                        data-nivel="fase" data-id="{{ fase_data.obj.id }}"
+                        data-bs-toggle="tooltip" title="Eliminar fase">
+                    <i class="fa-solid fa-trash"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="form-fase-{{ fase_data.obj.id }}"
+              class="form-detail form-editar-entidad"
+              data-nivel="fase"
+              data-entidad-id="{{ fase_data.obj.id }}">
+            <div class="row g-3">
+
+                {# Fecha inicio #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha inicio</label>
+                    <input type="text" class="form-control"
+                           value="{{ fase_data.obj.fecha_inicio.strftime('%d/%m/%Y') if fase_data.obj.fecha_inicio else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_inicio" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_inicio" data-modo-editar
+                           value="{{ fase_data.obj.fecha_inicio.isoformat() if fase_data.obj.fecha_inicio else '' }}">
+                </div>
+
+                {# Fecha fin #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha fin</label>
+                    <input type="text" class="form-control"
+                           value="{{ fase_data.obj.fecha_fin.strftime('%d/%m/%Y') if fase_data.obj.fecha_fin else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_fin" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_fin" data-modo-editar
+                           value="{{ fase_data.obj.fecha_fin.isoformat() if fase_data.obj.fecha_fin else '' }}">
+                </div>
+
+                {# Resultado #}
+                <div class="col-md-4">
+                    <label class="fw-semibold">Resultado</label>
+                    <input type="text" class="form-control"
+                           value="{{ fase_data.obj.resultado_fase.nombre if fase_data.obj.resultado_fase else '' }}"
+                           readonly data-modo-ver data-display-for="resultado_fase_id">
+                    <select class="form-select d-none" name="resultado_fase_id" data-modo-editar>
+                        <option value="">— Sin resultado —</option>
+                        {% for rf in resultados_fase %}
+                        <option value="{{ rf.id }}"
+                                {% if fase_data.obj.resultado_fase_id == rf.id %}selected{% endif %}>
+                            {{ rf.nombre }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                {# Observaciones #}
+                <div class="col-12">
+                    <label class="fw-semibold">Observaciones</label>
+                    <textarea class="form-control" name="observaciones" rows="2"
+                              readonly>{{ fase_data.obj.observaciones or '' }}</textarea>
+                </div>
+
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_cuerpo_fase.html
+++ b/app/templates/vistas/vista3/_cuerpo_fase.html
@@ -6,19 +6,19 @@
         <span><i class="{{ fase_data.estado | icono_fase }} {{ fase_data.estado | color_fase }} me-1"></i> {{ fase_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-fase-{{ fase_data.obj.id }}"
-                        class="btn btn-sm btn-success">
+                        class="btn btn-sm btn-light">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
                         data-nivel="fase" data-id="{{ fase_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar fase">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_cuerpo_fase.html
+++ b/app/templates/vistas/vista3/_cuerpo_fase.html
@@ -6,19 +6,19 @@
         <span><i class="{{ fase_data.estado | icono_fase }} {{ fase_data.estado | color_fase }} me-1"></i> {{ fase_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-fase-{{ fase_data.obj.id }}"
-                        class="btn btn-sm btn-light">
+                        class="btn btn-sm btn-success">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
                         data-nivel="fase" data-id="{{ fase_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar fase">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_cuerpo_fase.html
+++ b/app/templates/vistas/vista3/_cuerpo_fase.html
@@ -3,7 +3,7 @@
 #}
 <div class="card mb-3">
     <div class="card-header card-header-fase d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-sitemap me-1"></i> {{ fase_data.nombre }}</span>
+        <span><i class="{{ fase_data.estado | icono_fase }} {{ fase_data.estado | color_fase }} me-1"></i> {{ fase_data.nombre }}</span>
         <div>
             <div data-modo-ver>
                 <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">

--- a/app/templates/vistas/vista3/_cuerpo_fase.html
+++ b/app/templates/vistas/vista3/_cuerpo_fase.html
@@ -2,7 +2,7 @@
    Contexto: fase_data, resultados_fase
 #}
 <div class="card mb-3">
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+    <div class="card-header card-header-fase d-flex justify-content-between align-items-center">
         <span><i class="fa-solid fa-sitemap me-1"></i> {{ fase_data.nombre }}</span>
         <div>
             <div data-modo-ver>

--- a/app/templates/vistas/vista3/_cuerpo_solicitud.html
+++ b/app/templates/vistas/vista3/_cuerpo_solicitud.html
@@ -3,7 +3,7 @@
 #}
 <div class="card mb-3">
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-file-contract me-1"></i> Solicitud</span>
+        <span><i class="{{ sol_data.obj.estado | icono_solicitud }} {{ sol_data.obj.estado | color_solicitud }} me-1"></i> Solicitud</span>
         <div>
             <div data-modo-ver>
                 <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">

--- a/app/templates/vistas/vista3/_cuerpo_solicitud.html
+++ b/app/templates/vistas/vista3/_cuerpo_solicitud.html
@@ -1,0 +1,92 @@
+{# Cuerpo de solicitud — patrón V4 (ver/editar inline)
+   Contexto: sol_data
+#}
+<div class="card mb-3">
+    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-file-contract me-1"></i> Solicitud</span>
+        <div>
+            <div data-modo-ver>
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                    <i class="fa-solid fa-pen"></i> Editar
+                </button>
+            </div>
+            <div data-modo-editar class="d-none d-flex gap-1">
+                <button type="submit" form="form-solicitud-{{ sol_data.obj.id }}"
+                        class="btn btn-sm btn-success">
+                    <i class="fa-solid fa-save"></i> Guardar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                        data-nivel="solicitud" data-id="{{ sol_data.obj.id }}"
+                        data-bs-toggle="tooltip" title="Eliminar solicitud">
+                    <i class="fa-solid fa-trash"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="form-solicitud-{{ sol_data.obj.id }}"
+              class="form-detail form-editar-entidad"
+              data-nivel="solicitud"
+              data-entidad-id="{{ sol_data.obj.id }}">
+            <div class="row g-3">
+
+                {# Tipos — siempre readonly (N:M, no editable aquí) #}
+                <div class="col-md-4">
+                    <label class="fw-semibold">Tipos</label>
+                    <input type="text" class="form-control"
+                           value="{{ sol_data.tipos_str }}" readonly
+                           data-siempre-deshabilitado="1"
+                           data-bs-toggle="tooltip"
+                           title="Los tipos se gestionan al crear la solicitud">
+                </div>
+
+                {# Estado #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Estado</label>
+                    <input type="text" class="form-control"
+                           value="{{ sol_data.obj.estado }}" readonly
+                           data-modo-ver data-display-for="estado">
+                    <select class="form-select d-none" name="estado" data-modo-editar>
+                        {% for val in ['EN_TRAMITE','RESUELTA','DESISTIDA','ARCHIVADA'] %}
+                        <option value="{{ val }}"
+                                {% if sol_data.obj.estado == val %}selected{% endif %}>
+                            {{ val }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                {# Fecha solicitud #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha solicitud</label>
+                    <input type="text" class="form-control"
+                           value="{{ sol_data.obj.fecha_solicitud.strftime('%d/%m/%Y') if sol_data.obj.fecha_solicitud else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_solicitud" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_solicitud" data-modo-editar
+                           value="{{ sol_data.obj.fecha_solicitud.isoformat() if sol_data.obj.fecha_solicitud else '' }}">
+                </div>
+
+                {# Fecha fin #}
+                <div class="col-md-2">
+                    <label class="fw-semibold">Fecha fin</label>
+                    <input type="text" class="form-control"
+                           value="{{ sol_data.obj.fecha_fin.strftime('%d/%m/%Y') if sol_data.obj.fecha_fin else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_fin" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_fin" data-modo-editar
+                           value="{{ sol_data.obj.fecha_fin.isoformat() if sol_data.obj.fecha_fin else '' }}">
+                </div>
+
+                {# Observaciones #}
+                <div class="col-12">
+                    <label class="fw-semibold">Observaciones</label>
+                    <textarea class="form-control" name="observaciones" rows="2"
+                              readonly>{{ sol_data.obj.observaciones or '' }}</textarea>
+                </div>
+
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -6,19 +6,19 @@
         <span><i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }} me-1"></i> {{ tarea_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-tarea-{{ tarea_data.obj.id }}"
-                        class="btn btn-sm btn-light">
+                        class="btn btn-sm btn-success">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
                         data-nivel="tarea" data-id="{{ tarea_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar tarea">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -3,7 +3,7 @@
 #}
 <div class="card mb-3">
     <div class="card-header card-header-tarea d-flex justify-content-between align-items-center">
-        <span><i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }} me-1"></i> {{ tarea_data.nombre }}</span>
+        <span><i class="{{ tarea_data.codigo | icono_tarea_tipo }} {{ tarea_data.estado | color_tarea }} me-1"></i> {{ tarea_data.nombre }}</span>
         <div>
             <div data-modo-ver>
                 <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -6,19 +6,19 @@
         <span><i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }} me-1"></i> {{ tarea_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-tarea-{{ tarea_data.obj.id }}"
-                        class="btn btn-sm btn-success">
+                        class="btn btn-sm btn-light">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
                         data-nivel="tarea" data-id="{{ tarea_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar tarea">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -3,7 +3,7 @@
 #}
 <div class="card mb-3">
     <div class="card-header card-header-tarea d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-pen-to-square me-1"></i> {{ tarea_data.nombre }}</span>
+        <span><i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }} me-1"></i> {{ tarea_data.nombre }}</span>
         <div>
             <div data-modo-ver>
                 <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -1,0 +1,107 @@
+{# Cuerpo de tarea — patrón V4 (ver/editar inline) + tabla documentos
+   Contexto: tarea_data (con tarea_data.documentos)
+#}
+<div class="card mb-3">
+    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-pen-to-square me-1"></i> {{ tarea_data.nombre }}</span>
+        <div>
+            <div data-modo-ver>
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                    <i class="fa-solid fa-pen"></i> Editar
+                </button>
+            </div>
+            <div data-modo-editar class="d-none d-flex gap-1">
+                <button type="submit" form="form-tarea-{{ tarea_data.obj.id }}"
+                        class="btn btn-sm btn-success">
+                    <i class="fa-solid fa-save"></i> Guardar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                        data-nivel="tarea" data-id="{{ tarea_data.obj.id }}"
+                        data-bs-toggle="tooltip" title="Eliminar tarea">
+                    <i class="fa-solid fa-trash"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="form-tarea-{{ tarea_data.obj.id }}"
+              class="form-detail form-editar-entidad"
+              data-nivel="tarea"
+              data-entidad-id="{{ tarea_data.obj.id }}">
+            <div class="row g-3">
+
+                {# Fecha inicio #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha inicio</label>
+                    <input type="text" class="form-control"
+                           value="{{ tarea_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tarea_data.obj.fecha_inicio else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_inicio" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_inicio" data-modo-editar
+                           value="{{ tarea_data.obj.fecha_inicio.isoformat() if tarea_data.obj.fecha_inicio else '' }}">
+                </div>
+
+                {# Fecha fin #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha fin</label>
+                    <input type="text" class="form-control"
+                           value="{{ tarea_data.obj.fecha_fin.strftime('%d/%m/%Y') if tarea_data.obj.fecha_fin else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_fin" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_fin" data-modo-editar
+                           value="{{ tarea_data.obj.fecha_fin.isoformat() if tarea_data.obj.fecha_fin else '' }}">
+                </div>
+
+                {# Notas #}
+                <div class="col-12">
+                    <label class="fw-semibold">Notas</label>
+                    <textarea class="form-control" name="notas" rows="2"
+                              readonly>{{ tarea_data.obj.notas or '' }}</textarea>
+                </div>
+
+            </div>
+        </form>
+
+        {# Tabla de documentos asociados #}
+        {% if tarea_data.documentos %}
+        <div class="mt-3">
+            <h6 class="fw-semibold mb-2">
+                <i class="fa-solid fa-file me-1"></i> Documentos ({{ tarea_data.documentos | length }})
+            </h6>
+            <table class="table table-sm table-hover mb-0">
+                <thead class="table-success">
+                    <tr>
+                        <th>Relación</th>
+                        <th>Documento</th>
+                        <th>Fecha</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for doc_data in tarea_data.documentos %}
+                    <tr>
+                        <td>
+                            <span class="badge bg-secondary">{{ doc_data.tipo_relacion }}</span>
+                        </td>
+                        <td>{{ doc_data.obj.nombre if doc_data.obj.nombre else 'Doc ' ~ doc_data.obj.id }}</td>
+                        <td class="small">
+                            {{ doc_data.obj.fecha_creacion.strftime('%d/%m/%Y') if doc_data.obj.fecha_creacion else '—' }}
+                        </td>
+                        <td>
+                            {% if doc_data.obj.ruta %}
+                            <a href="{{ url_for('static', filename='uploads/' ~ doc_data.obj.ruta) }}"
+                               class="btn btn-sm btn-outline-secondary" target="_blank"
+                               title="Descargar">
+                                <i class="fa-solid fa-download"></i>
+                            </a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_cuerpo_tarea.html
+++ b/app/templates/vistas/vista3/_cuerpo_tarea.html
@@ -2,7 +2,7 @@
    Contexto: tarea_data (con tarea_data.documentos)
 #}
 <div class="card mb-3">
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+    <div class="card-header card-header-tarea d-flex justify-content-between align-items-center">
         <span><i class="fa-solid fa-pen-to-square me-1"></i> {{ tarea_data.nombre }}</span>
         <div>
             <div data-modo-ver>

--- a/app/templates/vistas/vista3/_cuerpo_tramite.html
+++ b/app/templates/vistas/vista3/_cuerpo_tramite.html
@@ -1,0 +1,66 @@
+{# Cuerpo de trámite — patrón V4 (ver/editar inline)
+   Contexto: tram_data
+#}
+<div class="card mb-3">
+    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+        <span><i class="fa-solid fa-clipboard-list me-1"></i> {{ tram_data.nombre }}</span>
+        <div>
+            <div data-modo-ver>
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                    <i class="fa-solid fa-pen"></i> Editar
+                </button>
+            </div>
+            <div data-modo-editar class="d-none d-flex gap-1">
+                <button type="submit" form="form-tramite-{{ tram_data.obj.id }}"
+                        class="btn btn-sm btn-success">
+                    <i class="fa-solid fa-save"></i> Guardar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                    Cancelar
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                        data-nivel="tramite" data-id="{{ tram_data.obj.id }}"
+                        data-bs-toggle="tooltip" title="Eliminar trámite">
+                    <i class="fa-solid fa-trash"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="form-tramite-{{ tram_data.obj.id }}"
+              class="form-detail form-editar-entidad"
+              data-nivel="tramite"
+              data-entidad-id="{{ tram_data.obj.id }}">
+            <div class="row g-3">
+
+                {# Fecha inicio #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha inicio</label>
+                    <input type="text" class="form-control"
+                           value="{{ tram_data.obj.fecha_inicio.strftime('%d/%m/%Y') if tram_data.obj.fecha_inicio else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_inicio" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_inicio" data-modo-editar
+                           value="{{ tram_data.obj.fecha_inicio.isoformat() if tram_data.obj.fecha_inicio else '' }}">
+                </div>
+
+                {# Fecha fin #}
+                <div class="col-md-3">
+                    <label class="fw-semibold">Fecha fin</label>
+                    <input type="text" class="form-control"
+                           value="{{ tram_data.obj.fecha_fin.strftime('%d/%m/%Y') if tram_data.obj.fecha_fin else '' }}"
+                           readonly data-modo-ver data-display-for="fecha_fin" data-display-format="date">
+                    <input type="date" class="form-control d-none" name="fecha_fin" data-modo-editar
+                           value="{{ tram_data.obj.fecha_fin.isoformat() if tram_data.obj.fecha_fin else '' }}">
+                </div>
+
+                {# Observaciones #}
+                <div class="col-12">
+                    <label class="fw-semibold">Observaciones</label>
+                    <textarea class="form-control" name="observaciones" rows="2"
+                              readonly>{{ tram_data.obj.observaciones or '' }}</textarea>
+                </div>
+
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_cuerpo_tramite.html
+++ b/app/templates/vistas/vista3/_cuerpo_tramite.html
@@ -6,19 +6,19 @@
         <span><i class="{{ tram_data.estado | icono_tramite }} {{ tram_data.estado | color_tramite }} me-1"></i> {{ tram_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-tramite-{{ tram_data.obj.id }}"
-                        class="btn btn-sm btn-light">
+                        class="btn btn-sm btn-success">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
                         data-nivel="tramite" data-id="{{ tram_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar trámite">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_cuerpo_tramite.html
+++ b/app/templates/vistas/vista3/_cuerpo_tramite.html
@@ -2,7 +2,7 @@
    Contexto: tram_data
 #}
 <div class="card mb-3">
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+    <div class="card-header card-header-tramite d-flex justify-content-between align-items-center">
         <span><i class="fa-solid fa-clipboard-list me-1"></i> {{ tram_data.nombre }}</span>
         <div>
             <div data-modo-ver>

--- a/app/templates/vistas/vista3/_cuerpo_tramite.html
+++ b/app/templates/vistas/vista3/_cuerpo_tramite.html
@@ -3,7 +3,7 @@
 #}
 <div class="card mb-3">
     <div class="card-header card-header-tramite d-flex justify-content-between align-items-center">
-        <span><i class="fa-solid fa-clipboard-list me-1"></i> {{ tram_data.nombre }}</span>
+        <span><i class="{{ tram_data.estado | icono_tramite }} {{ tram_data.estado | color_tramite }} me-1"></i> {{ tram_data.nombre }}</span>
         <div>
             <div data-modo-ver>
                 <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">

--- a/app/templates/vistas/vista3/_cuerpo_tramite.html
+++ b/app/templates/vistas/vista3/_cuerpo_tramite.html
@@ -6,19 +6,19 @@
         <span><i class="{{ tram_data.estado | icono_tramite }} {{ tram_data.estado | color_tramite }} me-1"></i> {{ tram_data.nombre }}</span>
         <div>
             <div data-modo-ver>
-                <button type="button" class="btn btn-sm btn-outline-primary btn-editar-entidad">
+                <button type="button" class="btn btn-sm btn-outline-light btn-editar-entidad">
                     <i class="fa-solid fa-pen"></i> Editar
                 </button>
             </div>
             <div data-modo-editar class="d-none d-flex gap-1">
                 <button type="submit" form="form-tramite-{{ tram_data.obj.id }}"
-                        class="btn btn-sm btn-success">
+                        class="btn btn-sm btn-light">
                     <i class="fa-solid fa-save"></i> Guardar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-edicion">
+                <button type="button" class="btn btn-sm btn-outline-light btn-cancelar-edicion">
                     Cancelar
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-danger btn-borrar-entidad"
+                <button type="button" class="btn btn-sm btn-danger btn-borrar-entidad"
                         data-nivel="tramite" data-id="{{ tram_data.obj.id }}"
                         data-bs-toggle="tooltip" title="Eliminar trámite">
                     <i class="fa-solid fa-trash"></i>

--- a/app/templates/vistas/vista3/_modal_nueva_fase.html
+++ b/app/templates/vistas/vista3/_modal_nueva_fase.html
@@ -1,0 +1,35 @@
+{# Modal para crear nueva fase
+   El data-parent-id se actualiza desde JS antes de abrir
+#}
+<div class="modal fade" id="modal-nueva-fase" tabindex="-1"
+     aria-labelledby="modal-nueva-fase-label">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal-nueva-fase-label">
+                    <i class="fa-solid fa-sitemap me-1"></i> Nueva Fase
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form class="form-nueva-entidad" data-nivel="fase">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Tipo de fase <span class="text-danger">*</span></label>
+                        <select class="form-select" name="tipo_fase_id" required>
+                            <option value="">— Selecciona tipo —</option>
+                            {% for t in tipos_fase %}
+                            <option value="{{ t.id }}">{{ t.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-plus me-1"></i> Crear
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_modal_nueva_solicitud.html
+++ b/app/templates/vistas/vista3/_modal_nueva_solicitud.html
@@ -18,7 +18,7 @@
                         <select class="form-select" name="tipo_solicitud_id[]"
                                 multiple size="5" required>
                             {% for t in tipos_solicitud %}
-                            <option value="{{ t.id }}">{{ t.siglas }} — {{ t.nombre }}</option>
+                            <option value="{{ t.id }}">{{ t.siglas }} — {{ t.descripcion }}</option>
                             {% endfor %}
                         </select>
                         <div class="form-text">Mantén Ctrl para seleccionar varios tipos.</div>

--- a/app/templates/vistas/vista3/_modal_nueva_solicitud.html
+++ b/app/templates/vistas/vista3/_modal_nueva_solicitud.html
@@ -1,0 +1,42 @@
+{# Modal para crear nueva solicitud
+   El data-parent-id se actualiza desde JS antes de abrir
+#}
+<div class="modal fade" id="modal-nueva-solicitud" tabindex="-1"
+     aria-labelledby="modal-nueva-solicitud-label">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal-nueva-solicitud-label">
+                    <i class="fa-solid fa-file-contract me-1"></i> Nueva Solicitud
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form class="form-nueva-entidad" data-nivel="solicitud">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Tipo(s) de solicitud <span class="text-danger">*</span></label>
+                        <select class="form-select" name="tipo_solicitud_id[]"
+                                multiple size="5" required>
+                            {% for t in tipos_solicitud %}
+                            <option value="{{ t.id }}">{{ t.siglas }} — {{ t.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Mantén Ctrl para seleccionar varios tipos.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Fecha solicitud <span class="text-danger">*</span></label>
+                        <input type="date" class="form-control" name="fecha_solicitud"
+                               required
+                               value="">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-plus me-1"></i> Crear
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_modal_nueva_tarea.html
+++ b/app/templates/vistas/vista3/_modal_nueva_tarea.html
@@ -1,0 +1,35 @@
+{# Modal para crear nueva tarea
+   El data-parent-id se actualiza desde JS antes de abrir
+#}
+<div class="modal fade" id="modal-nueva-tarea" tabindex="-1"
+     aria-labelledby="modal-nueva-tarea-label">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal-nueva-tarea-label">
+                    <i class="fa-solid fa-pen-to-square me-1"></i> Nueva Tarea
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form class="form-nueva-entidad" data-nivel="tarea">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Tipo de tarea <span class="text-danger">*</span></label>
+                        <select class="form-select" name="tipo_tarea_id" required>
+                            <option value="">— Selecciona tipo —</option>
+                            {% for t in tipos_tarea %}
+                            <option value="{{ t.id }}">{{ t.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-plus me-1"></i> Crear
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_modal_nuevo_tramite.html
+++ b/app/templates/vistas/vista3/_modal_nuevo_tramite.html
@@ -1,0 +1,35 @@
+{# Modal para crear nuevo trámite
+   El data-parent-id se actualiza desde JS antes de abrir
+#}
+<div class="modal fade" id="modal-nueva-tramite" tabindex="-1"
+     aria-labelledby="modal-nueva-tramite-label">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modal-nueva-tramite-label">
+                    <i class="fa-solid fa-clipboard-list me-1"></i> Nuevo Trámite
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form class="form-nueva-entidad" data-nivel="tramite">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Tipo de trámite <span class="text-danger">*</span></label>
+                        <select class="form-select" name="tipo_tramite_id" required>
+                            <option value="">— Selecciona tipo —</option>
+                            {% for t in tipos_tramite %}
+                            <option value="{{ t.id }}">{{ t.nombre }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-plus me-1"></i> Crear
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/templates/vistas/vista3/_tabs_fases.html
+++ b/app/templates/vistas/vista3/_tabs_fases.html
@@ -28,7 +28,7 @@
 
 <div class="tab-content mt-2">
     {% for fase_data in sol_data.fases %}
-    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+    <div class="tab-pane {% if loop.first %}show active{% endif %}"
          id="panel-fase-{{ fase_data.obj.id }}"
          role="tabpanel"
          aria-labelledby="tab-fase-{{ fase_data.obj.id }}">

--- a/app/templates/vistas/vista3/_tabs_fases.html
+++ b/app/templates/vistas/vista3/_tabs_fases.html
@@ -13,7 +13,7 @@
             <span class="tab-icon">
                 <i class="{{ fase_data.estado | icono_fase }} {{ fase_data.estado | color_fase }}"></i>
             </span>
-            <span class="tab-label">{{ fase_data.nombre }}</span>
+            <span class="tab-label">{{ fase_data.codigo | formato_codigo }}</span>
         </button>
     </li>
     {% endfor %}

--- a/app/templates/vistas/vista3/_tabs_fases.html
+++ b/app/templates/vistas/vista3/_tabs_fases.html
@@ -1,0 +1,47 @@
+{# Tabs nivel 2 — Fases de una solicitud
+   Contexto requerido: sol_data (con sol_data.fases)
+#}
+<ul class="nav nav-tabs tramitacion-tabs" role="tablist">
+    {% for fase_data in sol_data.fases %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link {% if loop.first %}active{% endif %}"
+                id="tab-fase-{{ fase_data.obj.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#panel-fase-{{ fase_data.obj.id }}"
+                type="button" role="tab"
+                title="{{ fase_data.nombre }}">
+            <span class="tab-icon">
+                <i class="{{ fase_data.estado | icono_fase }} {{ fase_data.estado | color_fase }}"></i>
+            </span>
+            <span class="tab-label">{{ fase_data.nombre }}</span>
+        </button>
+    </li>
+    {% endfor %}
+    <li class="nav-item li-btn-nueva">
+        <button class="nav-link btn-nueva-entidad" type="button"
+                data-nivel="fase" data-parent-id="{{ sol_data.obj.id }}"
+                title="Nueva fase">
+            <i class="fa-solid fa-plus"></i>
+        </button>
+    </li>
+</ul>
+
+<div class="tab-content mt-2">
+    {% for fase_data in sol_data.fases %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="panel-fase-{{ fase_data.obj.id }}"
+         role="tabpanel"
+         aria-labelledby="tab-fase-{{ fase_data.obj.id }}">
+
+        {% include 'vistas/vista3/_cuerpo_fase.html' %}
+
+        <div class="tabs-nivel-3"
+             data-tabs-nivel="tramite"
+             data-parent-id="{{ fase_data.obj.id }}">
+            {% include 'vistas/vista3/_tabs_tramites.html' %}
+        </div>
+    </div>
+    {% else %}
+    <p class="text-secondary small mt-2">Sin fases en esta solicitud.</p>
+    {% endfor %}
+</div>

--- a/app/templates/vistas/vista3/_tabs_solicitudes.html
+++ b/app/templates/vistas/vista3/_tabs_solicitudes.html
@@ -1,0 +1,51 @@
+{# Tabs nivel 1 — Solicitudes
+   Contexto requerido: solicitudes_arbol, expediente
+#}
+<ul class="nav nav-tabs tramitacion-tabs" role="tablist">
+    {% for sol_data in solicitudes_arbol %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link {% if loop.first %}active{% endif %}"
+                id="tab-solicitud-{{ sol_data.obj.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#panel-solicitud-{{ sol_data.obj.id }}"
+                type="button" role="tab"
+                title="{{ sol_data.tipos_str }}">
+            <span class="tab-icon">
+                <i class="{{ sol_data.obj.estado | icono_solicitud }} {{ sol_data.obj.estado | color_solicitud }}"></i>
+            </span>
+            <span class="tab-label">{{ sol_data.tipos_str }}</span>
+        </button>
+    </li>
+    {% endfor %}
+    <li class="nav-item li-btn-nueva">
+        <button class="nav-link btn-nueva-entidad" type="button"
+                data-nivel="solicitud" data-parent-id="{{ expediente.id }}"
+                title="Nueva solicitud">
+            <i class="fa-solid fa-plus"></i>
+        </button>
+    </li>
+</ul>
+
+<div class="tab-content mt-2">
+    {% for sol_data in solicitudes_arbol %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="panel-solicitud-{{ sol_data.obj.id }}"
+         role="tabpanel"
+         aria-labelledby="tab-solicitud-{{ sol_data.obj.id }}">
+
+        {% include 'vistas/vista3/_cuerpo_solicitud.html' %}
+
+        <div class="tabs-nivel-2 mt-3"
+             data-tabs-nivel="fase"
+             data-parent-id="{{ sol_data.obj.id }}">
+            {% include 'vistas/vista3/_tabs_fases.html' %}
+        </div>
+    </div>
+    {% else %}
+    <div class="alert alert-info mt-3">
+        <i class="fa-solid fa-info-circle me-2"></i>
+        Este expediente no tiene solicitudes registradas.
+        Pulse <strong><i class="fa-solid fa-plus"></i></strong> para crear la primera.
+    </div>
+    {% endfor %}
+</div>

--- a/app/templates/vistas/vista3/_tabs_solicitudes.html
+++ b/app/templates/vistas/vista3/_tabs_solicitudes.html
@@ -28,7 +28,7 @@
 
 <div class="tab-content mt-2">
     {% for sol_data in solicitudes_arbol %}
-    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+    <div class="tab-pane {% if loop.first %}show active{% endif %}"
          id="panel-solicitud-{{ sol_data.obj.id }}"
          role="tabpanel"
          aria-labelledby="tab-solicitud-{{ sol_data.obj.id }}">

--- a/app/templates/vistas/vista3/_tabs_tareas.html
+++ b/app/templates/vistas/vista3/_tabs_tareas.html
@@ -9,11 +9,12 @@
                 data-bs-toggle="tab"
                 data-bs-target="#panel-tarea-{{ tarea_data.obj.id }}"
                 type="button" role="tab"
+                data-tipo-codigo="{{ tarea_data.codigo }}"
                 title="{{ tarea_data.nombre }}">
             <span class="tab-icon">
-                <i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }}"></i>
+                <i class="{{ tarea_data.codigo | icono_tarea_tipo }} {{ tarea_data.estado | color_tarea }}"></i>
             </span>
-            <span class="tab-label">{{ tarea_data.nombre }}</span>
+            <span class="tab-label">{{ tarea_data.codigo | formato_codigo }}</span>
         </button>
     </li>
     {% endfor %}

--- a/app/templates/vistas/vista3/_tabs_tareas.html
+++ b/app/templates/vistas/vista3/_tabs_tareas.html
@@ -1,0 +1,40 @@
+{# Tabs nivel 4 — Tareas de un trámite
+   Contexto requerido: tram_data (con tram_data.tareas)
+#}
+<ul class="nav nav-tabs tramitacion-tabs" role="tablist">
+    {% for tarea_data in tram_data.tareas %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link {% if loop.first %}active{% endif %}"
+                id="tab-tarea-{{ tarea_data.obj.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#panel-tarea-{{ tarea_data.obj.id }}"
+                type="button" role="tab"
+                title="{{ tarea_data.nombre }}">
+            <span class="tab-icon">
+                <i class="{{ tarea_data.estado | icono_tarea }} {{ tarea_data.estado | color_tarea }}"></i>
+            </span>
+            <span class="tab-label">{{ tarea_data.nombre }}</span>
+        </button>
+    </li>
+    {% endfor %}
+    <li class="nav-item li-btn-nueva">
+        <button class="nav-link btn-nueva-entidad" type="button"
+                data-nivel="tarea" data-parent-id="{{ tram_data.obj.id }}"
+                title="Nueva tarea">
+            <i class="fa-solid fa-plus"></i>
+        </button>
+    </li>
+</ul>
+
+<div class="tab-content mt-2">
+    {% for tarea_data in tram_data.tareas %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="panel-tarea-{{ tarea_data.obj.id }}"
+         role="tabpanel"
+         aria-labelledby="tab-tarea-{{ tarea_data.obj.id }}">
+        {% include 'vistas/vista3/_cuerpo_tarea.html' %}
+    </div>
+    {% else %}
+    <p class="text-secondary small mt-2">Sin tareas en este trámite.</p>
+    {% endfor %}
+</div>

--- a/app/templates/vistas/vista3/_tabs_tareas.html
+++ b/app/templates/vistas/vista3/_tabs_tareas.html
@@ -28,7 +28,7 @@
 
 <div class="tab-content mt-2">
     {% for tarea_data in tram_data.tareas %}
-    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+    <div class="tab-pane {% if loop.first %}show active{% endif %}"
          id="panel-tarea-{{ tarea_data.obj.id }}"
          role="tabpanel"
          aria-labelledby="tab-tarea-{{ tarea_data.obj.id }}">

--- a/app/templates/vistas/vista3/_tabs_tramites.html
+++ b/app/templates/vistas/vista3/_tabs_tramites.html
@@ -28,7 +28,7 @@
 
 <div class="tab-content mt-2">
     {% for tram_data in fase_data.tramites %}
-    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+    <div class="tab-pane {% if loop.first %}show active{% endif %}"
          id="panel-tramite-{{ tram_data.obj.id }}"
          role="tabpanel"
          aria-labelledby="tab-tramite-{{ tram_data.obj.id }}">

--- a/app/templates/vistas/vista3/_tabs_tramites.html
+++ b/app/templates/vistas/vista3/_tabs_tramites.html
@@ -13,7 +13,7 @@
             <span class="tab-icon">
                 <i class="{{ tram_data.estado | icono_tramite }} {{ tram_data.estado | color_tramite }}"></i>
             </span>
-            <span class="tab-label">{{ tram_data.nombre }}</span>
+            <span class="tab-label">{{ tram_data.codigo | formato_codigo }}</span>
         </button>
     </li>
     {% endfor %}

--- a/app/templates/vistas/vista3/_tabs_tramites.html
+++ b/app/templates/vistas/vista3/_tabs_tramites.html
@@ -1,0 +1,47 @@
+{# Tabs nivel 3 — Trámites de una fase
+   Contexto requerido: fase_data (con fase_data.tramites)
+#}
+<ul class="nav nav-tabs tramitacion-tabs" role="tablist">
+    {% for tram_data in fase_data.tramites %}
+    <li class="nav-item" role="presentation">
+        <button class="nav-link {% if loop.first %}active{% endif %}"
+                id="tab-tramite-{{ tram_data.obj.id }}"
+                data-bs-toggle="tab"
+                data-bs-target="#panel-tramite-{{ tram_data.obj.id }}"
+                type="button" role="tab"
+                title="{{ tram_data.nombre }}">
+            <span class="tab-icon">
+                <i class="{{ tram_data.estado | icono_tramite }} {{ tram_data.estado | color_tramite }}"></i>
+            </span>
+            <span class="tab-label">{{ tram_data.nombre }}</span>
+        </button>
+    </li>
+    {% endfor %}
+    <li class="nav-item li-btn-nueva">
+        <button class="nav-link btn-nueva-entidad" type="button"
+                data-nivel="tramite" data-parent-id="{{ fase_data.obj.id }}"
+                title="Nuevo trámite">
+            <i class="fa-solid fa-plus"></i>
+        </button>
+    </li>
+</ul>
+
+<div class="tab-content mt-2">
+    {% for tram_data in fase_data.tramites %}
+    <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+         id="panel-tramite-{{ tram_data.obj.id }}"
+         role="tabpanel"
+         aria-labelledby="tab-tramite-{{ tram_data.obj.id }}">
+
+        {% include 'vistas/vista3/_cuerpo_tramite.html' %}
+
+        <div class="tabs-nivel-4"
+             data-tabs-nivel="tarea"
+             data-parent-id="{{ tram_data.obj.id }}">
+            {% include 'vistas/vista3/_tabs_tareas.html' %}
+        </div>
+    </div>
+    {% else %}
+    <p class="text-secondary small mt-2">Sin trámites en esta fase.</p>
+    {% endfor %}
+</div>

--- a/docs/GUIA_VISTAS_BOOTSTRAP.md
+++ b/docs/GUIA_VISTAS_BOOTSTRAP.md
@@ -212,69 +212,96 @@ def get_expedientes():
 
 ---
 
-## 🛠️ Vista V3 - Tramitación (Acordeón)
+## 🛠️ Vista V3 - Tramitación (Tabs 4 niveles)
 
-### ⚠️ Cambio Arquitectónico (12/02/2026)
-**De:** Sidebar lateral (250px) + panel detalle  
-**A:** Acordeón completo Bootstrap 5 en 100% ancho
+### Cambios Arquitectónicos
+| Fecha | Cambio |
+|-------|--------|
+| 12/02/2026 | De sidebar → Acordeón completo Bootstrap 5 en 100% ancho |
+| 28/02/2026 | De acordeón lazy-loading → **Tabs 4 niveles renderizados en servidor** (issue #150) |
 
-### Decisiones de Diseño
+### Arquitectura Actual (Tabs 4 niveles)
 
-#### Panel Contexto Fijo (Sticky)
-- **Contenido:** Expediente + Proyecto juntos (NO en acordeón)
-- **Razón:** No son parte de jerarquía de tramitación, mantienen contexto
-- **CSS:** `position: sticky; top: 60px; z-index: 100;`
-
-#### Jerarquía Acordeón
+#### Jerarquía de Tabs
 ```
-Panel Contexto (sticky)
-└── Acordeón Solicitudes (Bootstrap 5)
-    └── Detalle Solicitud
-        └── Acordeón Fases (anidado)
-            └── Detalle Fase
-                └── Acordeón Trámites (anidado)
-                    └── Detalle Trámite
-                        └── Acordeón Tareas (anidado)
+Cabecera fija (expediente + proyecto)
+└── Tabs Nivel 1: Solicitudes   [data-tabs-nivel="solicitud"]
+    └── Cuerpo Solicitud (V4)
+    └── Tabs Nivel 2: Fases      [data-tabs-nivel="fase"]
+        └── Cuerpo Fase (V4)
+        └── Tabs Nivel 3: Trámites [data-tabs-nivel="tramite"]
+            └── Cuerpo Trámite (V4)
+            └── Tabs Nivel 4: Tareas [data-tabs-nivel="tarea"]
+                └── Cuerpo Tarea (V4) + tabla documentos
 ```
 
-#### Cabeceras con Columnas Customizadas
-```html
-<button class="accordion-button collapsed">
-  <span class="col-tipo">Solicitud 1: AAP+AAC</span>
-  <span class="col-fases">Fases (1/2)</span>
-  <span class="col-tramites">Trámites (1/5)</span>
-  <span class="badge bg-success">Activa</span>
-</button>
+#### Template principal
+- `app/modules/expedientes/templates/expedientes/tramitacion_v3.html`
+- Extiende `base_fullwidth.html` (para `lista-cabecera` / `lista-scroll-container`)
+- URL: `/expedientes/<id>/tramitacion_v3`
+- Ruta: `app/modules/expedientes/routes.py :: tramitacion_v3`
+
+#### Archivos de soporte
+| Archivo | Propósito |
+|---------|-----------|
+| `app/static/css/v3-tramitacion.css` | Estilos acordeón (legacy) + tabs nuevos |
+| `app/static/js/v3-tabs-main.js` | Crear/editar/borrar entidades SFTT |
+| `app/routes/vista3.py :: _construir_arbol` | Construye árbol completo para render servidor |
+
+#### Partials del sistema de tabs
+```
+app/templates/vistas/vista3/
+├── _expediente_body.html        ← cabecera (sin cambios)
+├── _tabs_solicitudes.html       ← nivel 1
+├── _tabs_fases.html             ← nivel 2 (usa sol_data del contexto)
+├── _tabs_tramites.html          ← nivel 3 (usa fase_data del contexto)
+├── _tabs_tareas.html            ← nivel 4 (usa tram_data del contexto)
+├── _cuerpo_solicitud.html       ← V4 inline
+├── _cuerpo_fase.html            ← V4 inline (requiere resultados_fase en contexto)
+├── _cuerpo_tramite.html         ← V4 inline
+├── _cuerpo_tarea.html           ← V4 inline + tabla docs
+├── _modal_nueva_solicitud.html  ← modal crear solicitud
+├── _modal_nueva_fase.html       ← modal crear fase
+├── _modal_nuevo_tramite.html    ← modal crear trámite
+└── _modal_nueva_tarea.html      ← modal crear tarea
 ```
 
-```css
-.accordion-button {
-  display: flex;
-  justify-content: space-between;
-}
+#### Edición inline (patrón V4 en tabs)
+- Botón "Editar" → activa modo editar via JS: `[data-modo-ver]` se ocultan, `[data-modo-editar]` aparecen
+- Campos especiales:
+  - Fechas: `<input type="text" data-modo-ver data-display-for="campo" data-display-format="date">` + `<input type="date" name="campo" data-modo-editar>`
+  - Selects: `<input type="text" data-modo-ver data-display-for="campo">` + `<select name="campo" data-modo-editar>`
+  - Textareas (observaciones, notas): un solo elemento, toggle `readonly`
 
-.col-tipo { width: 200px; }
-.col-fases { width: 100px; }
-.col-tramites { width: 100px; }
-```
+#### Creación de entidades hija
+- Clic en `.btn-nueva-entidad` → JS actualiza `data-parent-id` en el modal y lo abre
+- Submit del modal → POST al endpoint existente → `location.reload()`
 
-#### Anidación Visual (Indentación)
-```css
-/* Cada nivel anidado: margen + borde color */
-.accordion .accordion {
-  margin-left: 2rem;
-  border-left: 3px solid #0d6efd;
-  padding-left: 1rem;
-}
+#### Borrado
+- Clic en `.btn-borrar-entidad` → confirm → POST `/api/vista3/<nivel>/<id>/borrar`
+- Si ok → DOM: activar tab anterior, eliminar `<li>` + `<div.tab-pane>`
 
-.accordion .accordion .accordion {
-  border-left-color: #198754; /* Trámites */
-}
+#### Endpoints backend
+| Operación | URL |
+|-----------|-----|
+| Crear solicitud | POST `/api/vista3/expediente/<id>/solicitudes/nueva` |
+| Crear fase | POST `/api/vista3/solicitud/<id>/fases/nueva` |
+| Crear trámite | POST `/api/vista3/fase/<id>/tramites/nuevo` |
+| Crear tarea | POST `/api/vista3/tramite/<id>/tareas/nueva` |
+| Editar solicitud | POST `/api/vista3/solicitud/<id>/editar` |
+| Editar fase | POST `/api/vista3/fase/<id>/editar` |
+| Editar trámite | POST `/api/vista3/tramite/<id>/editar` |
+| Editar tarea | POST `/api/vista3/tarea/<id>/editar` |
+| Borrar solicitud | POST `/api/vista3/solicitud/<id>/borrar` |
+| Borrar fase | POST `/api/vista3/fase/<id>/borrar` |
+| Borrar trámite | POST `/api/vista3/tramite/<id>/borrar` |
+| Borrar tarea | POST `/api/vista3/tarea/<id>/borrar` |
 
-.accordion .accordion .accordion .accordion {
-  border-left-color: #ffc107; /* Tareas */
-}
-```
+#### Filtros Jinja2 registrados (app/__init__.py)
+`icono_solicitud`, `color_solicitud`, `icono_fase`, `color_fase`,
+`icono_tramite`, `color_tramite`, `icono_tarea`, `color_tarea`
+
+### Modelo de Datos Crítico
 
 ### Modelo de Datos Crítico
 


### PR DESCRIPTION
## Resumen

Implementación completa de la vista V3 de tramitación con tabs anidados (4 niveles: Solicitud → Fase → Trámite → Tarea), incluyendo bugs críticos, mejoras UX y ajustes de diseño.

### Bugs críticos (A)
- **A1** — Fix campo `solicitudid` en `crear_solicitud` (era `solicitud_id`)
- **A2+A4** — Fix scope `_toggleModoEditar` usaba `.tab-pane` en vez de `.card`; cancelar restaura valores con `form.reset()`
- **A3** — Borrado cascade explícito en `borrar_tramite/fase/solicitud` (SQLAlchemy sin cascade intentaba SET NULL en FK NOT NULL)
- **Fix motor de reglas** — `_check_borrar` tomaba el ancestro en vez de la entidad objetivo
- **Fix botón Crear disabled** — el modal no destruye el DOM al cerrarse; ahora se re-habilita y resetea al abrirse

### Mejoras UX (B)
- **B1** — Eliminado `fade` de tab-panes (sin destello blanco al cambiar tabs)
- **B2** → evolucionado a inyección DOM sin recarga: `_insertarNuevoTab` hace fetch en background, extrae el nuevo tab+panel con DOMParser y lo inyecta sin `location.reload()`
- Cancelar edición inline al cambiar de tab (`hide.bs.tab`)

### Diseño (C)
- **C1** — Headers pálidos por nivel (azul/naranja/morado), tabs activos con fondo del nivel, botones `btn-outline-primary` coherentes con JA
- **C2** — Migración a Bootstrap Icons; iconos fase por estado (`bi-diagram-3-fill`), iconos tarea semánticos por tipo (NOTIFICAR→`bi-send`, FIRMAR→`bi-pen`, etc.) siguiendo `docs/mockups/Iconos_ESFTT+TAREAS-ESTADOS.html`
- **C3** — Tamaño icono tab aumentado a 1.1rem
- **C4** — Icono hereda color del tab activo (`color: inherit !important`) para evitar invisibilidad en fondos pálidos
- Labels de tab en MAYÚSCULAS (`REGISTRO SOLICITUD`, coherente con solicitudes)
- Label corto (`codigo`) en tab, nombre largo en tooltip

## Test plan
- [ ] Crear solicitud, fase, trámite, tarea → tab nuevo aparece sin recargar página, con foco en el nuevo elemento
- [ ] Borrar entidad sin fecha inicio → funciona; con fecha inicio → bloqueado por motor de reglas
- [ ] Editar inline → cancelar restaura valores originales
- [ ] Cambiar de tab con edición abierta → vuelve a modo ver automáticamente
- [ ] Abrir modal de nueva entidad dos veces → botón Crear habilitado en ambas
- [ ] Iconos de fase cambian con estado (diagram-3-fill en curso, diagram-3 resto)
- [ ] Iconos de tarea son semánticos por tipo (persona-gear, send, pen, etc.)
- [ ] Colores de tab activo coinciden con header del cuerpo correspondiente

🤖 Generated with [Claude Code](https://claude.com/claude-code)