### PR TITLE
[UI] Fix scroll independiente V3-BC y reorganizar C.1/C.2 (#199)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -15,12 +15,6 @@
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
-<style>
-  /* Full-width + C.1/C.2 scroll independiente (igual que pool_documentos) */
-  .app-main { overflow-y: hidden; }
-  .bc-view   { display: flex; flex-direction: column; flex: 1; min-height: 0;
-               max-width: none; margin: 0; }
-</style>
 {% endblock %}
 
 {% block content %}
@@ -59,8 +53,12 @@
           <strong>Tipo:</strong>
           {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
         </div>
-        <div class="col-auto ms-auto">
+        <div class="col-auto ms-auto d-flex align-items-center gap-2">
           <span class="badge bg-primary">{{ hijos | length }} solicitud(es)</span>
+          <button class="btn btn-sm btn-primary"
+                  data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
+            <i class="fas fa-plus me-1"></i> Nueva solicitud
+          </button>
         </div>
       </div>
     </div>
@@ -68,14 +66,7 @@
 </div>
 
 <!-- C.2: Listado de Solicitudes (scrollable) -->
-<div class="lista-scroll-container p-3">
-  <div class="d-flex justify-content-between align-items-center mb-2">
-    <h6 class="mb-0 fw-semibold">Solicitudes</h6>
-    <button class="btn btn-sm btn-primary"
-            data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
-      <i class="fas fa-plus me-1"></i> Nueva solicitud
-    </button>
-  </div>
+<div class="lista-scroll-container">
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -111,8 +111,12 @@
             {{- fase.resultado_fase.nombre if fase.resultado_fase else '—' -}}
           </span>
         </div>
-        <div class="col-auto ms-auto">
+        <div class="col-auto ms-auto d-flex align-items-center gap-2">
           <span class="badge bg-primary">{{ hijos | length }} trámite(s)</span>
+          <button class="btn btn-sm btn-primary"
+                  data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
+            <i class="fas fa-plus me-1"></i> Nuevo trámite
+          </button>
         </div>
       </div>
 
@@ -166,14 +170,7 @@
 </div>
 
 <!-- C.2: Listado de Trámites (scrollable) -->
-<div class="lista-scroll-container p-3">
-  <div class="d-flex justify-content-between align-items-center mb-2">
-    <h6 class="mb-0 fw-semibold">Trámites</h6>
-    <button class="btn btn-sm btn-primary"
-            data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
-      <i class="fas fa-plus me-1"></i> Nuevo trámite
-    </button>
-  </div>
+<div class="lista-scroll-container">
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -112,8 +112,12 @@
             {{ solicitud.estado | replace('_', ' ') | title }}
           </span>
         </div>
-        <div class="col-auto ms-auto">
+        <div class="col-auto ms-auto d-flex align-items-center gap-2">
           <span class="badge bg-primary">{{ hijos | length }} fase(s)</span>
+          <button class="btn btn-sm btn-primary"
+                  data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
+            <i class="fas fa-plus me-1"></i> Nueva fase
+          </button>
         </div>
       </div>
 
@@ -157,14 +161,7 @@
 </div>
 
 <!-- C.2: Listado de Fases (scrollable) -->
-<div class="lista-scroll-container p-3">
-  <div class="d-flex justify-content-between align-items-center mb-2">
-    <h6 class="mb-0 fw-semibold">Fases</h6>
-    <button class="btn btn-sm btn-primary"
-            data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
-      <i class="fas fa-plus me-1"></i> Nueva fase
-    </button>
-  </div>
+<div class="lista-scroll-container">
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -109,8 +109,12 @@
             {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
           </span>
         </div>
-        <div class="col-auto ms-auto">
+        <div class="col-auto ms-auto d-flex align-items-center gap-2">
           <span class="badge bg-primary">{{ hijos | length }} tarea(s)</span>
+          <button class="btn btn-sm btn-primary"
+                  data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
+            <i class="fas fa-plus me-1"></i> Nueva tarea
+          </button>
         </div>
       </div>
 
@@ -152,14 +156,7 @@
 </div>
 
 <!-- C.2: Listado de Tareas (scrollable) -->
-<div class="lista-scroll-container p-3">
-  <div class="d-flex justify-content-between align-items-center mb-2">
-    <h6 class="mb-0 fw-semibold">Tareas</h6>
-    <button class="btn btn-sm btn-primary"
-            data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
-      <i class="fas fa-plus me-1"></i> Nueva tarea
-    </button>
-  </div>
+<div class="lista-scroll-container">
   {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -61,12 +61,36 @@
     font-weight: 600;
 }
 
-/* ── Anchura máxima adaptativa ───────────────────────────────────────────── */
+/* ── Layout C.1/C.2 — scroll independiente (#199) ──────────────────────── */
+/* Antes estaba inline en tramitacion_bc.html y pool_documentos.html.
+   Centralizado aquí para que todas las vistas BC lo hereden. */
+
+.app-main {
+    overflow-y: hidden;
+}
 
 .bc-view {
-    max-width: 1200px;
-    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    max-width: none;
+    margin: 0;
     width: 100%;
+}
+
+/* Anular min-height de V2 — en BC el espacio disponible varía mucho */
+.lista-scroll-container {
+    min-height: 0;
+}
+
+/* ── Thead sticky en tabla de hijos (#199) ──────────────────────────────── */
+
+.lista-scroll-container .table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: var(--bs-table-bg, #f8f9fa);
 }
 
 /* ── Botones de acción en la cabecera (placeholders) ────────────────────── */

--- a/app/templates/vistas/vista3_bc/_tabla_hijos.html
+++ b/app/templates/vistas/vista3_bc/_tabla_hijos.html
@@ -20,7 +20,6 @@
 {% endmacro %}
 
 {% if hijos %}
-<div class="table-responsive">
   <table class="table table-hover table-sm align-middle mb-0">
     <thead class="table-light">
       <tr>
@@ -47,7 +46,6 @@
       {% endfor %}
     </tbody>
   </table>
-</div>
 {% else %}
 <div class="text-center text-muted py-4">
   <i class="bi bi-inbox fs-3 d-block mb-2"></i>


### PR DESCRIPTION
## Summary
- **Fix scroll C.1/C.2 en vistas V3-BC** (solicitud, fase, tramite, tarea): centralizado en v3-breadcrumbs.css con overflow-y hidden, flex layout y min-height 0
- **Thead sticky** en tabla de hijos: eliminado table-responsive que rompia position sticky
- **Boton Nueva X movido a C.1**: junto al badge de conteo en bc-meta, siempre visible
- **Eliminado h6 redundante** del titulo de hijos dentro de C.2
- **Eliminado style inline** de tramitacion_bc.html (hereda del CSS compartido)

Closes #199

## Test plan
- [ ] Tramitacion expediente con 6+ solicitudes: scroll independiente en C.2
- [ ] Ventana ~350px alto: ultimas filas accesibles via scroll
- [ ] Thead sticky al scrollear
- [ ] Boton + Nueva visible en C.1 sin scrollear
- [ ] Verificar los 4 niveles: expediente, solicitud, fase, tramite
- [ ] Pool de documentos no afectado
