### PR TITLE
UI: homogeneizar tablas V2 y BC (#202)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -49,19 +49,26 @@
         {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
       </div>
     </div>
-    <div class="page-subheader-actions">
-      <span class="badge bg-primary">{{ hijos | length }} solicitud(es)</span>
-      <button class="btn btn-sm btn-primary"
-              data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
-        <i class="fas fa-plus me-1"></i> Nueva solicitud
-      </button>
-    </div>
   </div>
 </div>
 
 <!-- C.2: Listado de Solicitudes (scrollable) -->
 <div class="lista-scroll-container">
-  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+  <div class="content-constrained py-3">
+    <div class="card tabla-bloque">
+      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+        <span class="fw-semibold">
+          <i class="fas fa-file-contract me-1"></i> Solicitudes
+          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+        </span>
+        <button class="btn btn-sm btn-primary"
+                data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
+          <i class="fas fa-plus me-1"></i> Nueva solicitud
+        </button>
+      </div>
+      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+    </div>
+  </div>
 </div>
 
 <!-- Modal Nueva Solicitud -->

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -124,13 +124,6 @@
             {{- fase.resultado_fase.nombre if fase.resultado_fase else '—' -}}
           </span>
         </div>
-        <div class="col-auto ms-auto d-flex align-items-center gap-2">
-          <span class="badge bg-primary">{{ hijos | length }} trámite(s)</span>
-          <button class="btn btn-sm btn-primary"
-                  data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
-            <i class="fas fa-plus me-1"></i> Nuevo trámite
-          </button>
-        </div>
       </div>
 
       {# Modo editar #}
@@ -185,7 +178,21 @@
 
 <!-- C.2: Listado de Trámites (scrollable) -->
 <div class="lista-scroll-container">
-  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+  <div class="content-constrained py-3">
+    <div class="card tabla-bloque">
+      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+        <span class="fw-semibold">
+          <i class="fas fa-clipboard-list me-1"></i> Trámites
+          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+        </span>
+        <button class="btn btn-sm btn-primary"
+                data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
+          <i class="fas fa-plus me-1"></i> Nuevo trámite
+        </button>
+      </div>
+      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+    </div>
+  </div>
 </div>
 
 <!-- Modal Nuevo Trámite -->

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -125,13 +125,6 @@
             {{ solicitud.estado | replace('_', ' ') | title }}
           </span>
         </div>
-        <div class="col-auto ms-auto d-flex align-items-center gap-2">
-          <span class="badge bg-primary">{{ hijos | length }} fase(s)</span>
-          <button class="btn btn-sm btn-primary"
-                  data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
-            <i class="fas fa-plus me-1"></i> Nueva fase
-          </button>
-        </div>
       </div>
 
       {# Modo editar: formulario #}
@@ -176,7 +169,21 @@
 
 <!-- C.2: Listado de Fases (scrollable) -->
 <div class="lista-scroll-container">
-  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+  <div class="content-constrained py-3">
+    <div class="card tabla-bloque">
+      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+        <span class="fw-semibold">
+          <i class="fas fa-sitemap me-1"></i> Fases
+          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+        </span>
+        <button class="btn btn-sm btn-primary"
+                data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
+          <i class="fas fa-plus me-1"></i> Nueva fase
+        </button>
+      </div>
+      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+    </div>
+  </div>
 </div>
 
 <!-- Modal Nueva Fase -->

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -122,13 +122,6 @@
             {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
           </span>
         </div>
-        <div class="col-auto ms-auto d-flex align-items-center gap-2">
-          <span class="badge bg-primary">{{ hijos | length }} tarea(s)</span>
-          <button class="btn btn-sm btn-primary"
-                  data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
-            <i class="fas fa-plus me-1"></i> Nueva tarea
-          </button>
-        </div>
       </div>
 
       {# Modo editar #}
@@ -171,7 +164,21 @@
 
 <!-- C.2: Listado de Tareas (scrollable) -->
 <div class="lista-scroll-container">
-  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+  <div class="content-constrained py-3">
+    <div class="card tabla-bloque">
+      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+        <span class="fw-semibold">
+          <i class="fas fa-tasks me-1"></i> Tareas
+          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+        </span>
+        <button class="btn btn-sm btn-primary"
+                data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
+          <i class="fas fa-plus me-1"></i> Nueva tarea
+        </button>
+      </div>
+      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+    </div>
+  </div>
 </div>
 
 <!-- Modal Nueva Tarea -->

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -35,12 +35,32 @@
   z-index: 10;
 }
 
+/* ===== BLOQUE CONTENEDOR DE TABLA (V2 y BC) — issue #202 ===== */
+/* Envuelve la tabla en un card con bordes redondeados al ~95% de ancho.
+ * Usar junto con content-constrained py-3 en el HTML.
+ * SIN overflow:hidden — rompería position:sticky del thead.
+ * Los bordes redondeados superiores se aplican directamente a las th. */
+.tabla-bloque {
+  border-radius: var(--border-radius-lg, 0.5rem);
+  box-shadow: var(--shadow-sm);
+  margin: 0;
+}
+
+/* Redondeado superior del thead cuando la tabla es hija directa del card (V2).
+ * expedientes-table usa border-collapse:separate → border-radius en th funciona. */
+.tabla-bloque > table.expedientes-table thead th:first-child {
+  border-top-left-radius: calc(var(--border-radius-lg, 0.5rem) - 1px);
+}
+.tabla-bloque > table.expedientes-table thead th:last-child {
+  border-top-right-radius: calc(var(--border-radius-lg, 0.5rem) - 1px);
+}
+
 /* ===== TABLA RESPONSIVE (FULL-WIDTH) ===== */
 .expedientes-table {
   width: 100%;
   background: var(--bg-card);
-  border-radius: 0; /* Sin border-radius para full-width */
-  box-shadow: none; /* Sin sombra para full-width */
+  border-radius: 0; /* Sin border-radius — la da .tabla-bloque */
+  box-shadow: none; /* Sin sombra — la da .tabla-bloque */
   border-collapse: separate;
   border-spacing: 0;
   /*overflow: hidden;*/  /* Comentado - bloqueaba sticky */
@@ -65,9 +85,10 @@
   position: sticky;
   top: var(--header-height);
   z-index: 100;
-  background: var(--primary);
-  background-image: var(--gradient);
-  color: var(--text-inverse);
+  /* Verde claro coherente con card-header-accent (#202) */
+  background: var(--primary-light, #c4ddca);
+  background-image: none;
+  color: var(--gris-principal, #111);
 }
 
 .expedientes-table td {

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -38,12 +38,18 @@
 /* ===== BLOQUE CONTENEDOR DE TABLA (V2 y BC) — issue #202 ===== */
 /* Envuelve la tabla en un card con bordes redondeados al ~95% de ancho.
  * Usar junto con content-constrained py-3 en el HTML.
- * SIN overflow:hidden — rompería position:sticky del thead.
- * Los bordes redondeados superiores se aplican directamente a las th. */
+ * Base SIN overflow:hidden — preserva position:sticky del thead (V2).
+ * Cuando el card tiene card-header (BC), no hay sticky → se puede recortar. */
 .tabla-bloque {
   border-radius: var(--border-radius-lg, 0.5rem);
   box-shadow: var(--shadow-sm);
   margin: 0;
+}
+
+/* BC: card-header como primer hijo → overflow:hidden para esquinas limpias.
+ * V2: primer hijo es <table> directa → esta regla no aplica, sticky intacto. */
+.tabla-bloque:has(> .card-header) {
+  overflow: hidden;
 }
 
 /* Redondeado superior del thead cuando la tabla es hija directa del card (V2).

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -52,6 +52,14 @@
   overflow: hidden;
 }
 
+/* V2: la tabla es hijo directo del card (sin card-header).
+ * Los th:first/last-child tienen border-radius, pero el card background (blanco)
+ * quedaba visible en el hueco de la esquina redondeada.
+ * Solución: igualar el bg del card al color del thead → el hueco es invisible. */
+.tabla-bloque:has(> table.expedientes-table) {
+  background-color: var(--primary-light, #c4ddca);
+}
+
 /* Redondeado superior del thead cuando la tabla es hija directa del card (V2).
  * expedientes-table usa border-collapse:separate → border-radius en th funciona. */
 .tabla-bloque > table.expedientes-table thead th:first-child {

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -84,12 +84,11 @@
     min-height: 0;
 }
 
-/* ── Thead sticky en tabla de hijos (#199, actualizado #202) ────────────── */
+/* ── Thead BC: color unificado, sin sticky (#199, #202) ─────────────────── */
+/* Las listas BC son cortas — no necesitan thead fijo.
+ * El sticky permanece solo en expedientes-table (V2), definido en v2-components.css. */
 
 .lista-scroll-container .table thead th {
-    position: sticky;
-    top: 0;
-    z-index: 10;
     /* Verde claro unificado con expedientes-table (#202) */
     background-color: var(--primary-light, #c4ddca);
     color: var(--gris-principal, #111);

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -84,13 +84,24 @@
     min-height: 0;
 }
 
-/* ── Thead sticky en tabla de hijos (#199) ──────────────────────────────── */
+/* ── Thead sticky en tabla de hijos (#199, actualizado #202) ────────────── */
 
 .lista-scroll-container .table thead th {
     position: sticky;
     top: 0;
     z-index: 10;
-    background-color: var(--bs-table-bg, #f8f9fa);
+    /* Verde claro unificado con expedientes-table (#202) */
+    background-color: var(--primary-light, #c4ddca);
+    color: var(--gris-principal, #111);
+}
+
+/* ── Responsive BC: ocultar columnas medias en mobile (#202) ────────────── */
+/* Primera columna (indicador estado) y última (flecha →) siempre visibles. */
+@media (max-width: 767px) {
+    .tabla-hijos th:not(:first-child):not(:last-child),
+    .tabla-hijos td:not(:first-child):not(:last-child) {
+        display: none;
+    }
 }
 
 /* ── Botones de acción en la cabecera (placeholders) ────────────────────── */

--- a/app/templates/layout/lista_v2_base.html
+++ b/app/templates/layout/lista_v2_base.html
@@ -109,17 +109,22 @@
     {#
        Clase base: 'expedientes-table' (estilos en v2-components.css).
        TODO Epic #93 Fase 3: renombrar a 'lista-table' en CSS y aquí.
+       Envuelta en .tabla-bloque para bordes redondeados y sombra (#202).
     #}
-    <table class="expedientes-table {% block tabla_clase %}{% endblock %}">
-        <thead>
-            <tr>
-                {% block thead_cols %}{% endblock %}
-            </tr>
-        </thead>
-        <tbody>
-            <!-- Filas cargadas dinámicamente por ScrollInfinito -->
-        </tbody>
-    </table>
+    <div class="content-constrained py-3">
+      <div class="card tabla-bloque">
+        <table class="expedientes-table {% block tabla_clase %}{% endblock %}">
+            <thead>
+                <tr>
+                    {% block thead_cols %}{% endblock %}
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Filas cargadas dinámicamente por ScrollInfinito -->
+            </tbody>
+        </table>
+      </div>
+    </div>
 
     <button id="tabla-scroll-to-top" aria-label="Volver arriba de la tabla">
         <i class="fas fa-chevron-up"></i>

--- a/app/templates/vistas/vista3_bc/_tabla_hijos.html
+++ b/app/templates/vistas/vista3_bc/_tabla_hijos.html
@@ -20,7 +20,7 @@
 {% endmacro %}
 
 {% if hijos %}
-  <table class="table table-hover table-sm align-middle mb-0">
+  <table class="table table-hover table-sm align-middle mb-0 tabla-hijos">
     <thead class="table-light">
       <tr>
         <th style="width:2rem"></th>

--- a/docs/GUIA_VISTAS_BOOTSTRAP.md
+++ b/docs/GUIA_VISTAS_BOOTSTRAP.md
@@ -15,9 +15,10 @@
 | **C.1** | Zona fija superior sin scroll (`lista-cabecera`) |
 | **C.2** | Zona scrollable independiente (`lista-scroll-container`) |
 | **Listado embebido** | Tabla dentro de una card V4 (ej: documentos en detalle de expediente, direcciones en detalle de entidad) |
-| **Tabla V2** | Tabla con clase `expedientes-table`, thead verde corporativo sticky, scroll infinito JS |
-| **Tabla BC** | Tabla generada por `_tabla_hijos.html`, Bootstrap puro `table-hover table-sm`, thead `table-light` |
+| **Tabla V2** | Tabla `expedientes-table` dentro de `card.tabla-bloque`, thead verde claro sticky, scroll infinito JS |
+| **Tabla BC** | Tabla `_tabla_hijos.html` dentro de `card.tabla-bloque`, thead verde claro (unificado con V2), sin sticky |
 | **Tabla Pool** | Tabla `#pool-tabla`, `table-layout: fixed`, thead sticky gris con `box-shadow inset` |
+| **`.tabla-bloque`** | Card contenedor de tabla (V2 y BC): bordes redondeados, sombra. Con `card-header` → `overflow:hidden` (esquinas limpias); con `expedientes-table` directa → bg verde claro (esquinas seamless + sticky intacto) |
 
 ---
 
@@ -140,13 +141,17 @@ A: app-container (grid header/main/footer)
     <div class="page-header content-constrained">Título + botón</div>
     <div class="filters-row content-constrained">Filtros + paginación</div>
   </div>
-  
+
   <div class="lista-scroll-container"> <!-- C.2: flex: 1, overflow-y: auto -->
-    <table class="expedientes-table"> <!-- D: thead sticky top: 0 -->
-      <thead>...</thead>
-      <tbody>...</tbody>
-    </table>
-    <button id="tabla-scroll-to-top">↑</button> <!-- sticky bottom: 1rem -->
+    <div class="content-constrained py-3">
+      <div class="card tabla-bloque"> <!-- bordes redondeados + sombra; bg verde → esquinas seamless -->
+        <table class="expedientes-table"> <!-- thead sticky top: 0 -->
+          <thead>...</thead>
+          <tbody><!-- filas JS ScrollInfinito --></tbody>
+        </table>
+      </div>
+    </div>
+    <button id="tabla-scroll-to-top">↑</button> <!-- sticky bottom: 1rem, FUERA del card -->
   </div>
 </main>
 ```
@@ -269,9 +274,19 @@ El breadcrumb del header permite volver a cualquier nivel superior.
 
   <!-- C.2: tabla de hijos -->
   <div class="lista-scroll-container">
-    <div class="bc-view">
-      <h6>Título listado hijos + botón Nuevo</h6>
-      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+    <div class="content-constrained py-3">
+      <div class="card tabla-bloque"> <!-- overflow:hidden vía :has(>.card-header) → esquinas limpias -->
+        <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+          <span class="fw-semibold">
+            <i class="fas fa-..."></i> [Título hijos]
+            <span class="badge bg-primary ms-2">{{ hijos|length }}</span>
+          </span>
+          <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#modal-nuevo-...">
+            <i class="fas fa-plus me-1"></i> Nuevo [hijo]
+          </button>
+        </div>
+        {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+      </div>
     </div>
   </div>
 </main>
@@ -286,14 +301,16 @@ Genera la tabla de hijos con columnas dinámicas desde Python:
 
 ```html
 <!-- Variables de contexto: hijos (lista de dicts), columnas (lista de {key, label}) -->
-<table class="table table-hover table-sm align-middle mb-0">
-  <thead class="table-light">
+<!-- Clase tabla-hijos: permite responsive mobile (oculta columnas medias en ≤767px) -->
+<table class="table table-hover table-sm align-middle mb-0 tabla-hijos">
+  <thead>
+    <!-- Sin table-light: el CSS de v3-breadcrumbs.css sobreescribe el bg a verde claro -->
     <tr>
-      <th style="width:2rem"></th>         <!-- indicador estado -->
+      <th style="width:2rem"></th>         <!-- indicador estado — siempre visible -->
       {% for col in columnas %}
-      <th>{{ col.label }}</th>
+      <th>{{ col.label }}</th>             <!-- ocultas en mobile vía .tabla-hijos media query -->
       {% endfor %}
-      <th style="width:3rem"></th>         <!-- botón → -->
+      <th style="width:3rem"></th>         <!-- botón → — siempre visible -->
     </tr>
   </thead>
   <tbody>
@@ -312,14 +329,16 @@ Genera la tabla de hijos con columnas dinámicas desde Python:
 
 Indicadores de estado: `bi-check-circle-fill` (finalizada), `bi-clock-fill` (en curso), `bi-circle` (planificada).
 
-### Clases CSS específicas (`v3-breadcrumbs.css`)
+### Clases CSS específicas (`v3-breadcrumbs.css` y `v2-components.css`)
 
-| Clase | Uso |
-|-------|-----|
-| `.bc-card-nodo` | Card del nodo actual — sombra discreta |
-| `.bc-meta` | Texto de metadatos (0.85rem, color secundario) |
-| `.bc-view` | Contenedor centrado `max-width: 1200px` |
-| `.bc-acciones-bar` | Flex row de botones de acción |
+| Clase | Archivo | Uso |
+|-------|---------|-----|
+| `.bc-card-nodo` | v3-breadcrumbs | Card del nodo actual — sombra discreta |
+| `.bc-meta` | v3-breadcrumbs | Texto de metadatos (0.85rem, color secundario) |
+| `.bc-view` | v3-breadcrumbs | Contenedor centrado `max-width: 1200px` |
+| `.bc-acciones-bar` | v3-breadcrumbs | Flex row de botones de acción |
+| `.tabla-bloque` | v2-components | Card contenedor de tabla (V2 y BC): `border-radius`, `box-shadow`. Ver vocabulario para comportamiento por variante. |
+| `.tabla-hijos` | v3-breadcrumbs | Clase en `<table>` de `_tabla_hijos.html`; activa responsive mobile (oculta columnas medias en ≤767px) |
 
 ### Archivos clave
 
@@ -694,6 +713,8 @@ particularidades propias.
 ### 2. NO usar `overflow: hidden` en contenedores con sticky
 Bloquea `position: sticky`. En C.1/C.2, el `overflow: hidden` va en `.app-main`, NO en `.lista-scroll-container`.
 
+**Excepción controlada:** `.tabla-bloque:has(> .card-header)` añade `overflow: hidden` via `:has()` solo cuando hay `card-header` (BC). En esos casos no hay sticky, así que es seguro. Para V2 (tabla directa sin card-header) se usa en cambio `background-color` verde en el card para que el hueco de la esquina redondeada sea invisible.
+
 ### 3. Botón scroll-to-top FUERA de `<table>`
 ```html
 <!-- MAL: Se mueve con scroll -->
@@ -772,7 +793,8 @@ container.addEventListener('scroll', toggleButton);
 
 ---
 
-**Versión:** 2.0
-**Fecha:** 8 de marzo de 2026
+**Versión:** 2.1
+**Fecha:** 11 de marzo de 2026
 **Cambios v2.0:** Eliminada V3 acordeón/tabs (legacy), documentada V3-BC, listados embebidos y Pool.
+**Cambios v2.1 (#202):** Unificado thead V2/BC (verde claro `#c4ddca`). Añadido `.tabla-bloque` como contenedor card de tabla. Thead BC sin sticky (listas cortas). Responsive mobile en `_tabla_hijos.html` (clase `.tabla-hijos`). Estructura C.2 actualizada en V2 y V3-BC.
 **Referencia estudio:** `docs/fuentesIA/ESTUDIO_HOMOGENEIZACION_UI.md`


### PR DESCRIPTION
## Resumen

- Thead V2 y BC unificado: verde claro corporativo `#c4ddca` (antes V2 era verde oscuro, BC era `table-light`)
- Nueva clase `.tabla-bloque`: card contenedor con bordes redondeados y sombra para V2 y BC
- Botón "Nueva X" movido a C.2 (card-header de `.tabla-bloque`) en todos los niveles BC
- Esquinas superiores limpias: `overflow:hidden` via `:has(>.card-header)` en BC; bg verde en V2
- Thead BC **sin sticky** (listas cortas, no lo necesitan); sticky se mantiene en V2
- Responsive mobile en `_tabla_hijos.html`: columnas medias ocultas en ≤767px (clase `.tabla-hijos`)
- `GUIA_VISTAS_BOOTSTRAP.md` actualizada a v2.1

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `app/static/css/v2-components.css` | `.tabla-bloque`, thead verde claro V2, bg verde para esquinas |
| `app/static/css/v3-breadcrumbs.css` | Thead BC verde claro, sin sticky, responsive `.tabla-hijos` |
| `app/templates/layout/lista_v2_base.html` | Envolver tabla en `card.tabla-bloque` |
| `app/templates/vistas/vista3_bc/_tabla_hijos.html` | Clase `tabla-hijos` |
| `app/modules/expedientes/templates/expedientes/tramitacion_bc*.html` (×4) | Card `tabla-bloque` en C.2 con card-header-accent + botón |
| `docs/GUIA_VISTAS_BOOTSTRAP.md` | v2.1: vocabulario, estructuras C.2, clases CSS |

## Test plan

- [x] `/expedientes/listado-v2` — thead verde claro, esquinas card limpias, sticky thead funciona
- [x] `/expedientes/<id>/tramitacion` — card BC con esquinas limpias, botón "Nueva solicitud" en header
- [x] `/expedientes/<id>/tramitacion/solicitud/<id>` — ídem con "Nueva fase"
- [x] Responsive mobile: columnas medias BC ocultas en ≤767px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
