### PR TITLE
[CRUD] Acciones contextuales INICIAR/FINALIZAR/BORRAR en Vista 3 BC — issue #164

### DIFF
--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -40,9 +40,41 @@
           <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
             <i class="fas fa-edit me-1"></i> Editar
           </button>
-          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-            Acciones
-          </button>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+              Acciones
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if not fase.fecha_inicio %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="iniciar"
+                   data-url="{{ url_for('vista3.iniciar_fase', fase_id=fase.id) }}">
+                  <i class="fas fa-play me-2 text-success"></i> Iniciar
+                </a>
+              </li>
+              {% endif %}
+              {% if fase.fecha_inicio and not fase.fecha_fin %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="finalizar"
+                   data-url="{{ url_for('vista3.finalizar_fase', fase_id=fase.id) }}">
+                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+                </a>
+              </li>
+              {% endif %}
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item text-danger" href="#"
+                   data-accion="borrar"
+                   data-url="{{ url_for('vista3.borrar_fase', fase_id=fase.id) }}"
+                   data-redirect="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
+                  <i class="fas fa-trash me-2"></i> Borrar
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
@@ -148,4 +180,5 @@
 {% block extra_js %}{{ super() }}
 <script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -42,9 +42,41 @@
           <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
             <i class="fas fa-edit me-1"></i> Editar
           </button>
-          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-            Acciones
-          </button>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+              Acciones
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if not solicitud.fecha_solicitud %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="iniciar"
+                   data-url="{{ url_for('vista3.iniciar_solicitud', sol_id=solicitud.id) }}">
+                  <i class="fas fa-play me-2 text-success"></i> Iniciar
+                </a>
+              </li>
+              {% endif %}
+              {% if solicitud.fecha_solicitud and not solicitud.fecha_fin %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="finalizar"
+                   data-url="{{ url_for('vista3.finalizar_solicitud', sol_id=solicitud.id) }}">
+                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+                </a>
+              </li>
+              {% endif %}
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item text-danger" href="#"
+                   data-accion="borrar"
+                   data-url="{{ url_for('vista3.borrar_solicitud', sol_id=solicitud.id) }}"
+                   data-redirect="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">
+                  <i class="fas fa-trash me-2"></i> Borrar
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         {# Modo editar: botones Guardar + Cancelar #}
         <div data-modo-editar class="d-none d-flex gap-1">
@@ -145,4 +177,5 @@
 {% block extra_js %}{{ super() }}
 <script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -48,9 +48,41 @@
           <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
             <i class="fas fa-edit me-1"></i> Editar
           </button>
-          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-            Acciones
-          </button>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+              Acciones
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if not tarea.fecha_inicio %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="iniciar"
+                   data-url="{{ url_for('vista3.iniciar_tarea', tarea_id=tarea.id) }}">
+                  <i class="fas fa-play me-2 text-success"></i> Iniciar
+                </a>
+              </li>
+              {% endif %}
+              {% if tarea.fecha_inicio and not tarea.fecha_fin %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="finalizar"
+                   data-url="{{ url_for('vista3.finalizar_tarea', tarea_id=tarea.id) }}">
+                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+                </a>
+              </li>
+              {% endif %}
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item text-danger" href="#"
+                   data-accion="borrar"
+                   data-url="{{ url_for('vista3.borrar_tarea', tarea_id=tarea.id) }}"
+                   data-redirect="{{ url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id) }}">
+                  <i class="fas fa-trash me-2"></i> Borrar
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
@@ -137,4 +169,5 @@
 {% block extra_js %}{{ super() }}
 <script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -44,9 +44,41 @@
           <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
             <i class="fas fa-edit me-1"></i> Editar
           </button>
-          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" disabled title="Próximamente">
-            Acciones
-          </button>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+              Acciones
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if not tramite.fecha_inicio %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="iniciar"
+                   data-url="{{ url_for('vista3.iniciar_tramite', tram_id=tramite.id) }}">
+                  <i class="fas fa-play me-2 text-success"></i> Iniciar
+                </a>
+              </li>
+              {% endif %}
+              {% if tramite.fecha_inicio and not tramite.fecha_fin %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-accion="finalizar"
+                   data-url="{{ url_for('vista3.finalizar_tramite', tram_id=tramite.id) }}">
+                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+                </a>
+              </li>
+              {% endif %}
+              <li><hr class="dropdown-divider"></li>
+              <li>
+                <a class="dropdown-item text-danger" href="#"
+                   data-accion="borrar"
+                   data-url="{{ url_for('vista3.borrar_tramite', tram_id=tramite.id) }}"
+                   data-redirect="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
+                  <i class="fas fa-trash me-2"></i> Borrar
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
@@ -134,4 +166,5 @@
 {% block extra_js %}{{ super() }}
 <script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
+<script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 {% endblock %}

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -640,3 +640,167 @@ def borrar_tarea(tarea_id):
     db.session.delete(tarea)
     db.session.commit()
     return jsonify({'ok': True})
+
+
+# ============================================
+# ENDPOINTS POST — ACCIONES contextuales (INICIAR / FINALIZAR)
+# ============================================
+
+@bp.route('/solicitud/<int:sol_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_solicitud(sol_id):
+    """Inicia una solicitud (establece fecha_solicitud = hoy) si el motor lo permite."""
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.fecha_solicitud is not None:
+        return jsonify({'ok': False, 'error': 'La solicitud ya tiene fecha de inicio'}), 422
+
+    res_eval = evaluar('INICIAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    sol.fecha_solicitud = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/solicitud/<int:sol_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_solicitud(sol_id):
+    """Finaliza una solicitud (establece fecha_fin = hoy) si el motor lo permite."""
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La solicitud ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    sol.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/fase/<int:fase_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_fase(fase_id):
+    """Inicia una fase (establece fecha_inicio = hoy) si el motor lo permite."""
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if fase.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'La fase ya está iniciada'}), 422
+
+    res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/fase/<int:fase_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_fase(fase_id):
+    """Finaliza una fase (establece fecha_fin = hoy) si el motor lo permite."""
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if fase.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La fase ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tramite/<int:tram_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_tramite(tram_id):
+    """Inicia un trámite (establece fecha_inicio = hoy) si el motor lo permite."""
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tramite.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'El trámite ya está iniciado'}), 422
+
+    res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tramite/<int:tram_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_tramite(tram_id):
+    """Finaliza un trámite (establece fecha_fin = hoy) si el motor lo permite."""
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tramite.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'El trámite ya está finalizado'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tarea/<int:tarea_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_tarea(tarea_id):
+    """Inicia una tarea (establece fecha_inicio = hoy) si el motor lo permite."""
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tarea.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'La tarea ya está iniciada'}), 422
+
+    res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tarea/<int:tarea_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_tarea(tarea_id):
+    """Finaliza una tarea (establece fecha_fin = hoy) si el motor lo permite."""
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tarea.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La tarea ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})

--- a/app/static/js/v3-breadcrumbs-acciones.js
+++ b/app/static/js/v3-breadcrumbs-acciones.js
@@ -1,0 +1,106 @@
+// v3-breadcrumbs-acciones.js
+// Menú [Acciones ▾] en Vista 3 Breadcrumbs — issue #164
+//
+// Convenciones en el HTML:
+//   - [data-accion]      → enlace del dropdown con la acción ('iniciar', 'finalizar', 'borrar')
+//   - [data-url]         → URL del endpoint POST a llamar
+//   - [data-redirect]    → URL de redirección tras BORRAR (URL del nivel padre)
+
+'use strict';
+
+// ── Helper toast (mismo patrón que v3-tabs-main.js) ────────────────────────
+
+function _toast_accion(mensaje, tipo) {
+    const contenedor = document.querySelector('.toast-container');
+    if (!contenedor) { alert(mensaje); return; }
+
+    const iconos = {
+        'success': 'fa-check-circle',
+        'danger':  'fa-exclamation-circle',
+        'warning': 'fa-exclamation-triangle',
+    };
+    const icono = iconos[tipo] || 'fa-info-circle';
+
+    const el = document.createElement('div');
+    el.className = `toast toast-${tipo}`;
+    el.setAttribute('role', 'alert');
+    el.setAttribute('data-bs-autohide', 'true');
+    el.setAttribute('data-bs-delay', '8000');
+    el.innerHTML = `
+        <div class="d-flex align-items-center p-3">
+            <div class="flex-grow-1">
+                <i class="fas ${icono} me-2"></i>${mensaje}
+            </div>
+            <button type="button" class="btn-close ms-3"
+                    data-bs-dismiss="toast" aria-label="Cerrar"></button>
+        </div>`;
+    contenedor.appendChild(el);
+    new bootstrap.Toast(el).show();
+    el.addEventListener('hidden.bs.toast', () => el.remove());
+}
+
+// ── Handler global de clics en acciones contextuales ───────────────────────
+
+document.addEventListener('click', async function (e) {
+    const item = e.target.closest('[data-accion]');
+    if (!item) return;
+    e.preventDefault();
+
+    const accion   = item.dataset.accion;
+    const url      = item.dataset.url;
+    const redirect = item.dataset.redirect;
+
+    // Confirmar antes de borrar
+    if (accion === 'borrar') {
+        if (!confirm('¿Confirmar borrado? Esta acción no se puede deshacer.')) return;
+    }
+
+    // Deshabilitar el toggle del dropdown mientras se procesa
+    const toggle = item.closest('.dropdown')?.querySelector('[data-bs-toggle="dropdown"]');
+    if (toggle) toggle.disabled = true;
+
+    try {
+        const resp = await fetch(url, { method: 'POST' });
+        const json = await resp.json();
+
+        if (!json.ok) {
+            // Motor bloqueó la acción o error de servidor
+            _toast_accion(
+                json.error + (json.norma ? ` — ${json.norma}` : ''),
+                'danger'
+            );
+        } else {
+            const mensajes_exito = {
+                'iniciar':   'Elemento iniciado correctamente.',
+                'finalizar': 'Elemento finalizado correctamente.',
+                'borrar':    'Elemento eliminado correctamente.',
+            };
+            const msg_ok = mensajes_exito[accion] || 'Acción realizada.';
+
+            if (json.nivel === 'ADVERTIR') {
+                // El motor permite con advertencia: mostrar warning y ejecutar
+                _toast_accion(
+                    json.mensaje + (json.norma ? ` — ${json.norma}` : ''),
+                    'warning'
+                );
+                setTimeout(() => _navegar_tras_accion(accion, redirect), 1500);
+            } else {
+                // Permitido sin advertencia
+                _toast_accion(msg_ok, 'success');
+                setTimeout(() => _navegar_tras_accion(accion, redirect), 800);
+            }
+        }
+    } catch (_e) {
+        _toast_accion('Error de comunicación con el servidor.', 'danger');
+    } finally {
+        if (toggle) toggle.disabled = false;
+    }
+});
+
+function _navegar_tras_accion(accion, redirect) {
+    if (accion === 'borrar' && redirect) {
+        window.location.href = redirect;
+    } else {
+        window.location.reload();
+    }
+}


### PR DESCRIPTION
## Resumen

- 8 endpoints POST nuevos en `vista3.py` para iniciar y finalizar los 4 niveles SFTT (BORRAR ya existía): `/solicitud/<id>/iniciar`, `/solicitud/<id>/finalizar`, `/fase/<id>/iniciar`, `/fase/<id>/finalizar`, `/tramite/<id>/iniciar`, `/tramite/<id>/finalizar`, `/tarea/<id>/iniciar`, `/tarea/<id>/finalizar`
- Cada endpoint consulta el motor de reglas: BLOQUEAR → 422 + error, ADVERTIR → 200 + nivel/mensaje, PERMITIDO → 200 ok
- Nuevo fichero `v3-breadcrumbs-acciones.js`: handler AJAX global + toasts dinámicos (danger/warning/success); BORRAR redirige al nivel padre, INICIAR/FINALIZAR recarga la página
- Los 4 templates BC reemplazan el botón `disabled` por un dropdown Bootstrap funcional; las opciones se muestran según estado: INICIAR si aún no iniciado, FINALIZAR si iniciado y no finalizado, BORRAR siempre

Closes #164

## Plan de prueba

- [ ] Acceder a un expediente → Tramitación → Solicitud → comprobar dropdown "Acciones"
- [ ] Verificar que INICIAR aparece solo si `fecha_inicio` es `None`
- [ ] Ejecutar INICIAR → toast success → página recarga con la fecha actualizada
- [ ] Ejecutar FINALIZAR → toast success → página recarga
- [ ] Ejecutar BORRAR → confirm dialog → toast success → redirección al nivel padre
- [ ] Verificar comportamiento cuando el motor bloquea (toast danger)
- [ ] Verificar comportamiento cuando el motor advierte (toast warning + acción ejecutada)
- [ ] Confirmar que en modo editar el dropdown desaparece (oculto por `[data-modo-ver]`)
- [ ] Repetir para los 4 niveles: Solicitud, Fase, Trámite, Tarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)