### PR TITLE
[UX] Mejoras visuales Vista 3 Breadcrumbs — issue #179

### DIFF
--- a/app/models/tipos_fases.py
+++ b/app/models/tipos_fases.py
@@ -62,11 +62,22 @@ class TipoFase(db.Model):
     )
     
     nombre = db.Column(
-        db.String(200), 
+        db.String(200),
         nullable=False,
         comment='Denominación completa de la fase para interfaz de usuario'
     )
-    
+
+    abrev = db.Column(
+        db.String(20),
+        nullable=True,
+        comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'
+    )
+
+    @property
+    def label_bc(self):
+        """Etiqueta corta para breadcrumb: abreviatura si existe, nombre completo si no."""
+        return self.abrev or self.nombre
+
     def __repr__(self):
         """Representación técnica para debugging."""
         return f'<TipoFase {self.codigo}>'

--- a/app/models/tipos_tareas.py
+++ b/app/models/tipos_tareas.py
@@ -60,11 +60,22 @@ class TipoTarea(db.Model):
     )
     
     nombre = db.Column(
-        db.String(200), 
+        db.String(200),
         nullable=False,
         comment='Denominación completa de la tarea para interfaz de usuario'
     )
-    
+
+    abrev = db.Column(
+        db.String(20),
+        nullable=True,
+        comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'
+    )
+
+    @property
+    def label_bc(self):
+        """Etiqueta corta para breadcrumb: abreviatura si existe, nombre completo si no."""
+        return self.abrev or self.nombre
+
     def __repr__(self):
         """Representación técnica para debugging."""
         return f'<TipoTarea {self.codigo}>'

--- a/app/models/tipos_tramites.py
+++ b/app/models/tipos_tramites.py
@@ -60,11 +60,22 @@ class TipoTramite(db.Model):
     )
     
     nombre = db.Column(
-        db.String(200), 
+        db.String(200),
         nullable=False,
         comment='Denominación completa del trámite para interfaz de usuario'
     )
-    
+
+    abrev = db.Column(
+        db.String(20),
+        nullable=True,
+        comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'
+    )
+
+    @property
+    def label_bc(self):
+        """Etiqueta corta para breadcrumb: abreviatura si existe, nombre completo si no."""
+        return self.abrev or self.nombre
+
     def __repr__(self):
         """Representación técnica para debugging."""
         return f'<TipoTramite {self.codigo}>'

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="bc-view">
 
 <!-- C.1: Card detalle del nodo actual (fijo, sin scroll) -->
 <div class="lista-cabecera px-3 pt-3">
@@ -118,6 +119,7 @@
   </div>
 </div>
 
+</div>
 {% endblock %}
 
 {% block extra_js %}{{ super() }}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -15,7 +15,7 @@
   Solicitud #{{ solicitud.id }}
 </a>
 <span>›</span>
-<span>{{ fase.tipo_fase.nombre if fase.tipo_fase else 'Fase #' ~ fase.id }}</span>
+<span>{{ fase.tipo_fase.label_bc if fase.tipo_fase else 'Fase #' ~ fase.id }}</span>
 {% endblock %}
 
 {% block extra_css %}{{ super() }}
@@ -24,6 +24,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="bc-view">
 
 <!-- C.1: Card detalle de la Fase (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
@@ -215,6 +216,7 @@
   </div>
 </div>
 
+</div>
 {% endblock %}
 
 {% block extra_js %}{{ super() }}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -12,7 +12,7 @@
 <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">Tramitación</a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
-  Solicitud #{{ solicitud.id }}
+  {{ solicitud.solicitud_tipos | map(attribute="tipo_solicitud.siglas") | join("+") or "Solicitud #" ~ solicitud.id }}
 </a>
 <span>›</span>
 <span>{{ fase.tipo_fase.label_bc if fase.tipo_fase else 'Fase #' ~ fase.id }}</span>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -29,13 +29,8 @@
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
       <span class="fw-semibold">
         <i class="fas fa-file-alt me-2"></i>
-        Solicitud #{{ solicitud.id }}
-        {% if solicitud.solicitud_tipos %}
-          —
-          {% for st in solicitud.solicitud_tipos %}
-            <span class="badge bg-primary ms-1">{{ st.tipo_solicitud.siglas }}</span>
-          {% endfor %}
-        {% endif %}
+        Solicitud:
+        {{ solicitud.solicitud_tipos | map(attribute='tipo_solicitud.siglas') | join(' + ') or '#' ~ solicitud.id }}
       </span>
       <div class="bc-acciones-bar">
         {# Modo ver: botones Editar + Acciones #}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -11,7 +11,7 @@
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">Tramitación</a>
 <span>›</span>
-<span>Solicitud #{{ solicitud.id }}</span>
+<span>{{ solicitud.solicitud_tipos | map(attribute="tipo_solicitud.siglas") | join("+") or "Solicitud #" ~ solicitud.id }}</span>
 {% endblock %}
 
 {% block extra_css %}{{ super() }}
@@ -20,6 +20,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="bc-view">
 
 <!-- C.1: Card detalle de la Solicitud (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
@@ -211,6 +212,7 @@
   </div>
 </div>
 
+</div>
 {% endblock %}
 
 {% block extra_js %}{{ super() }}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -12,7 +12,7 @@
 <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">Tramitación</a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
-  Solicitud #{{ solicitud.id }}
+  {{ solicitud.solicitud_tipos | map(attribute="tipo_solicitud.siglas") | join("+") or "Solicitud #" ~ solicitud.id }}
 </a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -16,14 +16,14 @@
 </a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
-  {{ fase.tipo_fase.nombre if fase.tipo_fase else 'Fase #' ~ fase.id }}
+  {{ fase.tipo_fase.label_bc if fase.tipo_fase else 'Fase #' ~ fase.id }}
 </a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id) }}">
-  {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else 'Trámite #' ~ tramite.id }}
+  {{ tramite.tipo_tramite.label_bc if tramite.tipo_tramite else 'Trámite #' ~ tramite.id }}
 </a>
 <span>›</span>
-<span>{{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else 'Tarea #' ~ tarea.id }}</span>
+<span>{{ tarea.tipo_tarea.label_bc if tarea.tipo_tarea else 'Tarea #' ~ tarea.id }}</span>
 {% endblock %}
 
 {% block extra_css %}{{ super() }}
@@ -32,6 +32,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="bc-view">
 
 <!-- C.1: Card detalle de la Tarea (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
@@ -164,6 +165,7 @@
   </div>
 </div>
 
+</div>
 {% endblock %}
 
 {% block extra_js %}{{ super() }}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -16,10 +16,10 @@
 </a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
-  {{ fase.tipo_fase.nombre if fase.tipo_fase else 'Fase #' ~ fase.id }}
+  {{ fase.tipo_fase.label_bc if fase.tipo_fase else 'Fase #' ~ fase.id }}
 </a>
 <span>›</span>
-<span>{{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else 'Trámite #' ~ tramite.id }}</span>
+<span>{{ tramite.tipo_tramite.label_bc if tramite.tipo_tramite else 'Trámite #' ~ tramite.id }}</span>
 {% endblock %}
 
 {% block extra_css %}{{ super() }}
@@ -28,6 +28,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="bc-view">
 
 <!-- C.1: Card detalle del Trámite (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
@@ -201,6 +202,7 @@
   </div>
 </div>
 
+</div>
 {% endblock %}
 
 {% block extra_js %}{{ super() }}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -12,7 +12,7 @@
 <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">Tramitación</a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
-  Solicitud #{{ solicitud.id }}
+  {{ solicitud.solicitud_tipos | map(attribute="tipo_solicitud.siglas") | join("+") or "Solicitud #" ~ solicitud.id }}
 </a>
 <span>›</span>
 <a href="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -238,7 +238,7 @@ def listar_expedientes():
             'num_solicitudes':     num_solicitudes,
             'num_activas':         num_activas,
             'estado_tramitacion':  estado_tramitacion,
-            'url_tramitacion':     url_for('expedientes.tramitacion_v3', id=exp.id)
+            'url_tramitacion':     url_for('expedientes.tramitacion_bc', exp_id=exp.id)
         }
         data.append(expediente_dict)
 

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -37,6 +37,31 @@
     padding-right: 0.5rem;
 }
 
+/* ── Breadcrumb — legibilidad y color corporativo ───────────────────────── */
+
+.header-breadcrumb-row .breadcrumb {
+    font-size: 0.9rem;
+}
+
+.header-breadcrumb-row .breadcrumb a {
+    color: var(--bs-primary);
+    font-weight: 500;
+}
+
+/* Segmento activo (último, sin enlace) visible en color oscuro */
+.header-breadcrumb-row .breadcrumb span:last-child {
+    color: #444;
+    font-weight: 600;
+}
+
+/* ── Anchura máxima adaptativa ───────────────────────────────────────────── */
+
+.bc-view {
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+}
+
 /* ── Botones de acción en la cabecera (placeholders) ────────────────────── */
 
 .bc-acciones-bar {

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -54,6 +54,13 @@
     font-weight: 600;
 }
 
+/* Separadores › más visibles */
+.header-breadcrumb-row .breadcrumb span:not(:last-child) {
+    color: #444;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
 /* ── Anchura máxima adaptativa ───────────────────────────────────────────── */
 
 .bc-view {

--- a/migrations/versions/0869cda75380_añadir_campo_abrev_a_tipos_fases_tipos_.py
+++ b/migrations/versions/0869cda75380_añadir_campo_abrev_a_tipos_fases_tipos_.py
@@ -1,0 +1,88 @@
+"""Añadir campo abrev a tipos_fases, tipos_tramites, tipos_tareas
+
+Revision ID: 0869cda75380
+Revises: f0d0988bb956
+Create Date: 2026-03-03 20:15:38.257083
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0869cda75380'
+down_revision = 'f0d0988bb956'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('tipos_fases',
+        sa.Column('abrev', sa.String(20), nullable=True,
+                  comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'),
+        schema='public'
+    )
+    op.add_column('tipos_tramites',
+        sa.Column('abrev', sa.String(20), nullable=True,
+                  comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'),
+        schema='public'
+    )
+    op.add_column('tipos_tareas',
+        sa.Column('abrev', sa.String(20), nullable=True,
+                  comment='Abreviatura para breadcrumb (máx 20 car.). Si nula, se usa nombre.'),
+        schema='public'
+    )
+
+    # Valores iniciales para tipos_fases
+    op.execute("""
+        UPDATE public.tipos_fases SET abrev = CASE codigo
+            WHEN 'REGISTRO_SOLICITUD'     THEN 'REG.SOL.'
+            WHEN 'ADMISIBILIDAD'          THEN 'ADMIS.'
+            WHEN 'ANALISIS_TECNICO'       THEN 'AN.TÉC.'
+            WHEN 'CONSULTA_MINISTERIO'    THEN 'CONS.MIN.'
+            WHEN 'COMPATIBILIDAD_AMBIENTAL' THEN 'COMP.AMB.'
+            WHEN 'ADMISION_TRAMITE'       THEN 'ADMIS.TR.'
+            WHEN 'CONSULTAS'              THEN 'CONSULTAS'
+            WHEN 'INFORMACION_PUBLICA'    THEN 'INF.PÚB.'
+            WHEN 'FIGURA_AMBIENTAL_EXTERNA' THEN 'FIG.AMB.'
+            WHEN 'AAU_AAUS_INTEGRADA'     THEN 'AAU/AAUS'
+            ELSE NULL
+        END
+    """)
+
+    # Valores iniciales para tipos_tramites
+    op.execute("""
+        UPDATE public.tipos_tramites SET abrev = CASE codigo
+            WHEN 'RECEPCION_SOLICITUD'         THEN 'REC.SOL.'
+            WHEN 'COMUNICACION_INICIO'         THEN 'COM.INI.'
+            WHEN 'COMPROBACION_ADMISIBILIDAD'  THEN 'COMP.ADM.'
+            WHEN 'REQUERIMIENTO_SUBSANACION'   THEN 'REQ.SUB.'
+            WHEN 'COMPROBACION_DOCUMENTAL'     THEN 'COMP.DOC.'
+            WHEN 'REQUERIMIENTO_MEJORA'        THEN 'REQ.MEJ.'
+            WHEN 'SOLICITUD_INFORME_MINISTERIO' THEN 'SOL.INF.'
+            WHEN 'RECEPCION_INFORME_MINISTERIO' THEN 'REC.INF.'
+            WHEN 'SOLICITUD_COMPATIBILIDAD'    THEN 'SOL.COMP.'
+            WHEN 'AUDIENCIA_COMPATIBILIDAD'    THEN 'AUD.COMP.'
+            ELSE NULL
+        END
+    """)
+
+    # Valores iniciales para tipos_tareas
+    op.execute("""
+        UPDATE public.tipos_tareas SET abrev = CASE codigo
+            WHEN 'ANALISIS'     THEN 'ANÁLISIS'
+            WHEN 'REDACTAR'     THEN 'REDACTAR'
+            WHEN 'FIRMAR'       THEN 'FIRMAR'
+            WHEN 'NOTIFICAR'    THEN 'NOTIFICAR'
+            WHEN 'PUBLICAR'     THEN 'PUBLICAR'
+            WHEN 'ESPERAR_PLAZO' THEN 'PLAZO'
+            WHEN 'INCORPORAR'   THEN 'INCORPORAR'
+            ELSE NULL
+        END
+    """)
+
+
+def downgrade():
+    op.drop_column('tipos_tareas',   'abrev', schema='public')
+    op.drop_column('tipos_tramites', 'abrev', schema='public')
+    op.drop_column('tipos_fases',    'abrev', schema='public')


### PR DESCRIPTION
## Summary

- Campo `abrev` (String 20, nullable) + property `label_bc` en `TipoFase`, `TipoTramite`, `TipoTarea`
- Migración manual con valores iniciales para todos los tipos existentes
- Breadcrumbs BC usan `label_bc` (abreviatura) en Fase/Trámite/Tarea; Solicitud muestra siglas (`AAP + AAC`)
- Cabecera card Solicitud homogeneizada al patrón `Solicitud: AAP + AAC`
- Separadores `›` del breadcrumb: color `#444`, `font-size 1.1rem`, `fw-semibold`
- Segmento activo visible en `#444 fw-semibold`; enlaces en verde corporativo (`--bs-primary`)
- `div.bc-view` con `max-width: 1200px` centrado en los 5 templates BC
- Fix: botón Tramitar del listado apuntaba a `tramitacion_v3` (legacy) en lugar de `tramitacion_bc`

## Test plan

- [ ] Navegar desde listado → botón Tramitar → llega a Vista BC (no a tramitacion_v3)
- [ ] Breadcrumb muestra siglas en nivel Solicitud y abreviaturas en Fase/Trámite/Tarea
- [ ] Cabecera card Solicitud muestra `Solicitud: AAP + AAC`
- [ ] Separadores `›` visibles y oscuros
- [ ] Vista centrada y con anchura máxima en pantallas anchas
- [ ] Tipos sin `abrev` muestran `nombre` completo (fallback correcto)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)