### PR TITLE
#180 Pool de documentos — explorador del servidor de ficheros

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,12 @@ class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-fallback'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
+    # Directorio donde se almacenan los ficheros subidos al pool documental.
+    # En producción apuntar a un volumen persistente (NAS, disco externo, etc.)
+    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER') or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'uploads'
+    )
+    MAX_CONTENT_LENGTH = int(os.environ.get('MAX_UPLOAD_MB', 200)) * 1024 * 1024
 
 class DevelopmentConfig(Config):
     """Desarrollo"""

--- a/app/config.py
+++ b/app/config.py
@@ -8,12 +8,10 @@ class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-fallback'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
-    # Directorio donde se almacenan los ficheros subidos al pool documental.
-    # En producción apuntar a un volumen persistente (NAS, disco externo, etc.)
-    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER') or os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'uploads'
-    )
-    MAX_CONTENT_LENGTH = int(os.environ.get('MAX_UPLOAD_MB', 200)) * 1024 * 1024
+    # Raíz del servidor de ficheros corporativo.
+    # Desarrollo: cualquier carpeta local (p.ej. D:/BDDAT/docs_prueba)
+    # Producción: W:\ALTA TENSION\Expedientes  o  \\HACACL0102\energia\ALTA TENSION\Expedientes
+    FILESYSTEM_BASE = os.environ.get('FILESYSTEM_BASE') or ''
 
 class DevelopmentConfig(Config):
     """Desarrollo"""

--- a/app/models/documentos.py
+++ b/app/models/documentos.py
@@ -119,9 +119,9 @@ class Documento(db.Model):
     )
 
     url = db.Column(
-        db.String(500),
+        db.Text,
         nullable=False,
-        comment='Ruta o URL del archivo físico en sistema de archivos o repositorio'
+        comment='Ruta absoluta en servidor de ficheros o URL externa (http/https)'
     )
     
     tipo_contenido = db.Column(

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -13,6 +13,9 @@ Rutas:
 - GET  /expedientes/<id>/editar          - Formulario editar expediente
 - POST /expedientes/<id>/editar          - Actualizar expediente + proyecto
 """
+import subprocess
+import sys
+import json as _json
 from datetime import date
 from flask import Blueprint, render_template, request, flash, redirect, url_for, abort, jsonify
 from flask_login import login_required
@@ -667,3 +670,73 @@ def pool_borrar_documento(id, doc_id):
         return jsonify({'ok': False, 'error': str(e)}), 500
 
     return jsonify({'ok': True})
+
+
+# Scripts tkinter para el selector nativo (se ejecutan en subproceso independiente)
+_SCRIPT_FICHEROS = """\
+import tkinter as tk
+from tkinter import filedialog
+import json, pathlib
+root = tk.Tk()
+root.withdraw()
+root.wm_attributes('-topmost', True)
+rutas = list(filedialog.askopenfilenames(title='Seleccionar ficheros \u2014 BDDAT Pool'))
+rutas = [str(pathlib.Path(r)) for r in rutas]
+root.destroy()
+print(json.dumps(rutas))
+"""
+
+_SCRIPT_CARPETA = """\
+import tkinter as tk
+from tkinter import filedialog
+import json, pathlib
+root = tk.Tk()
+root.withdraw()
+root.wm_attributes('-topmost', True)
+carpeta = filedialog.askdirectory(title='Seleccionar carpeta \u2014 BDDAT Pool')
+rutas = []
+if carpeta:
+    p = pathlib.Path(carpeta)
+    rutas = [str(f) for f in sorted(p.iterdir()) if f.is_file()]
+root.destroy()
+print(json.dumps(rutas))
+"""
+
+
+@bp.route('/<int:id>/documentos/selector-nativo', methods=['POST'])
+@login_required
+def pool_selector_nativo(id):
+    """
+    Abre un selector de ficheros o carpeta nativo del SO mediante tkinter
+    en un subproceso y devuelve las rutas completas como JSON.
+
+    Esto evita la restricción de seguridad del navegador que impide obtener
+    la ruta completa de ficheros arrastrados al área de drop.
+
+    Solo funciona cuando Flask corre en la misma máquina que el usuario.
+    """
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+
+    modo = (request.get_json(silent=True) or {}).get('modo', 'ficheros')
+    script = _SCRIPT_CARPETA if modo == 'carpeta' else _SCRIPT_FICHEROS
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, '-c', script],
+            capture_output=True,
+            text=True,
+            timeout=120,          # El usuario tiene 2 minutos para seleccionar
+        )
+        rutas = _json.loads(proc.stdout.strip() or '[]')
+    except subprocess.TimeoutExpired:
+        return jsonify({'ok': False, 'error': 'Tiempo de espera agotado (120 s)'}), 408
+    except _json.JSONDecodeError:
+        detalle = proc.stderr.strip() if proc.stderr else 'sin detalle'
+        return jsonify({'ok': False, 'error': f'Error en el selector: {detalle}'}), 500
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True, 'rutas': rutas})

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -14,10 +14,8 @@ Rutas:
 - POST /expedientes/<id>/editar          - Actualizar expediente + proyecto
 """
 import os
-import uuid as _uuid
 from datetime import date
-from werkzeug.utils import secure_filename
-from flask import current_app, send_from_directory
+from flask import current_app, send_file
 from flask import Blueprint, render_template, request, flash, redirect, url_for, abort, jsonify
 from flask_login import login_required
 from app import db
@@ -535,7 +533,7 @@ def pool_documentos(id):
 
     docs_lista = []
     for doc in documentos_raw:
-        filename = doc.url.rsplit('/', 1)[-1] if doc.url else ''
+        filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else ''
         nombre = filename or f'Documento {doc.id}'
         partes = filename.rsplit('.', 1)
         extension = partes[1].lower() if len(partes) == 2 and partes[1] else ''
@@ -558,61 +556,104 @@ def pool_documentos(id):
     )
 
 
-@bp.route('/<int:id>/documentos/subir', methods=['POST'])
-@login_required
-def pool_subir(id):
+def _path_seguro(ruta_relativa, base):
     """
-    Sube uno o varios ficheros al pool del expediente (multipart/form-data).
+    Devuelve ruta absoluta si está dentro de base; None si intenta path traversal.
+    ruta_relativa usa '/' como separador (enviado por JS).
+    """
+    base_norm = os.path.normpath(os.path.abspath(base))
+    if ruta_relativa:
+        ruta_full = os.path.normpath(os.path.join(base, ruta_relativa.replace('/', os.sep)))
+    else:
+        ruta_full = base_norm
+    if ruta_full != base_norm and not ruta_full.startswith(base_norm + os.sep):
+        return None
+    return ruta_full
 
-    Campos del formulario:
-      files          → ficheros (múltiple)
-      tipos[]        → tipo_doc_id por fichero (mismo índice)
-      fechas[]       → fecha_administrativa ISO por fichero
-      prioridades[]  → '1'/'0' por fichero
 
-    Almacena cada fichero en UPLOAD_FOLDER/expedientes/<id>/<uuid>/<nombre>.
-    Guarda la ruta relativa en Documento.url.
+@bp.route('/<int:id>/documentos/explorador-fs')
+@login_required
+def pool_explorador_fs(id):
+    """Explorador de carpetas del servidor de ficheros — devuelve JSON."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+
+    base = current_app.config.get('FILESYSTEM_BASE', '')
+    if not base or not os.path.isdir(base):
+        return jsonify({'ok': False, 'error': 'Servidor de ficheros no accesible'}), 503
+
+    ruta_rel = request.args.get('ruta', '').strip('/\\ ')
+    ruta_abs = _path_seguro(ruta_rel, base)
+    if not ruta_abs or not os.path.isdir(ruta_abs):
+        return jsonify({'ok': False, 'error': 'Ruta no válida'}), 400
+
+    try:
+        dirs, files = [], []
+        for e in sorted(os.scandir(ruta_abs), key=lambda x: (not x.is_dir(), x.name.lower())):
+            rel = os.path.relpath(e.path, base).replace(os.sep, '/')
+            if e.is_dir(follow_symlinks=False):
+                dirs.append({'nombre': e.name, 'ruta': rel})
+            elif e.is_file(follow_symlinks=False):
+                ext = e.name.rsplit('.', 1)[-1].lower() if '.' in e.name else ''
+                files.append({'nombre': e.name, 'ruta': rel,
+                              'tamano': e.stat().st_size, 'ext': ext})
+    except PermissionError:
+        return jsonify({'ok': False, 'error': 'Sin permisos en esta carpeta'}), 403
+
+    partes = ruta_rel.split('/') if ruta_rel else []
+    return jsonify({'ok': True, 'partes': partes, 'directorios': dirs, 'ficheros': files})
+
+
+@bp.route('/<int:id>/documentos/registrar-rutas', methods=['POST'])
+@login_required
+def pool_registrar_rutas(id):
+    """
+    Registra ficheros del servidor de ficheros en el pool del expediente.
+
+    Recibe JSON: [{ruta, tipo_doc_id, fecha_administrativa, asunto, prioridad}, ...]
+    donde ruta es relativa a FILESYSTEM_BASE (con '/' como separador).
+    Almacena la ruta absoluta normalizada en Documento.url.
     """
     expediente = Expediente.query.get_or_404(id)
     resultado = verificar_acceso_expediente(expediente, 'editar')
     if resultado:
         return resultado
 
-    files      = request.files.getlist('files')
-    tipos      = request.form.getlist('tipos[]')
-    fechas     = request.form.getlist('fechas[]')
-    prioridades = request.form.getlist('prioridades[]')
+    base = current_app.config.get('FILESYSTEM_BASE', '')
+    if not base or not os.path.isdir(base):
+        return jsonify({'ok': False, 'error': 'Servidor de ficheros no accesible'}), 503
 
-    upload_base = current_app.config['UPLOAD_FOLDER']
+    items = request.get_json(silent=True)
+    if not isinstance(items, list) or not items:
+        return jsonify({'ok': False, 'error': 'Payload inválido'}), 400
+
     creados = 0
-
     try:
-        for i, f in enumerate(files):
-            if not f or not f.filename:
+        for item in items:
+            ruta_rel = (item.get('ruta') or '').strip()
+            if not ruta_rel:
+                continue
+            ruta_abs = _path_seguro(ruta_rel, base)
+            if not ruta_abs or not os.path.isfile(ruta_abs):
                 continue
 
-            nombre_seguro = secure_filename(f.filename) or f'doc_{i}'
-            subdir = os.path.join('expedientes', str(id), str(_uuid.uuid4()))
-            ruta_abs = os.path.join(upload_base, subdir)
-            os.makedirs(ruta_abs, exist_ok=True)
-            f.save(os.path.join(ruta_abs, nombre_seguro))
-
-            # Guardar con separadores / para consistencia entre SO
-            url_relativa = subdir.replace(os.sep, '/') + '/' + nombre_seguro
-
             fecha_admin = None
-            if i < len(fechas) and fechas[i]:
+            fecha_raw = item.get('fecha_administrativa') or None
+            if fecha_raw:
                 try:
-                    fecha_admin = date.fromisoformat(fechas[i])
+                    fecha_admin = date.fromisoformat(fecha_raw)
                 except ValueError:
                     pass
 
             doc = Documento(
                 expediente_id=id,
-                url=url_relativa,
-                tipo_doc_id=int(tipos[i]) if i < len(tipos) and tipos[i] else 1,
+                url=ruta_abs,
+                tipo_doc_id=int(item.get('tipo_doc_id') or 1),
                 fecha_administrativa=fecha_admin,
-                prioridad=1 if (i < len(prioridades) and prioridades[i] == '1') else 0,
+                asunto=(item.get('asunto') or '').strip() or None,
+                prioridad=1 if item.get('prioridad') else 0,
             )
             db.session.add(doc)
             creados += 1
@@ -628,7 +669,7 @@ def pool_subir(id):
 @bp.route('/<int:id>/documentos/<int:doc_id>/fichero')
 @login_required
 def pool_descargar_documento(id, doc_id):
-    """Sirve un fichero subido al pool. Para URLs externas, redirige."""
+    """Sirve un fichero del servidor de ficheros. Para URLs externas, redirige."""
     expediente = Expediente.query.get_or_404(id)
     resultado = verificar_acceso_expediente(expediente, 'ver')
     if resultado:
@@ -638,14 +679,22 @@ def pool_descargar_documento(id, doc_id):
     if doc.expediente_id != id:
         abort(404)
 
-    if (doc.url or '').startswith(('http://', 'https://')):
-        from flask import redirect
-        return redirect(doc.url)
+    url = doc.url or ''
+    if url.startswith(('http://', 'https://')):
+        return redirect(url)
 
-    upload_base = current_app.config['UPLOAD_FOLDER']
-    dir_abs  = os.path.join(upload_base, os.path.dirname(doc.url))
-    filename = os.path.basename(doc.url)
-    return send_from_directory(dir_abs, filename)
+    ruta_abs = os.path.normpath(os.path.abspath(url))
+    if not os.path.isfile(ruta_abs):
+        abort(404)
+
+    base = current_app.config.get('FILESYSTEM_BASE', '')
+    if base:
+        base_norm = os.path.normpath(os.path.abspath(base))
+        if not ruta_abs.startswith(base_norm):
+            abort(403)
+
+    return send_file(ruta_abs, as_attachment=False,
+                     download_name=os.path.basename(ruta_abs))
 
 
 @bp.route('/<int:id>/documentos/url-externa', methods=['POST'])
@@ -753,19 +802,6 @@ def pool_borrar_documento(id, doc_id):
         }), 422
 
     try:
-        # Si es un fichero subido (no URL externa), eliminarlo del disco
-        url = doc.url or ''
-        if url and not url.startswith(('http://', 'https://')):
-            upload_base = current_app.config['UPLOAD_FOLDER']
-            file_abs = os.path.join(upload_base, url.replace('/', os.sep))
-            if os.path.isfile(file_abs):
-                os.remove(file_abs)
-            dir_abs = os.path.dirname(file_abs)
-            try:
-                os.rmdir(dir_abs)   # Solo borra si está vacío (cada doc tiene su UUID dir)
-            except OSError:
-                pass
-
         db.session.delete(doc)
         db.session.commit()
     except Exception as e:

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -13,10 +13,11 @@ Rutas:
 - GET  /expedientes/<id>/editar          - Formulario editar expediente
 - POST /expedientes/<id>/editar          - Actualizar expediente + proyecto
 """
-import subprocess
-import sys
-import json as _json
+import os
+import uuid as _uuid
 from datetime import date
+from werkzeug.utils import secure_filename
+from flask import current_app, send_from_directory
 from flask import Blueprint, render_template, request, flash, redirect, url_for, abort, jsonify
 from flask_login import login_required
 from app import db
@@ -534,19 +535,16 @@ def pool_documentos(id):
 
     docs_lista = []
     for doc in documentos_raw:
-        filename = doc.url.rsplit('/', 1)[-1].rsplit('\\', 1)[-1] if doc.url else ''
+        filename = doc.url.rsplit('/', 1)[-1] if doc.url else ''
         nombre = filename or f'Documento {doc.id}'
-        # Extensión para mostrar en la tabla (vacía si no hay punto en el nombre)
         partes = filename.rsplit('.', 1)
         extension = partes[1].lower() if len(partes) == 2 and partes[1] else ''
-        # ¿Es una URL clickable? Solo http/https y file:// (UNC \\ no funciona en browser)
-        url = doc.url or ''
-        es_clickable = url.startswith(('http://', 'https://', 'file:///'))
+        es_url_externa = (doc.url or '').startswith(('http://', 'https://'))
         docs_lista.append({
             'doc':             doc,
             'nombre_display':  nombre,
             'extension':       extension,
-            'es_clickable':    es_clickable,
+            'es_url_externa':  es_url_externa,
             'es_referenciado': _documento_es_referenciado(doc),
         })
 
@@ -560,46 +558,137 @@ def pool_documentos(id):
     )
 
 
-@bp.route('/<int:id>/documentos/carga-masiva', methods=['POST'])
+@bp.route('/<int:id>/documentos/subir', methods=['POST'])
 @login_required
-def pool_carga_masiva(id):
-    """Carga masiva de documentos al pool — recibe JSON, devuelve JSON."""
+def pool_subir(id):
+    """
+    Sube uno o varios ficheros al pool del expediente (multipart/form-data).
+
+    Campos del formulario:
+      files          → ficheros (múltiple)
+      tipos[]        → tipo_doc_id por fichero (mismo índice)
+      fechas[]       → fecha_administrativa ISO por fichero
+      prioridades[]  → '1'/'0' por fichero
+
+    Almacena cada fichero en UPLOAD_FOLDER/expedientes/<id>/<uuid>/<nombre>.
+    Guarda la ruta relativa en Documento.url.
+    """
     expediente = Expediente.query.get_or_404(id)
     resultado = verificar_acceso_expediente(expediente, 'editar')
     if resultado:
         return resultado
 
-    datos = request.get_json(silent=True) or []
+    files      = request.files.getlist('files')
+    tipos      = request.form.getlist('tipos[]')
+    fechas     = request.form.getlist('fechas[]')
+    prioridades = request.form.getlist('prioridades[]')
+
+    upload_base = current_app.config['UPLOAD_FOLDER']
     creados = 0
+
     try:
-        for entrada in datos:
-            url = (entrada.get('url') or '').strip()
-            if not url or entrada.get('excluir'):
+        for i, f in enumerate(files):
+            if not f or not f.filename:
                 continue
-            tipo_doc_id = entrada.get('tipo_doc_id') or 1
-            fecha_raw = entrada.get('fecha_administrativa') or None
+
+            nombre_seguro = secure_filename(f.filename) or f'doc_{i}'
+            subdir = os.path.join('expedientes', str(id), str(_uuid.uuid4()))
+            ruta_abs = os.path.join(upload_base, subdir)
+            os.makedirs(ruta_abs, exist_ok=True)
+            f.save(os.path.join(ruta_abs, nombre_seguro))
+
+            # Guardar con separadores / para consistencia entre SO
+            url_relativa = subdir.replace(os.sep, '/') + '/' + nombre_seguro
+
             fecha_admin = None
-            if fecha_raw:
+            if i < len(fechas) and fechas[i]:
                 try:
-                    fecha_admin = date.fromisoformat(fecha_raw)
+                    fecha_admin = date.fromisoformat(fechas[i])
                 except ValueError:
                     pass
+
             doc = Documento(
                 expediente_id=id,
-                url=url,
-                tipo_doc_id=int(tipo_doc_id),
+                url=url_relativa,
+                tipo_doc_id=int(tipos[i]) if i < len(tipos) and tipos[i] else 1,
                 fecha_administrativa=fecha_admin,
-                asunto=(entrada.get('asunto') or '').strip() or None,
-                prioridad=1 if entrada.get('prioridad') else 0,
+                prioridad=1 if (i < len(prioridades) and prioridades[i] == '1') else 0,
             )
             db.session.add(doc)
             creados += 1
+
         db.session.commit()
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500
 
     return jsonify({'ok': True, 'creados': creados})
+
+
+@bp.route('/<int:id>/documentos/<int:doc_id>/fichero')
+@login_required
+def pool_descargar_documento(id, doc_id):
+    """Sirve un fichero subido al pool. Para URLs externas, redirige."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+
+    doc = Documento.query.get_or_404(doc_id)
+    if doc.expediente_id != id:
+        abort(404)
+
+    if (doc.url or '').startswith(('http://', 'https://')):
+        from flask import redirect
+        return redirect(doc.url)
+
+    upload_base = current_app.config['UPLOAD_FOLDER']
+    dir_abs  = os.path.join(upload_base, os.path.dirname(doc.url))
+    filename = os.path.basename(doc.url)
+    return send_from_directory(dir_abs, filename)
+
+
+@bp.route('/<int:id>/documentos/url-externa', methods=['POST'])
+@login_required
+def pool_registrar_url_externa(id):
+    """
+    Registra una URL externa en el pool (BOE, Notifica, sede electrónica, etc.)
+    sin subir ningún fichero. Recibe JSON, devuelve JSON.
+    """
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+
+    datos = request.get_json(silent=True) or {}
+    url = (datos.get('url') or '').strip()
+    if not url:
+        return jsonify({'ok': False, 'error': 'La URL es obligatoria'}), 400
+
+    fecha_admin = None
+    fecha_raw = datos.get('fecha_administrativa') or None
+    if fecha_raw:
+        try:
+            fecha_admin = date.fromisoformat(fecha_raw)
+        except ValueError:
+            pass
+
+    try:
+        doc = Documento(
+            expediente_id=id,
+            url=url,
+            tipo_doc_id=int(datos.get('tipo_doc_id') or 1),
+            fecha_administrativa=fecha_admin,
+            asunto=(datos.get('asunto') or '').strip() or None,
+            prioridad=1 if datos.get('prioridad') else 0,
+        )
+        db.session.add(doc)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True})
 
 
 @bp.route('/<int:id>/documentos/<int:doc_id>/editar', methods=['POST'])
@@ -616,9 +705,9 @@ def pool_editar_documento(id, doc_id):
         abort(404)
 
     datos = request.get_json(silent=True) or {}
-    url = (datos.get('url') or '').strip()
-    if not url:
-        return jsonify({'ok': False, 'error': 'La URL es obligatoria'}), 400
+    # url es opcional en el payload: si viene vacía/null se conserva la existente
+    # (para ficheros subidos el campo URL está oculto en el modal)
+    url_nueva = (datos.get('url') or '').strip()
 
     fecha_raw = datos.get('fecha_administrativa') or None
     fecha_admin = None
@@ -629,7 +718,8 @@ def pool_editar_documento(id, doc_id):
             pass
 
     try:
-        doc.url = url
+        if url_nueva:
+            doc.url = url_nueva
         doc.tipo_doc_id = int(datos.get('tipo_doc_id') or 1)
         doc.fecha_administrativa = fecha_admin
         doc.asunto = (datos.get('asunto') or '').strip() or None
@@ -663,6 +753,19 @@ def pool_borrar_documento(id, doc_id):
         }), 422
 
     try:
+        # Si es un fichero subido (no URL externa), eliminarlo del disco
+        url = doc.url or ''
+        if url and not url.startswith(('http://', 'https://')):
+            upload_base = current_app.config['UPLOAD_FOLDER']
+            file_abs = os.path.join(upload_base, url.replace('/', os.sep))
+            if os.path.isfile(file_abs):
+                os.remove(file_abs)
+            dir_abs = os.path.dirname(file_abs)
+            try:
+                os.rmdir(dir_abs)   # Solo borra si está vacío (cada doc tiene su UUID dir)
+            except OSError:
+                pass
+
         db.session.delete(doc)
         db.session.commit()
     except Exception as e:
@@ -672,96 +775,3 @@ def pool_borrar_documento(id, doc_id):
     return jsonify({'ok': True})
 
 
-# Scripts tkinter para el selector nativo (se ejecutan en subproceso independiente).
-# sys.argv[1] recibe el último directorio usado para abrir el diálogo en él directamente.
-_SCRIPT_FICHEROS = """\
-import tkinter as tk
-from tkinter import filedialog
-import json, pathlib, sys
-
-initialdir = sys.argv[1] if len(sys.argv) > 1 else ''
-root = tk.Tk()
-root.withdraw()
-root.wm_attributes('-topmost', True)
-rutas = list(filedialog.askopenfilenames(
-    title='Seleccionar ficheros \u2014 BDDAT Pool',
-    initialdir=initialdir or None,
-))
-rutas = [str(pathlib.Path(r)) for r in rutas]
-root.destroy()
-print(json.dumps(rutas))
-"""
-
-_SCRIPT_CARPETA = """\
-import tkinter as tk
-from tkinter import filedialog
-import json, pathlib, sys
-
-initialdir = sys.argv[1] if len(sys.argv) > 1 else ''
-root = tk.Tk()
-root.withdraw()
-root.wm_attributes('-topmost', True)
-carpeta = filedialog.askdirectory(
-    title='Seleccionar carpeta \u2014 BDDAT Pool',
-    initialdir=initialdir or None,
-)
-rutas = []
-if carpeta:
-    p = pathlib.Path(carpeta)
-    rutas = [str(f) for f in sorted(p.iterdir()) if f.is_file()]
-root.destroy()
-print(json.dumps(rutas))
-"""
-
-# Último directorio usado — persiste en memoria durante la sesión del servidor.
-# Permite que el diálogo se abra directamente en la carpeta del uso anterior.
-_ultimo_directorio = ''
-
-
-@bp.route('/<int:id>/documentos/selector-nativo', methods=['POST'])
-@login_required
-def pool_selector_nativo(id):
-    """
-    Abre un selector de ficheros o carpeta nativo del SO mediante tkinter
-    en un subproceso y devuelve las rutas completas como JSON.
-
-    - Funciona cuando Flask corre en la misma máquina que el usuario (desarrollo/admin local).
-    - En producción con servidor remoto el diálogo se abriría en el servidor: no usar.
-      Para ese escenario, el usuario rellena la columna URL editable manualmente.
-
-    Recibe: { modo: 'ficheros' | 'carpeta' }
-    Devuelve: { ok: true, rutas: ['C:\\\\...', ...] }
-    """
-    global _ultimo_directorio
-
-    expediente = Expediente.query.get_or_404(id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
-    if resultado:
-        return resultado
-
-    datos = request.get_json(silent=True) or {}
-    modo = datos.get('modo', 'ficheros')
-    script = _SCRIPT_CARPETA if modo == 'carpeta' else _SCRIPT_FICHEROS
-
-    try:
-        proc = subprocess.run(
-            [sys.executable, '-c', script, _ultimo_directorio],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        rutas = _json.loads(proc.stdout.strip() or '[]')
-    except subprocess.TimeoutExpired:
-        return jsonify({'ok': False, 'error': 'Tiempo de espera agotado (120 s)'}), 408
-    except _json.JSONDecodeError:
-        detalle = proc.stderr.strip() if proc.stderr else 'sin detalle'
-        return jsonify({'ok': False, 'error': f'Error en el selector: {detalle}'}), 500
-    except Exception as e:
-        return jsonify({'ok': False, 'error': str(e)}), 500
-
-    # Memorizar el directorio de la primera ruta seleccionada para la próxima vez
-    if rutas:
-        import pathlib as _pl
-        _ultimo_directorio = str(_pl.Path(rutas[0]).parent)
-
-    return jsonify({'ok': True, 'rutas': rutas})

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -13,7 +13,8 @@ Rutas:
 - GET  /expedientes/<id>/editar          - Formulario editar expediente
 - POST /expedientes/<id>/editar          - Actualizar expediente + proyecto
 """
-from flask import Blueprint, render_template, request, flash, redirect, url_for, abort
+from datetime import date
+from flask import Blueprint, render_template, request, flash, redirect, url_for, abort, jsonify
 from flask_login import login_required
 from app import db
 from app.models.expedientes import Expediente
@@ -32,6 +33,8 @@ from app.models.solicitudes import Solicitud
 from app.models.fases import Fase
 from app.models.tramites import Tramite
 from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.models.tipos_documentos import TipoDocumento
 from app.decorators import role_required
 from app.utils.permisos import (
     puede_cambiar_responsable,
@@ -483,3 +486,175 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         tramite=tramite,
         tarea=tarea,
     )
+
+
+# ===========================================================================
+# POOL DE DOCUMENTOS — issue #180
+# Gestión masiva del pool documental de un expediente (Vía 1)
+# ===========================================================================
+
+def _documento_es_referenciado(doc):
+    """
+    True si el documento tiene referencias activas que impiden su borrado.
+
+    Usa únicamente backrefs SQLAlchemy — NO hardcodear SQL directo.
+    Si en el futuro se añade una nueva tabla con FK a documentos.id:
+      1. Añadir el backref en el modelo correspondiente.
+      2. Añadir un check aquí.
+
+    Backrefs consultados:
+      doc.proyecto_vinculado  → DocumentoProyecto.documento_id  (uselist=False)
+      doc.tareas_que_usan     → Tarea.documento_usado_id        (lista)
+      doc.tarea_productora    → Tarea.documento_producido_id    (lista, UNIQUE en BD)
+    """
+    if doc.proyecto_vinculado:
+        return True
+    if doc.tareas_que_usan:
+        return True
+    if doc.tarea_productora:
+        return True
+    return False
+
+
+@bp.route('/<int:id>/documentos')
+@login_required
+def pool_documentos(id):
+    """Pool de documentos — listado del expediente."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+
+    documentos_raw = Documento.query.filter_by(
+        expediente_id=id
+    ).order_by(Documento.id.desc()).all()
+
+    docs_lista = []
+    for doc in documentos_raw:
+        nombre = doc.url.rsplit('/', 1)[-1].rsplit('.', 1)[0] if doc.url else f'Documento {doc.id}'
+        docs_lista.append({
+            'doc':            doc,
+            'nombre_display': nombre,
+            'es_referenciado': _documento_es_referenciado(doc),
+        })
+
+    tipos_doc = TipoDocumento.query.order_by(TipoDocumento.nombre).all()
+
+    return render_template(
+        'expedientes/pool_documentos.html',
+        expediente=expediente,
+        docs_lista=docs_lista,
+        tipos_doc=tipos_doc,
+    )
+
+
+@bp.route('/<int:id>/documentos/carga-masiva', methods=['POST'])
+@login_required
+def pool_carga_masiva(id):
+    """Carga masiva de documentos al pool — recibe JSON, devuelve JSON."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+
+    datos = request.get_json(silent=True) or []
+    creados = 0
+    try:
+        for entrada in datos:
+            url = (entrada.get('url') or '').strip()
+            if not url or entrada.get('excluir'):
+                continue
+            tipo_doc_id = entrada.get('tipo_doc_id') or 1
+            fecha_raw = entrada.get('fecha_administrativa') or None
+            fecha_admin = None
+            if fecha_raw:
+                try:
+                    fecha_admin = date.fromisoformat(fecha_raw)
+                except ValueError:
+                    pass
+            doc = Documento(
+                expediente_id=id,
+                url=url,
+                tipo_doc_id=int(tipo_doc_id),
+                fecha_administrativa=fecha_admin,
+                asunto=(entrada.get('asunto') or '').strip() or None,
+                prioridad=1 if entrada.get('prioridad') else 0,
+            )
+            db.session.add(doc)
+            creados += 1
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True, 'creados': creados})
+
+
+@bp.route('/<int:id>/documentos/<int:doc_id>/editar', methods=['POST'])
+@login_required
+def pool_editar_documento(id, doc_id):
+    """Editar metadatos de un documento del pool — devuelve JSON."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+
+    doc = Documento.query.get_or_404(doc_id)
+    if doc.expediente_id != id:
+        abort(404)
+
+    datos = request.get_json(silent=True) or {}
+    url = (datos.get('url') or '').strip()
+    if not url:
+        return jsonify({'ok': False, 'error': 'La URL es obligatoria'}), 400
+
+    fecha_raw = datos.get('fecha_administrativa') or None
+    fecha_admin = None
+    if fecha_raw:
+        try:
+            fecha_admin = date.fromisoformat(fecha_raw)
+        except ValueError:
+            pass
+
+    try:
+        doc.url = url
+        doc.tipo_doc_id = int(datos.get('tipo_doc_id') or 1)
+        doc.fecha_administrativa = fecha_admin
+        doc.asunto = (datos.get('asunto') or '').strip() or None
+        doc.prioridad = 1 if datos.get('prioridad') else 0
+        doc.observaciones = (datos.get('observaciones') or '').strip() or None
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True})
+
+
+@bp.route('/<int:id>/documentos/<int:doc_id>/borrar', methods=['POST'])
+@login_required
+def pool_borrar_documento(id, doc_id):
+    """Borrar un documento del pool si no está referenciado — devuelve JSON."""
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return resultado
+
+    doc = Documento.query.get_or_404(doc_id)
+    if doc.expediente_id != id:
+        abort(404)
+
+    if _documento_es_referenciado(doc):
+        return jsonify({
+            'ok': False,
+            'error': 'El documento está referenciado en tramitación y no puede eliminarse'
+        }), 422
+
+    try:
+        db.session.delete(doc)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True})

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -531,10 +531,19 @@ def pool_documentos(id):
 
     docs_lista = []
     for doc in documentos_raw:
-        nombre = doc.url.rsplit('/', 1)[-1].rsplit('.', 1)[0] if doc.url else f'Documento {doc.id}'
+        filename = doc.url.rsplit('/', 1)[-1].rsplit('\\', 1)[-1] if doc.url else ''
+        nombre = filename or f'Documento {doc.id}'
+        # Extensión para mostrar en la tabla (vacía si no hay punto en el nombre)
+        partes = filename.rsplit('.', 1)
+        extension = partes[1].lower() if len(partes) == 2 and partes[1] else ''
+        # ¿Es una URL clickable? Solo http/https y file:// (UNC \\ no funciona en browser)
+        url = doc.url or ''
+        es_clickable = url.startswith(('http://', 'https://', 'file:///'))
         docs_lista.append({
-            'doc':            doc,
-            'nombre_display': nombre,
+            'doc':             doc,
+            'nombre_display':  nombre,
+            'extension':       extension,
+            'es_clickable':    es_clickable,
             'es_referenciado': _documento_es_referenciado(doc),
         })
 

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -672,15 +672,21 @@ def pool_borrar_documento(id, doc_id):
     return jsonify({'ok': True})
 
 
-# Scripts tkinter para el selector nativo (se ejecutan en subproceso independiente)
+# Scripts tkinter para el selector nativo (se ejecutan en subproceso independiente).
+# sys.argv[1] recibe el último directorio usado para abrir el diálogo en él directamente.
 _SCRIPT_FICHEROS = """\
 import tkinter as tk
 from tkinter import filedialog
-import json, pathlib
+import json, pathlib, sys
+
+initialdir = sys.argv[1] if len(sys.argv) > 1 else ''
 root = tk.Tk()
 root.withdraw()
 root.wm_attributes('-topmost', True)
-rutas = list(filedialog.askopenfilenames(title='Seleccionar ficheros \u2014 BDDAT Pool'))
+rutas = list(filedialog.askopenfilenames(
+    title='Seleccionar ficheros \u2014 BDDAT Pool',
+    initialdir=initialdir or None,
+))
 rutas = [str(pathlib.Path(r)) for r in rutas]
 root.destroy()
 print(json.dumps(rutas))
@@ -689,11 +695,16 @@ print(json.dumps(rutas))
 _SCRIPT_CARPETA = """\
 import tkinter as tk
 from tkinter import filedialog
-import json, pathlib
+import json, pathlib, sys
+
+initialdir = sys.argv[1] if len(sys.argv) > 1 else ''
 root = tk.Tk()
 root.withdraw()
 root.wm_attributes('-topmost', True)
-carpeta = filedialog.askdirectory(title='Seleccionar carpeta \u2014 BDDAT Pool')
+carpeta = filedialog.askdirectory(
+    title='Seleccionar carpeta \u2014 BDDAT Pool',
+    initialdir=initialdir or None,
+)
 rutas = []
 if carpeta:
     p = pathlib.Path(carpeta)
@@ -701,6 +712,10 @@ if carpeta:
 root.destroy()
 print(json.dumps(rutas))
 """
+
+# Último directorio usado — persiste en memoria durante la sesión del servidor.
+# Permite que el diálogo se abra directamente en la carpeta del uso anterior.
+_ultimo_directorio = ''
 
 
 @bp.route('/<int:id>/documentos/selector-nativo', methods=['POST'])
@@ -710,25 +725,30 @@ def pool_selector_nativo(id):
     Abre un selector de ficheros o carpeta nativo del SO mediante tkinter
     en un subproceso y devuelve las rutas completas como JSON.
 
-    Esto evita la restricción de seguridad del navegador que impide obtener
-    la ruta completa de ficheros arrastrados al área de drop.
+    - Funciona cuando Flask corre en la misma máquina que el usuario (desarrollo/admin local).
+    - En producción con servidor remoto el diálogo se abriría en el servidor: no usar.
+      Para ese escenario, el usuario rellena la columna URL editable manualmente.
 
-    Solo funciona cuando Flask corre en la misma máquina que el usuario.
+    Recibe: { modo: 'ficheros' | 'carpeta' }
+    Devuelve: { ok: true, rutas: ['C:\\\\...', ...] }
     """
+    global _ultimo_directorio
+
     expediente = Expediente.query.get_or_404(id)
     resultado = verificar_acceso_expediente(expediente, 'editar')
     if resultado:
         return resultado
 
-    modo = (request.get_json(silent=True) or {}).get('modo', 'ficheros')
+    datos = request.get_json(silent=True) or {}
+    modo = datos.get('modo', 'ficheros')
     script = _SCRIPT_CARPETA if modo == 'carpeta' else _SCRIPT_FICHEROS
 
     try:
         proc = subprocess.run(
-            [sys.executable, '-c', script],
+            [sys.executable, '-c', script, _ultimo_directorio],
             capture_output=True,
             text=True,
-            timeout=120,          # El usuario tiene 2 minutos para seleccionar
+            timeout=120,
         )
         rutas = _json.loads(proc.stdout.strip() or '[]')
     except subprocess.TimeoutExpired:
@@ -738,5 +758,10 @@ def pool_selector_nativo(id):
         return jsonify({'ok': False, 'error': f'Error en el selector: {detalle}'}), 500
     except Exception as e:
         return jsonify({'ok': False, 'error': str(e)}), 500
+
+    # Memorizar el directorio de la primera ruta seleccionada para la próxima vez
+    if rutas:
+        import pathlib as _pl
+        _ultimo_directorio = str(_pl.Path(rutas[0]).parent)
 
     return jsonify({'ok': True, 'rutas': rutas})

--- a/app/modules/expedientes/templates/expedientes/detalle.html
+++ b/app/modules/expedientes/templates/expedientes/detalle.html
@@ -295,15 +295,68 @@
 <div class="row">
     <div class="col-12">
         <div class="card shadow-sm">
-            <div class="card-header card-header-accent">
+            <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
                 <h6 class="mb-0 fw-semibold">
                     <i class="fas fa-file-alt me-2"></i>Documentos
+                    <span class="badge bg-secondary ms-2 fw-normal">{{ expediente.documentos | length }}</span>
                 </h6>
+                <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+                   class="btn btn-sm btn-outline-primary">
+                    <i class="fas fa-folder-open me-1"></i> Gestionar pool
+                </a>
             </div>
-            <div class="card-body text-center text-muted py-4">
-                <i class="fas fa-folder fa-2x mb-2"></i>
-                <p class="mb-0 small">Próximamente</p>
+            {% if expediente.documentos %}
+            <div class="card-body p-0">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th class="ps-3">Documento</th>
+                            <th>Tipo</th>
+                            <th>Fecha adm.</th>
+                            <th class="text-center">Prio.</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for doc in expediente.documentos | sort(attribute='id', reverse=True) %}
+                    {% set filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else 'Documento ' ~ doc.id %}
+                    {% set es_url = doc.url and (doc.url.startswith('http://') or doc.url.startswith('https://')) %}
+                    <tr>
+                        <td class="ps-3">
+                            {% if es_url %}
+                            <a href="{{ doc.url }}" target="_blank" rel="noopener">
+                                <i class="fas fa-external-link-alt fa-xs me-1 text-secondary"></i>{{ filename }}
+                            </a>
+                            {% else %}
+                            <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=doc.id) }}"
+                               target="_blank">
+                                <i class="fas fa-file fa-xs me-1 text-secondary"></i>{{ filename }}
+                            </a>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge border border-secondary text-secondary small">
+                                {{ doc.tipo_doc.nombre if doc.tipo_doc else '—' }}
+                            </span>
+                        </td>
+                        <td class="text-nowrap small">
+                            {{ doc.fecha_administrativa.strftime('%d/%m/%Y') if doc.fecha_administrativa else '—' }}
+                        </td>
+                        <td class="text-center">
+                            {% if doc.prioridad and doc.prioridad > 0 %}
+                            <span class="badge bg-warning text-dark">Sí</span>
+                            {% else %}<span class="text-secondary">—</span>{% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
             </div>
+            {% else %}
+            <div class="card-body text-center text-secondary py-3">
+                <i class="fas fa-inbox me-1"></i>
+                <span class="small">Sin documentos — usa "Gestionar pool" para añadir.</span>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -16,39 +16,62 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 <style>
-  .zona-explorador {
-    border: 2px dashed var(--bs-border-color);
-    border-radius: 0.5rem;
-    padding: 1.25rem 1rem;
-    text-align: center;
+  /* Fichas de entrada */
+  .ficha-entrada {
     cursor: pointer;
-    transition: border-color 0.15s, background-color 0.15s;
-    color: var(--bs-secondary-color);
+    border: 1px solid var(--bs-border-color);
+    transition: border-color 0.15s, box-shadow 0.15s;
     user-select: none;
   }
-  .zona-explorador:hover {
+  .ficha-entrada:hover {
     border-color: var(--bs-primary);
-    background-color: var(--bs-primary-bg-subtle);
-    color: var(--bs-primary);
+    box-shadow: 0 0 0 3px var(--bs-primary-bg-subtle);
+  }
+  /* Asunto truncado en tabla */
+  .asunto-celda {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 260px;
+    display: block;
+  }
+  /* Panel de seleccionados (explorador) */
+  .panel-seleccionados {
+    max-height: 110px;
+    overflow-y: auto;
+    background: var(--bs-light);
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.375rem;
+    padding: 0.4rem 0.6rem;
   }
   /* Explorador de carpetas */
   .fs-item { cursor: pointer; }
   .fs-item:hover { background-color: var(--bs-primary-bg-subtle); }
   .fs-breadcrumb a { cursor: pointer; text-decoration: none; }
   .fs-breadcrumb a:hover { text-decoration: underline; }
+  /* Toast container */
+  .toast-container-custom {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 1200;
+  }
 </style>
 {% endblock %}
 
 {% block content %}
 <div class="bc-view">
 
-{# Opciones de tipo — dentro del block content para que el DOM las encuentre #}
+{# Opciones de tipo — plantilla para JS #}
 <template id="tmpl-tipos-doc">
   <option value="">— Tipo —</option>
   {% for t in tipos_doc %}
   <option value="{{ t.id }}">{{ t.nombre }}</option>
   {% endfor %}
 </template>
+
+<!-- Toast container -->
+<div class="toast-container-custom" id="toast-container"></div>
 
 <!-- C.1 -->
 <div class="lista-cabecera px-3 pt-3">
@@ -60,11 +83,11 @@
       </span>
       <div class="bc-acciones-bar">
         <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-secondary">
+           class="btn btn-sm btn-outline-primary">
           <i class="fas fa-info-circle me-1"></i> Detalle
         </a>
         <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}"
-           class="btn btn-sm btn-outline-secondary">
+           class="btn btn-sm btn-outline-primary">
           <i class="fas fa-sitemap me-1"></i> Tramitación
         </a>
       </div>
@@ -94,20 +117,57 @@
 <!-- C.2 -->
 <div class="lista-scroll-container p-3">
 
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h6 class="mb-0 fw-semibold">Pool de Documentos</h6>
-    <button type="button" class="btn btn-sm btn-outline-secondary"
-            onclick="abrir_modal_url_externa()">
-      <i class="fas fa-link me-1"></i> Añadir URL externa
-    </button>
+  <h6 class="mb-3 fw-semibold">Pool de Documentos</h6>
+
+  <!-- Dos fichas de entrada -->
+  <div class="row g-2 mb-3">
+    <div class="col-6">
+      <div class="card ficha-entrada h-100" onclick="abrir_explorador()">
+        <div class="card-body text-center py-3">
+          <i class="fas fa-server fa-2x mb-2 text-primary"></i>
+          <div class="fw-semibold">Seleccionar del servidor</div>
+          <div class="small text-secondary">Archivos del servidor corporativo</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6">
+      <div class="card ficha-entrada h-100" onclick="abrir_modal_url_externa()">
+        <div class="card-body text-center py-3">
+          <i class="fas fa-link fa-2x mb-2 text-primary"></i>
+          <div class="fw-semibold">Añadir URL externa</div>
+          <div class="small text-secondary">BOE, Notifica, sede electrónica…</div>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <!-- Zona de entrada al explorador de servidor -->
-  <div class="zona-explorador mb-3" id="zona-entrada-principal"
-       onclick="abrir_explorador()">
-    <i class="fas fa-folder-open fa-2x mb-2"></i>
-    <p class="mb-0 fw-semibold">Selecciona ficheros del servidor de documentos</p>
-    <small class="text-secondary">Haz clic para abrir el explorador de carpetas</small>
+  <!-- Panel de edición masiva (oculto hasta que haya selección) -->
+  <div id="panel-masivo" class="card card-body bg-light border mb-3 d-none">
+    <div class="d-flex flex-wrap align-items-center gap-2">
+      <span class="fw-semibold small">
+        Edición masiva (<span id="masivo-count">0</span> seleccionado(s)):
+      </span>
+      <select class="form-select form-select-sm" id="masivo-tipo" style="width:auto;min-width:180px">
+        <option value="">— Tipo (sin cambio) —</option>
+        {% for t in tipos_doc %}
+        <option value="{{ t.id }}">{{ t.nombre }}</option>
+        {% endfor %}
+      </select>
+      <div id="ef-masivo-fecha" style="width:155px"></div>
+      <select class="form-select form-select-sm" id="masivo-prioridad-sel" style="width:auto">
+        <option value="">— Prioridad (sin cambio) —</option>
+        <option value="1">Prioritario</option>
+        <option value="0">No prioritario</option>
+      </select>
+      <button type="button" class="btn btn-sm btn-primary" onclick="aplicar_masivo()">
+        <i class="fas fa-check me-1"></i> Aplicar
+      </button>
+      <button type="button" class="btn btn-sm btn-outline-secondary ms-auto"
+              onclick="deseleccionar_todos()">
+        <i class="fas fa-times me-1"></i> Deseleccionar
+      </button>
+      <div id="masivo-error" class="text-danger small w-100 d-none"></div>
+    </div>
   </div>
 
   <!-- Tabla -->
@@ -115,17 +175,27 @@
   <table class="table table-hover table-sm align-middle">
     <thead class="table-light">
       <tr>
+        <th style="width:2rem">
+          <input type="checkbox" class="form-check-input" id="check-todos"
+                 onchange="toggle_todos(this.checked)"
+                 title="Seleccionar / deseleccionar todos">
+        </th>
         <th>Documento</th>
+        <th>Ext.</th>
         <th>Tipo</th>
         <th>Fecha adm.</th>
-        <th>Prioritario</th>
+        <th class="text-center">Prio.</th>
         <th class="text-end">Acciones</th>
       </tr>
     </thead>
     <tbody id="tbody-docs">
       {% for item in docs_lista %}
       {% set doc = item.doc %}
-      <tr id="fila-doc-{{ doc.id }}">
+      <tr id="fila-doc-{{ doc.id }}" data-doc-id="{{ doc.id }}">
+        <td>
+          <input type="checkbox" class="form-check-input doc-check"
+                 onchange="on_check_doc(this, {{ doc.id }})">
+        </td>
         <td>
           {% if item.es_url_externa %}
           <a href="{{ doc.url }}" target="_blank" rel="noopener" class="fw-semibold">
@@ -133,17 +203,22 @@
           </a>
           {% else %}
           <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=doc.id) }}"
-             class="fw-semibold">
-            <i class="fas fa-file-download fa-xs me-1 text-secondary"></i>{{ item.nombre_display }}
+             target="_blank" class="fw-semibold">
+            <i class="fas fa-file fa-xs me-1 text-secondary"></i>{{ item.nombre_display }}
           </a>
           {% endif %}
-          {% if item.extension %}
-          <span class="badge border border-secondary text-secondary ms-1 small">.{{ item.extension }}</span>
-          {% elif doc.tipo_contenido %}
-          <span class="badge bg-secondary ms-1 small">{{ doc.tipo_contenido }}</span>
-          {% endif %}
           {% if doc.asunto %}
-          <div class="text-secondary small">{{ doc.asunto }}</div>
+          <span class="asunto-celda text-secondary small"
+                title="{{ doc.asunto | e }}">{{ doc.asunto }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if item.extension %}
+          <span class="badge border border-secondary text-secondary">.{{ item.extension }}</span>
+          {% elif doc.tipo_contenido %}
+          <span class="badge bg-secondary small">{{ doc.tipo_contenido }}</span>
+          {% else %}
+          <span class="text-secondary">—</span>
           {% endif %}
         </td>
         <td>
@@ -162,6 +237,14 @@
           {% endif %}
         </td>
         <td class="text-end text-nowrap">
+          {% if not item.es_url_externa %}
+          <button type="button" class="btn btn-sm btn-outline-secondary"
+                  title="Copiar ruta al portapapeles — pégala en el Explorador de Windows para navegar al archivo"
+                  data-bs-toggle="tooltip" data-bs-placement="top"
+                  onclick="copiar_ruta('{{ doc.url | replace('\\', '/') | e }}')">
+            <i class="fas fa-copy"></i>
+          </button>
+          {% endif %}
           <button type="button" class="btn btn-sm btn-outline-secondary"
                   title="Editar metadatos"
                   onclick="abrir_modal_editar(this)"
@@ -183,7 +266,7 @@
           </button>
           {% else %}
           <button type="button" class="btn btn-sm btn-outline-danger"
-                  title="Borrar documento"
+                  title="Borrar registro del pool"
                   onclick="borrar_documento(this, '{{ url_for('expedientes.pool_borrar_documento', id=expediente.id, doc_id=doc.id) }}')"
                   data-doc-id="{{ doc.id }}">
             <i class="fas fa-times"></i>
@@ -197,7 +280,7 @@
   {% else %}
   <div class="text-center text-secondary py-4">
     <i class="fas fa-inbox fa-3x mb-3 d-block"></i>
-    No hay documentos en el pool. Arrastra ficheros en la zona de arriba.
+    Sin documentos en el pool. Usa las fichas de arriba para añadir.
   </div>
   {% endif %}
 
@@ -212,7 +295,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="modal-explorador-label">
-          <i class="fas fa-folder-open me-1"></i> Seleccionar ficheros del servidor
+          <i class="fas fa-server me-1"></i> Seleccionar ficheros del servidor
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
@@ -220,19 +303,20 @@
 
         <!-- Paso 1: Explorador de carpetas -->
         <div id="paso-explorador">
-          {# Breadcrumb de navegación #}
           <nav class="fs-breadcrumb mb-2 small" id="fs-breadcrumb">
             <span class="text-secondary">Cargando…</span>
           </nav>
-
           <div id="fs-error" class="alert alert-danger d-none"></div>
 
-          {# Lista de carpetas y ficheros #}
-          <div class="table-responsive" style="max-height:50vh; overflow-y:auto;">
+          <div class="table-responsive" style="max-height:35vh; overflow-y:auto;">
             <table class="table table-sm table-hover align-middle mb-0">
               <thead class="table-light sticky-top">
                 <tr>
-                  <th></th>
+                  <th style="width:2rem">
+                    <input type="checkbox" class="form-check-input" id="fs-check-todos"
+                           onchange="toggle_todos_fs(this.checked)"
+                           title="Seleccionar todos los ficheros de esta carpeta">
+                  </th>
                   <th>Nombre</th>
                   <th>Tamaño</th>
                   <th>Ext.</th>
@@ -246,12 +330,21 @@
             </table>
           </div>
 
-          <div class="mt-2 text-secondary small" id="fs-contador">
-            0 fichero(s) seleccionado(s)
+          <!-- Panel de seleccionados -->
+          <div id="panel-sel-wrap" class="mt-2 d-none">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+              <span class="small fw-semibold" id="fs-contador">0 fichero(s) seleccionado(s)</span>
+              <button type="button" class="btn btn-link btn-sm p-0 text-secondary"
+                      onclick="limpiar_seleccion_fs()">Limpiar</button>
+            </div>
+            <div class="panel-seleccionados" id="lista-seleccionados"></div>
+          </div>
+          <div class="mt-1 small text-secondary" id="fs-contador-vacio">
+            0 fichero(s) seleccionado(s) — puedes seleccionar de varias carpetas
           </div>
         </div>
 
-        <!-- Paso 2: Metadatos de los ficheros seleccionados -->
+        <!-- Paso 2: Metadatos -->
         <div id="paso-metadatos" class="d-none">
           <p class="text-secondary small mb-2" id="meta-contador"></p>
           <div class="table-responsive">
@@ -261,7 +354,7 @@
                   <th>Nombre</th>
                   <th>Tamaño</th>
                   <th style="min-width:180px">Tipo de documento</th>
-                  <th style="min-width:130px">Fecha adm.</th>
+                  <th style="min-width:155px">Fecha adm.</th>
                   <th class="text-center">Prioritario</th>
                 </tr>
               </thead>
@@ -419,26 +512,44 @@
 (function () {
   'use strict';
 
-  var URL_BASE_DOCS    = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
-  var URL_EXPLORADOR   = '{{ url_for('expedientes.pool_explorador_fs', id=expediente.id) }}';
+  var URL_BASE_DOCS  = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+  var URL_EXPLORADOR = '{{ url_for('expedientes.pool_explorador_fs', id=expediente.id) }}';
 
-  // Instancias de modales Bootstrap
-  var _modal_exp_bs    = null;
+  // ----------------------------------------------------------------
+  // Modales Bootstrap
+  // ----------------------------------------------------------------
+  var _modal_exp_bs     = null;
   var _modal_url_ext_bs = null;
   var _modal_editar_bs  = null;
   var _modal_editar_el  = document.getElementById('modal-editar-doc');
 
-  // EntradaFecha
+  // ----------------------------------------------------------------
+  // EntradaFecha — instancias
+  // ----------------------------------------------------------------
   var _ef_editar  = null;
   var _ef_url_ext = null;
-
-  // Estado del explorador
-  var _ruta_actual    = '';        // ruta relativa actual (vacío = raíz)
-  var _seleccionados  = [];        // [{ruta, nombre, ext, tamano}]
+  var _ef_masivo  = null;
+  var _ef_metas   = [];   // una por fila en paso 2
 
   // ----------------------------------------------------------------
-  // Init
+  // Estado explorador
   // ----------------------------------------------------------------
+  var _ruta_actual   = '';
+  var _seleccionados = [];   // [{ruta, nombre, ext, tamano}]
+
+  // ----------------------------------------------------------------
+  // Estado edición masiva (tabla)
+  // ----------------------------------------------------------------
+  var _masivo_ids = new Set();
+
+  // ----------------------------------------------------------------
+  // Docs registrados en sesión (para toast al cerrar)
+  // ----------------------------------------------------------------
+  var _registrados_sesion = 0;
+
+  // ================================================================
+  // INIT
+  // ================================================================
   document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
       new bootstrap.Tooltip(el);
@@ -447,28 +558,59 @@
     var el_modal = document.getElementById('modal-explorador');
     _modal_exp_bs = new bootstrap.Modal(el_modal);
 
-    // Al abrir el explorador, cargar raíz
     el_modal.addEventListener('show.bs.modal', function () {
-      _ruta_actual   = '';
-      _seleccionados = [];
+      _ruta_actual        = '';
+      _seleccionados      = [];
+      _registrados_sesion = 0;
       mostrar_paso_explorador();
       cargar_carpeta('');
     });
-    // Al cerrar, resetear
-    el_modal.addEventListener('hidden.bs.modal', resetear_explorador);
+    el_modal.addEventListener('hidden.bs.modal', function () {
+      resetear_explorador();
+      if (_registrados_sesion === 0) {
+        mostrar_toast('info', 'Carga cancelada — se han registrado 0 documentos.');
+      }
+    });
 
-    // EntradaFecha — inicializar cuando se abren los modales
+    // EntradaFecha — al abrir modales que los contienen
     document.getElementById('modal-url-externa').addEventListener('show.bs.modal', function () {
       if (!_ef_url_ext) _ef_url_ext = new EntradaFecha('#ef-url-ext-fecha', { name: '_f_url_ext' });
     });
     _modal_editar_el.addEventListener('show.bs.modal', function () {
       if (!_ef_editar) _ef_editar = new EntradaFecha('#ef-editar-fecha', { name: '_f_editar' });
     });
+
+    // EntradaFecha del panel masivo (en el DOM principal, inicializar ya)
+    _ef_masivo = new EntradaFecha('#ef-masivo-fecha', { name: '_f_masivo' });
   });
 
-  // ----------------------------------------------------------------
-  // Explorador — navegación
-  // ----------------------------------------------------------------
+  // ================================================================
+  // TOASTS
+  // ================================================================
+  function mostrar_toast(tipo, mensaje) {
+    var colores = {
+      success: 'bg-success text-white',
+      danger:  'bg-danger text-white',
+      info:    'bg-info text-dark',
+      warning: 'bg-warning text-dark'
+    };
+    var cls = colores[tipo] || colores.info;
+    var id  = 'toast-' + Date.now();
+    var html =
+      '<div id="' + id + '" class="toast align-items-center ' + cls + ' border-0" role="alert">' +
+      '<div class="d-flex"><div class="toast-body">' + escapar_html(mensaje) + '</div>' +
+      '<button type="button" class="btn-close btn-close-white me-2 m-auto"' +
+      ' data-bs-dismiss="toast"></button></div></div>';
+    document.getElementById('toast-container').insertAdjacentHTML('beforeend', html);
+    var el = document.getElementById(id);
+    var t  = new bootstrap.Toast(el, { delay: 4000 });
+    t.show();
+    el.addEventListener('hidden.bs.toast', function () { el.remove(); });
+  }
+
+  // ================================================================
+  // EXPLORADOR — navegación
+  // ================================================================
   window.abrir_explorador = function () {
     _modal_exp_bs.show();
   };
@@ -476,6 +618,7 @@
   function cargar_carpeta(ruta) {
     _ruta_actual = ruta;
     document.getElementById('fs-error').classList.add('d-none');
+    document.getElementById('fs-check-todos').checked = false;
     document.getElementById('fs-tbody').innerHTML =
       '<tr><td colspan="4" class="text-center text-secondary py-3">' +
       '<i class="fas fa-spinner fa-spin me-1"></i> Cargando…</td></tr>';
@@ -496,7 +639,7 @@
   }
 
   function renderizar_breadcrumb(partes) {
-    var bc = document.getElementById('fs-breadcrumb');
+    var bc   = document.getElementById('fs-breadcrumb');
     var html = '<a onclick="cargar_carpeta(\'\')" class="text-primary">Raíz</a>';
     var acum = [];
     partes.forEach(function (p, i) {
@@ -504,7 +647,7 @@
       var ruta = acum.join('/');
       if (i < partes.length - 1) {
         html += ' <span class="text-secondary">›</span> <a onclick="cargar_carpeta(\'' +
-                escapar_html(ruta) + '\')" class="text-primary">' + escapar_html(p) + '</a>';
+                escapar_attr(ruta) + '\')" class="text-primary">' + escapar_html(p) + '</a>';
       } else {
         html += ' <span class="text-secondary">›</span> <span class="fw-semibold">' +
                 escapar_html(p) + '</span>';
@@ -517,31 +660,32 @@
     var tbody = document.getElementById('fs-tbody');
     tbody.innerHTML = '';
 
-    // Botón "Subir un nivel"
+    // Subir un nivel
     if (_ruta_actual) {
       var partes = _ruta_actual.split('/');
       partes.pop();
       var padre = partes.join('/');
       var tr_up = document.createElement('tr');
       tr_up.className = 'fs-item';
-      tr_up.innerHTML = '<td><i class="fas fa-level-up-alt text-secondary"></i></td>' +
-                        '<td colspan="3"><em class="text-secondary">← Subir un nivel</em></td>';
+      tr_up.innerHTML =
+        '<td></td>' +
+        '<td colspan="3"><i class="fas fa-level-up-alt text-secondary me-1"></i>' +
+        '<em class="text-secondary">← Subir un nivel</em></td>';
       tr_up.onclick = function () { cargar_carpeta(padre); };
       tbody.appendChild(tr_up);
     }
 
-    // Carpetas
     dirs.forEach(function (d) {
       var tr = document.createElement('tr');
       tr.className = 'fs-item';
-      tr.innerHTML = '<td><i class="fas fa-folder text-warning"></i></td>' +
-                     '<td><strong>' + escapar_html(d.nombre) + '</strong></td>' +
-                     '<td></td><td></td>';
+      tr.innerHTML =
+        '<td></td>' +
+        '<td colspan="3"><i class="fas fa-folder text-warning me-1"></i>' +
+        '<strong>' + escapar_html(d.nombre) + '</strong></td>';
       tr.onclick = function () { cargar_carpeta(d.ruta); };
       tbody.appendChild(tr);
     });
 
-    // Ficheros
     files.forEach(function (f) {
       var tr = document.createElement('tr');
       tr._fs_item = f;
@@ -560,25 +704,65 @@
         } else {
           _seleccionados = _seleccionados.filter(function (s) { return s.ruta !== f.ruta; });
         }
-        actualizar_contador();
+        actualizar_panel_seleccionados();
       });
       tbody.appendChild(tr);
     });
 
-    if (dirs.length === 0 && files.length === 0 && !_ruta_actual) {
+    if (dirs.length === 0 && files.length === 0) {
       var tr_vac = document.createElement('tr');
       tr_vac.innerHTML = '<td colspan="4" class="text-center text-secondary py-3">Carpeta vacía</td>';
       tbody.appendChild(tr_vac);
     }
 
-    actualizar_contador();
+    actualizar_panel_seleccionados();
   }
 
-  function actualizar_contador() {
-    var n = _seleccionados.length;
-    document.getElementById('fs-contador').textContent =
-      n + ' fichero(s) seleccionado(s)';
+  window.toggle_todos_fs = function (checked) {
+    document.querySelectorAll('#fs-tbody .fs-check').forEach(function (chk) {
+      var tr = chk.closest('tr');
+      if (!tr || !tr._fs_item) return;
+      var f = tr._fs_item;
+      chk.checked = checked;
+      if (checked) {
+        if (!_seleccionados.some(function (s) { return s.ruta === f.ruta; })) {
+          _seleccionados.push(f);
+        }
+      } else {
+        _seleccionados = _seleccionados.filter(function (s) { return s.ruta !== f.ruta; });
+      }
+    });
+    actualizar_panel_seleccionados();
+  };
+
+  window.limpiar_seleccion_fs = function () {
+    _seleccionados = [];
+    document.querySelectorAll('#fs-tbody .fs-check').forEach(function (c) { c.checked = false; });
+    document.getElementById('fs-check-todos').checked = false;
+    actualizar_panel_seleccionados();
+  };
+
+  function actualizar_panel_seleccionados() {
+    var n     = _seleccionados.length;
+    var wrap  = document.getElementById('panel-sel-wrap');
+    var vacio = document.getElementById('fs-contador-vacio');
     document.getElementById('btn-exp-siguiente').disabled = (n === 0);
+
+    if (n === 0) {
+      wrap.classList.add('d-none');
+      vacio.classList.remove('d-none');
+    } else {
+      wrap.classList.remove('d-none');
+      vacio.classList.add('d-none');
+      document.getElementById('fs-contador').textContent = n + ' fichero(s) seleccionado(s)';
+      document.getElementById('lista-seleccionados').innerHTML =
+        _seleccionados.map(function (f) {
+          return '<div class="small"><i class="fas fa-file fa-xs me-1 text-secondary"></i>' +
+                 escapar_html(f.nombre) +
+                 ' <span class="text-secondary" style="font-size:0.78em">' +
+                 escapar_html(f.ruta) + '</span></div>';
+        }).join('');
+    }
   }
 
   function mostrar_error_exp(msg) {
@@ -588,9 +772,9 @@
     document.getElementById('fs-tbody').innerHTML = '';
   }
 
-  // ----------------------------------------------------------------
-  // Paso 2 — metadatos
-  // ----------------------------------------------------------------
+  // ================================================================
+  // PASO 2 — metadatos
+  // ================================================================
   window.ir_a_metadatos = function () {
     if (_seleccionados.length === 0) return;
     mostrar_paso_metadatos();
@@ -598,22 +782,25 @@
     var tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
     var tbody = document.getElementById('meta-tbody');
     tbody.innerHTML = '';
+    _ef_metas = [];
 
-    _seleccionados.forEach(function (f) {
-      var tr = document.createElement('tr');
-      tr._ruta = f.ruta;
+    _seleccionados.forEach(function (f, i) {
+      var tr    = document.createElement('tr');
+      tr._ruta  = f.ruta;
+      var ef_id = 'ef-meta-fecha-' + i;
       tr.innerHTML =
         '<td class="small">' + escapar_html(f.nombre) + '</td>' +
         '<td class="small text-secondary text-nowrap">' + formatear_bytes(f.tamano) + '</td>' +
         '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
-        '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
+        '<td><div id="' + ef_id + '"></div></td>' +
         '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>';
       tbody.appendChild(tr);
+      _ef_metas.push(new EntradaFecha('#' + ef_id, { name: '_ef_meta_' + i }));
     });
 
     var n = _seleccionados.length;
     document.getElementById('meta-contador').textContent =
-      n + ' fichero(s) seleccionado(s) para registrar';
+      n + ' fichero(s) listos para registrar';
     document.getElementById('btn-meta-texto').textContent =
       'Registrar ' + n + ' fichero(s)';
     document.getElementById('meta-error').classList.add('d-none');
@@ -643,11 +830,11 @@
 
   window.registrar_rutas = function (url_registrar) {
     var payload = [];
-    document.querySelectorAll('#meta-tbody tr').forEach(function (tr) {
+    document.querySelectorAll('#meta-tbody tr').forEach(function (tr, i) {
       payload.push({
         ruta:                 tr._ruta,
         tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || '1',
-        fecha_administrativa: tr.querySelector('.fecha-admin-input').value || null,
+        fecha_administrativa: _ef_metas[i] ? _ef_metas[i].getValue() : null,
         prioridad:            tr.querySelector('.prioridad-check').checked,
       });
     });
@@ -663,8 +850,19 @@
     })
     .then(function (r) { return r.json(); })
     .then(function (data) {
-      if (data.ok) { window.location.reload(); }
-      else {
+      if (data.ok) {
+        _registrados_sesion = data.creados || payload.length;
+        // Cerrar modal → el evento hidden.bs.modal ve _registrados_sesion > 0 y NO muestra
+        // el toast de cancelación. Mostramos el toast de éxito con un delay.
+        bootstrap.Modal.getInstance(
+          document.getElementById('modal-explorador')
+        ).hide();
+        setTimeout(function () {
+          mostrar_toast('success',
+            'Se han registrado ' + _registrados_sesion + ' documento(s) en el pool.');
+          setTimeout(function () { window.location.reload(); }, 1800);
+        }, 350);
+      } else {
         document.getElementById('meta-error').textContent = data.error || 'Error al registrar.';
         document.getElementById('meta-error').classList.remove('d-none');
         btn.disabled = false;
@@ -678,20 +876,114 @@
   };
 
   function resetear_explorador() {
-    _ruta_actual   = '';
+    _ruta_actual = '';
     _seleccionados = [];
+    _ef_metas = [];
     mostrar_paso_explorador();
-    document.getElementById('fs-tbody').innerHTML = '';
+    document.getElementById('fs-tbody').innerHTML      = '';
     document.getElementById('fs-breadcrumb').innerHTML = '';
     document.getElementById('fs-error').classList.add('d-none');
-    document.getElementById('meta-tbody').innerHTML = '';
+    document.getElementById('meta-tbody').innerHTML    = '';
     document.getElementById('meta-error').classList.add('d-none');
     document.getElementById('btn-exp-siguiente').disabled = true;
+    document.getElementById('fs-check-todos').checked     = false;
+    actualizar_panel_seleccionados();
   }
 
-  // ----------------------------------------------------------------
-  // URL externa
-  // ----------------------------------------------------------------
+  // ================================================================
+  // EDICIÓN MASIVA (tabla de docs)
+  // ================================================================
+  window.on_check_doc = function (chk, doc_id) {
+    if (chk.checked) {
+      _masivo_ids.add(doc_id);
+    } else {
+      _masivo_ids.delete(doc_id);
+      document.getElementById('check-todos').checked = false;
+    }
+    actualizar_panel_masivo();
+  };
+
+  window.toggle_todos = function (checked) {
+    document.querySelectorAll('.doc-check').forEach(function (c) { c.checked = checked; });
+    _masivo_ids.clear();
+    if (checked) {
+      document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
+        _masivo_ids.add(parseInt(tr.dataset.docId, 10));
+      });
+    }
+    actualizar_panel_masivo();
+  };
+
+  window.deseleccionar_todos = function () {
+    toggle_todos(false);
+    document.getElementById('check-todos').checked = false;
+  };
+
+  function actualizar_panel_masivo() {
+    var n = _masivo_ids.size;
+    var panel = document.getElementById('panel-masivo');
+    if (n > 0) {
+      panel.classList.remove('d-none');
+      document.getElementById('masivo-count').textContent = n;
+    } else {
+      panel.classList.add('d-none');
+    }
+  }
+
+  window.aplicar_masivo = function () {
+    if (_masivo_ids.size === 0) return;
+
+    // Solo incluir en el payload los campos que el usuario ha rellenado
+    var payload = {};
+    var tipo_doc_id = document.getElementById('masivo-tipo').value;
+    var fecha_admin = _ef_masivo ? _ef_masivo.getValue() : '';
+    var prio_val    = document.getElementById('masivo-prioridad-sel').value;
+
+    if (tipo_doc_id) payload.tipo_doc_id = parseInt(tipo_doc_id, 10);
+    if (fecha_admin) payload.fecha_administrativa = fecha_admin;
+    if (prio_val !== '') payload.prioridad = (prio_val === '1');
+
+    if (Object.keys(payload).length === 0) {
+      document.getElementById('masivo-error').textContent =
+        'Elige al menos un campo a modificar.';
+      document.getElementById('masivo-error').classList.remove('d-none');
+      return;
+    }
+    document.getElementById('masivo-error').classList.add('d-none');
+
+    var ids = Array.from(_masivo_ids);
+    var promesas = ids.map(function (doc_id) {
+      var url_editar =
+        URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
+      return fetch(url_editar, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }).then(function (r) { return r.json(); });
+    });
+
+    Promise.all(promesas)
+    .then(function (resultados) {
+      var errores = resultados.filter(function (r) { return !r.ok; });
+      if (errores.length > 0) {
+        document.getElementById('masivo-error').textContent =
+          errores.length + ' error(es) al aplicar. Recarga la página.';
+        document.getElementById('masivo-error').classList.remove('d-none');
+      } else {
+        mostrar_toast('success',
+          'Cambios aplicados a ' + ids.length + ' documento(s).');
+        setTimeout(function () { window.location.reload(); }, 1200);
+      }
+    })
+    .catch(function () {
+      document.getElementById('masivo-error').textContent = 'Error de red.';
+      document.getElementById('masivo-error').classList.remove('d-none');
+    });
+  };
+
+  // ================================================================
+  // URL EXTERNA
+  // ================================================================
   window.abrir_modal_url_externa = function () {
     document.getElementById('url-ext-url').value    = '';
     document.getElementById('url-ext-tipo').value   = '';
@@ -726,8 +1018,10 @@
     })
     .then(function (r) { return r.json(); })
     .then(function (data) {
-      if (data.ok) { window.location.reload(); }
-      else {
+      if (data.ok) {
+        mostrar_toast('success', 'URL externa registrada correctamente.');
+        setTimeout(function () { window.location.reload(); }, 1200);
+      } else {
         document.getElementById('url-ext-error').textContent = data.error || 'Error al guardar.';
         document.getElementById('url-ext-error').classList.remove('d-none');
       }
@@ -738,19 +1032,19 @@
     });
   };
 
-  // ----------------------------------------------------------------
-  // Editar metadatos
-  // ----------------------------------------------------------------
+  // ================================================================
+  // EDITAR METADATOS (individual)
+  // ================================================================
   window.abrir_modal_editar = function (btn) {
     document.getElementById('editar-doc-id').value        = btn.dataset.docId;
     document.getElementById('editar-url').value           = btn.dataset.docUrl;
     document.getElementById('editar-tipo-doc-id').value   = btn.dataset.docTipoDocId;
     document.getElementById('editar-asunto').value        = btn.dataset.docAsunto;
-    document.getElementById('editar-prioridad').checked   = btn.dataset.docPrioridad !== '0' && btn.dataset.docPrioridad !== '';
+    document.getElementById('editar-prioridad').checked   =
+      btn.dataset.docPrioridad !== '0' && btn.dataset.docPrioridad !== '';
     document.getElementById('editar-observaciones').value = btn.dataset.docObservaciones;
     document.getElementById('editar-error').classList.add('d-none');
 
-    // Campo URL: solo editable para URL externas
     var campo_url = document.getElementById('editar-url-campo');
     campo_url.classList.toggle('d-none', btn.dataset.docEsUrlExterna !== 'true');
 
@@ -767,7 +1061,8 @@
 
   window.guardar_edicion = function () {
     var doc_id     = document.getElementById('editar-doc-id').value;
-    var url_editar = URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
+    var url_editar =
+      URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
 
     var payload = {
       url:                  document.getElementById('editar-url').value.trim() || null,
@@ -797,11 +1092,11 @@
     });
   };
 
-  // ----------------------------------------------------------------
-  // Borrar
-  // ----------------------------------------------------------------
+  // ================================================================
+  // BORRAR (individual)
+  // ================================================================
   window.borrar_documento = function (btn, url_borrar) {
-    if (!confirm('¿Borrar este registro del pool? El fichero del servidor NO se eliminará.')) return;
+    if (!confirm('¿Borrar este registro del pool?\nEl fichero del servidor NO se eliminará.')) return;
     var doc_id = btn.dataset.docId;
     fetch(url_borrar, { method: 'POST' })
     .then(function (r) { return r.json(); })
@@ -809,18 +1104,42 @@
       if (data.ok) {
         var fila = document.getElementById('fila-doc-' + doc_id);
         if (fila) fila.remove();
+        _masivo_ids.delete(parseInt(doc_id, 10));
+        actualizar_panel_masivo();
+        mostrar_toast('info', 'Registro eliminado del pool.');
       } else { alert(data.error || 'No se pudo borrar.'); }
     })
     .catch(function () { alert('Error de red al borrar.'); });
   };
 
-  // ----------------------------------------------------------------
-  // Utilidades
-  // ----------------------------------------------------------------
+  // ================================================================
+  // COPIAR RUTA AL PORTAPAPELES
+  // ================================================================
+  window.copiar_ruta = function (ruta) {
+    // Normalizar separadores a backslash para Windows
+    var ruta_win = ruta.replace(/\//g, '\\');
+    if (!navigator.clipboard) {
+      alert('Tu navegador no soporta copia al portapapeles.\nRuta:\n' + ruta_win);
+      return;
+    }
+    navigator.clipboard.writeText(ruta_win).then(function () {
+      mostrar_toast('info', 'Ruta copiada al portapapeles — pégala en el Explorador de Windows.');
+    }).catch(function () {
+      alert('No se pudo copiar automáticamente.\nRuta:\n' + ruta_win);
+    });
+  };
+
+  // ================================================================
+  // UTILIDADES
+  // ================================================================
   function escapar_html(str) {
     return String(str)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function escapar_attr(str) {
+    return String(str).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
   }
 
   function formatear_bytes(bytes) {

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -26,21 +26,19 @@
     color: var(--bs-secondary-color);
     user-select: none;
   }
-  .zona-drop:hover,
-  .zona-drop.drag-over {
+  .zona-drop:hover, .zona-drop.drag-over {
     border-color: var(--bs-primary);
     background-color: var(--bs-primary-bg-subtle);
     color: var(--bs-primary);
   }
   .zona-drop-compacta { padding: 1.25rem 1rem; }
-  .url-texto { font-family: monospace; font-size: 0.82em; word-break: break-all; }
 </style>
 {% endblock %}
 
 {% block content %}
 <div class="bc-view">
 
-{# Plantilla de opciones de tipo — dentro del block content para que el DOM la encuentre #}
+{# Opciones de tipo — dentro del block content para que el DOM las encuentre #}
 <template id="tmpl-tipos-doc">
   <option value="">— Tipo —</option>
   {% for t in tipos_doc %}
@@ -48,7 +46,7 @@
   {% endfor %}
 </template>
 
-<!-- C.1: Card expediente (fijo) -->
+<!-- C.1 -->
 <div class="lista-cabecera px-3 pt-3">
   <div class="card bc-card-nodo">
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -89,29 +87,31 @@
   </div>
 </div>
 
-<!-- C.2: Pool de documentos (scrollable) -->
+<!-- C.2 -->
 <div class="lista-scroll-container p-3">
 
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h6 class="mb-0 fw-semibold">Pool de Documentos</h6>
+    <button type="button" class="btn btn-sm btn-outline-secondary"
+            onclick="abrir_modal_url_externa()">
+      <i class="fas fa-link me-1"></i> Añadir URL externa
+    </button>
   </div>
 
-  <!-- Zona de entrada compacta — abre el modal -->
-  <div class="zona-drop zona-drop-compacta mb-3" id="zona-entrada-principal"
-       title="Arrastra ficheros o una carpeta — el explorador nativo se abrirá con la ruta completa">
+  <!-- Zona de entrada compacta -->
+  <div class="zona-drop zona-drop-compacta mb-3" id="zona-entrada-principal">
     <i class="fas fa-file-import fa-2x mb-2"></i>
     <p class="mb-0 fw-semibold">Arrastra ficheros o una carpeta aquí</p>
-    <small>O haz clic para seleccionar una carpeta con el explorador de archivos</small>
+    <small class="text-secondary">O haz clic para seleccionar ficheros con el explorador</small>
   </div>
-  <input type="file" id="input-carpeta-principal" webkitdirectory multiple class="d-none">
+  <input type="file" id="input-ficheros-principal" multiple class="d-none">
 
-  <!-- Tabla de documentos existentes -->
+  <!-- Tabla -->
   {% if docs_lista %}
   <table class="table table-hover table-sm align-middle">
     <thead class="table-light">
       <tr>
-        <th>Nombre</th>
-        <th>Ruta / URL</th>
+        <th>Documento</th>
         <th>Tipo</th>
         <th>Fecha adm.</th>
         <th>Prioritario</th>
@@ -123,28 +123,23 @@
       {% set doc = item.doc %}
       <tr id="fila-doc-{{ doc.id }}">
         <td>
-          <span class="fw-semibold">{{ item.nombre_display }}</span>
-          {% if not item.extension and doc.tipo_contenido %}
-          <span class="badge bg-secondary ms-1 small">{{ doc.tipo_contenido }}</span>
-          {% elif item.extension %}
+          {% if item.es_url_externa %}
+          <a href="{{ doc.url }}" target="_blank" rel="noopener" class="fw-semibold">
+            <i class="fas fa-external-link-alt fa-xs me-1 text-secondary"></i>{{ item.nombre_display }}
+          </a>
+          {% else %}
+          <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=doc.id) }}"
+             class="fw-semibold">
+            <i class="fas fa-file-download fa-xs me-1 text-secondary"></i>{{ item.nombre_display }}
+          </a>
+          {% endif %}
+          {% if item.extension %}
           <span class="badge border border-secondary text-secondary ms-1 small">.{{ item.extension }}</span>
+          {% elif doc.tipo_contenido %}
+          <span class="badge bg-secondary ms-1 small">{{ doc.tipo_contenido }}</span>
           {% endif %}
           {% if doc.asunto %}
           <div class="text-secondary small">{{ doc.asunto }}</div>
-          {% endif %}
-        </td>
-        <td>
-          {% if item.es_clickable %}
-          <a href="{{ doc.url }}" target="_blank" rel="noopener"
-             class="url-texto" title="{{ doc.url }}">{{ doc.url }}</a>
-          {% else %}
-          <span class="url-texto text-secondary" title="{{ doc.url }}">{{ doc.url }}</span>
-          <button type="button"
-                  class="btn btn-link btn-sm p-0 ms-1 align-baseline"
-                  title="Copiar ruta"
-                  onclick="navigator.clipboard.writeText('{{ doc.url | replace("'", "\\'") }}').then(function(){this.innerHTML='<i class=\'fas fa-check text-success\'></i>'; setTimeout(function(b){b.innerHTML='<i class=\'fas fa-copy\'></i>'}.bind(null,this),1500)}.bind(this))">
-            <i class="fas fa-copy text-secondary"></i>
-          </button>
           {% endif %}
         </td>
         <td>
@@ -163,17 +158,17 @@
           {% endif %}
         </td>
         <td class="text-end text-nowrap">
-          <button type="button"
-                  class="btn btn-sm btn-outline-secondary"
+          <button type="button" class="btn btn-sm btn-outline-secondary"
                   title="Editar metadatos"
                   onclick="abrir_modal_editar(this)"
                   data-doc-id="{{ doc.id }}"
-                  data-doc-url="{{ doc.url | e }}"
                   data-doc-tipo-doc-id="{{ doc.tipo_doc_id }}"
                   data-doc-fecha-admin="{{ doc.fecha_administrativa.isoformat() if doc.fecha_administrativa else '' }}"
                   data-doc-asunto="{{ doc.asunto | e if doc.asunto else '' }}"
                   data-doc-prioridad="{{ doc.prioridad or 0 }}"
-                  data-doc-observaciones="{{ doc.observaciones | e if doc.observaciones else '' }}">
+                  data-doc-observaciones="{{ doc.observaciones | e if doc.observaciones else '' }}"
+                  data-doc-es-url-externa="{{ 'true' if item.es_url_externa else 'false' }}"
+                  data-doc-url="{{ doc.url | e }}">
             <i class="fas fa-pencil-alt"></i>
           </button>
           {% if item.es_referenciado %}
@@ -183,8 +178,7 @@
             <i class="fas fa-lock"></i>
           </button>
           {% else %}
-          <button type="button"
-                  class="btn btn-sm btn-outline-danger"
+          <button type="button" class="btn btn-sm btn-outline-danger"
                   title="Borrar documento"
                   onclick="borrar_documento(this, '{{ url_for('expedientes.pool_borrar_documento', id=expediente.id, doc_id=doc.id) }}')"
                   data-doc-id="{{ doc.id }}">
@@ -197,90 +191,49 @@
     </tbody>
   </table>
   {% else %}
-  <div class="text-center text-secondary py-4" id="mensaje-vacio">
+  <div class="text-center text-secondary py-4">
     <i class="fas fa-inbox fa-3x mb-3 d-block"></i>
-    No hay documentos en el pool. Arrastra ficheros o una carpeta en la zona de arriba.
+    No hay documentos en el pool. Arrastra ficheros en la zona de arriba.
   </div>
   {% endif %}
 
-</div>{# fin lista-scroll-container #}
+</div>
 
 
 <!-- ============================================================ -->
-<!-- Modal: Carga de documentos (drag & drop / carpeta)           -->
+<!-- Modal: Subida de ficheros                                     -->
 <!-- ============================================================ -->
-<div class="modal fade" id="modal-carga-docs" tabindex="-1"
-     aria-labelledby="modal-carga-docs-label">
+<div class="modal fade" id="modal-subida" tabindex="-1" aria-labelledby="modal-subida-label">
   <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="modal-carga-docs-label">
-          <i class="fas fa-file-import me-1"></i> Incorporar documentos al pool
+        <h5 class="modal-title" id="modal-subida-label">
+          <i class="fas fa-file-import me-1"></i> Añadir documentos al pool
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
 
-        <!-- Zona de drop dentro del modal -->
-        <div class="zona-drop mb-2" id="zona-drop-modal">
-          <i class="fas fa-folder-open fa-2x mb-2"></i>
-          <p class="fw-semibold mb-1">Arrastra aquí ficheros o una carpeta</p>
-          <p class="small mb-0 text-secondary">
-            El explorador nativo se abrirá en el mismo directorio — un clic confirma la selección
+        <!-- Zona de drop del modal -->
+        <div class="zona-drop mb-3" id="zona-drop-modal">
+          <i class="fas fa-folder-open fa-3x mb-2"></i>
+          <p class="fw-semibold mb-1">Arrastra ficheros o una carpeta aquí</p>
+          <p class="small text-secondary mb-0">
+            O haz clic para seleccionar con el explorador
+            <span class="ms-2">— solo ficheros del primer nivel en carpetas</span>
           </p>
         </div>
-        <input type="file" id="input-carpeta-modal" webkitdirectory multiple class="d-none">
+        <input type="file" id="input-ficheros-modal" multiple class="d-none">
 
-        <!-- Selector nativo (vía Python/tkinter — obtiene rutas completas) -->
-        <div class="text-center mb-3" id="zona-selector-nativo">
-          <p class="text-secondary small mb-2">— o usa el explorador de archivos nativo —</p>
-          <div class="d-flex gap-2 justify-content-center">
-            <button type="button" class="btn btn-outline-secondary btn-selector-nativo"
-                    onclick="abrir_selector_nativo('ficheros')">
-              <i class="fas fa-file me-1"></i> Seleccionar ficheros…
-            </button>
-            <button type="button" class="btn btn-outline-secondary btn-selector-nativo"
-                    onclick="abrir_selector_nativo('carpeta')">
-              <i class="fas fa-folder-open me-1"></i> Seleccionar carpeta…
-            </button>
-          </div>
-          <div id="msg-cargando-selector" class="alert alert-info py-2 mt-2 d-none small">
-            <span class="spinner-border spinner-border-sm me-2"></span>
-            Selecciona los ficheros en la ventana del explorador que acaba de abrirse…
-          </div>
-        </div>
-
-        <!-- Preview: aparece tras seleccionar archivos -->
+        <!-- Preview: aparece tras seleccionar -->
         <div id="seccion-preview" class="d-none">
-
-          <div class="row g-2 mb-2 align-items-end">
-            <div class="col">
-              <label class="form-label fw-semibold mb-1">
-                Prefijo de ruta
-                <span class="text-secondary fw-normal small">
-                  — se antepone al nombre de cada fichero para construir la URL completa.
-                  Se guarda automáticamente para la próxima vez.
-                </span>
-              </label>
-              <input type="text" class="form-control font-monospace" id="prefijo-ruta"
-                     placeholder="\\servidor\expedientes\AT-{{ expediente.numero_at }}\  ó  https://docs.example.com/at{{ expediente.numero_at }}/">
-            </div>
-            <div class="col-auto">
-              <button type="button" class="btn btn-outline-secondary btn-sm mb-1"
-                      onclick="limpiar_seleccion()">
-                <i class="fas fa-redo me-1"></i> Nueva selección
-              </button>
-            </div>
-          </div>
-
           <p class="text-secondary small mb-2" id="contador-archivos"></p>
-
           <div class="table-responsive">
             <table class="table table-sm table-bordered align-middle">
               <thead class="table-light">
                 <tr>
-                  <th style="min-width:160px">Nombre de fichero</th>
-                  <th>URL / ruta <span class="fw-normal text-secondary">(editable)</span></th>
+                  <th>Nombre</th>
+                  <th>Tamaño</th>
                   <th style="min-width:180px">Tipo de documento</th>
                   <th style="min-width:130px">Fecha adm.</th>
                   <th class="text-center">Prioritario</th>
@@ -290,21 +243,27 @@
               <tbody id="preview-tbody"></tbody>
             </table>
           </div>
-
-          <div class="alert alert-info py-2 small mb-0" id="aviso-prefijo-manual">
-            <i class="fas fa-info-circle me-1"></i>
-            La columna <strong>URL / ruta resultante</strong> muestra el valor que se guardará.
-            Si las rutas no son correctas, ajusta el <strong>Prefijo de ruta</strong> arriba.
-          </div>
+          <button type="button" class="btn btn-sm btn-outline-secondary"
+                  onclick="limpiar_seleccion()">
+            <i class="fas fa-redo me-1"></i> Nueva selección
+          </button>
         </div>
 
-        <div id="carga-error" class="alert alert-danger d-none mt-2" role="alert"></div>
+        <div id="carga-error" class="alert alert-danger d-none mt-2"></div>
+        <div id="progreso-subida" class="d-none mt-2">
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated"
+                 style="width:100%"></div>
+          </div>
+          <p class="text-secondary small mt-1 mb-0 text-center">Subiendo ficheros…</p>
+        </div>
+
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="button" class="btn btn-primary d-none" id="btn-importar"
-                onclick="importar_masiva('{{ url_for('expedientes.pool_carga_masiva', id=expediente.id) }}')">
-          <i class="fas fa-file-import me-1"></i> Importar
+        <button type="button" class="btn btn-primary d-none" id="btn-subir"
+                onclick="subir_ficheros('{{ url_for('expedientes.pool_subir', id=expediente.id) }}')">
+          <i class="fas fa-upload me-1"></i> Subir
         </button>
       </div>
     </div>
@@ -313,7 +272,65 @@
 
 
 <!-- ============================================================ -->
-<!-- Modal: Editar documento                                       -->
+<!-- Modal: URL externa (BOE, Notifica, sede electrónica…)        -->
+<!-- ============================================================ -->
+<div class="modal fade" id="modal-url-externa" tabindex="-1"
+     aria-labelledby="modal-url-externa-label">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modal-url-externa-label">
+          <i class="fas fa-link me-1"></i> Añadir URL externa
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-secondary small">
+          Para documentos publicados en fuentes externas: BOE, BOP, Notifica, sede electrónica…
+          El documento no se sube — solo se registra el enlace.
+        </p>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">URL <span class="text-danger">*</span></label>
+          <input type="url" class="form-control" id="url-ext-url"
+                 placeholder="https://www.boe.es/...">
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Tipo de documento</label>
+          <select class="form-select" id="url-ext-tipo">
+            <option value="">— Tipo —</option>
+            {% for t in tipos_doc %}
+            <option value="{{ t.id }}">{{ t.nombre }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Fecha administrativa</label>
+          <div id="ef-url-ext-fecha"></div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Asunto</label>
+          <input type="text" class="form-control" id="url-ext-asunto" maxlength="500">
+        </div>
+        <div class="form-check mb-3">
+          <input type="checkbox" class="form-check-input" id="url-ext-prioridad">
+          <label class="form-check-label fw-semibold" for="url-ext-prioridad">Prioritario</label>
+        </div>
+        <div id="url-ext-error" class="alert alert-danger d-none"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary"
+                onclick="guardar_url_externa('{{ url_for('expedientes.pool_registrar_url_externa', id=expediente.id) }}')">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<!-- ============================================================ -->
+<!-- Modal: Editar metadatos                                       -->
 <!-- ============================================================ -->
 <div class="modal fade" id="modal-editar-doc" tabindex="-1"
      aria-labelledby="modal-editar-doc-label">
@@ -321,15 +338,16 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="modal-editar-doc-label">
-          <i class="fas fa-pencil-alt me-1"></i> Editar documento
+          <i class="fas fa-pencil-alt me-1"></i> Editar metadatos
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
         <input type="hidden" id="editar-doc-id">
-        <div class="mb-3">
-          <label class="form-label fw-semibold">URL / Ruta <span class="text-danger">*</span></label>
-          <input type="text" class="form-control font-monospace" id="editar-url" required>
+        {# URL editable solo para documentos de URL externa #}
+        <div class="mb-3" id="editar-url-campo">
+          <label class="form-label fw-semibold">URL <span class="text-danger">*</span></label>
+          <input type="text" class="form-control font-monospace" id="editar-url">
         </div>
         <div class="mb-3">
           <label class="form-label fw-semibold">Tipo de documento</label>
@@ -348,7 +366,7 @@
           <label class="form-label fw-semibold">Asunto</label>
           <input type="text" class="form-control" id="editar-asunto" maxlength="500">
         </div>
-        <div class="mb-3 form-check">
+        <div class="form-check mb-3">
           <input type="checkbox" class="form-check-input" id="editar-prioridad">
           <label class="form-check-label fw-semibold" for="editar-prioridad">Prioritario</label>
         </div>
@@ -356,7 +374,7 @@
           <label class="form-label fw-semibold">Observaciones</label>
           <textarea class="form-control" id="editar-observaciones" rows="2" maxlength="2000"></textarea>
         </div>
-        <div id="editar-error" class="alert alert-danger d-none" role="alert"></div>
+        <div id="editar-error" class="alert alert-danger d-none"></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
@@ -377,210 +395,146 @@
 (function () {
   'use strict';
 
-  // ----------------------------------------------------------------
-  // Constantes
-  // ----------------------------------------------------------------
-  var LS_PREFIJO_KEY  = 'bddat_pool_prefijo';
-  var URL_BASE_DOCS   = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
-  var URL_SEL_NATIVO  = '{{ url_for('expedientes.pool_selector_nativo', id=expediente.id) }}';
-  // El drop dispara el selector nativo solo cuando Flask corre en local
-  var ES_FLASK_LOCAL  = ['localhost', '127.0.0.1', '::1'].indexOf(window.location.hostname) !== -1;
+  var URL_BASE_DOCS = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
 
-  // ----------------------------------------------------------------
-  // Estado del módulo
-  // ----------------------------------------------------------------
-  /** @type {Array<{nombre: string, url_completa: string|null}>} */
+  // Instancias de modales Bootstrap
+  var _modal_subida     = null;
+  var _modal_url_ext_bs = null;
+  var _modal_editar_bs  = null;
+  var _modal_editar_el  = document.getElementById('modal-editar-doc');
+
+  // EntradaFecha
+  var _ef_editar  = null;
+  var _ef_url_ext = null;
+
+  // Ficheros pendientes de subir
+  /** @type {Array<File>} */
   var archivos_pendientes = [];
-  var _ef_editar_fecha   = null;
-  var _modal_carga       = null;
-  var _modal_editar_bs   = null;
-  var _modal_editar_el   = document.getElementById('modal-editar-doc');
 
   // ----------------------------------------------------------------
-  // Inicialización
+  // Init
   // ----------------------------------------------------------------
   document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
       new bootstrap.Tooltip(el);
     });
 
-    _modal_carga = new bootstrap.Modal(document.getElementById('modal-carga-docs'));
+    _modal_subida = new bootstrap.Modal(document.getElementById('modal-subida'));
 
-    // Zona de entrada principal (C.2)
-    var zona_principal = document.getElementById('zona-entrada-principal');
-    var input_principal = document.getElementById('input-carpeta-principal');
-    configurar_zona(zona_principal, input_principal, true);
+    // Zona principal (C.2)
+    configurar_zona(
+      document.getElementById('zona-entrada-principal'),
+      document.getElementById('input-ficheros-principal'),
+      true
+    );
+    // Zona del modal
+    configurar_zona(
+      document.getElementById('zona-drop-modal'),
+      document.getElementById('input-ficheros-modal'),
+      false
+    );
 
-    // Zona de drop dentro del modal
-    var zona_modal = document.getElementById('zona-drop-modal');
-    var input_modal = document.getElementById('input-carpeta-modal');
-    configurar_zona(zona_modal, input_modal, false);
+    document.getElementById('modal-subida').addEventListener('hidden.bs.modal', resetear_modal);
 
-    document.getElementById('modal-carga-docs').addEventListener('hidden.bs.modal', resetear_modal);
-
-    // EntradaFecha en modal editar
-    _modal_editar_el.addEventListener('show.bs.modal', function () {
-      if (!_ef_editar_fecha) {
-        _ef_editar_fecha = new EntradaFecha('#ef-editar-fecha', { name: '_fecha_admin_editar' });
-      }
+    // EntradaFecha — inicializar cuando se abren los modales
+    document.getElementById('modal-url-externa').addEventListener('show.bs.modal', function () {
+      if (!_ef_url_ext) _ef_url_ext = new EntradaFecha('#ef-url-ext-fecha', { name: '_f_url_ext' });
     });
-
-    // Prefijo de ruta: cargar de localStorage y actualizar al escribir
-    var input_prefijo = document.getElementById('prefijo-ruta');
-    if (input_prefijo) {
-      input_prefijo.value = localStorage.getItem(LS_PREFIJO_KEY) || '';
-      input_prefijo.addEventListener('input', function () {
-        localStorage.setItem(LS_PREFIJO_KEY, this.value);
-        actualizar_urls_preview();
-      });
-    }
+    _modal_editar_el.addEventListener('show.bs.modal', function () {
+      if (!_ef_editar) _ef_editar = new EntradaFecha('#ef-editar-fecha', { name: '_f_editar' });
+    });
   });
 
   // ----------------------------------------------------------------
-  // Configurar zona de drop + input carpeta
+  // Zona de drop + input file
   // ----------------------------------------------------------------
   function configurar_zona(zona, input, abre_modal) {
     zona.addEventListener('dragover', function (e) {
       e.preventDefault();
       zona.classList.add('drag-over');
     });
-    zona.addEventListener('dragleave', function () {
-      zona.classList.remove('drag-over');
-    });
+    zona.addEventListener('dragleave', function () { zona.classList.remove('drag-over'); });
+
     zona.addEventListener('drop', function (e) {
       e.preventDefault();
       zona.classList.remove('drag-over');
 
-      // CAPTURA SÍNCRONA — DataTransfer solo es válido mientras el handler no retorna.
-      var uri_list = '';
-      try { uri_list = e.dataTransfer.getData('text/uri-list') || ''; } catch (ex) {}
-
+      // Captura SÍNCRONA de entries (WebkitFileEntry expira al salir del handler)
       var entries = [];
-      var items_dt = e.dataTransfer.items;
-      for (var j = 0; j < items_dt.length; j++) {
-        var ent = items_dt[j].webkitGetAsEntry ? items_dt[j].webkitGetAsEntry() : null;
+      var items = e.dataTransfer.items;
+      for (var j = 0; j < items.length; j++) {
+        var ent = items[j].webkitGetAsEntry ? items[j].webkitGetAsEntry() : null;
         if (ent) entries.push(ent);
       }
+      // File objects son seguros de usar después del evento
+      var files_directos = Array.from(e.dataTransfer.files);
 
-      if (abre_modal) _modal_carga.show();
+      if (abre_modal) _modal_subida.show();
 
+      var tiene_dir = entries.some(function (en) { return en.isDirectory; });
       setTimeout(function () {
-        if (ES_FLASK_LOCAL && entries.length > 0) {
-          // Flask local: el drop es solo el gesto; Python obtiene la ruta completa.
-          // El selector nativo se abre en el último directorio usado → un clic y listo.
-          var hay_dir = entries.some(function (en) { return en.isDirectory; });
-          abrir_selector_nativo(hay_dir ? 'carpeta' : 'ficheros');
+        if (tiene_dir) {
+          leer_entradas_como_files(entries).then(procesar_files);
         } else {
-          // Flask remoto o sin entries: flujo navegador (solo nombres de fichero)
-          procesar_drop_con_datos(uri_list, entries);
+          procesar_files(files_directos);
         }
       }, abre_modal ? 100 : 0);
     });
+
     zona.addEventListener('click', function () {
-      if (abre_modal) _modal_carga.show();
+      if (abre_modal) _modal_subida.show();
       setTimeout(function () { input.click(); }, abre_modal ? 200 : 0);
     });
+
     input.addEventListener('change', function (e) {
-      procesar_input_carpeta(e.target.files);
+      procesar_files(Array.from(e.target.files));
       e.target.value = '';
     });
   }
 
   // ----------------------------------------------------------------
-  // Procesar drop con datos ya capturados sincrónicamente
-  // uri_list  → resultado de getData('text/uri-list') durante el evento
-  // entries   → array de FileSystemEntry capturados con webkitGetAsEntry()
+  // Leer FileSystemEntry → File objects (para directorios)
   // ----------------------------------------------------------------
-  function procesar_drop_con_datos(uri_list, entries) {
-    archivos_pendientes = [];
-
-    // Intento 1: text/uri-list — Firefox en Windows devuelve file:// URIs completas.
-    // Chrome/Edge bloquean este campo por política de seguridad (devuelven '').
-    if (uri_list) {
-      var uris = uri_list.split('\n')
-        .map(function (u) { return u.trim(); })
-        .filter(function (u) { return u && !u.startsWith('#'); });
-      var solo_ficheros = uris.filter(function (u) { return u.startsWith('file://'); });
-      if (solo_ficheros.length > 0 && solo_ficheros.length === uris.length) {
-        solo_ficheros.forEach(function (uri) {
-          var decoded = decodeURIComponent(uri);
-          var nombre = decoded.replace(/\/$/, '').split('/').pop().split('\\').pop();
-          archivos_pendientes.push({ nombre: nombre, url_completa: decoded });
-        });
-        mostrar_preview(true);
-        return;
-      }
-    }
-
-    // Intento 2: entradas ya capturadas sincrónicamente (funcionan en todos los navegadores)
-    if (entries.length === 0) {
-      mostrar_error_carga('No se pudieron leer los ficheros. Prueba con el selector de carpeta (clic).');
-      return;
-    }
+  function leer_entradas_como_files(entries) {
     var promesas = entries.map(function (entry) {
-      if (entry.isFile)      return entry_a_archivo(entry, null);
-      if (entry.isDirectory) return leer_directorio_primer_nivel(entry);
-      return Promise.resolve();
+      if (entry.isFile) {
+        return new Promise(function (res) { entry.file(function (f) { res([f]); }); });
+      }
+      if (entry.isDirectory) return leer_dir_como_files(entry);
+      return Promise.resolve([]);
     });
-    Promise.all(promesas).then(function () {
-      mostrar_preview(false);
-    }).catch(function (err) {
-      mostrar_error_carga('Error al leer los ficheros: ' + err);
-    });
-  }
-
-  function entry_a_archivo(file_entry, dir_nombre) {
-    return new Promise(function (resolve) {
-      file_entry.file(function (f) {
-        archivos_pendientes.push({ nombre: f.name, url_completa: null, dir_nombre: dir_nombre });
-        resolve();
-      });
+    return Promise.all(promesas).then(function (grupos) {
+      return [].concat.apply([], grupos);
     });
   }
 
-  function leer_directorio_primer_nivel(dir_entry) {
-    var dir_nombre = dir_entry.name;
+  function leer_dir_como_files(dir_entry) {
     return new Promise(function (resolve, reject) {
       var reader = dir_entry.createReader();
-      var leer_lote = function () {
+      var files = [];
+      var leer = function () {
         reader.readEntries(function (entries) {
-          if (entries.length === 0) { resolve(); return; }
-          var sub = [];
-          entries.forEach(function (e) {
-            if (e.isFile) sub.push(entry_a_archivo(e, dir_nombre));
-            // Subdirectorios ignorados
-          });
-          Promise.all(sub).then(leer_lote).catch(reject);
+          if (entries.length === 0) { resolve(files); return; }
+          var sub = entries
+            .filter(function (e) { return e.isFile; })
+            .map(function (e) { return new Promise(function (r) { e.file(function (f) { r(f); }); }); });
+          Promise.all(sub).then(function (fs) { files = files.concat(fs); leer(); });
         }, reject);
       };
-      leer_lote();
+      leer();
     });
   }
 
   // ----------------------------------------------------------------
-  // Procesar input webkitdirectory
+  // Procesar File[] → preview
   // ----------------------------------------------------------------
-  function procesar_input_carpeta(files) {
-    archivos_pendientes = [];
-    for (var i = 0; i < files.length; i++) {
-      var f = files[i];
-      var partes = f.webkitRelativePath ? f.webkitRelativePath.split('/') : [];
-      if (partes.length === 2) {  // solo primer nivel: carpeta/fichero
-        archivos_pendientes.push({ nombre: f.name, url_completa: null, dir_nombre: partes[0] });
-      }
-    }
-    mostrar_preview(false);
-  }
-
-  // ----------------------------------------------------------------
-  // Mostrar preview
-  // ----------------------------------------------------------------
-  function mostrar_preview(tiene_urls_completas) {
-    if (archivos_pendientes.length === 0) {
+  function procesar_files(files_arr) {
+    if (!files_arr || files_arr.length === 0) {
       mostrar_error_carga('No se encontraron ficheros en la selección.');
       return;
     }
 
+    archivos_pendientes = files_arr;
     document.getElementById('carga-error').classList.add('d-none');
     document.getElementById('zona-drop-modal').classList.add('d-none');
 
@@ -588,138 +542,109 @@
     var tbody = document.getElementById('preview-tbody');
     tbody.innerHTML = '';
 
-    // Si tenemos URLs completas, ocultar campo prefijo (no hace falta)
-    var seccion_prefijo = document.getElementById('prefijo-ruta').closest('.row');
-    if (tiene_urls_completas) {
-      seccion_prefijo.classList.add('d-none');
-    } else {
-      seccion_prefijo.classList.remove('d-none');
-      // Si todos los ficheros vienen del mismo directorio, auto-rellenar prefijo
-      // (pero sin sobreescribir el que el usuario ya tenía si está relleno)
-      var prefijo_input = document.getElementById('prefijo-ruta');
-      if (!prefijo_input.value && archivos_pendientes.length > 0 && archivos_pendientes[0].dir_nombre) {
-        // No podemos auto-rellenar la ruta completa, pero indicamos el nombre de la carpeta
-        // mediante el placeholder dinámico para orientar al usuario
-        prefijo_input.placeholder = '… \\' + archivos_pendientes[0].dir_nombre + '\\';
-      }
-    }
-
-    archivos_pendientes.forEach(function (arch) {
-      var url_inicial = arch.url_completa || (document.getElementById('prefijo-ruta').value + arch.nombre);
+    files_arr.forEach(function (f) {
       var tr = document.createElement('tr');
-      tr.dataset.nombre = arch.nombre;
+      tr._file = f;  // Referencia al File object para subir
       tr.innerHTML =
-        '<td class="small text-nowrap">' + escapar_html(arch.nombre) + '</td>' +
-        '<td><input type="text" class="form-control form-control-sm font-monospace url-input"' +
-          ' value="' + escapar_html(url_inicial) + '"' +
-          ' data-manual="' + (arch.url_completa ? 'true' : 'false') + '"' +
-          ' oninput="this.dataset.manual=\'true\'"' +
-          ' placeholder="Ruta o URL completa del fichero"></td>' +
+        '<td class="small">' + escapar_html(f.name) + '</td>' +
+        '<td class="small text-secondary">' + formatear_bytes(f.size) + '</td>' +
         '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
         '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check" title="Marcar como prioritario"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check" title="No importar este fichero"></td>';
+        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>' +
+        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check"></td>';
       tbody.appendChild(tr);
     });
 
     document.getElementById('contador-archivos').textContent =
-      archivos_pendientes.length + ' fichero(s) preparados para importar';
+      files_arr.length + ' fichero(s) listos para subir';
     document.getElementById('seccion-preview').classList.remove('d-none');
-    document.getElementById('btn-importar').classList.remove('d-none');
-    document.getElementById('btn-importar').innerHTML =
-      '<i class="fas fa-file-import me-1"></i> Importar ' + archivos_pendientes.length + ' documento(s)';
+    document.getElementById('btn-subir').classList.remove('d-none');
+    document.getElementById('btn-subir').innerHTML =
+      '<i class="fas fa-upload me-1"></i> Subir ' + files_arr.length + ' fichero(s)';
   }
 
-  // ----------------------------------------------------------------
-  // Actualizar columna URL cuando cambia el prefijo
-  // Solo actualiza filas que el usuario NO ha editado manualmente (data-manual="false")
-  // ----------------------------------------------------------------
-  window.actualizar_urls_preview = function () {
-    var prefijo = document.getElementById('prefijo-ruta').value;
-    document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
-      var input = tr.querySelector('.url-input');
-      if (!input || input.dataset.manual === 'true') return;
-      input.value = prefijo + tr.dataset.nombre;
-    });
-  };
-
-  // ----------------------------------------------------------------
-  // Selector nativo (Python/tkinter) — obtiene rutas completas del SO
-  // ----------------------------------------------------------------
-  window.abrir_selector_nativo = function (modo) {
-    var url_selector = '{{ url_for('expedientes.pool_selector_nativo', id=expediente.id) }}';
-    var btns = document.querySelectorAll('.btn-selector-nativo');
-    var msg  = document.getElementById('msg-cargando-selector');
-
-    btns.forEach(function (b) { b.disabled = true; });
-    msg.classList.remove('d-none');
-    document.getElementById('carga-error').classList.add('d-none');
-
-    fetch(url_selector, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ modo: modo }),
-    })
-    .then(function (r) { return r.json(); })
-    .then(function (data) {
-      btns.forEach(function (b) { b.disabled = false; });
-      msg.classList.add('d-none');
-      if (!data.ok) { mostrar_error_carga(data.error || 'Error al abrir el selector.'); return; }
-      if (!data.rutas || data.rutas.length === 0) return;  // Usuario canceló
-
-      archivos_pendientes = data.rutas.map(function (ruta) {
-        var nombre = ruta.replace(/\\/g, '/').split('/').pop();
-        return { nombre: nombre, url_completa: ruta };
-      });
-      mostrar_preview(true);
-    })
-    .catch(function () {
-      btns.forEach(function (b) { b.disabled = false; });
-      msg.classList.add('d-none');
-      mostrar_error_carga('No se pudo abrir el selector nativo. ¿Está Flask corriendo localmente?');
-    });
-  };
-
-  // ----------------------------------------------------------------
-  // Limpiar selección
-  // ----------------------------------------------------------------
   window.limpiar_seleccion = function () {
     archivos_pendientes = [];
     document.getElementById('seccion-preview').classList.add('d-none');
-    document.getElementById('btn-importar').classList.add('d-none');
+    document.getElementById('btn-subir').classList.add('d-none');
     document.getElementById('zona-drop-modal').classList.remove('d-none');
     document.getElementById('carga-error').classList.add('d-none');
     document.getElementById('preview-tbody').innerHTML = '';
   };
 
   // ----------------------------------------------------------------
-  // Importar masivo (POST JSON)
+  // Subida real (multipart/form-data)
   // ----------------------------------------------------------------
-  window.importar_masiva = function (url_masiva) {
-    var prefijo = document.getElementById('prefijo-ruta').value;
-    var payload = [];
+  window.subir_ficheros = function (url_subir) {
+    var formData = new FormData();
+    var count = 0;
 
     document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
       if (tr.querySelector('.excluir-check').checked) return;
-      var url_final = tr.querySelector('.url-input').value.trim() || tr.dataset.nombre;
-      payload.push({
-        url:                  url_final,
-        tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || 1,
-        fecha_administrativa: tr.querySelector('.fecha-admin-input').value || null,
-        prioridad:            tr.querySelector('.prioridad-check').checked,
-      });
+      formData.append('files', tr._file, tr._file.name);
+      formData.append('tipos[]',       tr.querySelector('.tipo-doc-select').value || '1');
+      formData.append('fechas[]',      tr.querySelector('.fecha-admin-input').value || '');
+      formData.append('prioridades[]', tr.querySelector('.prioridad-check').checked ? '1' : '0');
+      count++;
     });
 
-    if (payload.length === 0) {
-      mostrar_error_carga('No hay documentos para importar (todos excluidos).');
+    if (count === 0) {
+      mostrar_error_carga('No hay ficheros para subir (todos excluidos).');
       return;
     }
 
-    var btn = document.getElementById('btn-importar');
+    var btn = document.getElementById('btn-subir');
     btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Importando…';
+    document.getElementById('progreso-subida').classList.remove('d-none');
 
-    fetch(url_masiva, {
+    fetch(url_subir, { method: 'POST', body: formData })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) { window.location.reload(); }
+      else {
+        mostrar_error_carga(data.error || 'Error al subir.');
+        btn.disabled = false;
+        document.getElementById('progreso-subida').classList.add('d-none');
+      }
+    })
+    .catch(function () {
+      mostrar_error_carga('Error de red al subir los ficheros.');
+      btn.disabled = false;
+      document.getElementById('progreso-subida').classList.add('d-none');
+    });
+  };
+
+  // ----------------------------------------------------------------
+  // URL externa
+  // ----------------------------------------------------------------
+  window.abrir_modal_url_externa = function () {
+    document.getElementById('url-ext-url').value    = '';
+    document.getElementById('url-ext-tipo').value   = '';
+    document.getElementById('url-ext-asunto').value = '';
+    document.getElementById('url-ext-prioridad').checked = false;
+    document.getElementById('url-ext-error').classList.add('d-none');
+    if (!_modal_url_ext_bs) {
+      _modal_url_ext_bs = new bootstrap.Modal(document.getElementById('modal-url-externa'));
+    }
+    _modal_url_ext_bs.show();
+    setTimeout(function () { if (_ef_url_ext) _ef_url_ext.clear(); }, 150);
+  };
+
+  window.guardar_url_externa = function (url_ruta) {
+    var url = document.getElementById('url-ext-url').value.trim();
+    if (!url) {
+      document.getElementById('url-ext-error').textContent = 'La URL es obligatoria.';
+      document.getElementById('url-ext-error').classList.remove('d-none');
+      return;
+    }
+    var payload = {
+      url:                  url,
+      tipo_doc_id:          document.getElementById('url-ext-tipo').value || 1,
+      fecha_administrativa: _ef_url_ext ? _ef_url_ext.getValue() : null,
+      asunto:               document.getElementById('url-ext-asunto').value.trim(),
+      prioridad:            document.getElementById('url-ext-prioridad').checked,
+    };
+    fetch(url_ruta, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -728,20 +653,18 @@
     .then(function (data) {
       if (data.ok) { window.location.reload(); }
       else {
-        mostrar_error_carga(data.error || 'Error al importar.');
-        btn.disabled = false;
-        btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
+        document.getElementById('url-ext-error').textContent = data.error || 'Error al guardar.';
+        document.getElementById('url-ext-error').classList.remove('d-none');
       }
     })
     .catch(function () {
-      mostrar_error_carga('Error de red al importar.');
-      btn.disabled = false;
-      btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
+      document.getElementById('url-ext-error').textContent = 'Error de red.';
+      document.getElementById('url-ext-error').classList.remove('d-none');
     });
   };
 
   // ----------------------------------------------------------------
-  // Editar documento
+  // Editar metadatos
   // ----------------------------------------------------------------
   window.abrir_modal_editar = function (btn) {
     document.getElementById('editar-doc-id').value        = btn.dataset.docId;
@@ -752,15 +675,17 @@
     document.getElementById('editar-observaciones').value = btn.dataset.docObservaciones;
     document.getElementById('editar-error').classList.add('d-none');
 
+    // Campo URL: solo editable para URL externas
+    var campo_url = document.getElementById('editar-url-campo');
+    campo_url.classList.toggle('d-none', btn.dataset.docEsUrlExterna !== 'true');
+
     if (!_modal_editar_bs) _modal_editar_bs = new bootstrap.Modal(_modal_editar_el);
     _modal_editar_bs.show();
 
-    // EntradaFecha.setValue() acepta formato ISO 'yyyy-mm-dd'
     setTimeout(function () {
-      if (_ef_editar_fecha) {
-        _ef_editar_fecha.clear();
-        var fecha_iso = btn.dataset.docFechaAdmin;
-        if (fecha_iso) _ef_editar_fecha.setValue(fecha_iso);
+      if (_ef_editar) {
+        _ef_editar.clear();
+        if (btn.dataset.docFechaAdmin) _ef_editar.setValue(btn.dataset.docFechaAdmin);
       }
     }, 150);
   };
@@ -769,19 +694,14 @@
     var doc_id     = document.getElementById('editar-doc-id').value;
     var url_editar = URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
 
-    // EntradaFecha.getValue() devuelve ISO 'yyyy-mm-dd' o ''
-    var fecha_iso = _ef_editar_fecha ? _ef_editar_fecha.getValue() : null;
-
     var payload = {
-      url:                  document.getElementById('editar-url').value.trim(),
+      url:                  document.getElementById('editar-url').value.trim() || null,
       tipo_doc_id:          document.getElementById('editar-tipo-doc-id').value || 1,
-      fecha_administrativa: fecha_iso || null,
+      fecha_administrativa: _ef_editar ? _ef_editar.getValue() : null,
       asunto:               document.getElementById('editar-asunto').value.trim(),
       prioridad:            document.getElementById('editar-prioridad').checked,
       observaciones:        document.getElementById('editar-observaciones').value.trim(),
     };
-
-    if (!payload.url) { mostrar_error_editar('La URL / ruta es obligatoria.'); return; }
 
     fetch(url_editar, {
       method: 'POST',
@@ -791,16 +711,22 @@
     .then(function (r) { return r.json(); })
     .then(function (data) {
       if (data.ok) { window.location.reload(); }
-      else { mostrar_error_editar(data.error || 'Error al guardar.'); }
+      else {
+        document.getElementById('editar-error').textContent = data.error || 'Error.';
+        document.getElementById('editar-error').classList.remove('d-none');
+      }
     })
-    .catch(function () { mostrar_error_editar('Error de red.'); });
+    .catch(function () {
+      document.getElementById('editar-error').textContent = 'Error de red.';
+      document.getElementById('editar-error').classList.remove('d-none');
+    });
   };
 
   // ----------------------------------------------------------------
-  // Borrar documento
+  // Borrar
   // ----------------------------------------------------------------
   window.borrar_documento = function (btn, url_borrar) {
-    if (!confirm('¿Borrar este documento del pool? Esta acción no se puede deshacer.')) return;
+    if (!confirm('¿Borrar este documento? El fichero se eliminará del servidor.')) return;
     var doc_id = btn.dataset.docId;
     fetch(url_borrar, { method: 'POST' })
     .then(function (r) { return r.json(); })
@@ -808,20 +734,21 @@
       if (data.ok) {
         var fila = document.getElementById('fila-doc-' + doc_id);
         if (fila) fila.remove();
-      } else { alert(data.error || 'No se pudo borrar el documento.'); }
+      } else { alert(data.error || 'No se pudo borrar.'); }
     })
     .catch(function () { alert('Error de red al borrar.'); });
   };
 
   // ----------------------------------------------------------------
-  // Utilidades internas
+  // Utilidades
   // ----------------------------------------------------------------
   function resetear_modal() {
     archivos_pendientes = [];
     document.getElementById('seccion-preview').classList.add('d-none');
-    document.getElementById('btn-importar').classList.add('d-none');
+    document.getElementById('btn-subir').classList.add('d-none');
     document.getElementById('zona-drop-modal').classList.remove('d-none');
     document.getElementById('carga-error').classList.add('d-none');
+    document.getElementById('progreso-subida').classList.add('d-none');
     document.getElementById('preview-tbody').innerHTML = '';
   }
 
@@ -831,16 +758,16 @@
     el.classList.remove('d-none');
   }
 
-  function mostrar_error_editar(msg) {
-    var el = document.getElementById('editar-error');
-    el.textContent = msg;
-    el.classList.remove('d-none');
-  }
-
   function escapar_html(str) {
     return String(str)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;')
       .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function formatear_bytes(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
   }
 
 }());

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -16,22 +16,26 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 <style>
-  .zona-drop {
+  .zona-explorador {
     border: 2px dashed var(--bs-border-color);
     border-radius: 0.5rem;
-    padding: 2rem 1rem;
+    padding: 1.25rem 1rem;
     text-align: center;
     cursor: pointer;
     transition: border-color 0.15s, background-color 0.15s;
     color: var(--bs-secondary-color);
     user-select: none;
   }
-  .zona-drop:hover, .zona-drop.drag-over {
+  .zona-explorador:hover {
     border-color: var(--bs-primary);
     background-color: var(--bs-primary-bg-subtle);
     color: var(--bs-primary);
   }
-  .zona-drop-compacta { padding: 1.25rem 1rem; }
+  /* Explorador de carpetas */
+  .fs-item { cursor: pointer; }
+  .fs-item:hover { background-color: var(--bs-primary-bg-subtle); }
+  .fs-breadcrumb a { cursor: pointer; text-decoration: none; }
+  .fs-breadcrumb a:hover { text-decoration: underline; }
 </style>
 {% endblock %}
 
@@ -98,13 +102,13 @@
     </button>
   </div>
 
-  <!-- Zona de entrada compacta -->
-  <div class="zona-drop zona-drop-compacta mb-3" id="zona-entrada-principal">
-    <i class="fas fa-file-import fa-2x mb-2"></i>
-    <p class="mb-0 fw-semibold">Arrastra ficheros o una carpeta aquí</p>
-    <small class="text-secondary">O haz clic para seleccionar ficheros con el explorador</small>
+  <!-- Zona de entrada al explorador de servidor -->
+  <div class="zona-explorador mb-3" id="zona-entrada-principal"
+       onclick="abrir_explorador()">
+    <i class="fas fa-folder-open fa-2x mb-2"></i>
+    <p class="mb-0 fw-semibold">Selecciona ficheros del servidor de documentos</p>
+    <small class="text-secondary">Haz clic para abrir el explorador de carpetas</small>
   </div>
-  <input type="file" id="input-ficheros-principal" multiple class="d-none">
 
   <!-- Tabla -->
   {% if docs_lista %}
@@ -201,33 +205,55 @@
 
 
 <!-- ============================================================ -->
-<!-- Modal: Subida de ficheros                                     -->
+<!-- Modal: Explorador de servidor de ficheros (dos pasos)        -->
 <!-- ============================================================ -->
-<div class="modal fade" id="modal-subida" tabindex="-1" aria-labelledby="modal-subida-label">
+<div class="modal fade" id="modal-explorador" tabindex="-1" aria-labelledby="modal-explorador-label">
   <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="modal-subida-label">
-          <i class="fas fa-file-import me-1"></i> Añadir documentos al pool
+        <h5 class="modal-title" id="modal-explorador-label">
+          <i class="fas fa-folder-open me-1"></i> Seleccionar ficheros del servidor
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
 
-        <!-- Zona de drop del modal -->
-        <div class="zona-drop mb-3" id="zona-drop-modal">
-          <i class="fas fa-folder-open fa-3x mb-2"></i>
-          <p class="fw-semibold mb-1">Arrastra ficheros o una carpeta aquí</p>
-          <p class="small text-secondary mb-0">
-            O haz clic para seleccionar con el explorador
-            <span class="ms-2">— solo ficheros del primer nivel en carpetas</span>
-          </p>
-        </div>
-        <input type="file" id="input-ficheros-modal" multiple class="d-none">
+        <!-- Paso 1: Explorador de carpetas -->
+        <div id="paso-explorador">
+          {# Breadcrumb de navegación #}
+          <nav class="fs-breadcrumb mb-2 small" id="fs-breadcrumb">
+            <span class="text-secondary">Cargando…</span>
+          </nav>
 
-        <!-- Preview: aparece tras seleccionar -->
-        <div id="seccion-preview" class="d-none">
-          <p class="text-secondary small mb-2" id="contador-archivos"></p>
+          <div id="fs-error" class="alert alert-danger d-none"></div>
+
+          {# Lista de carpetas y ficheros #}
+          <div class="table-responsive" style="max-height:50vh; overflow-y:auto;">
+            <table class="table table-sm table-hover align-middle mb-0">
+              <thead class="table-light sticky-top">
+                <tr>
+                  <th></th>
+                  <th>Nombre</th>
+                  <th>Tamaño</th>
+                  <th>Ext.</th>
+                </tr>
+              </thead>
+              <tbody id="fs-tbody">
+                <tr><td colspan="4" class="text-center text-secondary py-3">
+                  <i class="fas fa-spinner fa-spin me-1"></i> Cargando…
+                </td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="mt-2 text-secondary small" id="fs-contador">
+            0 fichero(s) seleccionado(s)
+          </div>
+        </div>
+
+        <!-- Paso 2: Metadatos de los ficheros seleccionados -->
+        <div id="paso-metadatos" class="d-none">
+          <p class="text-secondary small mb-2" id="meta-contador"></p>
           <div class="table-responsive">
             <table class="table table-sm table-bordered align-middle">
               <thead class="table-light">
@@ -237,33 +263,31 @@
                   <th style="min-width:180px">Tipo de documento</th>
                   <th style="min-width:130px">Fecha adm.</th>
                   <th class="text-center">Prioritario</th>
-                  <th class="text-center">Excluir</th>
                 </tr>
               </thead>
-              <tbody id="preview-tbody"></tbody>
+              <tbody id="meta-tbody"></tbody>
             </table>
           </div>
-          <button type="button" class="btn btn-sm btn-outline-secondary"
-                  onclick="limpiar_seleccion()">
-            <i class="fas fa-redo me-1"></i> Nueva selección
-          </button>
-        </div>
-
-        <div id="carga-error" class="alert alert-danger d-none mt-2"></div>
-        <div id="progreso-subida" class="d-none mt-2">
-          <div class="progress">
-            <div class="progress-bar progress-bar-striped progress-bar-animated"
-                 style="width:100%"></div>
-          </div>
-          <p class="text-secondary small mt-1 mb-0 text-center">Subiendo ficheros…</p>
+          <div id="meta-error" class="alert alert-danger d-none"></div>
         </div>
 
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="button" class="btn btn-primary d-none" id="btn-subir"
-                onclick="subir_ficheros('{{ url_for('expedientes.pool_subir', id=expediente.id) }}')">
-          <i class="fas fa-upload me-1"></i> Subir
+        {# Paso 1 #}
+        <button type="button" class="btn btn-secondary" id="btn-exp-cancelar"
+                data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary" id="btn-exp-siguiente"
+                onclick="ir_a_metadatos()" disabled>
+          Siguiente <i class="fas fa-arrow-right ms-1"></i>
+        </button>
+        {# Paso 2 — ocultos al inicio #}
+        <button type="button" class="btn btn-outline-secondary d-none" id="btn-meta-volver"
+                onclick="volver_a_explorador()">
+          <i class="fas fa-arrow-left me-1"></i> Volver
+        </button>
+        <button type="button" class="btn btn-primary d-none" id="btn-meta-registrar"
+                onclick="registrar_rutas('{{ url_for('expedientes.pool_registrar_rutas', id=expediente.id) }}')">
+          <i class="fas fa-save me-1"></i> <span id="btn-meta-texto">Registrar</span>
         </button>
       </div>
     </div>
@@ -395,10 +419,11 @@
 (function () {
   'use strict';
 
-  var URL_BASE_DOCS = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+  var URL_BASE_DOCS    = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+  var URL_EXPLORADOR   = '{{ url_for('expedientes.pool_explorador_fs', id=expediente.id) }}';
 
   // Instancias de modales Bootstrap
-  var _modal_subida     = null;
+  var _modal_exp_bs    = null;
   var _modal_url_ext_bs = null;
   var _modal_editar_bs  = null;
   var _modal_editar_el  = document.getElementById('modal-editar-doc');
@@ -407,9 +432,9 @@
   var _ef_editar  = null;
   var _ef_url_ext = null;
 
-  // Ficheros pendientes de subir
-  /** @type {Array<File>} */
-  var archivos_pendientes = [];
+  // Estado del explorador
+  var _ruta_actual    = '';        // ruta relativa actual (vacío = raíz)
+  var _seleccionados  = [];        // [{ruta, nombre, ext, tamano}]
 
   // ----------------------------------------------------------------
   // Init
@@ -419,22 +444,18 @@
       new bootstrap.Tooltip(el);
     });
 
-    _modal_subida = new bootstrap.Modal(document.getElementById('modal-subida'));
+    var el_modal = document.getElementById('modal-explorador');
+    _modal_exp_bs = new bootstrap.Modal(el_modal);
 
-    // Zona principal (C.2)
-    configurar_zona(
-      document.getElementById('zona-entrada-principal'),
-      document.getElementById('input-ficheros-principal'),
-      true
-    );
-    // Zona del modal
-    configurar_zona(
-      document.getElementById('zona-drop-modal'),
-      document.getElementById('input-ficheros-modal'),
-      false
-    );
-
-    document.getElementById('modal-subida').addEventListener('hidden.bs.modal', resetear_modal);
+    // Al abrir el explorador, cargar raíz
+    el_modal.addEventListener('show.bs.modal', function () {
+      _ruta_actual   = '';
+      _seleccionados = [];
+      mostrar_paso_explorador();
+      cargar_carpeta('');
+    });
+    // Al cerrar, resetear
+    el_modal.addEventListener('hidden.bs.modal', resetear_explorador);
 
     // EntradaFecha — inicializar cuando se abren los modales
     document.getElementById('modal-url-externa').addEventListener('show.bs.modal', function () {
@@ -446,173 +467,227 @@
   });
 
   // ----------------------------------------------------------------
-  // Zona de drop + input file
+  // Explorador — navegación
   // ----------------------------------------------------------------
-  function configurar_zona(zona, input, abre_modal) {
-    zona.addEventListener('dragover', function (e) {
-      e.preventDefault();
-      zona.classList.add('drag-over');
-    });
-    zona.addEventListener('dragleave', function () { zona.classList.remove('drag-over'); });
+  window.abrir_explorador = function () {
+    _modal_exp_bs.show();
+  };
 
-    zona.addEventListener('drop', function (e) {
-      e.preventDefault();
-      zona.classList.remove('drag-over');
+  function cargar_carpeta(ruta) {
+    _ruta_actual = ruta;
+    document.getElementById('fs-error').classList.add('d-none');
+    document.getElementById('fs-tbody').innerHTML =
+      '<tr><td colspan="4" class="text-center text-secondary py-3">' +
+      '<i class="fas fa-spinner fa-spin me-1"></i> Cargando…</td></tr>';
 
-      // Captura SÍNCRONA de entries (WebkitFileEntry expira al salir del handler)
-      var entries = [];
-      var items = e.dataTransfer.items;
-      for (var j = 0; j < items.length; j++) {
-        var ent = items[j].webkitGetAsEntry ? items[j].webkitGetAsEntry() : null;
-        if (ent) entries.push(ent);
+    fetch(URL_EXPLORADOR + '?ruta=' + encodeURIComponent(ruta))
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (!data.ok) {
+        mostrar_error_exp(data.error || 'Error al cargar carpeta.');
+        return;
       }
-      // File objects son seguros de usar después del evento
-      var files_directos = Array.from(e.dataTransfer.files);
-
-      if (abre_modal) _modal_subida.show();
-
-      var tiene_dir = entries.some(function (en) { return en.isDirectory; });
-      setTimeout(function () {
-        if (tiene_dir) {
-          leer_entradas_como_files(entries).then(procesar_files);
-        } else {
-          procesar_files(files_directos);
-        }
-      }, abre_modal ? 100 : 0);
-    });
-
-    zona.addEventListener('click', function () {
-      if (abre_modal) _modal_subida.show();
-      setTimeout(function () { input.click(); }, abre_modal ? 200 : 0);
-    });
-
-    input.addEventListener('change', function (e) {
-      procesar_files(Array.from(e.target.files));
-      e.target.value = '';
+      renderizar_breadcrumb(data.partes);
+      renderizar_contenido(data.directorios, data.ficheros);
+    })
+    .catch(function () {
+      mostrar_error_exp('Error de red al acceder al servidor de ficheros.');
     });
   }
 
-  // ----------------------------------------------------------------
-  // Leer FileSystemEntry → File objects (para directorios)
-  // ----------------------------------------------------------------
-  function leer_entradas_como_files(entries) {
-    var promesas = entries.map(function (entry) {
-      if (entry.isFile) {
-        return new Promise(function (res) { entry.file(function (f) { res([f]); }); });
+  function renderizar_breadcrumb(partes) {
+    var bc = document.getElementById('fs-breadcrumb');
+    var html = '<a onclick="cargar_carpeta(\'\')" class="text-primary">Raíz</a>';
+    var acum = [];
+    partes.forEach(function (p, i) {
+      acum.push(p);
+      var ruta = acum.join('/');
+      if (i < partes.length - 1) {
+        html += ' <span class="text-secondary">›</span> <a onclick="cargar_carpeta(\'' +
+                escapar_html(ruta) + '\')" class="text-primary">' + escapar_html(p) + '</a>';
+      } else {
+        html += ' <span class="text-secondary">›</span> <span class="fw-semibold">' +
+                escapar_html(p) + '</span>';
       }
-      if (entry.isDirectory) return leer_dir_como_files(entry);
-      return Promise.resolve([]);
     });
-    return Promise.all(promesas).then(function (grupos) {
-      return [].concat.apply([], grupos);
-    });
+    bc.innerHTML = html;
   }
 
-  function leer_dir_como_files(dir_entry) {
-    return new Promise(function (resolve, reject) {
-      var reader = dir_entry.createReader();
-      var files = [];
-      var leer = function () {
-        reader.readEntries(function (entries) {
-          if (entries.length === 0) { resolve(files); return; }
-          var sub = entries
-            .filter(function (e) { return e.isFile; })
-            .map(function (e) { return new Promise(function (r) { e.file(function (f) { r(f); }); }); });
-          Promise.all(sub).then(function (fs) { files = files.concat(fs); leer(); });
-        }, reject);
-      };
-      leer();
-    });
-  }
-
-  // ----------------------------------------------------------------
-  // Procesar File[] → preview
-  // ----------------------------------------------------------------
-  function procesar_files(files_arr) {
-    if (!files_arr || files_arr.length === 0) {
-      mostrar_error_carga('No se encontraron ficheros en la selección.');
-      return;
-    }
-
-    archivos_pendientes = files_arr;
-    document.getElementById('carga-error').classList.add('d-none');
-    document.getElementById('zona-drop-modal').classList.add('d-none');
-
-    var tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
-    var tbody = document.getElementById('preview-tbody');
+  function renderizar_contenido(dirs, files) {
+    var tbody = document.getElementById('fs-tbody');
     tbody.innerHTML = '';
 
-    files_arr.forEach(function (f) {
+    // Botón "Subir un nivel"
+    if (_ruta_actual) {
+      var partes = _ruta_actual.split('/');
+      partes.pop();
+      var padre = partes.join('/');
+      var tr_up = document.createElement('tr');
+      tr_up.className = 'fs-item';
+      tr_up.innerHTML = '<td><i class="fas fa-level-up-alt text-secondary"></i></td>' +
+                        '<td colspan="3"><em class="text-secondary">← Subir un nivel</em></td>';
+      tr_up.onclick = function () { cargar_carpeta(padre); };
+      tbody.appendChild(tr_up);
+    }
+
+    // Carpetas
+    dirs.forEach(function (d) {
       var tr = document.createElement('tr');
-      tr._file = f;  // Referencia al File object para subir
-      tr.innerHTML =
-        '<td class="small">' + escapar_html(f.name) + '</td>' +
-        '<td class="small text-secondary">' + formatear_bytes(f.size) + '</td>' +
-        '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
-        '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check"></td>';
+      tr.className = 'fs-item';
+      tr.innerHTML = '<td><i class="fas fa-folder text-warning"></i></td>' +
+                     '<td><strong>' + escapar_html(d.nombre) + '</strong></td>' +
+                     '<td></td><td></td>';
+      tr.onclick = function () { cargar_carpeta(d.ruta); };
       tbody.appendChild(tr);
     });
 
-    document.getElementById('contador-archivos').textContent =
-      files_arr.length + ' fichero(s) listos para subir';
-    document.getElementById('seccion-preview').classList.remove('d-none');
-    document.getElementById('btn-subir').classList.remove('d-none');
-    document.getElementById('btn-subir').innerHTML =
-      '<i class="fas fa-upload me-1"></i> Subir ' + files_arr.length + ' fichero(s)';
-  }
-
-  window.limpiar_seleccion = function () {
-    archivos_pendientes = [];
-    document.getElementById('seccion-preview').classList.add('d-none');
-    document.getElementById('btn-subir').classList.add('d-none');
-    document.getElementById('zona-drop-modal').classList.remove('d-none');
-    document.getElementById('carga-error').classList.add('d-none');
-    document.getElementById('preview-tbody').innerHTML = '';
-  };
-
-  // ----------------------------------------------------------------
-  // Subida real (multipart/form-data)
-  // ----------------------------------------------------------------
-  window.subir_ficheros = function (url_subir) {
-    var formData = new FormData();
-    var count = 0;
-
-    document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
-      if (tr.querySelector('.excluir-check').checked) return;
-      formData.append('files', tr._file, tr._file.name);
-      formData.append('tipos[]',       tr.querySelector('.tipo-doc-select').value || '1');
-      formData.append('fechas[]',      tr.querySelector('.fecha-admin-input').value || '');
-      formData.append('prioridades[]', tr.querySelector('.prioridad-check').checked ? '1' : '0');
-      count++;
+    // Ficheros
+    files.forEach(function (f) {
+      var tr = document.createElement('tr');
+      tr._fs_item = f;
+      var checked = _seleccionados.some(function (s) { return s.ruta === f.ruta; });
+      tr.innerHTML =
+        '<td><input type="checkbox" class="form-check-input fs-check"' +
+        (checked ? ' checked' : '') + '></td>' +
+        '<td class="small">' + escapar_html(f.nombre) + '</td>' +
+        '<td class="small text-secondary text-nowrap">' + formatear_bytes(f.tamano) + '</td>' +
+        '<td class="small text-secondary">' + escapar_html(f.ext) + '</td>';
+      tr.querySelector('.fs-check').addEventListener('change', function (e) {
+        if (e.target.checked) {
+          if (!_seleccionados.some(function (s) { return s.ruta === f.ruta; })) {
+            _seleccionados.push(f);
+          }
+        } else {
+          _seleccionados = _seleccionados.filter(function (s) { return s.ruta !== f.ruta; });
+        }
+        actualizar_contador();
+      });
+      tbody.appendChild(tr);
     });
 
-    if (count === 0) {
-      mostrar_error_carga('No hay ficheros para subir (todos excluidos).');
-      return;
+    if (dirs.length === 0 && files.length === 0 && !_ruta_actual) {
+      var tr_vac = document.createElement('tr');
+      tr_vac.innerHTML = '<td colspan="4" class="text-center text-secondary py-3">Carpeta vacía</td>';
+      tbody.appendChild(tr_vac);
     }
 
-    var btn = document.getElementById('btn-subir');
-    btn.disabled = true;
-    document.getElementById('progreso-subida').classList.remove('d-none');
+    actualizar_contador();
+  }
 
-    fetch(url_subir, { method: 'POST', body: formData })
+  function actualizar_contador() {
+    var n = _seleccionados.length;
+    document.getElementById('fs-contador').textContent =
+      n + ' fichero(s) seleccionado(s)';
+    document.getElementById('btn-exp-siguiente').disabled = (n === 0);
+  }
+
+  function mostrar_error_exp(msg) {
+    var el = document.getElementById('fs-error');
+    el.textContent = msg;
+    el.classList.remove('d-none');
+    document.getElementById('fs-tbody').innerHTML = '';
+  }
+
+  // ----------------------------------------------------------------
+  // Paso 2 — metadatos
+  // ----------------------------------------------------------------
+  window.ir_a_metadatos = function () {
+    if (_seleccionados.length === 0) return;
+    mostrar_paso_metadatos();
+
+    var tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
+    var tbody = document.getElementById('meta-tbody');
+    tbody.innerHTML = '';
+
+    _seleccionados.forEach(function (f) {
+      var tr = document.createElement('tr');
+      tr._ruta = f.ruta;
+      tr.innerHTML =
+        '<td class="small">' + escapar_html(f.nombre) + '</td>' +
+        '<td class="small text-secondary text-nowrap">' + formatear_bytes(f.tamano) + '</td>' +
+        '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
+        '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
+        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>';
+      tbody.appendChild(tr);
+    });
+
+    var n = _seleccionados.length;
+    document.getElementById('meta-contador').textContent =
+      n + ' fichero(s) seleccionado(s) para registrar';
+    document.getElementById('btn-meta-texto').textContent =
+      'Registrar ' + n + ' fichero(s)';
+    document.getElementById('meta-error').classList.add('d-none');
+  };
+
+  window.volver_a_explorador = function () {
+    mostrar_paso_explorador();
+  };
+
+  function mostrar_paso_explorador() {
+    document.getElementById('paso-explorador').classList.remove('d-none');
+    document.getElementById('paso-metadatos').classList.add('d-none');
+    document.getElementById('btn-exp-cancelar').classList.remove('d-none');
+    document.getElementById('btn-exp-siguiente').classList.remove('d-none');
+    document.getElementById('btn-meta-volver').classList.add('d-none');
+    document.getElementById('btn-meta-registrar').classList.add('d-none');
+  }
+
+  function mostrar_paso_metadatos() {
+    document.getElementById('paso-explorador').classList.add('d-none');
+    document.getElementById('paso-metadatos').classList.remove('d-none');
+    document.getElementById('btn-exp-cancelar').classList.add('d-none');
+    document.getElementById('btn-exp-siguiente').classList.add('d-none');
+    document.getElementById('btn-meta-volver').classList.remove('d-none');
+    document.getElementById('btn-meta-registrar').classList.remove('d-none');
+  }
+
+  window.registrar_rutas = function (url_registrar) {
+    var payload = [];
+    document.querySelectorAll('#meta-tbody tr').forEach(function (tr) {
+      payload.push({
+        ruta:                 tr._ruta,
+        tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || '1',
+        fecha_administrativa: tr.querySelector('.fecha-admin-input').value || null,
+        prioridad:            tr.querySelector('.prioridad-check').checked,
+      });
+    });
+    if (payload.length === 0) return;
+
+    var btn = document.getElementById('btn-meta-registrar');
+    btn.disabled = true;
+
+    fetch(url_registrar, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
     .then(function (r) { return r.json(); })
     .then(function (data) {
       if (data.ok) { window.location.reload(); }
       else {
-        mostrar_error_carga(data.error || 'Error al subir.');
+        document.getElementById('meta-error').textContent = data.error || 'Error al registrar.';
+        document.getElementById('meta-error').classList.remove('d-none');
         btn.disabled = false;
-        document.getElementById('progreso-subida').classList.add('d-none');
       }
     })
     .catch(function () {
-      mostrar_error_carga('Error de red al subir los ficheros.');
+      document.getElementById('meta-error').textContent = 'Error de red.';
+      document.getElementById('meta-error').classList.remove('d-none');
       btn.disabled = false;
-      document.getElementById('progreso-subida').classList.add('d-none');
     });
   };
+
+  function resetear_explorador() {
+    _ruta_actual   = '';
+    _seleccionados = [];
+    mostrar_paso_explorador();
+    document.getElementById('fs-tbody').innerHTML = '';
+    document.getElementById('fs-breadcrumb').innerHTML = '';
+    document.getElementById('fs-error').classList.add('d-none');
+    document.getElementById('meta-tbody').innerHTML = '';
+    document.getElementById('meta-error').classList.add('d-none');
+    document.getElementById('btn-exp-siguiente').disabled = true;
+  }
 
   // ----------------------------------------------------------------
   // URL externa
@@ -726,7 +801,7 @@
   // Borrar
   // ----------------------------------------------------------------
   window.borrar_documento = function (btn, url_borrar) {
-    if (!confirm('¿Borrar este documento? El fichero se eliminará del servidor.')) return;
+    if (!confirm('¿Borrar este registro del pool? El fichero del servidor NO se eliminará.')) return;
     var doc_id = btn.dataset.docId;
     fetch(url_borrar, { method: 'POST' })
     .then(function (r) { return r.json(); })
@@ -742,22 +817,6 @@
   // ----------------------------------------------------------------
   // Utilidades
   // ----------------------------------------------------------------
-  function resetear_modal() {
-    archivos_pendientes = [];
-    document.getElementById('seccion-preview').classList.add('d-none');
-    document.getElementById('btn-subir').classList.add('d-none');
-    document.getElementById('zona-drop-modal').classList.remove('d-none');
-    document.getElementById('carga-error').classList.add('d-none');
-    document.getElementById('progreso-subida').classList.add('d-none');
-    document.getElementById('preview-tbody').innerHTML = '';
-  }
-
-  function mostrar_error_carga(msg) {
-    var el = document.getElementById('carga-error');
-    el.textContent = msg;
-    el.classList.remove('d-none');
-  }
-
   function escapar_html(str) {
     return String(str)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;')

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -98,7 +98,7 @@
 
   <!-- Zona de entrada compacta — abre el modal -->
   <div class="zona-drop zona-drop-compacta mb-3" id="zona-entrada-principal"
-       title="Arrastra ficheros o una carpeta, o haz clic para seleccionar carpeta">
+       title="Arrastra ficheros o una carpeta — el explorador nativo se abrirá con la ruta completa">
     <i class="fas fa-file-import fa-2x mb-2"></i>
     <p class="mb-0 fw-semibold">Arrastra ficheros o una carpeta aquí</p>
     <small>O haz clic para seleccionar una carpeta con el explorador de archivos</small>
@@ -225,7 +225,9 @@
         <div class="zona-drop mb-2" id="zona-drop-modal">
           <i class="fas fa-folder-open fa-2x mb-2"></i>
           <p class="fw-semibold mb-1">Arrastra aquí ficheros o una carpeta</p>
-          <p class="small mb-0 text-secondary">Solo se procesan los ficheros del primer nivel</p>
+          <p class="small mb-0 text-secondary">
+            El explorador nativo se abrirá en el mismo directorio — un clic confirma la selección
+          </p>
         </div>
         <input type="file" id="input-carpeta-modal" webkitdirectory multiple class="d-none">
 
@@ -378,8 +380,11 @@
   // ----------------------------------------------------------------
   // Constantes
   // ----------------------------------------------------------------
-  var LS_PREFIJO_KEY = 'bddat_pool_prefijo';  // Clave localStorage para el prefijo
-  var URL_BASE_DOCS  = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+  var LS_PREFIJO_KEY  = 'bddat_pool_prefijo';
+  var URL_BASE_DOCS   = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+  var URL_SEL_NATIVO  = '{{ url_for('expedientes.pool_selector_nativo', id=expediente.id) }}';
+  // El drop dispara el selector nativo solo cuando Flask corre en local
+  var ES_FLASK_LOCAL  = ['localhost', '127.0.0.1', '::1'].indexOf(window.location.hostname) !== -1;
 
   // ----------------------------------------------------------------
   // Estado del módulo
@@ -447,24 +452,29 @@
       zona.classList.remove('drag-over');
 
       // CAPTURA SÍNCRONA — DataTransfer solo es válido mientras el handler no retorna.
-      // getText/uri-list y webkitGetAsEntry() devuelven vacío/null si se llaman en un setTimeout.
       var uri_list = '';
       try { uri_list = e.dataTransfer.getData('text/uri-list') || ''; } catch (ex) {}
 
       var entries = [];
-      var items = e.dataTransfer.items;
-      for (var j = 0; j < items.length; j++) {
-        var ent = items[j].webkitGetAsEntry ? items[j].webkitGetAsEntry() : null;
+      var items_dt = e.dataTransfer.items;
+      for (var j = 0; j < items_dt.length; j++) {
+        var ent = items_dt[j].webkitGetAsEntry ? items_dt[j].webkitGetAsEntry() : null;
         if (ent) entries.push(ent);
       }
 
-      if (abre_modal) {
-        _modal_carga.show();
-        // Solo el show() se difiere; los datos ya están capturados
-        setTimeout(function () { procesar_drop_con_datos(uri_list, entries); }, 100);
-      } else {
-        procesar_drop_con_datos(uri_list, entries);
-      }
+      if (abre_modal) _modal_carga.show();
+
+      setTimeout(function () {
+        if (ES_FLASK_LOCAL && entries.length > 0) {
+          // Flask local: el drop es solo el gesto; Python obtiene la ruta completa.
+          // El selector nativo se abre en el último directorio usado → un clic y listo.
+          var hay_dir = entries.some(function (en) { return en.isDirectory; });
+          abrir_selector_nativo(hay_dir ? 'carpeta' : 'ficheros');
+        } else {
+          // Flask remoto o sin entries: flujo navegador (solo nombres de fichero)
+          procesar_drop_con_datos(uri_list, entries);
+        }
+      }, abre_modal ? 100 : 0);
     });
     zona.addEventListener('click', function () {
       if (abre_modal) _modal_carga.show();

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -222,15 +222,31 @@
       <div class="modal-body">
 
         <!-- Zona de drop dentro del modal -->
-        <div class="zona-drop mb-3" id="zona-drop-modal">
-          <i class="fas fa-folder-open fa-3x mb-2"></i>
+        <div class="zona-drop mb-2" id="zona-drop-modal">
+          <i class="fas fa-folder-open fa-2x mb-2"></i>
           <p class="fw-semibold mb-1">Arrastra aquí ficheros o una carpeta</p>
-          <p class="small mb-0">
-            O haz clic para abrir el selector de carpeta
-            <span class="text-secondary">— solo se procesan los ficheros del primer nivel</span>
-          </p>
+          <p class="small mb-0 text-secondary">Solo se procesan los ficheros del primer nivel</p>
         </div>
         <input type="file" id="input-carpeta-modal" webkitdirectory multiple class="d-none">
+
+        <!-- Selector nativo (vía Python/tkinter — obtiene rutas completas) -->
+        <div class="text-center mb-3" id="zona-selector-nativo">
+          <p class="text-secondary small mb-2">— o usa el explorador de archivos nativo —</p>
+          <div class="d-flex gap-2 justify-content-center">
+            <button type="button" class="btn btn-outline-secondary btn-selector-nativo"
+                    onclick="abrir_selector_nativo('ficheros')">
+              <i class="fas fa-file me-1"></i> Seleccionar ficheros…
+            </button>
+            <button type="button" class="btn btn-outline-secondary btn-selector-nativo"
+                    onclick="abrir_selector_nativo('carpeta')">
+              <i class="fas fa-folder-open me-1"></i> Seleccionar carpeta…
+            </button>
+          </div>
+          <div id="msg-cargando-selector" class="alert alert-info py-2 mt-2 d-none small">
+            <span class="spinner-border spinner-border-sm me-2"></span>
+            Selecciona los ficheros en la ventana del explorador que acaba de abrirse…
+          </div>
+        </div>
 
         <!-- Preview: aparece tras seleccionar archivos -->
         <div id="seccion-preview" class="d-none">
@@ -614,6 +630,43 @@
       var input = tr.querySelector('.url-input');
       if (!input || input.dataset.manual === 'true') return;
       input.value = prefijo + tr.dataset.nombre;
+    });
+  };
+
+  // ----------------------------------------------------------------
+  // Selector nativo (Python/tkinter) — obtiene rutas completas del SO
+  // ----------------------------------------------------------------
+  window.abrir_selector_nativo = function (modo) {
+    var url_selector = '{{ url_for('expedientes.pool_selector_nativo', id=expediente.id) }}';
+    var btns = document.querySelectorAll('.btn-selector-nativo');
+    var msg  = document.getElementById('msg-cargando-selector');
+
+    btns.forEach(function (b) { b.disabled = true; });
+    msg.classList.remove('d-none');
+    document.getElementById('carga-error').classList.add('d-none');
+
+    fetch(url_selector, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modo: modo }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      btns.forEach(function (b) { b.disabled = false; });
+      msg.classList.add('d-none');
+      if (!data.ok) { mostrar_error_carga(data.error || 'Error al abrir el selector.'); return; }
+      if (!data.rutas || data.rutas.length === 0) return;  // Usuario canceló
+
+      archivos_pendientes = data.rutas.map(function (ruta) {
+        var nombre = ruta.replace(/\\/g, '/').split('/').pop();
+        return { nombre: nombre, url_completa: ruta };
+      });
+      mostrar_preview(true);
+    })
+    .catch(function () {
+      btns.forEach(function (b) { b.disabled = false; });
+      msg.classList.add('d-none');
+      mostrar_error_carga('No se pudo abrir el selector nativo. ¿Está Flask corriendo localmente?');
     });
   };
 

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -39,6 +39,9 @@
 </style>
 {% endblock %}
 
+{% block content %}
+<div class="bc-view">
+
 {# Plantilla de opciones de tipo — generada una sola vez en servidor #}
 <template id="tmpl-tipos-doc">
   <option value="">— Tipo —</option>
@@ -46,9 +49,6 @@
   <option value="{{ t.id }}">{{ t.nombre }}</option>
   {% endfor %}
 </template>
-
-{% block content %}
-<div class="bc-view">
 
 <!-- C.1: Card expediente (fijo) -->
 <div class="lista-cabecera px-3 pt-3">

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -1,0 +1,585 @@
+{% extends 'layout/base_fullwidth.html' %}
+
+{% block title %}Pool de Documentos — AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
+
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a>
+<span>›</span>
+<a href="{{ url_for('expedientes.detalle', id=expediente.id) }}">AT-{{ expediente.numero_at }}</a>
+<span>›</span>
+<span>Pool de Documentos</span>
+{% endblock %}
+
+{% block extra_css %}{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
+<style>
+  .zona-entrada-docs {
+    border: 2px dashed var(--bs-border-color);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+    color: var(--bs-secondary-color);
+  }
+  .zona-entrada-docs:hover {
+    border-color: var(--bs-primary);
+    background-color: var(--bs-primary-bg-subtle);
+    color: var(--bs-primary);
+  }
+</style>
+{% endblock %}
+
+{# Plantilla de tipos para el wizard (generada una sola vez en servidor) #}
+<template id="tmpl-tipos-doc">
+  <option value="">— Tipo —</option>
+  {% for t in tipos_doc %}
+  <option value="{{ t.id }}">{{ t.nombre }}</option>
+  {% endfor %}
+</template>
+
+{% block content %}
+<div class="bc-view">
+
+<!-- C.1: Card detalle del expediente (fijo) -->
+<div class="lista-cabecera px-3 pt-3">
+  <div class="card bc-card-nodo">
+    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
+      <span class="fw-semibold">
+        <i class="fas fa-folder-open me-2"></i>
+        Expediente <strong>AT-{{ expediente.numero_at }}</strong>
+      </span>
+      <div class="bc-acciones-bar">
+        <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+           class="btn btn-sm btn-outline-secondary">
+          <i class="fas fa-info-circle me-1"></i> Detalle
+        </a>
+        <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}"
+           class="btn btn-sm btn-outline-secondary">
+          <i class="fas fa-sitemap me-1"></i> Tramitación
+        </a>
+      </div>
+    </div>
+    <div class="card-body card-body-tinted py-2">
+      <div class="row g-2 bc-meta">
+        <div class="col-auto">
+          <strong>Titular:</strong>
+          {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
+        </div>
+        <div class="col-auto">
+          <strong>Responsable:</strong>
+          {{ expediente.responsable.siglas if expediente.responsable else '—' }}
+        </div>
+        <div class="col-auto">
+          <strong>Tipo:</strong>
+          {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
+        </div>
+        <div class="col-auto ms-auto">
+          <span class="badge bg-primary">{{ docs_lista | length }} documento(s)</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- C.2: Pool de documentos (scrollable) -->
+<div class="lista-scroll-container p-3">
+
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h6 class="mb-0 fw-semibold">Pool de Documentos</h6>
+  </div>
+
+  <!-- Zona de entrada -->
+  <div class="zona-entrada-docs mb-3" id="zona-entrada-docs">
+    <i class="fas fa-file-import fa-2x mb-2"></i>
+    <p class="mb-0 fw-semibold">Haz clic aquí para incorporar documentos al pool</p>
+    <small>Puedes añadir una o varias URLs a la vez</small>
+  </div>
+
+  <!-- Tabla de documentos -->
+  {% if docs_lista %}
+  <table class="table table-hover table-sm align-middle">
+    <thead class="table-light">
+      <tr>
+        <th>Nombre</th>
+        <th>Tipo</th>
+        <th>Fecha adm.</th>
+        <th class="text-center" title="Prioridad">P</th>
+        <th class="text-end">Acciones</th>
+      </tr>
+    </thead>
+    <tbody id="tbody-docs">
+      {% for item in docs_lista %}
+      {% set doc = item.doc %}
+      <tr id="fila-doc-{{ doc.id }}">
+        <td>
+          <a href="{{ doc.url }}" target="_blank" rel="noopener"
+             class="text-break" title="{{ doc.url }}">
+            {{ item.nombre_display }}
+          </a>
+          {% if doc.asunto %}
+          <div class="text-secondary small">{{ doc.asunto }}</div>
+          {% endif %}
+        </td>
+        <td>
+          <span class="badge border border-secondary text-secondary">
+            {{ doc.tipo_doc.nombre if doc.tipo_doc else '—' }}
+          </span>
+        </td>
+        <td class="text-nowrap">
+          {{ doc.fecha_administrativa.strftime('%d/%m/%Y') if doc.fecha_administrativa else '—' }}
+        </td>
+        <td class="text-center">
+          {% if doc.prioridad and doc.prioridad > 0 %}
+          <span class="badge bg-warning text-dark" title="Prioritario">!</span>
+          {% else %}
+          <span class="text-secondary">—</span>
+          {% endif %}
+        </td>
+        <td class="text-end text-nowrap">
+          <button type="button"
+                  class="btn btn-sm btn-outline-secondary"
+                  title="Editar metadatos"
+                  onclick="abrir_modal_editar(this)"
+                  data-doc-id="{{ doc.id }}"
+                  data-doc-url="{{ doc.url }}"
+                  data-doc-tipo-doc-id="{{ doc.tipo_doc_id }}"
+                  data-doc-fecha-admin="{{ doc.fecha_administrativa.isoformat() if doc.fecha_administrativa else '' }}"
+                  data-doc-asunto="{{ doc.asunto or '' }}"
+                  data-doc-prioridad="{{ doc.prioridad or 0 }}"
+                  data-doc-observaciones="{{ doc.observaciones or '' }}">
+            <i class="fas fa-pencil-alt"></i>
+          </button>
+          {% if item.es_referenciado %}
+          <button type="button"
+                  class="btn btn-sm btn-outline-secondary"
+                  disabled
+                  data-bs-toggle="tooltip"
+                  title="Referenciado en tramitación — no se puede eliminar">
+            <i class="fas fa-lock"></i>
+          </button>
+          {% else %}
+          <button type="button"
+                  class="btn btn-sm btn-outline-danger"
+                  title="Borrar documento"
+                  onclick="borrar_documento(this, '{{ url_for('expedientes.pool_borrar_documento', id=expediente.id, doc_id=doc.id) }}')"
+                  data-doc-id="{{ doc.id }}">
+            <i class="fas fa-times"></i>
+          </button>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="text-center text-secondary py-4">
+    <i class="fas fa-inbox fa-3x mb-3 d-block"></i>
+    No hay documentos en el pool de este expediente.
+    Usa la zona de arriba para incorporar documentos.
+  </div>
+  {% endif %}
+
+</div>{# fin lista-scroll-container #}
+
+<!-- ============================================================ -->
+<!-- Modal: Editar documento                                       -->
+<!-- ============================================================ -->
+<div class="modal fade" id="modal-editar-doc" tabindex="-1"
+     aria-labelledby="modal-editar-doc-label">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modal-editar-doc-label">
+          <i class="fas fa-pencil-alt me-1"></i> Editar documento
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" id="editar-doc-id">
+        <div class="mb-3">
+          <label class="form-label fw-semibold">URL <span class="text-danger">*</span></label>
+          <input type="url" class="form-control" id="editar-url" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Tipo de documento</label>
+          <select class="form-select" id="editar-tipo-doc-id">
+            <option value="">— Tipo —</option>
+            {% for t in tipos_doc %}
+            <option value="{{ t.id }}">{{ t.nombre }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Fecha administrativa</label>
+          <div id="ef-editar-fecha"></div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Asunto</label>
+          <input type="text" class="form-control" id="editar-asunto" maxlength="500">
+        </div>
+        <div class="mb-3 form-check">
+          <input type="checkbox" class="form-check-input" id="editar-prioridad">
+          <label class="form-check-label fw-semibold" for="editar-prioridad">Prioritario</label>
+        </div>
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Observaciones</label>
+          <textarea class="form-control" id="editar-observaciones" rows="2" maxlength="2000"></textarea>
+        </div>
+        <div id="editar-error" class="alert alert-danger d-none" role="alert"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary" onclick="guardar_edicion()">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- Modal: Wizard unificado para añadir URLs                     -->
+<!-- ============================================================ -->
+<div class="modal fade" id="modal-wizard-urls" tabindex="-1"
+     aria-labelledby="modal-wizard-urls-label">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modal-wizard-urls-label">
+          <i class="fas fa-file-import me-1"></i> Incorporar documentos al pool
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+
+        <!-- PASO 1: Introducir URLs -->
+        <div id="paso-urls">
+          <p class="text-secondary mb-2">
+            Introduce una URL por línea. Para un solo documento, escribe una sola URL.
+          </p>
+          <textarea class="form-control font-monospace" id="wizard-textarea"
+                    rows="8"
+                    placeholder="https://servidor/docs/doc1.pdf&#10;https://servidor/docs/doc2.pdf"></textarea>
+        </div>
+
+        <!-- PASO 2: Previsualización y metadatos -->
+        <div id="paso-preview" class="d-none">
+          <p class="text-secondary mb-2">
+            Revisa y completa los metadatos de cada documento.
+            Marca <strong>Excluir</strong> para omitir una fila.
+          </p>
+          <div class="table-responsive">
+            <table class="table table-sm table-bordered align-middle">
+              <thead class="table-light">
+                <tr>
+                  <th>Nombre inferido</th>
+                  <th style="min-width:180px">Tipo</th>
+                  <th style="min-width:140px">Fecha adm.</th>
+                  <th class="text-center">Prior.</th>
+                  <th class="text-center">Excluir</th>
+                </tr>
+              </thead>
+              <tbody id="preview-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="wizard-error" class="alert alert-danger d-none mt-2" role="alert"></div>
+      </div>
+      <div class="modal-footer">
+        <!-- Paso 1 -->
+        <div id="footer-paso1" class="d-flex gap-2">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="button" class="btn btn-primary" onclick="previsualizar_urls()">
+            Previsualizar <i class="fas fa-arrow-right ms-1"></i>
+          </button>
+        </div>
+        <!-- Paso 2 (oculto inicialmente) -->
+        <div id="footer-paso2" class="d-none d-flex gap-2">
+          <button type="button" class="btn btn-secondary" onclick="volver_paso1()">
+            <i class="fas fa-arrow-left me-1"></i> Volver
+          </button>
+          <button type="button" class="btn btn-primary" id="btn-importar"
+                  onclick="importar_masiva('{{ url_for('expedientes.pool_carga_masiva', id=expediente.id) }}')">
+            <i class="fas fa-file-import me-1"></i> Importar
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</div>{# fin bc-view #}
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script>
+(function () {
+  'use strict';
+
+  // ----------------------------------------------------------------
+  // Variables globales del módulo
+  // ----------------------------------------------------------------
+  const URL_EDITAR_BASE = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}'.replace('/documentos', '/documentos/');
+  let _ef_editar_fecha = null;
+  const _modal_editar = document.getElementById('modal-editar-doc');
+  const _modal_wizard = document.getElementById('modal-wizard-urls');
+
+  // ----------------------------------------------------------------
+  // Inicialización
+  // ----------------------------------------------------------------
+  document.addEventListener('DOMContentLoaded', function () {
+    // Tooltips
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+      new bootstrap.Tooltip(el);
+    });
+
+    // Zona de entrada → abrir wizard
+    document.getElementById('zona-entrada-docs').addEventListener('click', function () {
+      const modal = new bootstrap.Modal(_modal_wizard);
+      // Resetear wizard al abrir
+      document.getElementById('wizard-textarea').value = '';
+      document.getElementById('paso-urls').classList.remove('d-none');
+      document.getElementById('paso-preview').classList.add('d-none');
+      document.getElementById('footer-paso1').classList.remove('d-none');
+      document.getElementById('footer-paso2').classList.add('d-none');
+      document.getElementById('wizard-error').classList.add('d-none');
+      modal.show();
+    });
+
+    // EntradaFecha en modal editar — inicializar al abrir
+    _modal_editar.addEventListener('show.bs.modal', function () {
+      if (!_ef_editar_fecha) {
+        _ef_editar_fecha = new EntradaFecha('#ef-editar-fecha', { name: '_fecha_admin_editar' });
+      }
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Wizard — Paso 1 → Paso 2
+  // ----------------------------------------------------------------
+  window.previsualizar_urls = function () {
+    const texto = document.getElementById('wizard-textarea').value;
+    const urls = texto.split('\n').map(function (u) { return u.trim(); }).filter(Boolean);
+    if (urls.length === 0) {
+      mostrar_error_wizard('Introduce al menos una URL.');
+      return;
+    }
+    document.getElementById('wizard-error').classList.add('d-none');
+
+    // Construir tabla de previsualización
+    const tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
+    const tbody = document.getElementById('preview-tbody');
+    tbody.innerHTML = '';
+    urls.forEach(function (url, idx) {
+      const partes = url.split('/');
+      const ultimo = partes[partes.length - 1] || url;
+      const nombre = ultimo.replace(/\.[^.]+$/, '') || url;
+      const tr = document.createElement('tr');
+      tr.dataset.url = url;
+      tr.innerHTML =
+        '<td class="text-break small" title="' + escapar_html(url) + '">' + escapar_html(nombre) + '</td>' +
+        '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
+        '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
+        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>' +
+        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check"></td>';
+      tbody.appendChild(tr);
+    });
+
+    // Actualizar texto del botón importar
+    document.getElementById('btn-importar').innerHTML =
+      '<i class="fas fa-file-import me-1"></i> Importar ' + urls.length + ' documento(s)';
+
+    // Cambiar paso
+    document.getElementById('paso-urls').classList.add('d-none');
+    document.getElementById('paso-preview').classList.remove('d-none');
+    document.getElementById('footer-paso1').classList.add('d-none');
+    document.getElementById('footer-paso2').classList.remove('d-none');
+  };
+
+  window.volver_paso1 = function () {
+    document.getElementById('paso-urls').classList.remove('d-none');
+    document.getElementById('paso-preview').classList.add('d-none');
+    document.getElementById('footer-paso1').classList.remove('d-none');
+    document.getElementById('footer-paso2').classList.add('d-none');
+    document.getElementById('wizard-error').classList.add('d-none');
+  };
+
+  // ----------------------------------------------------------------
+  // Wizard — Importar (POST masivo)
+  // ----------------------------------------------------------------
+  window.importar_masiva = function (url_masiva) {
+    const filas = document.querySelectorAll('#preview-tbody tr');
+    const payload = [];
+    filas.forEach(function (tr) {
+      const excluir = tr.querySelector('.excluir-check').checked;
+      if (excluir) return;
+      payload.push({
+        url:                   tr.dataset.url,
+        tipo_doc_id:           tr.querySelector('.tipo-doc-select').value || 1,
+        fecha_administrativa:  tr.querySelector('.fecha-admin-input').value || null,
+        prioridad:             tr.querySelector('.prioridad-check').checked,
+        excluir:               false,
+      });
+    });
+
+    if (payload.length === 0) {
+      mostrar_error_wizard('No hay documentos para importar (todos excluidos).');
+      return;
+    }
+
+    const btn = document.getElementById('btn-importar');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Importando…';
+
+    fetch(url_masiva, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        window.location.reload();
+      } else {
+        mostrar_error_wizard(data.error || 'Error al importar.');
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
+      }
+    })
+    .catch(function () {
+      mostrar_error_wizard('Error de red al importar.');
+      btn.disabled = false;
+      btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
+    });
+  };
+
+  // ----------------------------------------------------------------
+  // Editar documento
+  // ----------------------------------------------------------------
+  window.abrir_modal_editar = function (btn) {
+    document.getElementById('editar-doc-id').value        = btn.dataset.docId;
+    document.getElementById('editar-url').value           = btn.dataset.docUrl;
+    document.getElementById('editar-tipo-doc-id').value   = btn.dataset.docTipoDocId;
+    document.getElementById('editar-asunto').value        = btn.dataset.docAsunto;
+    document.getElementById('editar-prioridad').checked   = btn.dataset.docPrioridad !== '0' && btn.dataset.docPrioridad !== '';
+    document.getElementById('editar-observaciones').value = btn.dataset.docObservaciones;
+    document.getElementById('editar-error').classList.add('d-none');
+
+    // Esperar a que EntradaFecha esté inicializada
+    const intentar_fecha = function () {
+      if (_ef_editar_fecha) {
+        _ef_editar_fecha.clear();
+        const fecha_iso = btn.dataset.docFechaAdmin;
+        if (fecha_iso) {
+          // Convertir ISO → dd/mm/yyyy para EntradaFecha
+          const partes = fecha_iso.split('-');
+          if (partes.length === 3) {
+            _ef_editar_fecha.setValue(partes[2] + '/' + partes[1] + '/' + partes[0]);
+          }
+        }
+      }
+    };
+
+    new bootstrap.Modal(_modal_editar).show();
+    // Dar tiempo al evento show.bs.modal para inicializar _ef_editar_fecha
+    setTimeout(intentar_fecha, 150);
+  };
+
+  window.guardar_edicion = function () {
+    const doc_id = document.getElementById('editar-doc-id').value;
+    const url_editar = URL_EDITAR_BASE + doc_id + '/editar';
+
+    // Leer fecha desde el input oculto que crea EntradaFecha
+    let fecha_iso = null;
+    const input_oculto = document.querySelector('#ef-editar-fecha input[type="hidden"]');
+    if (input_oculto && input_oculto.value) {
+      // EntradaFecha guarda en formato dd/mm/yyyy o ISO según configuración
+      // Intentamos leer el value tal cual (puede ser ISO si EntradaFecha lo formatea así)
+      const raw = input_oculto.value;
+      if (raw.includes('/')) {
+        // dd/mm/yyyy → yyyy-mm-dd
+        const p = raw.split('/');
+        if (p.length === 3) fecha_iso = p[2] + '-' + p[1] + '-' + p[0];
+      } else {
+        fecha_iso = raw;
+      }
+    }
+
+    const payload = {
+      url:                  document.getElementById('editar-url').value.trim(),
+      tipo_doc_id:          document.getElementById('editar-tipo-doc-id').value || 1,
+      fecha_administrativa: fecha_iso,
+      asunto:               document.getElementById('editar-asunto').value.trim(),
+      prioridad:            document.getElementById('editar-prioridad').checked,
+      observaciones:        document.getElementById('editar-observaciones').value.trim(),
+    };
+
+    if (!payload.url) {
+      mostrar_error_editar('La URL es obligatoria.');
+      return;
+    }
+
+    fetch(url_editar, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        window.location.reload();
+      } else {
+        mostrar_error_editar(data.error || 'Error al guardar.');
+      }
+    })
+    .catch(function () { mostrar_error_editar('Error de red.'); });
+  };
+
+  // ----------------------------------------------------------------
+  // Borrar documento
+  // ----------------------------------------------------------------
+  window.borrar_documento = function (btn, url_borrar) {
+    if (!confirm('¿Borrar este documento del pool? Esta acción no se puede deshacer.')) return;
+
+    const doc_id = btn.dataset.docId;
+    fetch(url_borrar, { method: 'POST' })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (data.ok) {
+        const fila = document.getElementById('fila-doc-' + doc_id);
+        if (fila) fila.remove();
+      } else {
+        alert(data.error || 'No se pudo borrar el documento.');
+      }
+    })
+    .catch(function () { alert('Error de red al borrar.'); });
+  };
+
+  // ----------------------------------------------------------------
+  // Utilidades
+  // ----------------------------------------------------------------
+  function mostrar_error_wizard(msg) {
+    const el = document.getElementById('wizard-error');
+    el.textContent = msg;
+    el.classList.remove('d-none');
+  }
+
+  function mostrar_error_editar(msg) {
+    const el = document.getElementById('editar-error');
+    el.textContent = msg;
+    el.classList.remove('d-none');
+  }
+
+  function escapar_html(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+}());
+</script>
+{% endblock %}

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -16,24 +16,30 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 <style>
-  .zona-entrada-docs {
+  .zona-drop {
     border: 2px dashed var(--bs-border-color);
     border-radius: 0.5rem;
-    padding: 1.5rem;
+    padding: 2rem 1rem;
     text-align: center;
     cursor: pointer;
-    transition: border-color 0.2s, background-color 0.2s;
+    transition: border-color 0.15s, background-color 0.15s;
     color: var(--bs-secondary-color);
+    user-select: none;
   }
-  .zona-entrada-docs:hover {
+  .zona-drop:hover,
+  .zona-drop.drag-over {
     border-color: var(--bs-primary);
     background-color: var(--bs-primary-bg-subtle);
     color: var(--bs-primary);
   }
+  /* Zona compacta en el C.2 (fuera del modal) */
+  .zona-drop-compacta {
+    padding: 1.25rem 1rem;
+  }
 </style>
 {% endblock %}
 
-{# Plantilla de tipos para el wizard (generada una sola vez en servidor) #}
+{# Plantilla de opciones de tipo — generada una sola vez en servidor #}
 <template id="tmpl-tipos-doc">
   <option value="">— Tipo —</option>
   {% for t in tipos_doc %}
@@ -44,7 +50,7 @@
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle del expediente (fijo) -->
+<!-- C.1: Card expediente (fijo) -->
 <div class="lista-cabecera px-3 pt-3">
   <div class="card bc-card-nodo">
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -92,14 +98,19 @@
     <h6 class="mb-0 fw-semibold">Pool de Documentos</h6>
   </div>
 
-  <!-- Zona de entrada -->
-  <div class="zona-entrada-docs mb-3" id="zona-entrada-docs">
+  <!-- Zona de entrada compacta — abre el modal al interactuar -->
+  <div class="zona-drop zona-drop-compacta mb-3"
+       id="zona-entrada-principal"
+       title="Arrastra ficheros o una carpeta aquí, o haz clic para seleccionar carpeta">
     <i class="fas fa-file-import fa-2x mb-2"></i>
-    <p class="mb-0 fw-semibold">Haz clic aquí para incorporar documentos al pool</p>
-    <small>Puedes añadir una o varias URLs a la vez</small>
+    <p class="mb-0 fw-semibold">Arrastra ficheros o una carpeta aquí</p>
+    <small>O haz clic para seleccionar una carpeta con el explorador</small>
   </div>
 
-  <!-- Tabla de documentos -->
+  <!-- Input carpeta oculto (activado por clic en zona principal) -->
+  <input type="file" id="input-carpeta-principal" webkitdirectory multiple class="d-none">
+
+  <!-- Tabla de documentos existentes -->
   {% if docs_lista %}
   <table class="table table-hover table-sm align-middle">
     <thead class="table-light">
@@ -176,14 +187,96 @@
     </tbody>
   </table>
   {% else %}
-  <div class="text-center text-secondary py-4">
+  <div class="text-center text-secondary py-4" id="mensaje-vacio">
     <i class="fas fa-inbox fa-3x mb-3 d-block"></i>
-    No hay documentos en el pool de este expediente.
-    Usa la zona de arriba para incorporar documentos.
+    No hay documentos en el pool. Arrastra ficheros o una carpeta en la zona de arriba.
   </div>
   {% endif %}
 
 </div>{# fin lista-scroll-container #}
+
+
+<!-- ============================================================ -->
+<!-- Modal: Carga de documentos (drag & drop / carpeta)           -->
+<!-- ============================================================ -->
+<div class="modal fade" id="modal-carga-docs" tabindex="-1"
+     aria-labelledby="modal-carga-docs-label">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modal-carga-docs-label">
+          <i class="fas fa-file-import me-1"></i> Incorporar documentos al pool
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+
+        <!-- Zona de drop dentro del modal -->
+        <div class="zona-drop mb-3" id="zona-drop-modal">
+          <i class="fas fa-folder-open fa-3x mb-2"></i>
+          <p class="fw-semibold mb-1">Arrastra aquí ficheros o una carpeta</p>
+          <p class="small mb-0">
+            O haz clic para abrir el selector de carpeta
+            <span class="text-secondary">— solo se procesan los ficheros del primer nivel</span>
+          </p>
+        </div>
+        <input type="file" id="input-carpeta-modal" webkitdirectory multiple class="d-none">
+
+        <!-- Preview: aparece tras seleccionar archivos -->
+        <div id="seccion-preview" class="d-none">
+
+          <div class="row g-2 mb-3 align-items-end">
+            <div class="col">
+              <label class="form-label fw-semibold mb-1">
+                Prefijo de ruta
+                <span class="text-secondary fw-normal small">
+                  (opcional — se antepone al nombre de cada fichero para construir la URL)
+                </span>
+              </label>
+              <input type="text" class="form-control font-monospace" id="prefijo-ruta"
+                     placeholder="\\servidor\expedientes\AT-{{ expediente.numero_at }}\  ó  https://docs.example.com/at{{ expediente.numero_at }}/"
+                     oninput="actualizar_urls_preview()">
+            </div>
+            <div class="col-auto">
+              <button type="button" class="btn btn-outline-secondary btn-sm"
+                      onclick="limpiar_seleccion()">
+                <i class="fas fa-redo me-1"></i> Nueva selección
+              </button>
+            </div>
+          </div>
+
+          <p class="text-secondary small mb-2" id="contador-archivos"></p>
+
+          <div class="table-responsive">
+            <table class="table table-sm table-bordered align-middle">
+              <thead class="table-light">
+                <tr>
+                  <th>Nombre de fichero</th>
+                  <th>URL resultante</th>
+                  <th style="min-width:180px">Tipo</th>
+                  <th style="min-width:130px">Fecha adm.</th>
+                  <th class="text-center">Prior.</th>
+                  <th class="text-center">Excluir</th>
+                </tr>
+              </thead>
+              <tbody id="preview-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <div id="carga-error" class="alert alert-danger d-none mt-2" role="alert"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary d-none" id="btn-importar"
+                onclick="importar_masiva('{{ url_for('expedientes.pool_carga_masiva', id=expediente.id) }}')">
+          <i class="fas fa-file-import me-1"></i> Importar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
 
 <!-- ============================================================ -->
 <!-- Modal: Editar documento                                       -->
@@ -202,7 +295,7 @@
         <input type="hidden" id="editar-doc-id">
         <div class="mb-3">
           <label class="form-label fw-semibold">URL <span class="text-danger">*</span></label>
-          <input type="url" class="form-control" id="editar-url" required>
+          <input type="text" class="form-control font-monospace" id="editar-url" required>
         </div>
         <div class="mb-3">
           <label class="form-label fw-semibold">Tipo de documento</label>
@@ -241,78 +334,6 @@
   </div>
 </div>
 
-<!-- ============================================================ -->
-<!-- Modal: Wizard unificado para añadir URLs                     -->
-<!-- ============================================================ -->
-<div class="modal fade" id="modal-wizard-urls" tabindex="-1"
-     aria-labelledby="modal-wizard-urls-label">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="modal-wizard-urls-label">
-          <i class="fas fa-file-import me-1"></i> Incorporar documentos al pool
-        </h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-
-        <!-- PASO 1: Introducir URLs -->
-        <div id="paso-urls">
-          <p class="text-secondary mb-2">
-            Introduce una URL por línea. Para un solo documento, escribe una sola URL.
-          </p>
-          <textarea class="form-control font-monospace" id="wizard-textarea"
-                    rows="8"
-                    placeholder="https://servidor/docs/doc1.pdf&#10;https://servidor/docs/doc2.pdf"></textarea>
-        </div>
-
-        <!-- PASO 2: Previsualización y metadatos -->
-        <div id="paso-preview" class="d-none">
-          <p class="text-secondary mb-2">
-            Revisa y completa los metadatos de cada documento.
-            Marca <strong>Excluir</strong> para omitir una fila.
-          </p>
-          <div class="table-responsive">
-            <table class="table table-sm table-bordered align-middle">
-              <thead class="table-light">
-                <tr>
-                  <th>Nombre inferido</th>
-                  <th style="min-width:180px">Tipo</th>
-                  <th style="min-width:140px">Fecha adm.</th>
-                  <th class="text-center">Prior.</th>
-                  <th class="text-center">Excluir</th>
-                </tr>
-              </thead>
-              <tbody id="preview-tbody"></tbody>
-            </table>
-          </div>
-        </div>
-
-        <div id="wizard-error" class="alert alert-danger d-none mt-2" role="alert"></div>
-      </div>
-      <div class="modal-footer">
-        <!-- Paso 1 -->
-        <div id="footer-paso1" class="d-flex gap-2">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="button" class="btn btn-primary" onclick="previsualizar_urls()">
-            Previsualizar <i class="fas fa-arrow-right ms-1"></i>
-          </button>
-        </div>
-        <!-- Paso 2 (oculto inicialmente) -->
-        <div id="footer-paso2" class="d-none d-flex gap-2">
-          <button type="button" class="btn btn-secondary" onclick="volver_paso1()">
-            <i class="fas fa-arrow-left me-1"></i> Volver
-          </button>
-          <button type="button" class="btn btn-primary" id="btn-importar"
-                  onclick="importar_masiva('{{ url_for('expedientes.pool_carga_masiva', id=expediente.id) }}')">
-            <i class="fas fa-file-import me-1"></i> Importar
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
 </div>{# fin bc-view #}
 {% endblock %}
 
@@ -323,12 +344,14 @@
   'use strict';
 
   // ----------------------------------------------------------------
-  // Variables globales del módulo
+  // Estado del módulo
   // ----------------------------------------------------------------
-  const URL_EDITAR_BASE = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}'.replace('/documentos', '/documentos/');
-  let _ef_editar_fecha = null;
-  const _modal_editar = document.getElementById('modal-editar-doc');
-  const _modal_wizard = document.getElementById('modal-wizard-urls');
+  /** @type {Array<{nombre: string}>} */
+  var archivos_pendientes = [];
+  var _ef_editar_fecha = null;
+  var _modal_carga = null;
+  var _modal_editar_bs = null;
+  var _modal_editar_el = document.getElementById('modal-editar-doc');
 
   // ----------------------------------------------------------------
   // Inicialización
@@ -339,21 +362,26 @@
       new bootstrap.Tooltip(el);
     });
 
-    // Zona de entrada → abrir wizard
-    document.getElementById('zona-entrada-docs').addEventListener('click', function () {
-      const modal = new bootstrap.Modal(_modal_wizard);
-      // Resetear wizard al abrir
-      document.getElementById('wizard-textarea').value = '';
-      document.getElementById('paso-urls').classList.remove('d-none');
-      document.getElementById('paso-preview').classList.add('d-none');
-      document.getElementById('footer-paso1').classList.remove('d-none');
-      document.getElementById('footer-paso2').classList.add('d-none');
-      document.getElementById('wizard-error').classList.add('d-none');
-      modal.show();
+    // Instancia del modal de carga
+    _modal_carga = new bootstrap.Modal(document.getElementById('modal-carga-docs'));
+
+    // Zona de entrada principal (C.2) — drop + clic
+    var zona_principal = document.getElementById('zona-entrada-principal');
+    var input_principal = document.getElementById('input-carpeta-principal');
+    configurar_zona(zona_principal, input_principal, true);
+
+    // Zona de drop dentro del modal
+    var zona_modal = document.getElementById('zona-drop-modal');
+    var input_modal = document.getElementById('input-carpeta-modal');
+    configurar_zona(zona_modal, input_modal, false);
+
+    // Cuando el modal de carga se cierra, reiniciamos
+    document.getElementById('modal-carga-docs').addEventListener('hidden.bs.modal', function () {
+      resetear_modal();
     });
 
-    // EntradaFecha en modal editar — inicializar al abrir
-    _modal_editar.addEventListener('show.bs.modal', function () {
+    // EntradaFecha en modal editar — inicializar al abrirse
+    _modal_editar_el.addEventListener('show.bs.modal', function () {
       if (!_ef_editar_fecha) {
         _ef_editar_fecha = new EntradaFecha('#ef-editar-fecha', { name: '_fecha_admin_editar' });
       }
@@ -361,29 +389,135 @@
   });
 
   // ----------------------------------------------------------------
-  // Wizard — Paso 1 → Paso 2
+  // Configurar zona de drop + input file
   // ----------------------------------------------------------------
-  window.previsualizar_urls = function () {
-    const texto = document.getElementById('wizard-textarea').value;
-    const urls = texto.split('\n').map(function (u) { return u.trim(); }).filter(Boolean);
-    if (urls.length === 0) {
-      mostrar_error_wizard('Introduce al menos una URL.');
+  function configurar_zona(zona, input, abre_modal) {
+    // Drag events
+    zona.addEventListener('dragover', function (e) {
+      e.preventDefault();
+      zona.classList.add('drag-over');
+    });
+    zona.addEventListener('dragleave', function () {
+      zona.classList.remove('drag-over');
+    });
+    zona.addEventListener('drop', function (e) {
+      e.preventDefault();
+      zona.classList.remove('drag-over');
+      if (abre_modal) _modal_carga.show();
+      procesar_drop(e.dataTransfer.items);
+    });
+
+    // Clic → selector de carpeta
+    zona.addEventListener('click', function () {
+      if (abre_modal) _modal_carga.show();
+      // Pequeño delay para que el modal esté visible antes de abrir el picker
+      setTimeout(function () { input.click(); }, abre_modal ? 200 : 0);
+    });
+
+    // Input carpeta seleccionada
+    input.addEventListener('change', function (e) {
+      procesar_input_carpeta(e.target.files);
+      // Resetear input para que vuelva a dispararse si el usuario elige la misma carpeta
+      e.target.value = '';
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Procesar drop (ficheros y/o carpetas)
+  // ----------------------------------------------------------------
+  function procesar_drop(items) {
+    archivos_pendientes = [];
+    var promesas = [];
+
+    for (var i = 0; i < items.length; i++) {
+      var entry = items[i].webkitGetAsEntry ? items[i].webkitGetAsEntry() : null;
+      if (!entry) continue;
+
+      if (entry.isFile) {
+        promesas.push(entry_a_nombre(entry));
+      } else if (entry.isDirectory) {
+        promesas.push(leer_directorio_primer_nivel(entry));
+      }
+    }
+
+    Promise.all(promesas).then(function () {
+      mostrar_preview();
+    }).catch(function (err) {
+      mostrar_error_carga('Error al leer los ficheros: ' + err);
+    });
+  }
+
+  function entry_a_nombre(file_entry) {
+    return new Promise(function (resolve) {
+      file_entry.file(function (f) {
+        archivos_pendientes.push({ nombre: f.name });
+        resolve();
+      });
+    });
+  }
+
+  function leer_directorio_primer_nivel(dir_entry) {
+    return new Promise(function (resolve, reject) {
+      var reader = dir_entry.createReader();
+      // readEntries puede devolver lotes; para primer nivel suele bastar una llamada
+      var leer_lote = function () {
+        reader.readEntries(function (entries) {
+          if (entries.length === 0) {
+            resolve();
+            return;
+          }
+          var sub = [];
+          entries.forEach(function (e) {
+            if (e.isFile) {
+              sub.push(entry_a_nombre(e));
+            }
+            // Subdirectorios ignorados (solo primer nivel)
+          });
+          Promise.all(sub).then(leer_lote).catch(reject);
+        }, reject);
+      };
+      leer_lote();
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Procesar input webkitdirectory
+  // ----------------------------------------------------------------
+  function procesar_input_carpeta(files) {
+    archivos_pendientes = [];
+    for (var i = 0; i < files.length; i++) {
+      var f = files[i];
+      // webkitRelativePath: "carpeta/archivo.pdf" → split('/').length === 2 = primer nivel
+      var partes = f.webkitRelativePath ? f.webkitRelativePath.split('/') : [];
+      if (partes.length === 2) {
+        archivos_pendientes.push({ nombre: f.name });
+      }
+    }
+    mostrar_preview();
+  }
+
+  // ----------------------------------------------------------------
+  // Mostrar preview
+  // ----------------------------------------------------------------
+  function mostrar_preview() {
+    if (archivos_pendientes.length === 0) {
+      mostrar_error_carga('No se encontraron ficheros en la selección.');
       return;
     }
-    document.getElementById('wizard-error').classList.add('d-none');
 
-    // Construir tabla de previsualización
-    const tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
-    const tbody = document.getElementById('preview-tbody');
+    document.getElementById('carga-error').classList.add('d-none');
+    document.getElementById('zona-drop-modal').classList.add('d-none');
+
+    var tmpl_tipos = document.getElementById('tmpl-tipos-doc').innerHTML;
+    var tbody = document.getElementById('preview-tbody');
     tbody.innerHTML = '';
-    urls.forEach(function (url, idx) {
-      const partes = url.split('/');
-      const ultimo = partes[partes.length - 1] || url;
-      const nombre = ultimo.replace(/\.[^.]+$/, '') || url;
-      const tr = document.createElement('tr');
-      tr.dataset.url = url;
+
+    archivos_pendientes.forEach(function (arch, idx) {
+      var tr = document.createElement('tr');
+      tr.dataset.nombre = arch.nombre;
       tr.innerHTML =
-        '<td class="text-break small" title="' + escapar_html(url) + '">' + escapar_html(nombre) + '</td>' +
+        '<td class="small text-break">' + escapar_html(arch.nombre) + '</td>' +
+        '<td class="small font-monospace text-break url-resultante text-secondary">' + escapar_html(arch.nombre) + '</td>' +
         '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
         '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
         '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>' +
@@ -391,49 +525,66 @@
       tbody.appendChild(tr);
     });
 
-    // Actualizar texto del botón importar
+    document.getElementById('contador-archivos').textContent =
+      archivos_pendientes.length + ' fichero(s) seleccionado(s)';
+    document.getElementById('prefijo-ruta').value = '';
+    document.getElementById('seccion-preview').classList.remove('d-none');
+    document.getElementById('btn-importar').classList.remove('d-none');
+    document.getElementById('btn-importar').textContent = '';
     document.getElementById('btn-importar').innerHTML =
-      '<i class="fas fa-file-import me-1"></i> Importar ' + urls.length + ' documento(s)';
+      '<i class="fas fa-file-import me-1"></i> Importar ' + archivos_pendientes.length + ' documento(s)';
+  }
 
-    // Cambiar paso
-    document.getElementById('paso-urls').classList.add('d-none');
-    document.getElementById('paso-preview').classList.remove('d-none');
-    document.getElementById('footer-paso1').classList.add('d-none');
-    document.getElementById('footer-paso2').classList.remove('d-none');
-  };
-
-  window.volver_paso1 = function () {
-    document.getElementById('paso-urls').classList.remove('d-none');
-    document.getElementById('paso-preview').classList.add('d-none');
-    document.getElementById('footer-paso1').classList.remove('d-none');
-    document.getElementById('footer-paso2').classList.add('d-none');
-    document.getElementById('wizard-error').classList.add('d-none');
+  // ----------------------------------------------------------------
+  // Actualizar columna "URL resultante" cuando cambia el prefijo
+  // ----------------------------------------------------------------
+  window.actualizar_urls_preview = function () {
+    var prefijo = document.getElementById('prefijo-ruta').value;
+    document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
+      var url_el = tr.querySelector('.url-resultante');
+      if (url_el) {
+        url_el.textContent = prefijo + tr.dataset.nombre;
+      }
+    });
   };
 
   // ----------------------------------------------------------------
-  // Wizard — Importar (POST masivo)
+  // Limpiar selección → volver a mostrar zona de drop
+  // ----------------------------------------------------------------
+  window.limpiar_seleccion = function () {
+    archivos_pendientes = [];
+    document.getElementById('seccion-preview').classList.add('d-none');
+    document.getElementById('btn-importar').classList.add('d-none');
+    document.getElementById('zona-drop-modal').classList.remove('d-none');
+    document.getElementById('carga-error').classList.add('d-none');
+    document.getElementById('preview-tbody').innerHTML = '';
+  };
+
+  // ----------------------------------------------------------------
+  // Importar (POST masivo)
   // ----------------------------------------------------------------
   window.importar_masiva = function (url_masiva) {
-    const filas = document.querySelectorAll('#preview-tbody tr');
-    const payload = [];
+    var prefijo = document.getElementById('prefijo-ruta').value;
+    var filas = document.querySelectorAll('#preview-tbody tr');
+    var payload = [];
+
     filas.forEach(function (tr) {
-      const excluir = tr.querySelector('.excluir-check').checked;
-      if (excluir) return;
+      if (tr.querySelector('.excluir-check').checked) return;
+      var nombre = tr.dataset.nombre;
       payload.push({
-        url:                   tr.dataset.url,
-        tipo_doc_id:           tr.querySelector('.tipo-doc-select').value || 1,
-        fecha_administrativa:  tr.querySelector('.fecha-admin-input').value || null,
-        prioridad:             tr.querySelector('.prioridad-check').checked,
-        excluir:               false,
+        url:                  prefijo + nombre,
+        tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || 1,
+        fecha_administrativa: tr.querySelector('.fecha-admin-input').value || null,
+        prioridad:            tr.querySelector('.prioridad-check').checked,
       });
     });
 
     if (payload.length === 0) {
-      mostrar_error_wizard('No hay documentos para importar (todos excluidos).');
+      mostrar_error_carga('No hay documentos para importar (todos excluidos).');
       return;
     }
 
-    const btn = document.getElementById('btn-importar');
+    var btn = document.getElementById('btn-importar');
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Importando…';
 
@@ -447,13 +598,13 @@
       if (data.ok) {
         window.location.reload();
       } else {
-        mostrar_error_wizard(data.error || 'Error al importar.');
+        mostrar_error_carga(data.error || 'Error al importar.');
         btn.disabled = false;
         btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
       }
     })
     .catch(function () {
-      mostrar_error_wizard('Error de red al importar.');
+      mostrar_error_carga('Error de red al importar.');
       btn.disabled = false;
       btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
     });
@@ -471,47 +622,41 @@
     document.getElementById('editar-observaciones').value = btn.dataset.docObservaciones;
     document.getElementById('editar-error').classList.add('d-none');
 
-    // Esperar a que EntradaFecha esté inicializada
-    const intentar_fecha = function () {
+    if (!_modal_editar_bs) {
+      _modal_editar_bs = new bootstrap.Modal(_modal_editar_el);
+    }
+    _modal_editar_bs.show();
+
+    // Poblar EntradaFecha después de que el modal la haya inicializado
+    setTimeout(function () {
       if (_ef_editar_fecha) {
         _ef_editar_fecha.clear();
-        const fecha_iso = btn.dataset.docFechaAdmin;
+        var fecha_iso = btn.dataset.docFechaAdmin;
         if (fecha_iso) {
-          // Convertir ISO → dd/mm/yyyy para EntradaFecha
-          const partes = fecha_iso.split('-');
-          if (partes.length === 3) {
-            _ef_editar_fecha.setValue(partes[2] + '/' + partes[1] + '/' + partes[0]);
-          }
+          var p = fecha_iso.split('-');
+          if (p.length === 3) _ef_editar_fecha.setValue(p[2] + '/' + p[1] + '/' + p[0]);
         }
       }
-    };
-
-    new bootstrap.Modal(_modal_editar).show();
-    // Dar tiempo al evento show.bs.modal para inicializar _ef_editar_fecha
-    setTimeout(intentar_fecha, 150);
+    }, 150);
   };
 
   window.guardar_edicion = function () {
-    const doc_id = document.getElementById('editar-doc-id').value;
-    const url_editar = URL_EDITAR_BASE + doc_id + '/editar';
+    var doc_id = document.getElementById('editar-doc-id').value;
+    var url_editar = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}'.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
 
-    // Leer fecha desde el input oculto que crea EntradaFecha
-    let fecha_iso = null;
-    const input_oculto = document.querySelector('#ef-editar-fecha input[type="hidden"]');
+    var fecha_iso = null;
+    var input_oculto = document.querySelector('#ef-editar-fecha input[type="hidden"]');
     if (input_oculto && input_oculto.value) {
-      // EntradaFecha guarda en formato dd/mm/yyyy o ISO según configuración
-      // Intentamos leer el value tal cual (puede ser ISO si EntradaFecha lo formatea así)
-      const raw = input_oculto.value;
+      var raw = input_oculto.value;
       if (raw.includes('/')) {
-        // dd/mm/yyyy → yyyy-mm-dd
-        const p = raw.split('/');
+        var p = raw.split('/');
         if (p.length === 3) fecha_iso = p[2] + '-' + p[1] + '-' + p[0];
       } else {
         fecha_iso = raw;
       }
     }
 
-    const payload = {
+    var payload = {
       url:                  document.getElementById('editar-url').value.trim(),
       tipo_doc_id:          document.getElementById('editar-tipo-doc-id').value || 1,
       fecha_administrativa: fecha_iso,
@@ -532,11 +677,8 @@
     })
     .then(function (r) { return r.json(); })
     .then(function (data) {
-      if (data.ok) {
-        window.location.reload();
-      } else {
-        mostrar_error_editar(data.error || 'Error al guardar.');
-      }
+      if (data.ok) { window.location.reload(); }
+      else { mostrar_error_editar(data.error || 'Error al guardar.'); }
     })
     .catch(function () { mostrar_error_editar('Error de red.'); });
   };
@@ -547,12 +689,12 @@
   window.borrar_documento = function (btn, url_borrar) {
     if (!confirm('¿Borrar este documento del pool? Esta acción no se puede deshacer.')) return;
 
-    const doc_id = btn.dataset.docId;
+    var doc_id = btn.dataset.docId;
     fetch(url_borrar, { method: 'POST' })
     .then(function (r) { return r.json(); })
     .then(function (data) {
       if (data.ok) {
-        const fila = document.getElementById('fila-doc-' + doc_id);
+        var fila = document.getElementById('fila-doc-' + doc_id);
         if (fila) fila.remove();
       } else {
         alert(data.error || 'No se pudo borrar el documento.');
@@ -562,22 +704,35 @@
   };
 
   // ----------------------------------------------------------------
-  // Utilidades
+  // Utilidades internas
   // ----------------------------------------------------------------
-  function mostrar_error_wizard(msg) {
-    const el = document.getElementById('wizard-error');
+  function resetear_modal() {
+    archivos_pendientes = [];
+    document.getElementById('seccion-preview').classList.add('d-none');
+    document.getElementById('btn-importar').classList.add('d-none');
+    document.getElementById('zona-drop-modal').classList.remove('d-none');
+    document.getElementById('carga-error').classList.add('d-none');
+    document.getElementById('preview-tbody').innerHTML = '';
+  }
+
+  function mostrar_error_carga(msg) {
+    var el = document.getElementById('carga-error');
     el.textContent = msg;
     el.classList.remove('d-none');
   }
 
   function mostrar_error_editar(msg) {
-    const el = document.getElementById('editar-error');
+    var el = document.getElementById('editar-error');
     el.textContent = msg;
     el.classList.remove('d-none');
   }
 
   function escapar_html(str) {
-    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
 }());

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -429,9 +429,26 @@
     zona.addEventListener('drop', function (e) {
       e.preventDefault();
       zona.classList.remove('drag-over');
-      if (abre_modal) _modal_carga.show();
-      // Pequeño delay para que el modal esté visible antes de procesar
-      setTimeout(function () { procesar_drop(e.dataTransfer); }, abre_modal ? 100 : 0);
+
+      // CAPTURA SÍNCRONA — DataTransfer solo es válido mientras el handler no retorna.
+      // getText/uri-list y webkitGetAsEntry() devuelven vacío/null si se llaman en un setTimeout.
+      var uri_list = '';
+      try { uri_list = e.dataTransfer.getData('text/uri-list') || ''; } catch (ex) {}
+
+      var entries = [];
+      var items = e.dataTransfer.items;
+      for (var j = 0; j < items.length; j++) {
+        var ent = items[j].webkitGetAsEntry ? items[j].webkitGetAsEntry() : null;
+        if (ent) entries.push(ent);
+      }
+
+      if (abre_modal) {
+        _modal_carga.show();
+        // Solo el show() se difiere; los datos ya están capturados
+        setTimeout(function () { procesar_drop_con_datos(uri_list, entries); }, 100);
+      } else {
+        procesar_drop_con_datos(uri_list, entries);
+      }
     });
     zona.addEventListener('click', function () {
       if (abre_modal) _modal_carga.show();
@@ -444,47 +461,41 @@
   }
 
   // ----------------------------------------------------------------
-  // Procesar drop — intenta obtener rutas completas vía text/uri-list
-  // (funciona en Firefox; Chrome solo da el nombre del fichero)
+  // Procesar drop con datos ya capturados sincrónicamente
+  // uri_list  → resultado de getData('text/uri-list') durante el evento
+  // entries   → array de FileSystemEntry capturados con webkitGetAsEntry()
   // ----------------------------------------------------------------
-  function procesar_drop(dt) {
+  function procesar_drop_con_datos(uri_list, entries) {
     archivos_pendientes = [];
 
-    // Intento 1: text/uri-list puede dar file:// URIs completas (Firefox, algunos entornos)
-    var uri_list = '';
-    try { uri_list = dt.getData('text/uri-list') || ''; } catch (e) {}
-
+    // Intento 1: text/uri-list — Firefox en Windows devuelve file:// URIs completas.
+    // Chrome/Edge bloquean este campo por política de seguridad (devuelven '').
     if (uri_list) {
       var uris = uri_list.split('\n')
         .map(function (u) { return u.trim(); })
         .filter(function (u) { return u && !u.startsWith('#'); });
-
-      // Solo usar si son URIs de fichero (no directorios — no podemos distinguirlos aquí)
       var solo_ficheros = uris.filter(function (u) { return u.startsWith('file://'); });
       if (solo_ficheros.length > 0 && solo_ficheros.length === uris.length) {
         solo_ficheros.forEach(function (uri) {
           var decoded = decodeURIComponent(uri);
-          // Nombre = último segmento de la URI
           var nombre = decoded.replace(/\/$/, '').split('/').pop().split('\\').pop();
           archivos_pendientes.push({ nombre: nombre, url_completa: decoded });
         });
-        mostrar_preview(true);  // true = tenemos URLs completas
+        mostrar_preview(true);
         return;
       }
     }
 
-    // Intento 2: webkitGetAsEntry (da solo nombres, no rutas)
-    var items = dt.items;
-    var promesas = [];
-    for (var i = 0; i < items.length; i++) {
-      var entry = items[i].webkitGetAsEntry ? items[i].webkitGetAsEntry() : null;
-      if (!entry) continue;
-      if (entry.isFile) {
-        promesas.push(entry_a_archivo(entry, null));
-      } else if (entry.isDirectory) {
-        promesas.push(leer_directorio_primer_nivel(entry));
-      }
+    // Intento 2: entradas ya capturadas sincrónicamente (funcionan en todos los navegadores)
+    if (entries.length === 0) {
+      mostrar_error_carga('No se pudieron leer los ficheros. Prueba con el selector de carpeta (clic).');
+      return;
     }
+    var promesas = entries.map(function (entry) {
+      if (entry.isFile)      return entry_a_archivo(entry, null);
+      if (entry.isDirectory) return leer_directorio_primer_nivel(entry);
+      return Promise.resolve();
+    });
     Promise.all(promesas).then(function () {
       mostrar_preview(false);
     }).catch(function (err) {

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -261,8 +261,8 @@
             <table class="table table-sm table-bordered align-middle">
               <thead class="table-light">
                 <tr>
-                  <th>Nombre de fichero</th>
-                  <th>URL / ruta resultante</th>
+                  <th style="min-width:160px">Nombre de fichero</th>
+                  <th>URL / ruta <span class="fw-normal text-secondary">(editable)</span></th>
                   <th style="min-width:180px">Tipo de documento</th>
                   <th style="min-width:130px">Fecha adm.</th>
                   <th class="text-center">Prioritario</th>
@@ -582,10 +582,13 @@
       var url_inicial = arch.url_completa || (document.getElementById('prefijo-ruta').value + arch.nombre);
       var tr = document.createElement('tr');
       tr.dataset.nombre = arch.nombre;
-      tr.dataset.urlCompleta = arch.url_completa || '';
       tr.innerHTML =
-        '<td class="small">' + escapar_html(arch.nombre) + '</td>' +
-        '<td class="small font-monospace text-break url-resultante text-secondary">' + escapar_html(url_inicial) + '</td>' +
+        '<td class="small text-nowrap">' + escapar_html(arch.nombre) + '</td>' +
+        '<td><input type="text" class="form-control form-control-sm font-monospace url-input"' +
+          ' value="' + escapar_html(url_inicial) + '"' +
+          ' data-manual="' + (arch.url_completa ? 'true' : 'false') + '"' +
+          ' oninput="this.dataset.manual=\'true\'"' +
+          ' placeholder="Ruta o URL completa del fichero"></td>' +
         '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
         '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
         '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check" title="Marcar como prioritario"></td>' +
@@ -602,14 +605,15 @@
   }
 
   // ----------------------------------------------------------------
-  // Actualizar columna URL resultante cuando cambia el prefijo
+  // Actualizar columna URL cuando cambia el prefijo
+  // Solo actualiza filas que el usuario NO ha editado manualmente (data-manual="false")
   // ----------------------------------------------------------------
   window.actualizar_urls_preview = function () {
     var prefijo = document.getElementById('prefijo-ruta').value;
     document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
-      if (tr.dataset.urlCompleta) return;  // tiene URL completa, no tocar
-      var url_el = tr.querySelector('.url-resultante');
-      if (url_el) url_el.textContent = prefijo + tr.dataset.nombre;
+      var input = tr.querySelector('.url-input');
+      if (!input || input.dataset.manual === 'true') return;
+      input.value = prefijo + tr.dataset.nombre;
     });
   };
 
@@ -634,7 +638,7 @@
 
     document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
       if (tr.querySelector('.excluir-check').checked) return;
-      var url_final = tr.dataset.urlCompleta || (prefijo + tr.dataset.nombre);
+      var url_final = tr.querySelector('.url-input').value.trim() || tr.dataset.nombre;
       payload.push({
         url:                  url_final,
         tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || 1,

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -32,17 +32,15 @@
     background-color: var(--bs-primary-bg-subtle);
     color: var(--bs-primary);
   }
-  /* Zona compacta en el C.2 (fuera del modal) */
-  .zona-drop-compacta {
-    padding: 1.25rem 1rem;
-  }
+  .zona-drop-compacta { padding: 1.25rem 1rem; }
+  .url-texto { font-family: monospace; font-size: 0.82em; word-break: break-all; }
 </style>
 {% endblock %}
 
 {% block content %}
 <div class="bc-view">
 
-{# Plantilla de opciones de tipo — generada una sola vez en servidor #}
+{# Plantilla de opciones de tipo — dentro del block content para que el DOM la encuentre #}
 <template id="tmpl-tipos-doc">
   <option value="">— Tipo —</option>
   {% for t in tipos_doc %}
@@ -98,16 +96,13 @@
     <h6 class="mb-0 fw-semibold">Pool de Documentos</h6>
   </div>
 
-  <!-- Zona de entrada compacta — abre el modal al interactuar -->
-  <div class="zona-drop zona-drop-compacta mb-3"
-       id="zona-entrada-principal"
-       title="Arrastra ficheros o una carpeta aquí, o haz clic para seleccionar carpeta">
+  <!-- Zona de entrada compacta — abre el modal -->
+  <div class="zona-drop zona-drop-compacta mb-3" id="zona-entrada-principal"
+       title="Arrastra ficheros o una carpeta, o haz clic para seleccionar carpeta">
     <i class="fas fa-file-import fa-2x mb-2"></i>
     <p class="mb-0 fw-semibold">Arrastra ficheros o una carpeta aquí</p>
-    <small>O haz clic para seleccionar una carpeta con el explorador</small>
+    <small>O haz clic para seleccionar una carpeta con el explorador de archivos</small>
   </div>
-
-  <!-- Input carpeta oculto (activado por clic en zona principal) -->
   <input type="file" id="input-carpeta-principal" webkitdirectory multiple class="d-none">
 
   <!-- Tabla de documentos existentes -->
@@ -116,9 +111,10 @@
     <thead class="table-light">
       <tr>
         <th>Nombre</th>
+        <th>Ruta / URL</th>
         <th>Tipo</th>
         <th>Fecha adm.</th>
-        <th class="text-center" title="Prioridad">P</th>
+        <th>Prioritario</th>
         <th class="text-end">Acciones</th>
       </tr>
     </thead>
@@ -127,12 +123,28 @@
       {% set doc = item.doc %}
       <tr id="fila-doc-{{ doc.id }}">
         <td>
-          <a href="{{ doc.url }}" target="_blank" rel="noopener"
-             class="text-break" title="{{ doc.url }}">
-            {{ item.nombre_display }}
-          </a>
+          <span class="fw-semibold">{{ item.nombre_display }}</span>
+          {% if not item.extension and doc.tipo_contenido %}
+          <span class="badge bg-secondary ms-1 small">{{ doc.tipo_contenido }}</span>
+          {% elif item.extension %}
+          <span class="badge border border-secondary text-secondary ms-1 small">.{{ item.extension }}</span>
+          {% endif %}
           {% if doc.asunto %}
           <div class="text-secondary small">{{ doc.asunto }}</div>
+          {% endif %}
+        </td>
+        <td>
+          {% if item.es_clickable %}
+          <a href="{{ doc.url }}" target="_blank" rel="noopener"
+             class="url-texto" title="{{ doc.url }}">{{ doc.url }}</a>
+          {% else %}
+          <span class="url-texto text-secondary" title="{{ doc.url }}">{{ doc.url }}</span>
+          <button type="button"
+                  class="btn btn-link btn-sm p-0 ms-1 align-baseline"
+                  title="Copiar ruta"
+                  onclick="navigator.clipboard.writeText('{{ doc.url | replace("'", "\\'") }}').then(function(){this.innerHTML='<i class=\'fas fa-check text-success\'></i>'; setTimeout(function(b){b.innerHTML='<i class=\'fas fa-copy\'></i>'}.bind(null,this),1500)}.bind(this))">
+            <i class="fas fa-copy text-secondary"></i>
+          </button>
           {% endif %}
         </td>
         <td>
@@ -145,7 +157,7 @@
         </td>
         <td class="text-center">
           {% if doc.prioridad and doc.prioridad > 0 %}
-          <span class="badge bg-warning text-dark" title="Prioritario">!</span>
+          <span class="badge bg-warning text-dark">Sí</span>
           {% else %}
           <span class="text-secondary">—</span>
           {% endif %}
@@ -156,18 +168,16 @@
                   title="Editar metadatos"
                   onclick="abrir_modal_editar(this)"
                   data-doc-id="{{ doc.id }}"
-                  data-doc-url="{{ doc.url }}"
+                  data-doc-url="{{ doc.url | e }}"
                   data-doc-tipo-doc-id="{{ doc.tipo_doc_id }}"
                   data-doc-fecha-admin="{{ doc.fecha_administrativa.isoformat() if doc.fecha_administrativa else '' }}"
-                  data-doc-asunto="{{ doc.asunto or '' }}"
+                  data-doc-asunto="{{ doc.asunto | e if doc.asunto else '' }}"
                   data-doc-prioridad="{{ doc.prioridad or 0 }}"
-                  data-doc-observaciones="{{ doc.observaciones or '' }}">
+                  data-doc-observaciones="{{ doc.observaciones | e if doc.observaciones else '' }}">
             <i class="fas fa-pencil-alt"></i>
           </button>
           {% if item.es_referenciado %}
-          <button type="button"
-                  class="btn btn-sm btn-outline-secondary"
-                  disabled
+          <button type="button" class="btn btn-sm btn-outline-secondary" disabled
                   data-bs-toggle="tooltip"
                   title="Referenciado en tramitación — no se puede eliminar">
             <i class="fas fa-lock"></i>
@@ -225,20 +235,20 @@
         <!-- Preview: aparece tras seleccionar archivos -->
         <div id="seccion-preview" class="d-none">
 
-          <div class="row g-2 mb-3 align-items-end">
+          <div class="row g-2 mb-2 align-items-end">
             <div class="col">
               <label class="form-label fw-semibold mb-1">
                 Prefijo de ruta
                 <span class="text-secondary fw-normal small">
-                  (opcional — se antepone al nombre de cada fichero para construir la URL)
+                  — se antepone al nombre de cada fichero para construir la URL completa.
+                  Se guarda automáticamente para la próxima vez.
                 </span>
               </label>
               <input type="text" class="form-control font-monospace" id="prefijo-ruta"
-                     placeholder="\\servidor\expedientes\AT-{{ expediente.numero_at }}\  ó  https://docs.example.com/at{{ expediente.numero_at }}/"
-                     oninput="actualizar_urls_preview()">
+                     placeholder="\\servidor\expedientes\AT-{{ expediente.numero_at }}\  ó  https://docs.example.com/at{{ expediente.numero_at }}/">
             </div>
             <div class="col-auto">
-              <button type="button" class="btn btn-outline-secondary btn-sm"
+              <button type="button" class="btn btn-outline-secondary btn-sm mb-1"
                       onclick="limpiar_seleccion()">
                 <i class="fas fa-redo me-1"></i> Nueva selección
               </button>
@@ -252,15 +262,21 @@
               <thead class="table-light">
                 <tr>
                   <th>Nombre de fichero</th>
-                  <th>URL resultante</th>
-                  <th style="min-width:180px">Tipo</th>
+                  <th>URL / ruta resultante</th>
+                  <th style="min-width:180px">Tipo de documento</th>
                   <th style="min-width:130px">Fecha adm.</th>
-                  <th class="text-center">Prior.</th>
+                  <th class="text-center">Prioritario</th>
                   <th class="text-center">Excluir</th>
                 </tr>
               </thead>
               <tbody id="preview-tbody"></tbody>
             </table>
+          </div>
+
+          <div class="alert alert-info py-2 small mb-0" id="aviso-prefijo-manual">
+            <i class="fas fa-info-circle me-1"></i>
+            La columna <strong>URL / ruta resultante</strong> muestra el valor que se guardará.
+            Si las rutas no son correctas, ajusta el <strong>Prefijo de ruta</strong> arriba.
           </div>
         </div>
 
@@ -294,7 +310,7 @@
       <div class="modal-body">
         <input type="hidden" id="editar-doc-id">
         <div class="mb-3">
-          <label class="form-label fw-semibold">URL <span class="text-danger">*</span></label>
+          <label class="form-label fw-semibold">URL / Ruta <span class="text-danger">*</span></label>
           <input type="text" class="form-control font-monospace" id="editar-url" required>
         </div>
         <div class="mb-3">
@@ -344,28 +360,32 @@
   'use strict';
 
   // ----------------------------------------------------------------
+  // Constantes
+  // ----------------------------------------------------------------
+  var LS_PREFIJO_KEY = 'bddat_pool_prefijo';  // Clave localStorage para el prefijo
+  var URL_BASE_DOCS  = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}';
+
+  // ----------------------------------------------------------------
   // Estado del módulo
   // ----------------------------------------------------------------
-  /** @type {Array<{nombre: string}>} */
+  /** @type {Array<{nombre: string, url_completa: string|null}>} */
   var archivos_pendientes = [];
-  var _ef_editar_fecha = null;
-  var _modal_carga = null;
-  var _modal_editar_bs = null;
-  var _modal_editar_el = document.getElementById('modal-editar-doc');
+  var _ef_editar_fecha   = null;
+  var _modal_carga       = null;
+  var _modal_editar_bs   = null;
+  var _modal_editar_el   = document.getElementById('modal-editar-doc');
 
   // ----------------------------------------------------------------
   // Inicialización
   // ----------------------------------------------------------------
   document.addEventListener('DOMContentLoaded', function () {
-    // Tooltips
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
       new bootstrap.Tooltip(el);
     });
 
-    // Instancia del modal de carga
     _modal_carga = new bootstrap.Modal(document.getElementById('modal-carga-docs'));
 
-    // Zona de entrada principal (C.2) — drop + clic
+    // Zona de entrada principal (C.2)
     var zona_principal = document.getElementById('zona-entrada-principal');
     var input_principal = document.getElementById('input-carpeta-principal');
     configurar_zona(zona_principal, input_principal, true);
@@ -375,24 +395,30 @@
     var input_modal = document.getElementById('input-carpeta-modal');
     configurar_zona(zona_modal, input_modal, false);
 
-    // Cuando el modal de carga se cierra, reiniciamos
-    document.getElementById('modal-carga-docs').addEventListener('hidden.bs.modal', function () {
-      resetear_modal();
-    });
+    document.getElementById('modal-carga-docs').addEventListener('hidden.bs.modal', resetear_modal);
 
-    // EntradaFecha en modal editar — inicializar al abrirse
+    // EntradaFecha en modal editar
     _modal_editar_el.addEventListener('show.bs.modal', function () {
       if (!_ef_editar_fecha) {
         _ef_editar_fecha = new EntradaFecha('#ef-editar-fecha', { name: '_fecha_admin_editar' });
       }
     });
+
+    // Prefijo de ruta: cargar de localStorage y actualizar al escribir
+    var input_prefijo = document.getElementById('prefijo-ruta');
+    if (input_prefijo) {
+      input_prefijo.value = localStorage.getItem(LS_PREFIJO_KEY) || '';
+      input_prefijo.addEventListener('input', function () {
+        localStorage.setItem(LS_PREFIJO_KEY, this.value);
+        actualizar_urls_preview();
+      });
+    }
   });
 
   // ----------------------------------------------------------------
-  // Configurar zona de drop + input file
+  // Configurar zona de drop + input carpeta
   // ----------------------------------------------------------------
   function configurar_zona(zona, input, abre_modal) {
-    // Drag events
     zona.addEventListener('dragover', function (e) {
       e.preventDefault();
       zona.classList.add('drag-over');
@@ -404,74 +430,88 @@
       e.preventDefault();
       zona.classList.remove('drag-over');
       if (abre_modal) _modal_carga.show();
-      procesar_drop(e.dataTransfer.items);
+      // Pequeño delay para que el modal esté visible antes de procesar
+      setTimeout(function () { procesar_drop(e.dataTransfer); }, abre_modal ? 100 : 0);
     });
-
-    // Clic → selector de carpeta
     zona.addEventListener('click', function () {
       if (abre_modal) _modal_carga.show();
-      // Pequeño delay para que el modal esté visible antes de abrir el picker
       setTimeout(function () { input.click(); }, abre_modal ? 200 : 0);
     });
-
-    // Input carpeta seleccionada
     input.addEventListener('change', function (e) {
       procesar_input_carpeta(e.target.files);
-      // Resetear input para que vuelva a dispararse si el usuario elige la misma carpeta
       e.target.value = '';
     });
   }
 
   // ----------------------------------------------------------------
-  // Procesar drop (ficheros y/o carpetas)
+  // Procesar drop — intenta obtener rutas completas vía text/uri-list
+  // (funciona en Firefox; Chrome solo da el nombre del fichero)
   // ----------------------------------------------------------------
-  function procesar_drop(items) {
+  function procesar_drop(dt) {
     archivos_pendientes = [];
-    var promesas = [];
 
+    // Intento 1: text/uri-list puede dar file:// URIs completas (Firefox, algunos entornos)
+    var uri_list = '';
+    try { uri_list = dt.getData('text/uri-list') || ''; } catch (e) {}
+
+    if (uri_list) {
+      var uris = uri_list.split('\n')
+        .map(function (u) { return u.trim(); })
+        .filter(function (u) { return u && !u.startsWith('#'); });
+
+      // Solo usar si son URIs de fichero (no directorios — no podemos distinguirlos aquí)
+      var solo_ficheros = uris.filter(function (u) { return u.startsWith('file://'); });
+      if (solo_ficheros.length > 0 && solo_ficheros.length === uris.length) {
+        solo_ficheros.forEach(function (uri) {
+          var decoded = decodeURIComponent(uri);
+          // Nombre = último segmento de la URI
+          var nombre = decoded.replace(/\/$/, '').split('/').pop().split('\\').pop();
+          archivos_pendientes.push({ nombre: nombre, url_completa: decoded });
+        });
+        mostrar_preview(true);  // true = tenemos URLs completas
+        return;
+      }
+    }
+
+    // Intento 2: webkitGetAsEntry (da solo nombres, no rutas)
+    var items = dt.items;
+    var promesas = [];
     for (var i = 0; i < items.length; i++) {
       var entry = items[i].webkitGetAsEntry ? items[i].webkitGetAsEntry() : null;
       if (!entry) continue;
-
       if (entry.isFile) {
-        promesas.push(entry_a_nombre(entry));
+        promesas.push(entry_a_archivo(entry, null));
       } else if (entry.isDirectory) {
         promesas.push(leer_directorio_primer_nivel(entry));
       }
     }
-
     Promise.all(promesas).then(function () {
-      mostrar_preview();
+      mostrar_preview(false);
     }).catch(function (err) {
       mostrar_error_carga('Error al leer los ficheros: ' + err);
     });
   }
 
-  function entry_a_nombre(file_entry) {
+  function entry_a_archivo(file_entry, dir_nombre) {
     return new Promise(function (resolve) {
       file_entry.file(function (f) {
-        archivos_pendientes.push({ nombre: f.name });
+        archivos_pendientes.push({ nombre: f.name, url_completa: null, dir_nombre: dir_nombre });
         resolve();
       });
     });
   }
 
   function leer_directorio_primer_nivel(dir_entry) {
+    var dir_nombre = dir_entry.name;
     return new Promise(function (resolve, reject) {
       var reader = dir_entry.createReader();
-      // readEntries puede devolver lotes; para primer nivel suele bastar una llamada
       var leer_lote = function () {
         reader.readEntries(function (entries) {
-          if (entries.length === 0) {
-            resolve();
-            return;
-          }
+          if (entries.length === 0) { resolve(); return; }
           var sub = [];
           entries.forEach(function (e) {
-            if (e.isFile) {
-              sub.push(entry_a_nombre(e));
-            }
-            // Subdirectorios ignorados (solo primer nivel)
+            if (e.isFile) sub.push(entry_a_archivo(e, dir_nombre));
+            // Subdirectorios ignorados
           });
           Promise.all(sub).then(leer_lote).catch(reject);
         }, reject);
@@ -487,19 +527,18 @@
     archivos_pendientes = [];
     for (var i = 0; i < files.length; i++) {
       var f = files[i];
-      // webkitRelativePath: "carpeta/archivo.pdf" → split('/').length === 2 = primer nivel
       var partes = f.webkitRelativePath ? f.webkitRelativePath.split('/') : [];
-      if (partes.length === 2) {
-        archivos_pendientes.push({ nombre: f.name });
+      if (partes.length === 2) {  // solo primer nivel: carpeta/fichero
+        archivos_pendientes.push({ nombre: f.name, url_completa: null, dir_nombre: partes[0] });
       }
     }
-    mostrar_preview();
+    mostrar_preview(false);
   }
 
   // ----------------------------------------------------------------
   // Mostrar preview
   // ----------------------------------------------------------------
-  function mostrar_preview() {
+  function mostrar_preview(tiene_urls_completas) {
     if (archivos_pendientes.length === 0) {
       mostrar_error_carga('No se encontraron ficheros en la selección.');
       return;
@@ -512,44 +551,59 @@
     var tbody = document.getElementById('preview-tbody');
     tbody.innerHTML = '';
 
-    archivos_pendientes.forEach(function (arch, idx) {
+    // Si tenemos URLs completas, ocultar campo prefijo (no hace falta)
+    var seccion_prefijo = document.getElementById('prefijo-ruta').closest('.row');
+    if (tiene_urls_completas) {
+      seccion_prefijo.classList.add('d-none');
+    } else {
+      seccion_prefijo.classList.remove('d-none');
+      // Si todos los ficheros vienen del mismo directorio, auto-rellenar prefijo
+      // (pero sin sobreescribir el que el usuario ya tenía si está relleno)
+      var prefijo_input = document.getElementById('prefijo-ruta');
+      if (!prefijo_input.value && archivos_pendientes.length > 0 && archivos_pendientes[0].dir_nombre) {
+        // No podemos auto-rellenar la ruta completa, pero indicamos el nombre de la carpeta
+        // mediante el placeholder dinámico para orientar al usuario
+        prefijo_input.placeholder = '… \\' + archivos_pendientes[0].dir_nombre + '\\';
+      }
+    }
+
+    archivos_pendientes.forEach(function (arch) {
+      var url_inicial = arch.url_completa || (document.getElementById('prefijo-ruta').value + arch.nombre);
       var tr = document.createElement('tr');
       tr.dataset.nombre = arch.nombre;
+      tr.dataset.urlCompleta = arch.url_completa || '';
       tr.innerHTML =
-        '<td class="small text-break">' + escapar_html(arch.nombre) + '</td>' +
-        '<td class="small font-monospace text-break url-resultante text-secondary">' + escapar_html(arch.nombre) + '</td>' +
+        '<td class="small">' + escapar_html(arch.nombre) + '</td>' +
+        '<td class="small font-monospace text-break url-resultante text-secondary">' + escapar_html(url_inicial) + '</td>' +
         '<td><select class="form-select form-select-sm tipo-doc-select">' + tmpl_tipos + '</select></td>' +
         '<td><input type="date" class="form-control form-control-sm fecha-admin-input"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check"></td>' +
-        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check"></td>';
+        '<td class="text-center"><input type="checkbox" class="form-check-input prioridad-check" title="Marcar como prioritario"></td>' +
+        '<td class="text-center"><input type="checkbox" class="form-check-input excluir-check" title="No importar este fichero"></td>';
       tbody.appendChild(tr);
     });
 
     document.getElementById('contador-archivos').textContent =
-      archivos_pendientes.length + ' fichero(s) seleccionado(s)';
-    document.getElementById('prefijo-ruta').value = '';
+      archivos_pendientes.length + ' fichero(s) preparados para importar';
     document.getElementById('seccion-preview').classList.remove('d-none');
     document.getElementById('btn-importar').classList.remove('d-none');
-    document.getElementById('btn-importar').textContent = '';
     document.getElementById('btn-importar').innerHTML =
       '<i class="fas fa-file-import me-1"></i> Importar ' + archivos_pendientes.length + ' documento(s)';
   }
 
   // ----------------------------------------------------------------
-  // Actualizar columna "URL resultante" cuando cambia el prefijo
+  // Actualizar columna URL resultante cuando cambia el prefijo
   // ----------------------------------------------------------------
   window.actualizar_urls_preview = function () {
     var prefijo = document.getElementById('prefijo-ruta').value;
     document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
+      if (tr.dataset.urlCompleta) return;  // tiene URL completa, no tocar
       var url_el = tr.querySelector('.url-resultante');
-      if (url_el) {
-        url_el.textContent = prefijo + tr.dataset.nombre;
-      }
+      if (url_el) url_el.textContent = prefijo + tr.dataset.nombre;
     });
   };
 
   // ----------------------------------------------------------------
-  // Limpiar selección → volver a mostrar zona de drop
+  // Limpiar selección
   // ----------------------------------------------------------------
   window.limpiar_seleccion = function () {
     archivos_pendientes = [];
@@ -561,18 +615,17 @@
   };
 
   // ----------------------------------------------------------------
-  // Importar (POST masivo)
+  // Importar masivo (POST JSON)
   // ----------------------------------------------------------------
   window.importar_masiva = function (url_masiva) {
     var prefijo = document.getElementById('prefijo-ruta').value;
-    var filas = document.querySelectorAll('#preview-tbody tr');
     var payload = [];
 
-    filas.forEach(function (tr) {
+    document.querySelectorAll('#preview-tbody tr').forEach(function (tr) {
       if (tr.querySelector('.excluir-check').checked) return;
-      var nombre = tr.dataset.nombre;
+      var url_final = tr.dataset.urlCompleta || (prefijo + tr.dataset.nombre);
       payload.push({
-        url:                  prefijo + nombre,
+        url:                  url_final,
         tipo_doc_id:          tr.querySelector('.tipo-doc-select').value || 1,
         fecha_administrativa: tr.querySelector('.fecha-admin-input').value || null,
         prioridad:            tr.querySelector('.prioridad-check').checked,
@@ -595,9 +648,8 @@
     })
     .then(function (r) { return r.json(); })
     .then(function (data) {
-      if (data.ok) {
-        window.location.reload();
-      } else {
+      if (data.ok) { window.location.reload(); }
+      else {
         mostrar_error_carga(data.error || 'Error al importar.');
         btn.disabled = false;
         btn.innerHTML = '<i class="fas fa-file-import me-1"></i> Importar';
@@ -622,53 +674,36 @@
     document.getElementById('editar-observaciones').value = btn.dataset.docObservaciones;
     document.getElementById('editar-error').classList.add('d-none');
 
-    if (!_modal_editar_bs) {
-      _modal_editar_bs = new bootstrap.Modal(_modal_editar_el);
-    }
+    if (!_modal_editar_bs) _modal_editar_bs = new bootstrap.Modal(_modal_editar_el);
     _modal_editar_bs.show();
 
-    // Poblar EntradaFecha después de que el modal la haya inicializado
+    // EntradaFecha.setValue() acepta formato ISO 'yyyy-mm-dd'
     setTimeout(function () {
       if (_ef_editar_fecha) {
         _ef_editar_fecha.clear();
         var fecha_iso = btn.dataset.docFechaAdmin;
-        if (fecha_iso) {
-          var p = fecha_iso.split('-');
-          if (p.length === 3) _ef_editar_fecha.setValue(p[2] + '/' + p[1] + '/' + p[0]);
-        }
+        if (fecha_iso) _ef_editar_fecha.setValue(fecha_iso);
       }
     }, 150);
   };
 
   window.guardar_edicion = function () {
-    var doc_id = document.getElementById('editar-doc-id').value;
-    var url_editar = '{{ url_for('expedientes.pool_documentos', id=expediente.id) }}'.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
+    var doc_id     = document.getElementById('editar-doc-id').value;
+    var url_editar = URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';
 
-    var fecha_iso = null;
-    var input_oculto = document.querySelector('#ef-editar-fecha input[type="hidden"]');
-    if (input_oculto && input_oculto.value) {
-      var raw = input_oculto.value;
-      if (raw.includes('/')) {
-        var p = raw.split('/');
-        if (p.length === 3) fecha_iso = p[2] + '-' + p[1] + '-' + p[0];
-      } else {
-        fecha_iso = raw;
-      }
-    }
+    // EntradaFecha.getValue() devuelve ISO 'yyyy-mm-dd' o ''
+    var fecha_iso = _ef_editar_fecha ? _ef_editar_fecha.getValue() : null;
 
     var payload = {
       url:                  document.getElementById('editar-url').value.trim(),
       tipo_doc_id:          document.getElementById('editar-tipo-doc-id').value || 1,
-      fecha_administrativa: fecha_iso,
+      fecha_administrativa: fecha_iso || null,
       asunto:               document.getElementById('editar-asunto').value.trim(),
       prioridad:            document.getElementById('editar-prioridad').checked,
       observaciones:        document.getElementById('editar-observaciones').value.trim(),
     };
 
-    if (!payload.url) {
-      mostrar_error_editar('La URL es obligatoria.');
-      return;
-    }
+    if (!payload.url) { mostrar_error_editar('La URL / ruta es obligatoria.'); return; }
 
     fetch(url_editar, {
       method: 'POST',
@@ -688,7 +723,6 @@
   // ----------------------------------------------------------------
   window.borrar_documento = function (btn, url_borrar) {
     if (!confirm('¿Borrar este documento del pool? Esta acción no se puede deshacer.')) return;
-
     var doc_id = btn.dataset.docId;
     fetch(url_borrar, { method: 'POST' })
     .then(function (r) { return r.json(); })
@@ -696,9 +730,7 @@
       if (data.ok) {
         var fila = document.getElementById('fila-doc-' + doc_id);
         if (fila) fila.remove();
-      } else {
-        alert(data.error || 'No se pudo borrar el documento.');
-      }
+      } else { alert(data.error || 'No se pudo borrar el documento.'); }
     })
     .catch(function () { alert('Error de red al borrar.'); });
   };
@@ -729,10 +761,8 @@
 
   function escapar_html(str) {
     return String(str)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
 }());

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -33,6 +33,10 @@
            class="btn btn-sm btn-outline-secondary">
           <i class="fas fa-info-circle me-1"></i> Detalle
         </a>
+        <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+           class="btn btn-sm btn-outline-secondary">
+          <i class="fas fa-file-alt me-1"></i> Pool de Docs
+        </a>
         {# [Editar] y [Acciones ▾] — placeholder, funcionalidad en issue posterior #}
         <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
           <i class="fas fa-edit me-1"></i> Editar

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -30,11 +30,11 @@
       </span>
       <div class="bc-acciones-bar">
         <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-secondary">
+           class="btn btn-sm btn-outline-primary">
           <i class="fas fa-info-circle me-1"></i> Detalle
         </a>
         <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-secondary">
+           class="btn btn-sm btn-outline-primary">
           <i class="fas fa-file-alt me-1"></i> Pool de Docs
         </a>
         {# [Editar] y [Acciones ▾] — placeholder, funcionalidad en issue posterior #}

--- a/app/templates/dashboard/index_v1.html
+++ b/app/templates/dashboard/index_v1.html
@@ -106,13 +106,7 @@
         <p class="card-description">Próximamente</p>
     </div>
     
-    <div class="dashboard-card disabled">
-        <div class="card-icon">
-            <i class="fas fa-file-alt"></i>
-        </div>
-        <h2 class="card-title">Documentos</h2>
-        <p class="card-description">Próximamente</p>
-    </div>
+    {# <div class="dashboard-card disabled"><div class="card-icon"><i class="fas fa-file-alt"></i></div><h2 class="card-title">Documentos</h2><p class="card-description">Búsqueda documental global — pendiente</p></div> #}
     {% endif %}
     
     {% if 'SUPERVISOR' in user_roles or 'ADMIN' in user_roles %}

--- a/migrations/versions/45b0d1302dd4_url_documento_varchar_a_text.py
+++ b/migrations/versions/45b0d1302dd4_url_documento_varchar_a_text.py
@@ -1,0 +1,30 @@
+"""url_documento_varchar_a_text
+
+Revision ID: 45b0d1302dd4
+Revises: fd2bc02d2474
+Create Date: 2026-03-07 20:28:27.334886
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '45b0d1302dd4'
+down_revision = 'fd2bc02d2474'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('documentos', 'url',
+        existing_type=sa.String(length=500),
+        type_=sa.Text(),
+        schema='public')
+
+
+def downgrade():
+    op.alter_column('documentos', 'url',
+        existing_type=sa.Text(),
+        type_=sa.String(length=500),
+        schema='public')


### PR DESCRIPTION
## Resumen

Reemplaza el sistema de upload de ficheros por un explorador integrado del servidor de ficheros corporativo. BDDAT ya no copia archivos: almacena la ruta absoluta en `Documento.url` y sirve el fichero bajo demanda con `send_file()`.

## Cambios principales

- **Arquitectura**: `UPLOAD_FOLDER` → `FILESYSTEM_BASE` (ruta raíz del servidor corporativo). En producción apuntará a `W:\ALTA TENSION\Expedientes` o la UNC equivalente.
- **BD**: migración `url VARCHAR(500)` → `TEXT` (rutas absolutas pueden superar 500 chars en UNC).
- **Rutas nuevas**: `pool_explorador_fs` (GET JSON, navega carpetas) y `pool_registrar_rutas` (POST JSON, registra rutas en BD). Eliminado `pool_subir`.
- **Seguridad**: helper `_path_seguro()` previene path traversal; `pool_descargar_documento` valida que la ruta esté dentro de `FILESYSTEM_BASE`.
- **Pool UI**: dos fichas de entrada (servidor / URL externa); tabla con checkbox, columna Ext., asunto truncado con tooltip, botón copiar-ruta al portapapeles; panel de edición masiva (tipo, fecha, prioridad selectiva).
- **Modal explorador**: dos pasos — navegación de carpetas con select-all y panel de seleccionados con rutas; metadatos con `EntradaFecha` por fila.
- **Toasts**: al cancelar ("0 documentos registrados") y al completar con éxito.
- **Documentos en nueva pestaña**: `target="_blank"` en todos los enlaces del pool.
- **Detalle expediente**: sección Documentos muestra listado compacto clicable + botón "Gestionar pool" (sustituye "Próximamente").
- **Tramitación y pool**: botones → `btn-outline-primary` (CDN Junta de Andalucía).
- **Dashboard**: ficha "Documentos" comentada (sin vista global en esta fase).

## Test plan

- [ ] `FILESYSTEM_BASE=D:/BDDAT/docs_prueba` en `.env`
- [ ] Crear carpeta `docs_prueba/Expedientes/AT-TEST/` con 2-3 PDFs
- [ ] Pool → ficha "Seleccionar del servidor" → navegar → seleccionar → metadatos → Registrar → toast éxito → aparecen en tabla
- [ ] Clic en nombre de documento → abre en nueva pestaña
- [ ] Botón copiar ruta → toast + ruta en portapapeles
- [ ] Edición masiva: seleccionar varios → cambiar tipo → Aplicar → recarga con cambios
- [ ] Ficha "Añadir URL externa" → sigue funcionando
- [ ] Cancelar modal → toast "0 documentos"
- [ ] Borrar registro → fichero del servidor NO se elimina
- [ ] Detalle expediente → listado de docs visible con enlace al pool
- [ ] Renombrar fichero en disco → enlace devuelve 404 (correcto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)