### PR TITLE
[UI] Homogeneizar page-header y ancho ~95% en todas las vistas (#211)

### DIFF
--- a/app/modules/entidades/templates/entidades/detalle.html
+++ b/app/modules/entidades/templates/entidades/detalle.html
@@ -25,40 +25,37 @@
 {% endif %}
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
-<div class="p-4 v4-content">
 
 {% if modo == 'editar' %}
 <form id="form_entidad" class="form-detail"
       action="{{ url_for('entidades.editar', entidad_id=entidad.id) }}" method="POST">
 {% endif %}
 
-<!-- Encabezado de página -->
-<div class="row mb-3 gy-2 align-items-center">
-    <div class="col">
-        <h2>
-            <i class="fas fa-building me-2"></i>
-            {{ entidad.nombre_completo }}
-        </h2>
-    </div>
-    <div class="col-auto d-flex flex-nowrap gap-2">
-        {% if modo == 'ver' %}
-            <a href="{{ url_for('entidades.index') }}" class="btn btn-outline-primary">
-                <i class="fas fa-arrow-left me-1"></i> Volver
-            </a>
-            <a href="{{ url_for('entidades.editar', entidad_id=entidad.id) }}" class="btn btn-primary">
-                <i class="fas fa-edit me-1"></i> Editar
-            </a>
-        {% else %}
-            <a href="{{ url_for('entidades.detalle', entidad_id=entidad.id) }}" class="btn btn-outline-primary">
-                <i class="fas fa-times me-1"></i> Cancelar
-            </a>
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-1"></i> Guardar cambios
-            </button>
-        {% endif %}
-    </div>
+<!-- C.1: Encabezado de página — homogéneo con el resto de vistas -->
+<div class="lista-cabecera">
+{% call page_header(entidad.nombre_completo, 'fas fa-building') %}
+    {% if modo == 'ver' %}
+        <a href="{{ url_for('entidades.index') }}" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left me-1"></i> Volver
+        </a>
+        <a href="{{ url_for('entidades.editar', entidad_id=entidad.id) }}" class="btn btn-primary">
+            <i class="fas fa-edit me-1"></i> Editar
+        </a>
+    {% else %}
+        <a href="{{ url_for('entidades.detalle', entidad_id=entidad.id) }}" class="btn btn-outline-primary">
+            <i class="fas fa-times me-1"></i> Cancelar
+        </a>
+        <button type="submit" class="btn btn-primary">
+            <i class="fas fa-save me-1"></i> Guardar cambios
+        </button>
+    {% endif %}
+{% endcall %}
 </div>
+
+<div class="v4-content content-constrained py-3">
 
 <!-- CARD 1 — Identificación -->
 <div class="card mb-3">
@@ -436,7 +433,7 @@
 </form>
 {% endif %}
 
-</div>{# /p-4 #}
+</div>{# /v4-content #}
 
 <!-- MODAL: Añadir / Editar dirección de notificación -->
 <div class="modal fade" id="modalDireccion" tabindex="-1" aria-labelledby="modalDireccionLabel" aria-hidden="true">

--- a/app/modules/expedientes/templates/expedientes/detalle.html
+++ b/app/modules/expedientes/templates/expedientes/detalle.html
@@ -25,8 +25,9 @@
 {% endif %}
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
-<div class="p-4 v4-content">
 
 {# Datos de municipios existentes para el selector JS (solo en edición) #}
 {% if modo == 'editar' %}
@@ -45,35 +46,31 @@
 <form id="form_expediente" class="form-detail" action="{{ url_for('expedientes.editar', id=expediente.id) }}" method="POST">
 {% endif %}
 
-<!-- Encabezado de página -->
-<div class="row mb-3 gy-2 align-items-center">
-    <div class="col">
-        <h2>
-            <i class="fas fa-folder-open me-2"></i>
-            Expediente <span class="text-primary">AT-{{ expediente.numero_at }}</span>
-        </h2>
-    </div>
-    <div class="col-auto d-flex flex-nowrap gap-2">
-        {% if modo == 'ver' %}
-            <a href="{{ url_for('expedientes.listado_v2') }}" class="btn btn-outline-primary">
-                <i class="fas fa-arrow-left me-1"></i> Volver
-            </a>
-            <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}" class="btn btn-primary">
-                <i class="fas fa-tasks me-1"></i> Tramitar
-            </a>
-            <a href="{{ url_for('expedientes.editar', id=expediente.id) }}" class="btn btn-primary">
-                <i class="fas fa-edit me-1"></i> Editar
-            </a>
-        {% else %}
-            <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}" class="btn btn-outline-primary">
-                <i class="fas fa-times me-1"></i> Cancelar
-            </a>
-            <button type="submit" class="btn btn-primary">
-                <i class="fas fa-save me-1"></i> Guardar Cambios
-            </button>
-        {% endif %}
-    </div>
+<!-- C.1: Encabezado de página — homogéneo con el resto de vistas -->
+<div class="lista-cabecera">
+{% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    {% if modo == 'ver' %}
+        <a href="{{ url_for('expedientes.listado_v2') }}" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left me-1"></i> Volver
+        </a>
+        <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}" class="btn btn-primary">
+            <i class="fas fa-tasks me-1"></i> Tramitar
+        </a>
+        <a href="{{ url_for('expedientes.editar', id=expediente.id) }}" class="btn btn-primary">
+            <i class="fas fa-edit me-1"></i> Editar
+        </a>
+    {% else %}
+        <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}" class="btn btn-outline-primary">
+            <i class="fas fa-times me-1"></i> Cancelar
+        </a>
+        <button type="submit" class="btn btn-primary">
+            <i class="fas fa-save me-1"></i> Guardar Cambios
+        </button>
+    {% endif %}
+{% endcall %}
 </div>
+
+<div class="v4-content content-constrained py-3">
 
 <!-- BARRA INFO: Datos del Expediente -->
 <div class="card shadow-sm mb-3">
@@ -365,7 +362,7 @@
 </form>
 {% endif %}
 
-</div>{# /p-4 #}
+</div>{# /v4-content #}
 {% endblock %}
 
 {% block extra_js %}

--- a/app/modules/expedientes/templates/expedientes/pool_documentos.html
+++ b/app/modules/expedientes/templates/expedientes/pool_documentos.html
@@ -127,46 +127,41 @@
   {% endfor %}
 </template>
 
-<!-- C.1 -->
-<div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-folder-open me-2"></i>
-        Expediente <strong>AT-{{ expediente.numero_at }}</strong>
-      </span>
-      <div class="bc-acciones-bar">
-        <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-primary">
-          <i class="fas fa-info-circle me-1"></i> Detalle
-        </a>
-        <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}"
-           class="btn btn-sm btn-outline-primary">
-          <i class="fas fa-sitemap me-1"></i> Tramitación
-        </a>
+{% from 'macros/page_header.html' import page_header %}
+
+<!-- C.1: Encabezado homogéneo -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-sitemap me-1"></i> Tramitación
+    </a>
+  {% endcall %}
+  <div class="page-subheader content-constrained">
+    <div class="page-subheader-data">
+      <div class="subheader-item">
+        <strong>Titular:</strong>
+        {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
+      </div>
+      <div class="subheader-item">
+        <strong>Responsable:</strong>
+        {{ expediente.responsable.siglas if expediente.responsable else '—' }}
+      </div>
+      <div class="subheader-item">
+        <strong>Tipo:</strong>
+        {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
       </div>
     </div>
-    <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>Titular:</strong>
-          {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
-        </div>
-        <div class="col-auto">
-          <strong>Responsable:</strong>
-          {{ expediente.responsable.siglas if expediente.responsable else '—' }}
-        </div>
-        <div class="col-auto">
-          <strong>Tipo:</strong>
-          {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
-        </div>
-        <div class="col-auto ms-auto">
-          <span class="badge bg-primary">{{ docs_lista | length }} documento(s)</span>
-        </div>
-      </div>
+    <div class="page-subheader-actions">
+      <span class="badge bg-primary">{{ docs_lista | length }} documento(s)</span>
     </div>
   </div>
 
+  <div class="content-constrained">
   <!-- Dos fichas de entrada -->
   <div class="row g-2 mb-2 mt-2">
     <div class="col-6">
@@ -248,7 +243,8 @@
     </select>
     <span id="filtro-count" class="text-secondary small ms-1"></span>
   </div>
-</div>
+  </div>{# /content-constrained #}
+</div>{# /lista-cabecera #}
 
 <!-- C.2 -->
 <div class="lista-scroll-container px-3 pt-0 pb-3">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -17,50 +17,44 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle del nodo actual (fijo, sin scroll) -->
-<div class="lista-cabecera px-3 pt-3">
-  <div class="card bc-card-nodo">
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-folder-open me-2"></i>
-        Expediente <strong>AT-{{ expediente.numero_at }}</strong>
-      </span>
-      <div class="bc-acciones-bar">
-        <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-primary">
-          <i class="fas fa-info-circle me-1"></i> Detalle
-        </a>
-        <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-primary">
-          <i class="fas fa-file-alt me-1"></i> Pool de Docs
-        </a>
+<!-- C.1: Encabezado homogéneo — expediente + navegación + datos secundarios -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-file-alt me-1"></i> Pool de Docs
+    </a>
+  {% endcall %}
+  <div class="page-subheader content-constrained">
+    <div class="page-subheader-data">
+      <div class="subheader-item">
+        <strong>Titular:</strong>
+        {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
+      </div>
+      <div class="subheader-item">
+        <strong>Responsable:</strong>
+        {{ expediente.responsable.siglas if expediente.responsable else '—' }}
+      </div>
+      <div class="subheader-item">
+        <strong>Tipo:</strong>
+        {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
       </div>
     </div>
-    <div class="card-body card-body-tinted py-2">
-      <div class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>Titular:</strong>
-          {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
-        </div>
-        <div class="col-auto">
-          <strong>Responsable:</strong>
-          {{ expediente.responsable.siglas if expediente.responsable else '—' }}
-        </div>
-        <div class="col-auto">
-          <strong>Tipo:</strong>
-          {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
-        </div>
-        <div class="col-auto ms-auto d-flex align-items-center gap-2">
-          <span class="badge bg-primary">{{ hijos | length }} solicitud(es)</span>
-          <button class="btn btn-sm btn-primary"
-                  data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
-            <i class="fas fa-plus me-1"></i> Nueva solicitud
-          </button>
-        </div>
-      </div>
+    <div class="page-subheader-actions">
+      <span class="badge bg-primary">{{ hijos | length }} solicitud(es)</span>
+      <button class="btn btn-sm btn-primary"
+              data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
+        <i class="fas fa-plus me-1"></i> Nueva solicitud
+      </button>
     </div>
   </div>
 </div>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -23,11 +23,24 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle de la Fase (fijo) -->
-<div class="lista-cabecera px-3 pt-3">
+<!-- C.1 -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-file-alt me-1"></i> Pool de Docs
+    </a>
+  {% endcall %}
+  <div class="content-constrained pb-3">
   <div class="card bc-card-nodo" data-bc-editable>
 
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -167,7 +180,8 @@
 
     </div>
   </div>
-</div>
+  </div>{# /content-constrained #}
+</div>{# /lista-cabecera #}
 
 <!-- C.2: Listado de Trámites (scrollable) -->
 <div class="lista-scroll-container">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -19,11 +19,24 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle de la Solicitud (fijo) -->
-<div class="lista-cabecera px-3 pt-3">
+<!-- C.1 -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-file-alt me-1"></i> Pool de Docs
+    </a>
+  {% endcall %}
+  <div class="content-constrained pb-3">
   <div class="card bc-card-nodo" data-bc-editable>
 
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -158,7 +171,8 @@
 
     </div>
   </div>
-</div>
+  </div>{# /content-constrained #}
+</div>{# /lista-cabecera #}
 
 <!-- C.2: Listado de Fases (scrollable) -->
 <div class="lista-scroll-container">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -31,11 +31,24 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle de la Tarea (fijo) -->
-<div class="lista-cabecera px-3 pt-3">
+<!-- C.1 -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-file-alt me-1"></i> Pool de Docs
+    </a>
+  {% endcall %}
+  <div class="content-constrained pb-3">
   <div class="card bc-card-nodo" data-bc-editable>
 
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -150,7 +163,8 @@
 
     </div>
   </div>
-</div>
+  </div>{# /content-constrained #}
+</div>{# /lista-cabecera #}
 
 <!-- C.2: Documentos (scrollable) -->
 <div class="lista-scroll-container p-3">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -27,11 +27,24 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
 <div class="bc-view">
 
-<!-- C.1: Card detalle del Trámite (fijo) -->
-<div class="lista-cabecera px-3 pt-3">
+<!-- C.1 -->
+<div class="lista-cabecera">
+  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-info-circle me-1"></i> Detalle
+    </a>
+    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+       class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-file-alt me-1"></i> Pool de Docs
+    </a>
+  {% endcall %}
+  <div class="content-constrained pb-3">
   <div class="card bc-card-nodo" data-bc-editable>
 
     <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
@@ -153,7 +166,8 @@
 
     </div>
   </div>
-</div>
+  </div>{# /content-constrained #}
+</div>{# /lista-cabecera #}
 
 <!-- C.2: Listado de Tareas (scrollable) -->
 <div class="lista-scroll-container">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_v3.html
@@ -16,17 +16,17 @@
 <span>Tramitación</span>
 {% endblock %}
 
+{% from 'macros/page_header.html' import page_header %}
+
 {% block content %}
-{# C.1: Cabecera fija — expediente + título #}
-<div class="lista-cabecera px-3 pt-3">
-    <div class="d-flex align-items-center justify-content-between mb-2">
-        <h2 class="mb-0">Tramitación AT-{{ expediente.numero_at }}</h2>
+{# C.1: Cabecera fija — expediente + acciones #}
+<div class="lista-cabecera">
+    {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
         <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-           class="btn btn-sm btn-outline-secondary">
-            <i class="fa-solid fa-arrow-left me-1"></i> Volver al detalle
+           class="btn btn-sm btn-outline-primary">
+            <i class="fas fa-arrow-left me-1"></i> Volver al detalle
         </a>
-    </div>
-    {% include 'vistas/vista3/_expediente_body.html' %}
+    {% endcall %}
 </div>
 
 {# C.2: Contenido con scroll — tabs 4 niveles #}

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -443,14 +443,11 @@
 /* Patrón para vistas que alternan modo lectura/edición con el mismo layout.
  * Ver: docs/GUIA_VISTAS_BOOTSTRAP.md - Vista V4 Detalle/Edición */
 
-/* Contenedor con ancho máximo: evita que fichas se estiren en pantallas anchas.
- * El default (--v4-max-width: 1200px) es sobreescribible por template via
- * {% block extra_css %}<style>:root { --v4-max-width: 900px; }</style>{% endblock %} */
+/* Contenedor del contenido V4 (detalle/edición).
+ * El ancho efectivo ~95% lo da padding: 0 var(--content-padding) heredado de content-constrained.
+ * Usar siempre junto con la clase content-constrained en el HTML. */
 .v4-content {
   width: 100%;
-  max-width: var(--v4-max-width);
-  margin-left: auto;
-  margin-right: auto;
 }
 
 /* Cabecera de ficha: verde corporativo secundario (primary-light) */

--- a/app/static/css/v2-layout.css
+++ b/app/static/css/v2-layout.css
@@ -220,10 +220,42 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem; /* Compacto */
+  margin-bottom: 0.75rem;
   padding-top: var(--content-padding); /* Margen superior solo aquí */
   flex-wrap: wrap;
   gap: 1rem;
+  min-height: 2.375rem; /* Iguala altura con/sin botón de acción (#202) */
+}
+
+/* Fila secundaria: datos de contexto (titular, responsable, tipo) para vistas V3 */
+.page-subheader {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+  padding-bottom: 0.875rem;
+  font-size: 0.875rem;
+  color: var(--gris-principal);
+  border-bottom: 1px solid var(--border-color);
+}
+.page-subheader .page-subheader-data {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+}
+.page-subheader .subheader-item {
+  padding-right: 1.25rem;
+}
+.page-subheader .subheader-item + .subheader-item {
+  padding-left: 1.25rem;
+  border-left: 1px solid var(--border-color);
+}
+.page-subheader .page-subheader-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .page-header h1 {
@@ -238,15 +270,12 @@
 
 /* Tablet (768px - 1199px) */
 @media (max-width: 1199px) {
-  :root {
-    --content-padding: 1.5rem;
-  }
+  /* --content-padding ya se adapta con max(1rem, 2.5vw), sin override necesario */
 }
 
 /* Mobile (<768px) */
 @media (max-width: 767px) {
   :root {
-    --content-padding: 1rem;
     --header-nav-height: 56px;
     --header-height: 92px;    /* nav(56) + breadcrumb(36) */
     --footer-height: auto;

--- a/app/static/css/v2-theme.css
+++ b/app/static/css/v2-theme.css
@@ -11,12 +11,11 @@
 :root {
   /* ===== LAYOUT ===== */
   --max-width: 100%;           /* Sin limitador max-width */
-  --content-padding: 2rem;
+  --content-padding: max(1rem, 2.5vw); /* ~2.5% cada lado → ~95% efectivo. Alineado con celdas de tabla */
   --header-nav-height: 60px;
   --breadcrumb-height: 36px;
   --header-height: 96px;       /* nav(60) + breadcrumb(36) */
   --footer-height: 50px;
-  --v4-max-width: 1200px;      /* Ancho máximo para vistas V4 (detalle/edición) */
   
   /* ===== COLORES CORPORATIVOS JUNTA DE ANDALUCÍA ===== */
   /* Identidad corporativa */

--- a/app/templates/macros/page_header.html
+++ b/app/templates/macros/page_header.html
@@ -1,0 +1,37 @@
+{#
+  Macro page_header — Encabezado de página homogéneo
+  ====================================================
+  Genera la zona invariante entre el breadcrumb y el contenido (filtros o cards).
+
+  USO CON BOTONES (caller):
+    {% from 'macros/page_header.html' import page_header %}
+    {% call page_header('Expedientes', 'fas fa-folder-open') %}
+      <a href="..." class="btn btn-primary">+ Nuevo Expediente</a>
+    {% endcall %}
+
+  CON TEXTO DESTACADO (p.ej. número AT en verde):
+    {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+      ...botones...
+    {% endcall %}
+    → Renderiza: <h1><i>...</i> Expediente <span class="text-primary">AT-1</span></h1>
+
+  SIN BOTONES (p.ej. Proyectos):
+    {% call page_header('Proyectos', 'fas fa-drafting-compass') %}{% endcall %}
+
+  PARÁMETROS:
+    title        — Texto del <h1>. Se auto-escapa (seguro para texto de usuario).
+    icon_class   — Clase FontAwesome del icono (opcional).
+    title_accent — Parte final del título con color primario (opcional, también auto-escapado).
+#}
+{%- macro page_header(title, icon_class='', title_accent='') -%}
+<div class="page-header content-constrained">
+  <h1>
+    {%- if icon_class %}<i class="{{ icon_class }}"></i>{% endif %}
+    {{ title -}}
+    {%- if title_accent %} <span class="text-primary">{{ title_accent }}</span>{% endif %}
+  </h1>
+  {%- if caller %}
+  <div class="d-flex flex-nowrap gap-2">{{ caller() }}</div>
+  {%- endif %}
+</div>
+{%- endmacro -%}


### PR DESCRIPTION
## Resumen

- **Ancho uniforme ~95%** en todas las vistas vía `--content-padding: max(1rem, 2.5vw)` — alineado automáticamente con las celdas de tabla que ya usaban esa variable
- **Macro `page_header`** (`app/templates/macros/page_header.html`) como fuente única de verdad para la zona entre breadcrumb y contenido
- **Fix Proyectos** (`min-height` en `.page-header`) para igualar altura de fila con/sin botón de acción
- **V4 detalle** (expediente y entidad): header extraído del container `v4-content`, eliminado `max-width: 1200px`
- **V3 tramitación** (`tramitacion_bc`, `pool_documentos`): card verde reemplazada por `page-header` + `page-subheader` (nueva clase con Titular/Responsable/Tipo)
- **V3 BC** (fase, solicitud, trámite, tarea): `page-header` del expediente añadido encima de la card ESFTT existente

## Ficheros modificados

| Tipo | Fichero |
|---|---|
| CSS | `v2-theme.css`, `v2-layout.css`, `v2-components.css` |
| Macro nuevo | `app/templates/macros/page_header.html` |
| V4 | `expedientes/detalle.html`, `entidades/detalle.html` |
| V3 | `tramitacion_bc.html`, `pool_documentos.html` |
| V3 BC | `bc_fase.html`, `bc_solicitud.html`, `bc_tramite.html`, `bc_tarea.html` |
| Legacy | `tramitacion_v3.html` |

## Plan de verificación

- [ ] `/expedientes` — page-header al 95%, altura igual a `/entidades`
- [ ] `/proyectos` — sin botón, altura igual gracias al `min-height`
- [ ] `/expedientes/104` — header fuera del container, ancho 95% como los listados
- [ ] `/expedientes/104/tramitacion` — page-header + page-subheader con datos del expediente
- [ ] `/expedientes/104/documentos` — mismo patrón que tramitación
- [ ] Niveles BC (fase, solicitud, trámite, tarea) — page-header del expediente en la parte superior

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
