### PR TITLE
Edición inline Vista 3 Breadcrumbs — issues #160–#163

### DIFF
--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -372,6 +372,8 @@ def tramitacion_bc_fase(exp_id, sol_id, fase_id):
         {'key': 'fecha_fin',    'label': 'F. Fin'},
     ]
 
+    resultados_fase = TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
+
     return render_template(
         'expedientes/tramitacion_bc_fase.html',
         expediente=expediente,
@@ -379,6 +381,7 @@ def tramitacion_bc_fase(exp_id, sol_id, fase_id):
         fase=fase,
         hijos=hijos,
         columnas=columnas,
+        resultados_fase=resultados_fase,
     )
 
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -20,46 +20,114 @@
 
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block content %}
 
 <!-- C.1: Card detalle de la Fase (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
+  <div class="card bc-card-nodo" data-bc-editable>
+
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
       <span class="fw-semibold">
         <i class="fas fa-layer-group me-2"></i>
         Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}
       </span>
       <div class="bc-acciones-bar">
-        {# Placeholder — funcionalidad en issue posterior #}
-        <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
-          <i class="fas fa-edit me-1"></i> Editar
-        </button>
-        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-          Acciones
-        </button>
+        {# Modo ver #}
+        <div data-modo-ver class="d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+            <i class="fas fa-edit me-1"></i> Editar
+          </button>
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
+            Acciones
+          </button>
+        </div>
+        {# Modo editar #}
+        <div data-modo-editar class="d-none d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+            <i class="fas fa-save me-1"></i> Guardar
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+            Cancelar
+          </button>
+        </div>
       </div>
     </div>
+
     <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
+
+      {# Modo ver #}
+      <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          {{ fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else '—' }}
+          <span id="disp-fecha_inicio">
+            {{- fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          {{ fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else '—' }}
+          <span id="disp-fecha_fin">
+            {{- fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>Resultado:</strong>
-          {{ fase.resultado_fase.nombre if fase.resultado_fase else '—' }}
+          <span id="disp-resultado_fase_id">
+            {{- fase.resultado_fase.nombre if fase.resultado_fase else '—' -}}
+          </span>
         </div>
         <div class="col-auto ms-auto">
           <span class="badge bg-primary">{{ hijos | length }} trámite(s)</span>
         </div>
       </div>
+
+      {# Modo editar #}
+      <form data-modo-editar class="d-none row g-2 pt-1"
+            data-url="{{ url_for('vista3.editar_fase', fase_id=fase.id) }}">
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">Tipo</label>
+          <input type="text" class="form-control form-control-sm" readonly
+                 value="{{ fase.tipo_fase.nombre if fase.tipo_fase else '—' }}"
+                 data-bs-toggle="tooltip" title="El tipo se establece al crear la fase">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label fw-semibold mb-1">F. Inicio</label>
+          <div id="ef-fecha_inicio"
+               data-ef-name="fecha_inicio"
+               data-ef-value="{{ fase.fecha_inicio.isoformat() if fase.fecha_inicio else '' }}">
+          </div>
+        </div>
+        <div class="col-md-2">
+          <label class="form-label fw-semibold mb-1">F. Fin</label>
+          <div id="ef-fecha_fin"
+               data-ef-name="fecha_fin"
+               data-ef-value="{{ fase.fecha_fin.isoformat() if fase.fecha_fin else '' }}">
+          </div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">Resultado</label>
+          <select class="form-select form-select-sm" name="resultado_fase_id">
+            <option value="">— Sin resultado —</option>
+            {% for r in resultados_fase %}
+            <option value="{{ r.id }}"
+                    {% if fase.resultado_fase_id == r.id %}selected{% endif %}>
+              {{ r.nombre }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-12">
+          <label class="form-label fw-semibold mb-1">Observaciones</label>
+          <textarea class="form-control form-control-sm" name="observaciones"
+                    rows="2">{{ fase.observaciones or '' }}</textarea>
+        </div>
+      </form>
+
+      {# Mensajes de error/advertencia del motor de reglas #}
+      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
     </div>
   </div>
 </div>
@@ -68,7 +136,6 @@
 <div class="lista-scroll-container p-3">
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h6 class="mb-0 fw-semibold">Trámites</h6>
-    {# Placeholder — funcionalidad en issue posterior #}
     <button class="btn btn-sm btn-success" disabled title="Próximamente">
       <i class="fas fa-plus me-1"></i> Nuevo trámite
     </button>
@@ -76,4 +143,9 @@
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -16,13 +16,15 @@
 
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block content %}
 
 <!-- C.1: Card detalle de la Solicitud (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
+  <div class="card bc-card-nodo" data-bc-editable>
+
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
       <span class="fw-semibold">
         <i class="fas fa-file-alt me-2"></i>
@@ -35,38 +37,93 @@
         {% endif %}
       </span>
       <div class="bc-acciones-bar">
-        {# Placeholder — funcionalidad en issue posterior #}
-        <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
-          <i class="fas fa-edit me-1"></i> Editar
-        </button>
-        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-          Acciones
-        </button>
+        {# Modo ver: botones Editar + Acciones #}
+        <div data-modo-ver class="d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+            <i class="fas fa-edit me-1"></i> Editar
+          </button>
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
+            Acciones
+          </button>
+        </div>
+        {# Modo editar: botones Guardar + Cancelar #}
+        <div data-modo-editar class="d-none d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+            <i class="fas fa-save me-1"></i> Guardar
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+            Cancelar
+          </button>
+        </div>
       </div>
     </div>
+
     <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
+
+      {# Modo ver: resumen de metadatos #}
+      <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Solicitud:</strong>
-          {{ solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '—' }}
+          <span id="disp-fecha_solicitud">
+            {{- solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>F. Resolución:</strong>
-          {{ solicitud.fecha_fin.strftime('%d/%m/%Y') if solicitud.fecha_fin else '—' }}
+          <span id="disp-fecha_fin">
+            {{- solicitud.fecha_fin.strftime('%d/%m/%Y') if solicitud.fecha_fin else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>Estado:</strong>
-          <span class="badge
+          <span id="disp-estado" class="badge
             {% if solicitud.estado == 'EN_TRAMITE' %}bg-primary
             {% elif solicitud.estado == 'RESUELTA' %}bg-success
+            {% elif solicitud.estado == 'DESISTIDA' %}bg-warning text-dark
             {% else %}bg-secondary{% endif %}">
-            {{ solicitud.estado }}
+            {{ solicitud.estado | replace('_', ' ') | title }}
           </span>
         </div>
         <div class="col-auto ms-auto">
           <span class="badge bg-primary">{{ hijos | length }} fase(s)</span>
         </div>
       </div>
+
+      {# Modo editar: formulario #}
+      <form data-modo-editar class="d-none row g-2 pt-1"
+            data-url="{{ url_for('vista3.editar_solicitud', sol_id=solicitud.id) }}">
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Solicitud</label>
+          <div id="ef-fecha_solicitud"
+               data-ef-name="fecha_solicitud"
+               data-ef-value="{{ solicitud.fecha_solicitud.isoformat() if solicitud.fecha_solicitud else '' }}">
+          </div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Resolución</label>
+          <div id="ef-fecha_fin"
+               data-ef-name="fecha_fin"
+               data-ef-value="{{ solicitud.fecha_fin.isoformat() if solicitud.fecha_fin else '' }}">
+          </div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">Estado</label>
+          <select class="form-select form-select-sm" name="estado">
+            {% for val, label in [('EN_TRAMITE','En trámite'),('RESUELTA','Resuelta'),('DESISTIDA','Desistida'),('ARCHIVADA','Archivada')] %}
+            <option value="{{ val }}" {% if solicitud.estado == val %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-12">
+          <label class="form-label fw-semibold mb-1">Observaciones</label>
+          <textarea class="form-control form-control-sm" name="observaciones"
+                    rows="2">{{ solicitud.observaciones or '' }}</textarea>
+        </div>
+      </form>
+
+      {# Mensajes de error/advertencia del motor de reglas #}
+      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
     </div>
   </div>
 </div>
@@ -83,4 +140,9 @@
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -28,94 +28,113 @@
 
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block content %}
 
-<!-- Nivel Tarea: sin tabla de hijos, solo detalle + docs -->
+<!-- C.1: Card detalle de la Tarea (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
+  <div class="card bc-card-nodo" data-bc-editable>
+
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
       <span class="fw-semibold">
         <i class="fas fa-check-square me-2"></i>
         Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}
       </span>
       <div class="bc-acciones-bar">
-        {# Placeholder — funcionalidad en issue posterior #}
-        <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
-          <i class="fas fa-edit me-1"></i> Editar
-        </button>
-        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-          Acciones
-        </button>
+        {# Modo ver #}
+        <div data-modo-ver class="d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+            <i class="fas fa-edit me-1"></i> Editar
+          </button>
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
+            Acciones
+          </button>
+        </div>
+        {# Modo editar #}
+        <div data-modo-editar class="d-none d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+            <i class="fas fa-save me-1"></i> Guardar
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+            Cancelar
+          </button>
+        </div>
       </div>
     </div>
+
     <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
+
+      {# Modo ver #}
+      <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          {{ tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' }}
+          <span id="disp-fecha_inicio">
+            {{- tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          {{ tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' }}
+          <span id="disp-fecha_fin">
+            {{- tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' -}}
+          </span>
         </div>
-        {% if tarea.notas %}
-        <div class="col-auto">
-          <strong>Notas:</strong> {{ tarea.notas | truncate(80) }}
-        </div>
-        {% endif %}
       </div>
+
+      {# Modo editar #}
+      <form data-modo-editar class="d-none row g-2 pt-1"
+            data-url="{{ url_for('vista3.editar_tarea', tarea_id=tarea.id) }}">
+        <div class="col-md-4">
+          <label class="form-label fw-semibold mb-1">Tipo</label>
+          <input type="text" class="form-control form-control-sm" readonly
+                 value="{{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '—' }}"
+                 data-bs-toggle="tooltip" title="El tipo se establece al crear la tarea">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Inicio</label>
+          <div id="ef-fecha_inicio"
+               data-ef-name="fecha_inicio"
+               data-ef-value="{{ tarea.fecha_inicio.isoformat() if tarea.fecha_inicio else '' }}">
+          </div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Fin</label>
+          <div id="ef-fecha_fin"
+               data-ef-name="fecha_fin"
+               data-ef-value="{{ tarea.fecha_fin.isoformat() if tarea.fecha_fin else '' }}">
+          </div>
+        </div>
+        <div class="col-12">
+          <label class="form-label fw-semibold mb-1">Notas</label>
+          <textarea class="form-control form-control-sm" name="notas"
+                    rows="2">{{ tarea.notas or '' }}</textarea>
+        </div>
+      </form>
+
+      {# Mensajes de error/advertencia del motor de reglas #}
+      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
     </div>
   </div>
 </div>
 
-<!-- Detalle completo + documentos (scrollable) -->
+<!-- C.2: Documentos (scrollable) -->
 <div class="lista-scroll-container p-3">
-
-  <!-- Detalle extendido -->
-  <div class="card mb-3">
-    <div class="card-header card-header-accent">
-      <h6 class="mb-0 fw-semibold"><i class="fas fa-info-circle me-2"></i>Detalle de la tarea</h6>
-    </div>
-    <div class="card-body card-body-tinted">
-      <div class="row g-3">
-        <div class="col-md-6">
-          <label class="form-label fw-semibold small">Tipo de tarea</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '—' }}">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold small">Fecha inicio</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' }}">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold small">Fecha fin</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' }}">
-        </div>
-        {% if tarea.notas %}
-        <div class="col-12">
-          <label class="form-label fw-semibold small">Notas</label>
-          <textarea class="form-control form-control-sm" readonly rows="3">{{ tarea.notas }}</textarea>
-        </div>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-
-  <!-- Documentos -->
   <div class="card">
     <div class="card-header card-header-accent">
       <h6 class="mb-0 fw-semibold"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
     </div>
-    <div class="card-body text-center text-muted py-4">
-      <i class="fas fa-folder fa-2x mb-2 d-block"></i>
-      <span class="small">Gestión de documentos — próximamente</span>
+    <div class="card-body text-center py-4">
+      <i class="fas fa-folder fa-2x mb-2 d-block text-secondary"></i>
+      <span class="small text-secondary">Gestión de documentos — próximamente</span>
     </div>
   </div>
-
 </div>
 
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -24,47 +24,96 @@
 
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block content %}
 
 <!-- C.1: Card detalle del Trámite (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
+  <div class="card bc-card-nodo" data-bc-editable>
+
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
       <span class="fw-semibold">
         <i class="fas fa-tasks me-2"></i>
         Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id }}
       </span>
       <div class="bc-acciones-bar">
-        {# Placeholder — funcionalidad en issue posterior #}
-        <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
-          <i class="fas fa-edit me-1"></i> Editar
-        </button>
-        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-          Acciones
-        </button>
+        {# Modo ver #}
+        <div data-modo-ver class="d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+            <i class="fas fa-edit me-1"></i> Editar
+          </button>
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
+            Acciones
+          </button>
+        </div>
+        {# Modo editar #}
+        <div data-modo-editar class="d-none d-flex gap-1">
+          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+            <i class="fas fa-save me-1"></i> Guardar
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+            Cancelar
+          </button>
+        </div>
       </div>
     </div>
+
     <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
+
+      {# Modo ver #}
+      <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          {{ tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else '—' }}
+          <span id="disp-fecha_inicio">
+            {{- tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else '—' -}}
+          </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          {{ tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' }}
+          <span id="disp-fecha_fin">
+            {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
+          </span>
         </div>
-        {% if tramite.observaciones %}
-        <div class="col-auto">
-          <strong>Obs:</strong> {{ tramite.observaciones | truncate(60) }}
-        </div>
-        {% endif %}
         <div class="col-auto ms-auto">
           <span class="badge bg-primary">{{ hijos | length }} tarea(s)</span>
         </div>
       </div>
+
+      {# Modo editar #}
+      <form data-modo-editar class="d-none row g-2 pt-1"
+            data-url="{{ url_for('vista3.editar_tramite', tram_id=tramite.id) }}">
+        <div class="col-md-4">
+          <label class="form-label fw-semibold mb-1">Tipo</label>
+          <input type="text" class="form-control form-control-sm" readonly
+                 value="{{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '—' }}"
+                 data-bs-toggle="tooltip" title="El tipo se establece al crear el trámite">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Inicio</label>
+          <div id="ef-fecha_inicio"
+               data-ef-name="fecha_inicio"
+               data-ef-value="{{ tramite.fecha_inicio.isoformat() if tramite.fecha_inicio else '' }}">
+          </div>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1">F. Fin</label>
+          <div id="ef-fecha_fin"
+               data-ef-name="fecha_fin"
+               data-ef-value="{{ tramite.fecha_fin.isoformat() if tramite.fecha_fin else '' }}">
+          </div>
+        </div>
+        <div class="col-12">
+          <label class="form-label fw-semibold mb-1">Observaciones</label>
+          <textarea class="form-control form-control-sm" name="observaciones"
+                    rows="2">{{ tramite.observaciones or '' }}</textarea>
+        </div>
+      </form>
+
+      {# Mensajes de error/advertencia del motor de reglas #}
+      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
     </div>
   </div>
 </div>
@@ -73,7 +122,6 @@
 <div class="lista-scroll-container p-3">
   <div class="d-flex justify-content-between align-items-center mb-2">
     <h6 class="mb-0 fw-semibold">Tareas</h6>
-    {# Placeholder — funcionalidad en issue posterior #}
     <button class="btn btn-sm btn-success" disabled title="Próximamente">
       <i class="fas fa-plus me-1"></i> Nueva tarea
     </button>
@@ -81,4 +129,9 @@
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 {% endblock %}

--- a/app/static/js/v3-breadcrumbs-edicion.js
+++ b/app/static/js/v3-breadcrumbs-edicion.js
@@ -1,0 +1,136 @@
+// v3-breadcrumbs-edicion.js
+// Gestión de edición inline en Vista 3 Breadcrumbs — válido para todos los niveles ESFTT
+//
+// Convenciones en el HTML:
+//   - [data-bc-editable]       → contenedor del card editable (generalmente .bc-card-nodo)
+//   - [data-modo-ver]          → elementos visibles solo en modo ver
+//   - [data-modo-editar]       → elementos visibles solo en modo editar
+//   - [data-ef-name][data-ef-value] → contenedores para EntradaFecha
+//   - #form-bc-<nivel>         → el formulario de edición, con data-url apuntando al endpoint
+//   - #disp-<campo>            → spans de visualización actualizables tras guardar
+//   - #alert-edicion           → div para mensajes de error/advertencia
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  const contenedor = document.querySelector('[data-bc-editable]');
+  if (!contenedor) return;
+
+  const btn_editar   = contenedor.querySelector('.btn-editar-bc');
+  const btn_cancelar = contenedor.querySelector('.btn-cancelar-bc');
+  const btn_guardar  = contenedor.querySelector('.btn-guardar-bc');
+  const form         = contenedor.querySelector('form[data-url]');
+  const alert_el     = document.getElementById('alert-edicion');
+
+  if (!btn_editar || !form) return;
+
+  // ── 1. Inicializar EntradaFecha en todos los campos [data-ef-name] ────────
+  const instancias_ef = {};
+  contenedor.querySelectorAll('[data-ef-name]').forEach(el => {
+    const ef = new EntradaFecha('#' + el.id, { name: el.dataset.efName });
+    if (el.dataset.efValue) ef.setValue(el.dataset.efValue);
+    instancias_ef[el.dataset.efName] = ef;
+  });
+
+  // ── 2. Toggle ver ↔ editar ────────────────────────────────────────────────
+  function activar_modo_editar() {
+    contenedor.querySelectorAll('[data-modo-ver]').forEach(el => el.classList.add('d-none'));
+    contenedor.querySelectorAll('[data-modo-editar]').forEach(el => el.classList.remove('d-none'));
+    _ocultar_alert();
+  }
+
+  function activar_modo_ver() {
+    contenedor.querySelectorAll('[data-modo-editar]').forEach(el => el.classList.add('d-none'));
+    contenedor.querySelectorAll('[data-modo-ver]').forEach(el => el.classList.remove('d-none'));
+  }
+
+  btn_editar.addEventListener('click', activar_modo_editar);
+  btn_cancelar.addEventListener('click', activar_modo_ver);
+
+  // ── 3. Submit AJAX ────────────────────────────────────────────────────────
+  btn_guardar.addEventListener('click', async function () {
+    const url   = form.dataset.url;
+    const datos = new FormData(form);
+
+    btn_guardar.disabled = true;
+    btn_guardar.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Guardando…';
+
+    try {
+      const resp = await fetch(url, { method: 'POST', body: datos });
+      const json = await resp.json();
+
+      if (!json.ok) {
+        _mostrar_alert('danger', json.error + (json.norma ? ` — ${json.norma}` : ''));
+      } else {
+        _actualizar_display(datos);
+        activar_modo_ver();
+        if (json.advertencia) {
+          _mostrar_alert('warning', json.advertencia.mensaje);
+        }
+      }
+    } catch (_e) {
+      _mostrar_alert('danger', 'Error de comunicación con el servidor.');
+    } finally {
+      btn_guardar.disabled = false;
+      btn_guardar.innerHTML = '<i class="fas fa-save me-1"></i> Guardar';
+    }
+  });
+
+  // ── 4. Actualizar display tras guardar ────────────────────────────────────
+  function _actualizar_display(datos) {
+    // Campos EntradaFecha: actualizar span de visualización
+    Object.entries(instancias_ef).forEach(([nombre, ef]) => {
+      const span = document.getElementById('disp-' + nombre);
+      if (!span) return;
+      const iso = ef.getValue();
+      span.textContent = iso ? _iso_a_dmy(iso) : '—';
+    });
+
+    // Estado (select normal con badge de color)
+    const estado = datos.get('estado');
+    if (estado) {
+      const span = document.getElementById('disp-estado');
+      if (span) {
+        span.textContent = _label_estado(estado);
+        span.className   = 'badge ' + _clase_estado(estado);
+      }
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function _iso_a_dmy(iso) {
+    const [y, m, d] = iso.split('-');
+    return `${d}/${m}/${y}`;
+  }
+
+  function _label_estado(estado) {
+    const mapa = {
+      'EN_TRAMITE': 'En trámite',
+      'RESUELTA':   'Resuelta',
+      'DESISTIDA':  'Desistida',
+      'ARCHIVADA':  'Archivada'
+    };
+    return mapa[estado] || estado;
+  }
+
+  function _clase_estado(estado) {
+    const mapa = {
+      'EN_TRAMITE': 'bg-primary',
+      'RESUELTA':   'bg-success',
+      'DESISTIDA':  'bg-warning text-dark',
+      'ARCHIVADA':  'bg-secondary'
+    };
+    return mapa[estado] || 'bg-secondary';
+  }
+
+  function _mostrar_alert(tipo, texto) {
+    if (!alert_el) return;
+    alert_el.className = `alert alert-${tipo} mt-2 py-2 mb-0`;
+    alert_el.textContent = texto;
+    alert_el.classList.remove('d-none');
+  }
+
+  function _ocultar_alert() {
+    if (alert_el) alert_el.classList.add('d-none');
+  }
+
+});

--- a/app/static/js/v3-breadcrumbs-edicion.js
+++ b/app/static/js/v3-breadcrumbs-edicion.js
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', function () {
       span.textContent = iso ? _iso_a_dmy(iso) : '—';
     });
 
-    // Estado (select normal con badge de color)
+    // Estado (select con badge de color — caso especial)
     const estado = datos.get('estado');
     if (estado) {
       const span = document.getElementById('disp-estado');
@@ -94,6 +94,15 @@ document.addEventListener('DOMContentLoaded', function () {
         span.className   = 'badge ' + _clase_estado(estado);
       }
     }
+
+    // Selects genéricos: actualizar #disp-{name} con el texto de la opción seleccionada
+    form.querySelectorAll('select').forEach(sel => {
+      if (sel.name === 'estado') return; // ya tratado arriba
+      const span = document.getElementById('disp-' + sel.name);
+      if (!span) return;
+      const opcion = sel.options[sel.selectedIndex];
+      span.textContent = (opcion && opcion.value) ? opcion.text : '—';
+    });
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumen

Implementa la edición inline en los cuatro niveles ESFTT de la Vista 3 Breadcrumbs:

- **#160** — Edición inline de Solicitud
- **#161** — Edición inline de Fase (incluye select Resultado de fase)
- **#162** — Edición inline de Trámite
- **#163** — Edición inline de Tarea (elimina card Detalle extendido redundante)

## Componentes añadidos

- `v3-breadcrumbs-edicion.js` — JS genérico compartido por los 4 niveles: toggle ver/editar, AJAX save, actualización de displays sin recarga
- `entrada_fecha.css` — estilos del componente EntradaFecha (ya en develop via `028451f`)

## Patrón implementado

Cada card C.1 sigue el mismo esquema:
- `[data-bc-editable]` en el contenedor
- `[data-modo-ver]` / `[data-modo-editar]` para el toggle
- `EntradaFecha` para campos de fecha (parser flexible `10/2/25` → `10/02/2025`)
- AJAX POST al endpoint `vista3.editar_*` con validación del motor de reglas
- `#disp-{campo}` para actualizar el display tras guardar sin recargar

Closes #160
Closes #161
Closes #162
Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)