### PR TITLE
[POOL] Pool documentos: mejoras UX (#196)

### DIFF
--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -534,8 +534,10 @@ def pool_documentos(id):
     docs_lista = []
     for doc in documentos_raw:
         filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else ''
-        nombre = filename or f'Documento {doc.id}'
-        partes = filename.rsplit('.', 1)
+        # Eliminar fragment (#...) y query string (?...) para nombre y extensión limpios
+        filename_limpio = filename.split('?')[0].split('#')[0]
+        nombre = filename_limpio or f'Documento {doc.id}'
+        partes = filename_limpio.rsplit('.', 1)
         extension = partes[1].lower() if len(partes) == 2 and partes[1] else ''
         es_url_externa = (doc.url or '').startswith(('http://', 'https://'))
         docs_lista.append({

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -811,3 +811,38 @@ def pool_borrar_documento(id, doc_id):
     return jsonify({'ok': True})
 
 
+@bp.route('/<int:id>/documentos/<int:doc_id>/abrir-en-carpeta', methods=['POST'])
+@login_required
+def pool_abrir_en_carpeta(id, doc_id):
+    """
+    Abre el Explorador de Windows enfocando el archivo.
+
+    Requiere que Flask corra en el mismo PC que el navegador (despliegue local).
+    No funciona con URLs externas ni si el fichero no existe en disco.
+    """
+    import subprocess
+
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+
+    doc = Documento.query.get_or_404(doc_id)
+    if doc.expediente_id != id:
+        abort(404)
+
+    url = doc.url or ''
+    if url.startswith(('http://', 'https://')):
+        return jsonify({'ok': False, 'error': 'No aplicable a URLs externas'}), 400
+
+    ruta_abs = os.path.normpath(os.path.abspath(url))
+    if not os.path.isfile(ruta_abs):
+        return jsonify({'ok': False, 'error': 'Fichero no encontrado en disco'}), 404
+
+    try:
+        subprocess.Popen(['explorer', f'/select,{ruta_abs}'])
+        return jsonify({'ok': True})
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -754,26 +754,36 @@ def pool_editar_documento(id, doc_id):
         abort(404)
 
     datos = request.get_json(silent=True) or {}
-    # url es opcional en el payload: si viene vacía/null se conserva la existente
-    # (para ficheros subidos el campo URL está oculto en el modal)
-    url_nueva = (datos.get('url') or '').strip()
-
-    fecha_raw = datos.get('fecha_administrativa') or None
-    fecha_admin = None
-    if fecha_raw:
-        try:
-            fecha_admin = date.fromisoformat(fecha_raw)
-        except ValueError:
-            pass
+    # Solo se actualizan los campos presentes en el payload.
+    # Esto permite edición masiva parcial (p.ej. solo cambiar prioridad)
+    # sin sobreescribir los demás metadatos.
 
     try:
+        url_nueva = (datos.get('url') or '').strip()
         if url_nueva:
             doc.url = url_nueva
-        doc.tipo_doc_id = int(datos.get('tipo_doc_id') or 1)
-        doc.fecha_administrativa = fecha_admin
-        doc.asunto = (datos.get('asunto') or '').strip() or None
-        doc.prioridad = 1 if datos.get('prioridad') else 0
-        doc.observaciones = (datos.get('observaciones') or '').strip() or None
+
+        if 'tipo_doc_id' in datos:
+            doc.tipo_doc_id = int(datos['tipo_doc_id'] or 1)
+
+        if 'fecha_administrativa' in datos:
+            fecha_raw = datos['fecha_administrativa']
+            doc.fecha_administrativa = None
+            if fecha_raw:
+                try:
+                    doc.fecha_administrativa = date.fromisoformat(fecha_raw)
+                except ValueError:
+                    pass
+
+        if 'asunto' in datos:
+            doc.asunto = (datos['asunto'] or '').strip() or None
+
+        if 'prioridad' in datos:
+            doc.prioridad = 1 if datos['prioridad'] else 0
+
+        if 'observaciones' in datos:
+            doc.observaciones = (datos['observaciones'] or '').strip() or None
+
         db.session.commit()
     except Exception as e:
         db.session.rollback()

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -840,7 +840,9 @@ def pool_abrir_en_carpeta(id, doc_id):
         return jsonify({'ok': False, 'error': 'Fichero no encontrado en disco'}), 404
 
     try:
-        subprocess.Popen(['explorer', f'/select,{ruta_abs}'])
+        # shell=True necesario: explorer.exe no parsea /select,ruta como argumento de lista.
+        # La ruta viene de BD (ya validada), no de input directo del usuario.
+        subprocess.Popen(f'explorer /select,"{ruta_abs}"', shell=True)
         return jsonify({'ok': True})
     except Exception as e:
         return jsonify({'ok': False, 'error': str(e)}), 500

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -62,7 +62,7 @@
   /* Anchos fijos de columnas — col 2 (Documento) y col 3 (Asunto) toman el espacio restante */
   #pool-tabla th:nth-child(1) { width: 36px; }
   /* col 2 Documento: flex — prioridad máxima, se acorta en último lugar */
-  #pool-tabla th:nth-child(3) { width: 200px; }   /* Asunto */
+  #pool-tabla th:nth-child(3) { width: calc(40% - 271px); }  /* Asunto: 40% del espacio flex */
   #pool-tabla th:nth-child(4) { width: 68px; }    /* Ext */
   #pool-tabla th:nth-child(5) { width: 100px; }   /* Tipo */
   #pool-tabla th:nth-child(6) { width: 108px; }   /* Fecha adm */

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -228,14 +228,14 @@
         </td>
         <td class="text-end text-nowrap">
           {% if not item.es_url_externa %}
-          <button type="button" class="btn btn-sm btn-outline-secondary"
-                  title="Copiar ruta al portapapeles — pégala en el Explorador de Windows para navegar al archivo"
+          <button type="button" class="btn btn-sm btn-outline-primary"
+                  title="Abrir ubicación en el Explorador de Windows"
                   data-bs-toggle="tooltip" data-bs-placement="top"
-                  onclick="copiar_ruta('{{ doc.url | replace('\\', '/') | e }}')">
-            <i class="fas fa-copy"></i>
+                  onclick="abrir_en_carpeta('{{ url_for('expedientes.pool_abrir_en_carpeta', id=expediente.id, doc_id=doc.id) }}')">
+            <i class="fas fa-folder-open"></i>
           </button>
           {% endif %}
-          <button type="button" class="btn btn-sm btn-outline-secondary"
+          <button type="button" class="btn btn-sm btn-outline-primary"
                   title="Editar metadatos"
                   onclick="abrir_modal_editar(this)"
                   data-doc-id="{{ doc.id }}"
@@ -1116,19 +1116,18 @@
   };
 
   // ================================================================
-  // COPIAR RUTA AL PORTAPAPELES
+  // ABRIR EN EXPLORADOR DE WINDOWS
   // ================================================================
-  window.copiar_ruta = function (ruta) {
-    // Normalizar separadores a backslash para Windows
-    var ruta_win = ruta.replace(/\//g, '\\');
-    if (!navigator.clipboard) {
-      alert('Tu navegador no soporta copia al portapapeles.\nRuta:\n' + ruta_win);
-      return;
-    }
-    navigator.clipboard.writeText(ruta_win).then(function () {
-      mostrar_toast('info', 'Ruta copiada al portapapeles — pégala en el Explorador de Windows.');
-    }).catch(function () {
-      alert('No se pudo copiar automáticamente.\nRuta:\n' + ruta_win);
+  window.abrir_en_carpeta = function (url_abrir) {
+    fetch(url_abrir, { method: 'POST' })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (!data.ok) {
+        mostrar_toast('warning', data.error || 'No se pudo abrir el Explorador.');
+      }
+    })
+    .catch(function () {
+      mostrar_toast('danger', 'Error de red al abrir en carpeta.');
     });
   };
 

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -61,11 +61,15 @@
   #pool-tabla th:nth-child(6) { width: 108px; }   /* Fecha adm */
   #pool-tabla th:nth-child(7) { width: 44px; }    /* ★ */
   #pool-tabla th:nth-child(8) { width: 122px; }   /* Acciones */
-  /* Celdas Documento y Asunto: truncar con ellipsis */
+  /* Celdas Documento y Asunto: line-clamp 2 (máximo 2 líneas, luego ...) */
   #pool-tabla td:nth-child(2), #pool-tabla td:nth-child(3) { overflow: hidden; max-width: 0; }
   #pool-tabla td:nth-child(2) a, #pool-tabla td:nth-child(3) .asunto-celda {
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    display: block; max-width: 100%;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    white-space: normal;
+    max-width: 100%;
   }
   /* Fila seleccionada para edición masiva */
   #tbody-docs tr.doc-seleccionada > td { background-color: var(--bs-primary-bg-subtle, #d1e7dd) !important; }

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -187,7 +187,7 @@
   </div>
 
   <!-- Filtros client-side (ocultos cuando hay selección masiva activa) -->
-  <div id="barra-filtros" class="d-flex align-items-center flex-wrap gap-2 pb-2">
+  <div id="barra-filtros" class="card card-body bg-light border mb-2 d-flex align-items-center flex-wrap gap-2">
     <i class="fas fa-search text-secondary small"></i>
     <input type="search" id="filtro-docs" class="form-control form-control-sm"
            placeholder="Nombre o asunto…" style="max-width:220px">

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -49,6 +49,13 @@
   .fs-item:hover { background-color: var(--bs-primary-bg-subtle); }
   .fs-breadcrumb a { cursor: pointer; text-decoration: none; }
   .fs-breadcrumb a:hover { text-decoration: underline; }
+  /* Thead sticky en C.2 */
+  #pool-tabla thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--bs-light);
+  }
 </style>
 {% endblock %}
 
@@ -102,15 +109,9 @@
       </div>
     </div>
   </div>
-</div>
-
-<!-- C.2 -->
-<div class="lista-scroll-container p-3">
-
-  <h6 class="mb-3 fw-semibold">Pool de Documentos</h6>
 
   <!-- Dos fichas de entrada -->
-  <div class="row g-2 mb-3">
+  <div class="row g-2 mb-2 mt-2">
     <div class="col-6">
       <div class="card ficha-entrada h-100" onclick="abrir_explorador()">
         <div class="card-body text-center py-3">
@@ -132,7 +133,7 @@
   </div>
 
   <!-- Panel de edición masiva (oculto hasta que haya selección) -->
-  <div id="panel-masivo" class="card card-body bg-light border mb-3 d-none">
+  <div id="panel-masivo" class="card card-body bg-light border mb-2 d-none">
     <div class="d-flex flex-wrap align-items-center gap-2">
       <span class="fw-semibold small">
         Edición masiva (<span id="masivo-count">0</span> seleccionado(s)):
@@ -160,9 +161,21 @@
     </div>
   </div>
 
+  <!-- Filtro client-side -->
+  <div class="d-flex align-items-center gap-2 pb-2">
+    <i class="fas fa-search text-secondary small"></i>
+    <input type="search" id="filtro-docs" class="form-control form-control-sm"
+           placeholder="Filtrar por nombre o asunto…" style="max-width:300px">
+    <span id="filtro-count" class="text-secondary small ms-1"></span>
+  </div>
+</div>
+
+<!-- C.2 -->
+<div class="lista-scroll-container px-3 pt-0 pb-3">
+
   <!-- Tabla -->
   {% if docs_lista %}
-  <table class="table table-hover table-sm align-middle">
+  <table class="table table-hover table-sm align-middle" id="pool-tabla">
     <thead class="table-light">
       <tr>
         <th style="width:2rem">
@@ -174,14 +187,18 @@
         <th>Ext.</th>
         <th>Tipo</th>
         <th>Fecha adm.</th>
-        <th class="text-center">Prio.</th>
+        <th class="text-center">
+          <i class="fas fa-star" title="Prioritario" data-bs-toggle="tooltip"></i>
+        </th>
         <th class="text-end">Acciones</th>
       </tr>
     </thead>
     <tbody id="tbody-docs">
       {% for item in docs_lista %}
       {% set doc = item.doc %}
-      <tr id="fila-doc-{{ doc.id }}" data-doc-id="{{ doc.id }}">
+      <tr id="fila-doc-{{ doc.id }}" data-doc-id="{{ doc.id }}"
+          data-nombre="{{ item.nombre_display | e }}"
+          data-asunto="{{ doc.asunto | e if doc.asunto else '' }}">
         <td>
           <input type="checkbox" class="form-check-input doc-check"
                  onchange="on_check_doc(this, {{ doc.id }})">
@@ -212,8 +229,10 @@
           {% endif %}
         </td>
         <td>
-          <span class="badge border border-secondary text-secondary">
-            {{ doc.tipo_doc.nombre if doc.tipo_doc else '—' }}
+          <span class="badge border border-secondary text-secondary"
+                title="{{ doc.tipo_doc.nombre if doc.tipo_doc else '' }}"
+                data-bs-toggle="tooltip">
+            {{ doc.tipo_doc.codigo if doc.tipo_doc else '—' }}
           </span>
         </td>
         <td class="text-nowrap">
@@ -221,7 +240,7 @@
         </td>
         <td class="text-center">
           {% if doc.prioridad and doc.prioridad > 0 %}
-          <span class="badge bg-warning text-dark">Sí</span>
+          <i class="fas fa-star text-warning"></i>
           {% else %}
           <span class="text-secondary">—</span>
           {% endif %}
@@ -544,6 +563,24 @@
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
       new bootstrap.Tooltip(el);
     });
+
+    // Filtro client-side
+    var el_filtro = document.getElementById('filtro-docs');
+    if (el_filtro) {
+      el_filtro.addEventListener('input', function () {
+        var q = this.value.trim().toLowerCase();
+        var visible = 0;
+        document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
+          var texto = (tr.dataset.nombre || '') + ' ' + (tr.dataset.asunto || '');
+          var mostrar = !q || texto.toLowerCase().includes(q);
+          tr.style.display = mostrar ? '' : 'none';
+          if (mostrar) visible++;
+        });
+        var total = document.querySelectorAll('#tbody-docs tr[data-doc-id]').length;
+        document.getElementById('filtro-count').textContent =
+          q ? '(' + visible + '/' + total + ')' : '';
+      });
+    }
 
     var el_modal = document.getElementById('modal-explorador');
     _modal_exp_bs = new bootstrap.Modal(el_modal);
@@ -903,13 +940,14 @@
   };
 
   window.toggle_todos = function (checked) {
-    document.querySelectorAll('.doc-check').forEach(function (c) { c.checked = checked; });
-    _masivo_ids.clear();
-    if (checked) {
-      document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
-        _masivo_ids.add(parseInt(tr.dataset.docId, 10));
-      });
-    }
+    // Solo actúa sobre filas visibles (respeta el filtro)
+    document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
+      if (tr.style.display === 'none') return;
+      var chk = tr.querySelector('.doc-check');
+      if (chk) chk.checked = checked;
+      var id = parseInt(tr.dataset.docId, 10);
+      if (checked) { _masivo_ids.add(id); } else { _masivo_ids.delete(id); }
+    });
     actualizar_panel_masivo();
   };
 
@@ -950,7 +988,15 @@
     }
     document.getElementById('masivo-error').classList.add('d-none');
 
-    var ids = Array.from(_masivo_ids);
+    // Cruzar _masivo_ids con filas visibles (respeta el filtro)
+    var ids_visibles = new Set();
+    document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
+      if (tr.style.display !== 'none') {
+        ids_visibles.add(parseInt(tr.dataset.docId, 10));
+      }
+    });
+    var ids = Array.from(_masivo_ids).filter(function (id) { return ids_visibles.has(id); });
+    if (ids.length === 0) return;
     var promesas = ids.map(function (doc_id) {
       var url_editar =
         URL_BASE_DOCS.replace(/\/documentos$/, '/documentos/') + doc_id + '/editar';

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -187,7 +187,7 @@
   </div>
 
   <!-- Filtros client-side (ocultos cuando hay selección masiva activa) -->
-  <div id="barra-filtros" class="card card-body bg-light border mb-2 d-flex align-items-center flex-wrap gap-2">
+  <div id="barra-filtros" class="card card-body bg-light border mb-2 d-flex flex-row align-items-center flex-wrap gap-2">
     <i class="fas fa-search text-secondary small"></i>
     <input type="search" id="filtro-docs" class="form-control form-control-sm"
            placeholder="Nombre o asunto…" style="max-width:220px">

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -308,7 +308,8 @@
         <td>
           {% if doc.asunto %}
           <span class="asunto-celda text-secondary"
-                title="{{ doc.asunto | e }}">{{ doc.asunto }}</span>
+                title="{{ doc.asunto | e }}"
+                data-bs-toggle="tooltip" data-bs-placement="top">{{ doc.asunto }}</span>
           {% else %}
           <span class="text-secondary">—</span>
           {% endif %}

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -56,6 +56,13 @@
     z-index: 10;
     background: var(--bs-light);
   }
+  /* C.1/C.2 scroll independiente + full-width:
+     - max-width:none elimina el centrado de bc-view (aquí la vista es full-width)
+     - overflow-y:hidden en app-main delega el scroll exclusivamente a C.2
+     - flex column + min-height:0 en bc-view para que C.2 ocupe la altura restante */
+  .app-main { overflow-y: hidden; }
+  .bc-view   { display: flex; flex-direction: column; flex: 1; min-height: 0;
+               max-width: none; margin: 0; }
 </style>
 {% endblock %}
 
@@ -161,11 +168,34 @@
     </div>
   </div>
 
-  <!-- Filtro client-side -->
-  <div class="d-flex align-items-center gap-2 pb-2">
+  <!-- Filtros client-side -->
+  <div class="d-flex align-items-center flex-wrap gap-2 pb-2">
     <i class="fas fa-search text-secondary small"></i>
     <input type="search" id="filtro-docs" class="form-control form-control-sm"
-           placeholder="Filtrar por nombre o asunto…" style="max-width:300px">
+           placeholder="Nombre o asunto…" style="max-width:220px">
+    <select id="filtro-ext" class="form-select form-select-sm" style="width:auto">
+      <option value="">Ext: Todas</option>
+      {% set extensiones = [] %}
+      {% for item in docs_lista %}
+        {% if item.extension and item.extension not in extensiones %}
+          {% set _ = extensiones.append(item.extension) %}
+        {% endif %}
+      {% endfor %}
+      {% for ext in extensiones | sort %}
+      <option value="{{ ext }}">.{{ ext }}</option>
+      {% endfor %}
+    </select>
+    <select id="filtro-tipo" class="form-select form-select-sm" style="width:auto;min-width:110px">
+      <option value="">Tipo: Todos</option>
+      {% for t in tipos_doc %}
+      <option value="{{ t.id }}">{{ t.codigo }}</option>
+      {% endfor %}
+    </select>
+    <select id="filtro-prio" class="form-select form-select-sm" style="width:auto">
+      <option value="">★ Todas</option>
+      <option value="1">★ Prioritarios</option>
+      <option value="0">— No prioritarios</option>
+    </select>
     <span id="filtro-count" class="text-secondary small ms-1"></span>
   </div>
 </div>
@@ -198,7 +228,10 @@
       {% set doc = item.doc %}
       <tr id="fila-doc-{{ doc.id }}" data-doc-id="{{ doc.id }}"
           data-nombre="{{ item.nombre_display | e }}"
-          data-asunto="{{ doc.asunto | e if doc.asunto else '' }}">
+          data-asunto="{{ doc.asunto | e if doc.asunto else '' }}"
+          data-ext="{{ item.extension }}"
+          data-tipo-id="{{ doc.tipo_doc_id or '' }}"
+          data-prioridad="{{ '1' if doc.prioridad and doc.prioridad > 0 else '0' }}">
         <td>
           <input type="checkbox" class="form-check-input doc-check"
                  onchange="on_check_doc(this, {{ doc.id }})">
@@ -564,23 +597,33 @@
       new bootstrap.Tooltip(el);
     });
 
-    // Filtro client-side
-    var el_filtro = document.getElementById('filtro-docs');
-    if (el_filtro) {
-      el_filtro.addEventListener('input', function () {
-        var q = this.value.trim().toLowerCase();
-        var visible = 0;
-        document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
-          var texto = (tr.dataset.nombre || '') + ' ' + (tr.dataset.asunto || '');
-          var mostrar = !q || texto.toLowerCase().includes(q);
-          tr.style.display = mostrar ? '' : 'none';
-          if (mostrar) visible++;
-        });
-        var total = document.querySelectorAll('#tbody-docs tr[data-doc-id]').length;
-        document.getElementById('filtro-count').textContent =
-          q ? '(' + visible + '/' + total + ')' : '';
+    // Filtro client-side (texto + extensión + tipo + prioridad)
+    function aplicar_filtro() {
+      var q    = (document.getElementById('filtro-docs').value || '').trim().toLowerCase();
+      var ext  = (document.getElementById('filtro-ext')  ? document.getElementById('filtro-ext').value  : '');
+      var tipo = (document.getElementById('filtro-tipo') ? document.getElementById('filtro-tipo').value : '');
+      var prio = (document.getElementById('filtro-prio') ? document.getElementById('filtro-prio').value : '');
+      var visible = 0;
+      document.querySelectorAll('#tbody-docs tr[data-doc-id]').forEach(function (tr) {
+        var texto   = (tr.dataset.nombre || '') + ' ' + (tr.dataset.asunto || '');
+        var ok_q    = !q    || texto.toLowerCase().includes(q);
+        var ok_ext  = !ext  || (tr.dataset.ext || '') === ext;
+        var ok_tipo = !tipo || (tr.dataset.tipoId || '') === tipo;
+        var ok_prio = !prio || (tr.dataset.prioridad || '0') === prio;
+        var mostrar = ok_q && ok_ext && ok_tipo && ok_prio;
+        tr.style.display = mostrar ? '' : 'none';
+        if (mostrar) visible++;
       });
+      var total = document.querySelectorAll('#tbody-docs tr[data-doc-id]').length;
+      var activo = q || ext || tipo || prio;
+      document.getElementById('filtro-count').textContent =
+        activo ? '(' + visible + '/' + total + ')' : '';
     }
+
+    ['filtro-docs', 'filtro-ext', 'filtro-tipo', 'filtro-prio'].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener('input', aplicar_filtro);
+    });
 
     var el_modal = document.getElementById('modal-explorador');
     _modal_exp_bs = new bootstrap.Modal(el_modal);

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -57,26 +57,57 @@
     top: -1px;
     z-index: 10;
     background-color: #f8f9fa;
-    box-shadow: inset 0 -2px 0 var(--bs-border-color, #dee2e6);
+    box-shadow: inset 0 -2px 0 #6c757d;
   }
   /* Anchos fijos de columnas — col 2 (Documento) y col 3 (Asunto) toman el espacio restante */
   #pool-tabla th:nth-child(1) { width: 36px; }
-  /* col 2 Documento: flex */
+  /* col 2 Documento: flex — prioridad máxima, se acorta en último lugar */
   #pool-tabla th:nth-child(3) { width: 200px; }   /* Asunto */
   #pool-tabla th:nth-child(4) { width: 68px; }    /* Ext */
   #pool-tabla th:nth-child(5) { width: 100px; }   /* Tipo */
   #pool-tabla th:nth-child(6) { width: 108px; }   /* Fecha adm */
   #pool-tabla th:nth-child(7) { width: 44px; }    /* ★ */
   #pool-tabla th:nth-child(8) { width: 122px; }   /* Acciones */
-  /* Celdas Documento y Asunto: line-clamp 2 (máximo 2 líneas, luego ...) */
-  #pool-tabla td:nth-child(2), #pool-tabla td:nth-child(3) { overflow: hidden; max-width: 0; }
-  #pool-tabla td:nth-child(2) a, #pool-tabla td:nth-child(3) .asunto-celda {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    white-space: normal;
-    max-width: 100%;
+  /* Documento: word-wrap sin truncar (se da todo el espacio disponible) */
+  #pool-tabla td:nth-child(2) { overflow: hidden; max-width: 0; }
+  #pool-tabla td:nth-child(2) a {
+    display: block; white-space: normal;
+    overflow-wrap: break-word; word-break: break-word; max-width: 100%;
+  }
+  /* Asunto: line-clamp 2 por defecto */
+  #pool-tabla td:nth-child(3) { overflow: hidden; max-width: 0; }
+  #pool-tabla td:nth-child(3) .asunto-celda {
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden; white-space: normal; max-width: 100%;
+  }
+  /* === Responsive: Documento es prioritario, otros columnas se sacrifican primero === */
+  /* Paso 0 (< 1400px): ocultar Ext → Documento gana 68px */
+  @media (max-width: 1399.98px) {
+    #pool-tabla th:nth-child(4), #pool-tabla td:nth-child(4) { display: none; }
+  }
+  /* Paso 1 (< 1100px): Asunto en word-wrap (sin line-clamp) */
+  @media (max-width: 1099.98px) {
+    #pool-tabla td:nth-child(3) .asunto-celda {
+      display: block; -webkit-line-clamp: unset; overflow: visible; white-space: normal;
+    }
+  }
+  /* Paso 2 (< 900px): ocultar Asunto → Documento gana 200px */
+  @media (max-width: 899.98px) {
+    #pool-tabla th:nth-child(3), #pool-tabla td:nth-child(3) { display: none; }
+  }
+  /* Paso 3 (< 700px): ocultar Tipo → Documento gana 100px */
+  @media (max-width: 699.98px) {
+    #pool-tabla th:nth-child(5), #pool-tabla td:nth-child(5) { display: none; }
+  }
+  /* Paso 4 (< 560px): ocultar Fecha → Documento gana 108px */
+  @media (max-width: 559.98px) {
+    #pool-tabla th:nth-child(6), #pool-tabla td:nth-child(6) { display: none; }
+  }
+  /* Solo clampear Documento cuando todo lo demás ya está oculto (< 420px) */
+  @media (max-width: 419.98px) {
+    #pool-tabla td:nth-child(2) a {
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+    }
   }
   /* Fila seleccionada para edición masiva */
   #tbody-docs tr.doc-seleccionada > td { background-color: var(--bs-primary-bg-subtle, #d1e7dd) !important; }

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -49,13 +49,33 @@
   .fs-item:hover { background-color: var(--bs-primary-bg-subtle); }
   .fs-breadcrumb a { cursor: pointer; text-decoration: none; }
   .fs-breadcrumb a:hover { text-decoration: underline; }
+  /* Línea separadora pertenece a C.1 (borde inferior), no al inicio de C.2 */
+  .lista-cabecera { border-bottom: 1px solid var(--bs-border-color, #dee2e6); }
   /* Thead sticky en C.2 */
+  #pool-tabla { table-layout: fixed; width: 100%; border-top: none; }
   #pool-tabla thead th {
     position: sticky;
     top: 0;
     z-index: 10;
     background: var(--bs-light);
   }
+  /* Anchos fijos de columnas (table-layout:fixed evita que varíen al filtrar) */
+  #pool-tabla th:nth-child(1) { width: 36px; }
+  /* col 2 (Documento) toma el espacio restante */
+  #pool-tabla th:nth-child(3) { width: 72px; }
+  #pool-tabla th:nth-child(4) { width: 115px; }
+  #pool-tabla th:nth-child(5) { width: 108px; }
+  #pool-tabla th:nth-child(6) { width: 44px; }
+  #pool-tabla th:nth-child(7) { width: 122px; }
+  /* Celda Documento: truncar nombre largo */
+  #pool-tabla td:nth-child(2) { overflow: hidden; max-width: 0; }
+  #pool-tabla td:nth-child(2) a,
+  #pool-tabla td:nth-child(2) .asunto-celda {
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    display: block; max-width: 100%;
+  }
+  /* Fila seleccionada para edición masiva */
+  #tbody-docs tr.doc-seleccionada > td { background-color: var(--bs-primary-bg-subtle, #d1e7dd) !important; }
   /* C.1/C.2 scroll independiente + full-width:
      - max-width:none elimina el centrado de bc-view (aquí la vista es full-width)
      - overflow-y:hidden en app-main delega el scroll exclusivamente a C.2
@@ -168,8 +188,8 @@
     </div>
   </div>
 
-  <!-- Filtros client-side -->
-  <div class="d-flex align-items-center flex-wrap gap-2 pb-2">
+  <!-- Filtros client-side (ocultos cuando hay selección masiva activa) -->
+  <div id="barra-filtros" class="d-flex align-items-center flex-wrap gap-2 pb-2">
     <i class="fas fa-search text-secondary small"></i>
     <input type="search" id="filtro-docs" class="form-control form-control-sm"
            placeholder="Nombre o asunto…" style="max-width:220px">
@@ -973,10 +993,13 @@
   // EDICIÓN MASIVA (tabla de docs)
   // ================================================================
   window.on_check_doc = function (chk, doc_id) {
+    var tr = chk.closest('tr');
     if (chk.checked) {
       _masivo_ids.add(doc_id);
+      if (tr) tr.classList.add('doc-seleccionada');
     } else {
       _masivo_ids.delete(doc_id);
+      if (tr) tr.classList.remove('doc-seleccionada');
       document.getElementById('check-todos').checked = false;
     }
     actualizar_panel_masivo();
@@ -989,7 +1012,13 @@
       var chk = tr.querySelector('.doc-check');
       if (chk) chk.checked = checked;
       var id = parseInt(tr.dataset.docId, 10);
-      if (checked) { _masivo_ids.add(id); } else { _masivo_ids.delete(id); }
+      if (checked) {
+        _masivo_ids.add(id);
+        tr.classList.add('doc-seleccionada');
+      } else {
+        _masivo_ids.delete(id);
+        tr.classList.remove('doc-seleccionada');
+      }
     });
     actualizar_panel_masivo();
   };
@@ -1000,13 +1029,17 @@
   };
 
   function actualizar_panel_masivo() {
-    var n = _masivo_ids.size;
-    var panel = document.getElementById('panel-masivo');
+    var n      = _masivo_ids.size;
+    var panel  = document.getElementById('panel-masivo');
+    var filtros = document.getElementById('barra-filtros');
     if (n > 0) {
+      // El panel masivo sustituye a la barra de filtros: mismo espacio, sin salto
       panel.classList.remove('d-none');
+      filtros.classList.add('d-none');
       document.getElementById('masivo-count').textContent = n;
     } else {
       panel.classList.add('d-none');
+      filtros.classList.remove('d-none');
     }
   }
 

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -50,8 +50,15 @@
   #pool-tabla td, #pool-tabla th { border-bottom: 1px solid var(--bs-border-color, #dee2e6); }
   /* Eliminar border-top que BS5 añade al tbody (2px por defecto → línea negra en C.2) */
   #pool-tabla > tbody { border-top: none; }
-  /* Thead sticky con fondo sólido (table-light) para cubrir filas al hacer scroll */
-  #pool-tabla thead th { position: sticky; top: 0; z-index: 10; background-color: #f8f9fa; }
+  /* Thead sticky: top:-1px solapa 1px para eliminar el gap de subpixel.
+     box-shadow inset dibuja la línea inferior sin gap y cubre filas al hacer scroll. */
+  #pool-tabla thead th {
+    position: sticky;
+    top: -1px;
+    z-index: 10;
+    background-color: #f8f9fa;
+    box-shadow: inset 0 -2px 0 var(--bs-border-color, #dee2e6);
+  }
   /* Anchos fijos de columnas — col 2 (Documento) y col 3 (Asunto) toman el espacio restante */
   #pool-tabla th:nth-child(1) { width: 36px; }
   /* col 2 Documento: flex */

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -27,14 +27,7 @@
     border-color: var(--bs-primary);
     box-shadow: 0 0 0 3px var(--bs-primary-bg-subtle);
   }
-  /* Asunto truncado en tabla */
-  .asunto-celda {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 260px;
-    display: block;
-  }
+  /* .asunto-celda: estructura definida en la regla td:nth-child(3) de #pool-tabla */
   /* Panel de seleccionados (explorador) */
   .panel-seleccionados {
     max-height: 110px;
@@ -51,35 +44,36 @@
   .fs-breadcrumb a:hover { text-decoration: underline; }
   /* Línea separadora pertenece a C.1 (borde inferior), no al inicio de C.2 */
   .lista-cabecera { border-bottom: 1px solid var(--bs-border-color, #dee2e6); }
-  /* Thead sticky en C.2 */
-  #pool-tabla { table-layout: fixed; width: 100%; border-top: none; }
-  #pool-tabla thead th {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    background: var(--bs-light);
-  }
-  /* Anchos fijos de columnas (table-layout:fixed evita que varíen al filtrar) */
+  /* border-collapse:separate permite sticky thead sin artefactos de subpixel.
+     border-spacing:0 reproduce el aspecto de collapse sin el bug. */
+  #pool-tabla { table-layout: fixed; width: 100%; border-collapse: separate; border-spacing: 0; }
+  #pool-tabla td, #pool-tabla th { border-bottom: 1px solid var(--bs-border-color, #dee2e6); }
+  /* Eliminar border-top que BS5 añade al tbody (2px por defecto → línea negra en C.2) */
+  #pool-tabla > tbody { border-top: none; }
+  /* Thead sticky con fondo sólido (table-light) para cubrir filas al hacer scroll */
+  #pool-tabla thead th { position: sticky; top: 0; z-index: 10; background-color: #f8f9fa; }
+  /* Anchos fijos de columnas — col 2 (Documento) y col 3 (Asunto) toman el espacio restante */
   #pool-tabla th:nth-child(1) { width: 36px; }
-  /* col 2 (Documento) toma el espacio restante */
-  #pool-tabla th:nth-child(3) { width: 72px; }
-  #pool-tabla th:nth-child(4) { width: 115px; }
-  #pool-tabla th:nth-child(5) { width: 108px; }
-  #pool-tabla th:nth-child(6) { width: 44px; }
-  #pool-tabla th:nth-child(7) { width: 122px; }
-  /* Celda Documento: truncar nombre largo */
-  #pool-tabla td:nth-child(2) { overflow: hidden; max-width: 0; }
-  #pool-tabla td:nth-child(2) a,
-  #pool-tabla td:nth-child(2) .asunto-celda {
+  /* col 2 Documento: flex */
+  #pool-tabla th:nth-child(3) { width: 200px; }   /* Asunto */
+  #pool-tabla th:nth-child(4) { width: 68px; }    /* Ext */
+  #pool-tabla th:nth-child(5) { width: 100px; }   /* Tipo */
+  #pool-tabla th:nth-child(6) { width: 108px; }   /* Fecha adm */
+  #pool-tabla th:nth-child(7) { width: 44px; }    /* ★ */
+  #pool-tabla th:nth-child(8) { width: 122px; }   /* Acciones */
+  /* Celdas Documento y Asunto: truncar con ellipsis */
+  #pool-tabla td:nth-child(2), #pool-tabla td:nth-child(3) { overflow: hidden; max-width: 0; }
+  #pool-tabla td:nth-child(2) a, #pool-tabla td:nth-child(3) .asunto-celda {
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     display: block; max-width: 100%;
   }
   /* Fila seleccionada para edición masiva */
   #tbody-docs tr.doc-seleccionada > td { background-color: var(--bs-primary-bg-subtle, #d1e7dd) !important; }
-  /* C.1/C.2 scroll independiente + full-width:
-     - max-width:none elimina el centrado de bc-view (aquí la vista es full-width)
-     - overflow-y:hidden en app-main delega el scroll exclusivamente a C.2
-     - flex column + min-height:0 en bc-view para que C.2 ocupe la altura restante */
+  /* entrada_fecha dentro del panel masivo: misma altura que form-select-sm */
+  #ef-masivo-fecha .ef-input {
+    font-size: 0.875rem; padding: 0.25rem 2rem 0.25rem 0.5rem; line-height: 1.5; height: auto;
+  }
+  /* C.1/C.2 scroll independiente + full-width */
   .app-main { overflow-y: hidden; }
   .bc-view   { display: flex; flex-direction: column; flex: 1; min-height: 0;
                max-width: none; margin: 0; }
@@ -234,6 +228,7 @@
                  title="Seleccionar / deseleccionar todos">
         </th>
         <th>Documento</th>
+        <th>Asunto</th>
         <th>Ext.</th>
         <th>Tipo</th>
         <th>Fecha adm.</th>
@@ -267,9 +262,13 @@
             <i class="fas fa-file fa-xs me-1 text-secondary"></i>{{ item.nombre_display }}
           </a>
           {% endif %}
+        </td>
+        <td>
           {% if doc.asunto %}
-          <span class="asunto-celda text-secondary small"
+          <span class="asunto-celda text-secondary"
                 title="{{ doc.asunto | e }}">{{ doc.asunto }}</span>
+          {% else %}
+          <span class="text-secondary">—</span>
           {% endif %}
         </td>
         <td>
@@ -672,6 +671,9 @@
 
     // EntradaFecha del panel masivo (en el DOM principal, inicializar ya)
     _ef_masivo = new EntradaFecha('#ef-masivo-fecha', { name: '_f_masivo' });
+
+    // Igualar alturas de panel-masivo y barra-filtros (sin salto al intercambiar)
+    sincronizar_altura_c1();
   });
 
   // ================================================================
@@ -1042,6 +1044,37 @@
       filtros.classList.remove('d-none');
     }
   }
+
+  // Iguala la altura de panel-masivo y barra-filtros para evitar salto al intercambiarlos.
+  // Muestra ambos (invisibles) para medir, toma el máximo y lo fija como min-height.
+  // Se llama al cargar y en cada resize para adaptarse a cualquier ancho de ventana.
+  function sincronizar_altura_c1() {
+    var panel   = document.getElementById('panel-masivo');
+    var filtros = document.getElementById('barra-filtros');
+    if (!panel || !filtros) return;
+    // Guardar estado visible/oculto actual
+    var panel_oculto   = panel.classList.contains('d-none');
+    var filtros_oculto = filtros.classList.contains('d-none');
+    // Resetear min-height para medir la altura natural
+    panel.style.minHeight   = '';
+    filtros.style.minHeight = '';
+    // Mostrar ambos de forma invisible para medir
+    panel.style.visibility   = 'hidden';
+    filtros.style.visibility = 'hidden';
+    panel.classList.remove('d-none');
+    filtros.classList.remove('d-none');
+    var h = Math.max(panel.offsetHeight, filtros.offsetHeight);
+    // Restaurar estado
+    if (panel_oculto)   panel.classList.add('d-none');
+    if (filtros_oculto) filtros.classList.add('d-none');
+    panel.style.visibility   = '';
+    filtros.style.visibility = '';
+    // Fijar min-height igual en ambos
+    panel.style.minHeight   = h + 'px';
+    filtros.style.minHeight = h + 'px';
+  }
+
+  window.addEventListener('resize', sincronizar_altura_c1);
 
   window.aplicar_masivo = function () {
     if (_masivo_ids.size === 0) return;

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -74,11 +74,11 @@
     display: block; white-space: normal;
     overflow-wrap: break-word; word-break: break-word; max-width: 100%;
   }
-  /* Asunto: line-clamp 2 por defecto */
+  /* Asunto: ellipsis una línea (tooltip muestra el texto completo) */
   #pool-tabla td:nth-child(3) { overflow: hidden; max-width: 0; }
   #pool-tabla td:nth-child(3) .asunto-celda {
-    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
-    overflow: hidden; white-space: normal; max-width: 100%;
+    display: block; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; max-width: 100%;
   }
   /* === Responsive: Documento es prioritario, otros columnas se sacrifican primero === */
   /* Paso 0 (< 1400px): ocultar Ext → Documento gana 68px */

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -64,7 +64,7 @@
   /* col 2 Documento: flex — prioridad máxima, se acorta en último lugar */
   #pool-tabla th:nth-child(3) { width: calc(40% - 271px); }  /* Asunto: 40% del espacio flex */
   #pool-tabla th:nth-child(4) { width: 68px; }    /* Ext */
-  #pool-tabla th:nth-child(5) { width: 100px; }   /* Tipo */
+  #pool-tabla th:nth-child(5) { width: 130px; }   /* Tipo */
   #pool-tabla th:nth-child(6) { width: 108px; }   /* Fecha adm */
   #pool-tabla th:nth-child(7) { width: 44px; }    /* ★ */
   #pool-tabla th:nth-child(8) { width: 122px; }   /* Acciones */

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -1106,9 +1106,13 @@
         _masivo_ids.delete(parseInt(doc_id, 10));
         actualizar_panel_masivo();
         mostrar_toast('info', 'Registro eliminado del pool.');
-      } else { alert(data.error || 'No se pudo borrar.'); }
+      } else {
+        mostrar_toast('danger', data.error || 'No se pudo borrar el documento.');
+      }
     })
-    .catch(function () { alert('Error de red al borrar.'); });
+    .catch(function () {
+      mostrar_toast('danger', 'Error de red al borrar.');
+    });
   };
 
   // ================================================================

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -49,13 +49,6 @@
   .fs-item:hover { background-color: var(--bs-primary-bg-subtle); }
   .fs-breadcrumb a { cursor: pointer; text-decoration: none; }
   .fs-breadcrumb a:hover { text-decoration: underline; }
-  /* Toast container */
-  .toast-container-custom {
-    position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
-    z-index: 1200;
-  }
 </style>
 {% endblock %}
 
@@ -69,9 +62,6 @@
   <option value="{{ t.id }}">{{ t.nombre }}</option>
   {% endfor %}
 </template>
-
-<!-- Toast container -->
-<div class="toast-container-custom" id="toast-container"></div>
 
 <!-- C.1 -->
 <div class="lista-cabecera px-3 pt-3">
@@ -585,26 +575,35 @@
   });
 
   // ================================================================
-  // TOASTS
+  // TOASTS — misma estructura y clases que el sistema base (custom.css)
   // ================================================================
   function mostrar_toast(tipo, mensaje) {
-    var colores = {
-      success: 'bg-success text-white',
-      danger:  'bg-danger text-white',
-      info:    'bg-info text-dark',
-      warning: 'bg-warning text-dark'
-    };
-    var cls = colores[tipo] || colores.info;
-    var id  = 'toast-' + Date.now();
+    var iconos   = { success: 'fa-check-circle', danger: 'fa-exclamation-circle',
+                     warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
+    var etiquetas = { success: 'Correcto', danger: 'Error',
+                      warning: 'Atención', info: 'Información' };
+    var id  = 'toast-js-' + Date.now();
     var html =
-      '<div id="' + id + '" class="toast align-items-center ' + cls + ' border-0" role="alert">' +
-      '<div class="d-flex"><div class="toast-body">' + escapar_html(mensaje) + '</div>' +
-      '<button type="button" class="btn-close btn-close-white me-2 m-auto"' +
-      ' data-bs-dismiss="toast"></button></div></div>';
-    document.getElementById('toast-container').insertAdjacentHTML('beforeend', html);
+      '<div id="' + id + '" class="toast toast-' + tipo + '" role="alert"' +
+      ' aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">' +
+      '<div class="d-flex align-items-center p-3"><div class="flex-grow-1">' +
+      '<i class="fas ' + (iconos[tipo] || iconos.info) + ' me-2"></i>' +
+      '<strong>' + (etiquetas[tipo] || 'Aviso') + ':</strong> ' + escapar_html(mensaje) +
+      '</div><button type="button" class="btn-close ms-3"' +
+      ' data-bs-dismiss="toast" aria-label="Cerrar"></button></div></div>';
+
+    // Inyectar en el contenedor de toasts del base template
+    var container = document.querySelector('.toast-container');
+    container.insertAdjacentHTML('beforeend', html);
     var el = document.getElementById(id);
-    var t  = new bootstrap.Toast(el, { delay: 4000 });
+    el.classList.add('showing');
+    var t = new bootstrap.Toast(el);
     t.show();
+    setTimeout(function () { el.classList.remove('showing'); }, 300);
+    el.addEventListener('hide.bs.toast', function () { el.classList.add('hide'); });
+    el.addEventListener('click', function (e) {
+      if (!e.target.closest('.btn-close')) { t.hide(); }
+    });
     el.addEventListener('hidden.bs.toast', function () { el.remove(); });
   }
 

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -85,13 +85,7 @@
   @media (max-width: 1399.98px) {
     #pool-tabla th:nth-child(4), #pool-tabla td:nth-child(4) { display: none; }
   }
-  /* Paso 1 (< 1100px): Asunto en word-wrap (sin line-clamp) */
-  @media (max-width: 1099.98px) {
-    #pool-tabla td:nth-child(3) .asunto-celda {
-      display: block; -webkit-line-clamp: unset; overflow: visible; white-space: normal;
-    }
-  }
-  /* Paso 2 (< 900px): ocultar Asunto → Documento gana 200px */
+  /* Paso 2 (< 900px): ocultar Asunto → Documento gana espacio */
   @media (max-width: 899.98px) {
     #pool-tabla th:nth-child(3), #pool-tabla td:nth-child(3) { display: none; }
   }

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -15,6 +15,12 @@
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
+<style>
+  /* Full-width + C.1/C.2 scroll independiente (igual que pool_documentos) */
+  .app-main { overflow-y: hidden; }
+  .bc-view   { display: flex; flex-direction: column; flex: 1; min-height: 0;
+               max-width: none; margin: 0; }
+</style>
 {% endblock %}
 
 {% block content %}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -43,10 +43,6 @@
            class="btn btn-sm btn-outline-primary">
           <i class="fas fa-file-alt me-1"></i> Pool de Docs
         </a>
-        {# [Editar] y [Acciones ▾] — placeholder, funcionalidad en issue posterior #}
-        <button class="btn btn-sm btn-outline-primary" disabled title="Próximamente">
-          <i class="fas fa-edit me-1"></i> Editar
-        </button>
       </div>
     </div>
     <div class="card-body card-body-tinted py-2">

--- a/docs/GUIA_COMPONENTES_INTERACTIVOS.md
+++ b/docs/GUIA_COMPONENTES_INTERACTIVOS.md
@@ -251,6 +251,94 @@ ef.disable()
 
 ---
 
+---
+
+## Toasts programáticos
+
+Sistema de notificaciones para uso desde JavaScript. Definido en `app/static/css/custom.css`
+y el contenedor vive en `app/templates/layout/base_fullwidth.html`.
+
+**No confundir con los flash messages de Flask**, que se inyectan en Jinja al renderizar
+la página. Los toasts programáticos se muestran como respuesta a acciones AJAX ya resueltas.
+
+### CSS (custom.css)
+
+Cuatro clases disponibles: `.toast-success`, `.toast-danger`, `.toast-warning`, `.toast-info`.
+Cada una aplica color de fondo sutil, texto oscuro y un botón de cierre con el filtro de color
+correspondiente. Sobreescribe el estilo base de Bootstrap.
+
+### Estructura HTML
+
+```html
+<div class="toast toast-success" role="alert"
+     aria-live="assertive" aria-atomic="true"
+     data-bs-autohide="true" data-bs-delay="5000">
+  <div class="d-flex align-items-center p-3">
+    <div class="flex-grow-1">
+      <i class="fas fa-check-circle me-2"></i>
+      <strong>Correcto:</strong> El mensaje aquí.
+    </div>
+    <button type="button" class="btn-close ms-3"
+            data-bs-dismiss="toast" aria-label="Cerrar"></button>
+  </div>
+</div>
+```
+
+| Tipo | Clase | Icono FA | Etiqueta |
+|------|-------|----------|----------|
+| `success` | `.toast-success` | `fa-check-circle` | Correcto |
+| `danger` | `.toast-danger` | `fa-exclamation-circle` | Error |
+| `warning` | `.toast-warning` | `fa-exclamation-triangle` | Atención |
+| `info` | `.toast-info` | `fa-info-circle` | Información |
+
+### Función JS reutilizable
+
+Copiar esta función en cualquier `<script>` que necesite mostrar toasts.
+Inyecta el elemento en el `.toast-container` ya presente en el base template
+y replica el ciclo de vida (clases `showing`/`hide`, autodestrucción).
+
+```javascript
+function mostrar_toast(tipo, mensaje) {
+  var iconos    = { success: 'fa-check-circle', danger: 'fa-exclamation-circle',
+                    warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
+  var etiquetas = { success: 'Correcto', danger: 'Error',
+                    warning: 'Atención',  info: 'Información' };
+  var id   = 'toast-js-' + Date.now();
+  var html =
+    '<div id="' + id + '" class="toast toast-' + tipo + '" role="alert"' +
+    ' aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">' +
+    '<div class="d-flex align-items-center p-3"><div class="flex-grow-1">' +
+    '<i class="fas ' + (iconos[tipo] || iconos.info) + ' me-2"></i>' +
+    '<strong>' + (etiquetas[tipo] || 'Aviso') + ':</strong> ' + mensaje +
+    '</div><button type="button" class="btn-close ms-3"' +
+    ' data-bs-dismiss="toast" aria-label="Cerrar"></button></div></div>';
+
+  var container = document.querySelector('.toast-container');
+  container.insertAdjacentHTML('beforeend', html);
+  var el = document.getElementById(id);
+  el.classList.add('showing');
+  var t = new bootstrap.Toast(el);
+  t.show();
+  setTimeout(function () { el.classList.remove('showing'); }, 300);
+  el.addEventListener('hide.bs.toast', function () { el.classList.add('hide'); });
+  el.addEventListener('click', function (e) {
+    if (!e.target.closest('.btn-close')) { t.hide(); }
+  });
+  el.addEventListener('hidden.bs.toast', function () { el.remove(); });
+}
+```
+
+### Uso
+
+```javascript
+mostrar_toast('success', 'Cambios guardados correctamente.');
+mostrar_toast('danger',  'Error al conectar con el servidor.');
+mostrar_toast('warning', 'El documento no tiene fecha administrativa.');
+mostrar_toast('info',    'Ruta copiada al portapapeles.');
+```
+
+---
+
 ## Próximos componentes (pendientes)
 
 - `SelectorMultiple` — selección acumulable con badges (variante del anterior)


### PR DESCRIPTION
## Resumen

Mejoras UX completas del Pool de Documentos (issue #196), incluyendo correcciones visuales y de comportamiento en tramitacion_bc.

### Layout C.1 / C.2
- Fichas de entrada, panel masivo y filtros movidos a C.1 (fijos al hacer scroll)
- C.2 contiene únicamente la tabla; `thead` sticky con `position:sticky`
- Vista full-width: override de `bc-view` y `app-main` para eliminar centrado y activar scroll independiente

### Tabla de documentos
- **Columna Prioridad**: cabecera ★ (icono), celda fa-star amarilla / `—`
- **Columna Tipo**: badge con `tipo_doc.codigo` corto + tooltip con nombre completo
- **Columna Asunto**: nueva columna separada del nombre del documento (reparto 60/40 del espacio flexible con Documento via `calc`)
- `table-layout:fixed` + anchos `th:nth-child` para columnas estables al filtrar
- Ellipsis en Asunto + tooltip Bootstrap para ver texto completo al pasar el ratón
- Ocultado progresivo de columnas según ancho de ventana: Ext → Asunto → Tipo → Fecha (Documento es prioritario)
- Sticky thead: `border-collapse:separate` + `top:-1px` + `box-shadow inset` para eliminar artefactos de subpixel y añadir línea separadora visible
- Fix extensión en URLs externas con `#fragment` o `?query` (ej. `doc.pdf#page=1` → badge `.pdf`)

### Filtrado y selección masiva
- Filtro client-side por nombre/asunto con contador (N/Total)
- Dropdowns adicionales: extensión, tipo, prioridad
- `toggle_todos` y `aplicar_masivo` respetan filas visibles del filtro
- `aplicar_masivo` solo actualiza campos explícitamente enviados (`if 'campo' in datos`)
- Highlight de filas seleccionadas (`doc-seleccionada`, fondo verde sutil)
- Panel masivo y barra de filtros se intercambian sin salto: mismo `card card-body`, `sincronizar_altura_c1()` iguala alturas en init y resize

### tramitacion_bc.html
- Botón "Editar" disabled eliminado → botones Detalle y Pool de Docs alineados correctamente a la derecha

## Test plan

- [ ] Pool se abre full-width y solo C.2 hace scroll
- [ ] Filtros (texto, ext, tipo, prio) funcionan y muestran contador
- [ ] Seleccionar documentos → aparece panel masivo sin salto; deseleccionar → vuelven filtros
- [ ] Aplicar masivo solo modifica los campos rellenados (no sobreescribe tipo/fecha si no se tocan)
- [ ] Filas seleccionadas muestran fondo verde
- [ ] Thead sticky permanece visible y tapa las filas al hacer scroll
- [ ] Columnas mantienen anchos al filtrar
- [ ] Columna Asunto muestra ellipsis + tooltip con texto completo
- [ ] URLs externas con `#fragment` muestran extensión limpia en el badge
- [ ] En tramitacion_bc, botones Detalle y Pool de Docs están a la derecha sin botón Editar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
