### PR TITLE
[STYLE] Eliminar colores hardcoded y btn-success fuera de semántica (#200)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -56,7 +56,7 @@
     position: sticky;
     top: -1px;
     z-index: 10;
-    background-color: #f8f9fa;
+    background-color: var(--bs-table-bg, #f8f9fa);
     box-shadow: inset 0 -2px 0 #6c757d;
   }
   /* Anchos fijos de columnas — col 2 (Documento) y col 3 (Asunto) toman el espacio restante */

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -79,7 +79,7 @@
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
             <i class="fas fa-save me-1"></i> Guardar
           </button>
           <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -76,7 +76,7 @@
         </div>
         {# Modo editar: botones Guardar + Cancelar #}
         <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
             <i class="fas fa-save me-1"></i> Guardar
           </button>
           <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -87,7 +87,7 @@
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
             <i class="fas fa-save me-1"></i> Guardar
           </button>
           <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -83,7 +83,7 @@
         </div>
         {# Modo editar #}
         <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-success btn-guardar-bc">
+          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
             <i class="fas fa-save me-1"></i> Guardar
           </button>
           <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -50,13 +50,13 @@
 
 /* Segmento activo (último, sin enlace) visible en color oscuro */
 .header-breadcrumb-row .breadcrumb span:last-child {
-    color: #444;
+    color: var(--bs-body-color);
     font-weight: 600;
 }
 
 /* Separadores › más visibles */
 .header-breadcrumb-row .breadcrumb span:not(:last-child) {
-    color: #444;
+    color: var(--bs-body-color);
     font-size: 1.1rem;
     font-weight: 600;
 }

--- a/app/templates/usuarios/editar.html
+++ b/app/templates/usuarios/editar.html
@@ -15,7 +15,7 @@
 <div class="row">
     <div class="col-md-8 mx-auto">
         <div class="card shadow-sm">
-            <div class="card-header bg-success text-white">
+            <div class="card-header card-header-accent">
                 <h5 class="mb-0">Editar Usuario: {{ usuario.siglas }}</h5>
             </div>
             <div class="card-body">
@@ -149,7 +149,7 @@
                         <a href="{{ url_for('usuarios.index') }}" class="btn btn-secondary">
                             <i class="fas fa-arrow-left me-2"></i>Volver
                         </a>
-                        <button type="submit" class="btn btn-success">
+                        <button type="submit" class="btn btn-primary">
                             <i class="fas fa-save me-2"></i>Guardar Cambios
                         </button>
                     </div>

--- a/app/templates/usuarios/index.html
+++ b/app/templates/usuarios/index.html
@@ -16,7 +16,7 @@
     </div>
     <div class="col-md-4 text-end">
         <!-- Botón que activa el Modal -->
-        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#crearUsuarioModal">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#crearUsuarioModal">
             <i class="fas fa-plus me-1"></i> Nuevo Usuario
         </button>
     </div>
@@ -26,7 +26,7 @@
 <div class="card shadow-sm">
     <div class="card-body p-0">
         <table class="table table-hover table-striped mb-0">
-            <thead class="table-success">
+            <thead class="table-light">
                 <tr>
                     <th>ID</th>
                     <th>Siglas</th>
@@ -49,7 +49,7 @@
                     <td>{{ usuario.nombre }} {{ usuario.apellido1 }} {{ usuario.apellido2 or '' }}</td>
                     <td>
                         {% for rol in usuario.roles %}
-                            <span class="badge me-1" style="background-color: #e6e6e5; color: #54585a;">{{ rol.nombre }}</span>
+                            <span class="badge me-1 bg-light text-dark">{{ rol.nombre }}</span>
                         {% else %}
                             <span class="text-muted small">Sin roles</span>
                         {% endfor %}
@@ -66,7 +66,7 @@
                                        onchange="this.form.submit();">
                                 <label class="form-check-label" for="switch_{{ usuario.id }}">
                                     {% if usuario.activo %}
-                                        <span class="badge" style="background-color: #00695c; color: white;">Activo</span>
+                                        <span class="badge bg-primary">Activo</span>
                                     {% else %}
                                         <span class="badge bg-secondary">Inactivo</span>
                                     {% endif %}
@@ -98,9 +98,9 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <form action="{{ url_for('usuarios.index') }}" method="POST">
-                <div class="modal-header bg-success text-white">
+                <div class="modal-header card-header-accent">
                     <h5 class="modal-title">Nuevo Usuario</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <!-- Datos Personales -->
@@ -218,7 +218,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-success">Guardar Usuario</button>
+                    <button type="submit" class="btn btn-primary">Guardar Usuario</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Eliminar colores hardcoded (`#444`, `#00695c`, `#e6e6e5`, `#54585a`, `#f8f9fa`) y sustituir por variables CSS o clases Bootstrap/corporativas
- Reemplazar `btn-success` por `btn-primary` en botones de acción principal (verde Bootstrap → verde corporativo)
- Reemplazar `bg-success text-white` por `card-header-accent` en headers de cards y modales de usuarios

## Archivos afectados (8)
- `app/templates/usuarios/index.html` — 6 cambios (thead, badges, modal header, botones)
- `app/templates/usuarios/editar.html` — 2 cambios (card header, botón guardar)
- `tramitacion_bc_solicitud.html` — btn-success → btn-primary (Guardar)
- `tramitacion_bc_fase.html` — btn-success → btn-primary (Guardar)
- `tramitacion_bc_tramite.html` — btn-success → btn-primary (Guardar)
- `tramitacion_bc_tarea.html` — btn-success → btn-primary (Guardar)
- `v3-breadcrumbs.css` — `#444` → `var(--bs-body-color)`
- `pool_documentos.html` — `#f8f9fa` → `var(--bs-table-bg, #f8f9fa)`

## Test plan
- [x] Verificar vista Usuarios: thead neutro, badges de rol legibles, badge Activo verde corporativo, modal con header corporativo
- [x] Verificar edición de usuario: card header verde corporativo, botón Guardar verde corporativo
- [x] Verificar V3-BC (solicitud, fase, trámite, tarea): botón Guardar en modo edición usa verde corporativo
- [x] Verificar breadcrumbs en V3-BC: texto legible sin color hardcoded
- [x] Verificar pool de documentos: thead sticky sin color hardcoded

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
