### PR TITLE
[UI] Migrar campos de fecha del wizard a EntradaFecha

### DIFF
--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -80,6 +80,8 @@
                                 <label class="form-label fw-semibold">
                                     Fecha del proyecto <span class="text-danger">*</span>
                                 </label>
+                                {# Componente EntradaFecha — construye su propio HTML internamente.
+                                   El error se valida a mano en JS porque el form usa novalidate. #}
                                 <div id="ef-fecha"></div>
                                 <div id="ef-fecha-error" class="text-danger small mt-1" style="display:none">Campo obligatorio.</div>
                                 <div class="form-text">Fecha de firma/visado.</div>

--- a/app/templates/expedientes/wizard_paso2.html
+++ b/app/templates/expedientes/wizard_paso2.html
@@ -77,13 +77,11 @@
 
                         <div class="row">
                             <div class="col-md-4 mb-3">
-                                <label for="fecha" class="form-label fw-semibold">
+                                <label class="form-label fw-semibold">
                                     Fecha del proyecto <span class="text-danger">*</span>
                                 </label>
-                                <input type="date" id="fecha" name="fecha"
-                                       class="form-control"
-                                       value="{{ paso2.get('fecha', '') }}"
-                                       required>
+                                <div id="ef-fecha"></div>
+                                <div id="ef-fecha-error" class="text-danger small mt-1" style="display:none">Campo obligatorio.</div>
                                 <div class="form-text">Fecha de firma/visado.</div>
                             </div>
                             <div class="col-md-8 mb-3">
@@ -178,10 +176,12 @@
 
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/selector_busqueda.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script>
 (function () {
     'use strict';
@@ -190,6 +190,11 @@
     const badgesDiv = document.getElementById('municipios-seleccionados');
     const hiddenDiv = document.getElementById('municipios-hidden-inputs');
     const errorDiv  = document.getElementById('municipios-error');
+
+    // ── EntradaFecha ──
+    const efFecha = new EntradaFecha('#ef-fecha', { name: 'fecha' });
+    {% if paso2.get('fecha') %}efFecha.setValue('{{ paso2.get("fecha") }}');{% endif %}
+    const efFechaError = document.getElementById('ef-fecha-error');
 
     // ── Selector de municipio (se habilita al seleccionar provincia) ──
     const muniSelector = new SelectorBusqueda('#wp2-municipio', [], {
@@ -262,11 +267,24 @@
 
     // ── Validación pre-submit ──
     document.getElementById('form-paso2').addEventListener('submit', function (e) {
-        if (!Object.keys(municipiosSeleccionados).length) {
-            e.preventDefault();
-            errorDiv.style.display = 'block';
-            provSelector._input.focus();
+        let ok = true;
+
+        if (!efFecha.getValue()) {
+            efFechaError.style.display = 'block';
+            ok = false;
+        } else {
+            efFechaError.style.display = 'none';
         }
+
+        if (!Object.keys(municipiosSeleccionados).length) {
+            errorDiv.style.display = 'block';
+            if (ok) provSelector._input.focus();
+            ok = false;
+        } else {
+            errorDiv.style.display = 'none';
+        }
+
+        if (!ok) e.preventDefault();
     });
 
     function escapeHtml(s) {

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -78,11 +78,11 @@
 
                         {# --- Fecha solicitud --- #}
                         <div class="mb-4">
-                            <label for="fecha_solicitud" class="form-label fw-semibold">
+                            <label class="form-label fw-semibold">
                                 Fecha de solicitud <span class="text-danger">*</span>
                             </label>
-                            <input type="date" id="fecha_solicitud" name="fecha_solicitud"
-                                   class="form-control w-auto" required>
+                            <div id="ef-fecha-solicitud"></div>
+                            <div id="ef-fecha-error" class="text-danger small mt-1" style="display:none">Campo obligatorio.</div>
                             <div class="form-text">Fecha oficial de presentación.</div>
                         </div>
 
@@ -161,13 +161,19 @@
 
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/selector_busqueda.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
 <script>
 (function () {
     'use strict';
+
+    // ── EntradaFecha ──
+    const efFecha = new EntradaFecha('#ef-fecha-solicitud', { name: 'fecha_solicitud' });
+    const efFechaError = document.getElementById('ef-fecha-error');
 
     // ------------------------------------------------------------------
     // A) Selectores de titular y solicitante
@@ -352,6 +358,14 @@
     // ------------------------------------------------------------------
     document.querySelector('form').addEventListener('submit', function (e) {
         let ok = true;
+
+        // Validar fecha solicitud
+        if (!efFecha.getValue()) {
+            efFechaError.style.display = 'block';
+            ok = false;
+        } else {
+            efFechaError.style.display = 'none';
+        }
 
         // Validar titular
         if (!entidadSel.getValue()) {

--- a/app/templates/expedientes/wizard_paso3.html
+++ b/app/templates/expedientes/wizard_paso3.html
@@ -81,6 +81,8 @@
                             <label class="form-label fw-semibold">
                                 Fecha de solicitud <span class="text-danger">*</span>
                             </label>
+                            {# Componente EntradaFecha — construye su propio HTML internamente.
+                               El error se valida a mano en JS porque el form usa novalidate. #}
                             <div id="ef-fecha-solicitud"></div>
                             <div id="ef-fecha-error" class="text-danger small mt-1" style="display:none">Campo obligatorio.</div>
                             <div class="form-text">Fecha oficial de presentación.</div>


### PR DESCRIPTION
## Resumen

Migración de los dos campos `type="date"` del wizard de creación de expediente al componente `EntradaFecha`, que es el selector de fecha estándar del proyecto.

## Cambios

- **wizard_paso2** — `fecha` (fecha del proyecto): reemplazado por `EntradaFecha`. El valor de sesión se restaura con `setValue()` al volver atrás en el wizard.
- **wizard_paso3** — `fecha_solicitud` (fecha de solicitud): reemplazado por `EntradaFecha`.
- Añadidos `entrada_fecha.css` y `entrada_fecha.js` en los bloques `extra_css`/`extra_js` de ambos pasos.
- Añadida validación manual en los submit handlers (el `required` nativo no funciona con `novalidate`).

## Plan de pruebas

- [x] Wizard paso 2: comprobar que el campo acepta fechas en formato dd/mm/aaaa y rechaza formatos inválidos
- [x] Wizard paso 2: volver atrás desde paso 3 y comprobar que la fecha se restaura correctamente
- [x] Wizard paso 2: intentar avanzar sin fecha → debe mostrar error inline
- [x] Wizard paso 3: comprobar que el campo acepta fechas en formato dd/mm/aaaa
- [x] Wizard paso 3: intentar finalizar sin fecha → debe mostrar error inline
- [x] Verificar que los datos llegan correctamente al servidor (formato ISO yyyy-mm-dd via input hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
