### PR TITLE
[DOCS] Sistema documental en nivel Tarea (Vista 3 BC)

### DIFF
--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -480,6 +480,10 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
     if tarea.tramite_id != tram_id:
         abort(404)
 
+    codigo_tipo = tarea.tipo_tarea.codigo if tarea.tipo_tarea else ''
+    requiere_doc_usado     = codigo_tipo in _TIPOS_REQUIEREN_DOC_USADO
+    requiere_doc_producido = codigo_tipo in _TIPOS_REQUIEREN_DOC_PRODUCIDO
+
     return render_template(
         'expedientes/tramitacion_bc_tarea.html',
         expediente=expediente,
@@ -487,7 +491,14 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         fase=fase,
         tramite=tramite,
         tarea=tarea,
+        requiere_doc_usado=requiere_doc_usado,
+        requiere_doc_producido=requiere_doc_producido,
     )
+
+
+# Conjuntos de tipos de tarea que requieren documentos (espejo de motor_reglas.py)
+_TIPOS_REQUIEREN_DOC_USADO     = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
 
 
 # ===========================================================================
@@ -556,6 +567,38 @@ def pool_documentos(id):
         docs_lista=docs_lista,
         tipos_doc=tipos_doc,
     )
+
+
+@bp.route('/<int:id>/documentos/json')
+@login_required
+def pool_documentos_json(id):
+    """API JSON — lista de documentos del expediente para SelectorBusqueda (issue #166).
+
+    Devuelve: { "ok": true, "docs": [{"v": "42", "t": "informe.pdf — Informe técnico — 15/01/2026"}, ...] }
+    """
+    expediente = Expediente.query.get_or_404(id)
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    documentos = Documento.query.filter_by(
+        expediente_id=id
+    ).order_by(Documento.id.desc()).all()
+
+    docs = []
+    for doc in documentos:
+        filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else ''
+        filename_limpio = filename.split('?')[0].split('#')[0]
+        nombre = filename_limpio or f'Documento {doc.id}'
+        tipo_nombre = doc.tipo_doc.nombre if doc.tipo_doc else 'Sin tipo'
+        if doc.fecha_administrativa:
+            fecha_str = doc.fecha_administrativa.strftime('%d/%m/%Y')
+        else:
+            fecha_str = 'Sin fecha'
+        texto = f'{nombre} — {tipo_nombre} — {fecha_str}'
+        docs.append({'v': str(doc.id), 't': texto})
+
+    return jsonify({'ok': True, 'docs': docs})
 
 
 def _path_seguro(ruta_relativa, base):

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -29,6 +29,7 @@
 {% block extra_css %}{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/selector_busqueda.css') }}">
 {% endblock %}
 
 {% from 'macros/page_header.html' import page_header %}
@@ -167,14 +168,88 @@
 </div>{# /lista-cabecera #}
 
 <!-- C.2: Documentos (scrollable) -->
-<div class="lista-scroll-container p-3">
+<div class="lista-scroll-container p-3" id="card-documentos">
   <div class="card">
     <div class="card-header card-header-accent">
       <h6 class="mb-0 fw-semibold"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
     </div>
-    <div class="card-body text-center py-4">
-      <i class="fas fa-folder fa-2x mb-2 d-block text-secondary"></i>
-      <span class="small text-secondary">Gestión de documentos — próximamente</span>
+    <div class="card-body card-body-tinted py-3">
+
+      {% if not requiere_doc_usado and not requiere_doc_producido %}
+      <p class="text-secondary mb-0 fst-italic small">Este tipo de tarea no requiere documentos.</p>
+
+      {% else %}
+
+      {# ── Documento usado ────────────────────────────────────────────────────── #}
+      {% if requiere_doc_usado %}
+      <div class="mb-3">
+        <label class="form-label fw-semibold mb-1">Documento de entrada</label>
+        {# Modo ver #}
+        <div class="doc-modo-ver">
+          {% if tarea.documento_usado %}
+            {% set nombre_usado = tarea.documento_usado.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+              <i class="fas fa-file-import text-secondary"></i>
+              <span id="disp-doc-usado" class="fw-semibold">{{ nombre_usado }}</span>
+              <small class="text-secondary">
+                — {{ tarea.documento_usado.tipo_doc.nombre if tarea.documento_usado.tipo_doc else '' }}
+                {% if tarea.documento_usado.fecha_administrativa %}
+                  — {{ tarea.documento_usado.fecha_administrativa.strftime('%d/%m/%Y') }}
+                {% endif %}
+              </small>
+              <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_usado.id) }}"
+                 class="btn btn-sm btn-outline-secondary ms-auto"
+                 target="_blank" rel="noopener">
+                <i class="fas fa-download me-1"></i>Descargar
+              </a>
+            </div>
+          {% else %}
+            <span id="disp-doc-usado" class="fst-italic text-secondary small">Sin documento asociado</span>
+          {% endif %}
+        </div>
+        {# Modo editar #}
+        <div class="doc-modo-editar d-none">
+          <div id="sb-doc-usado"></div>
+        </div>
+      </div>
+      {% endif %}
+
+      {# ── Documento producido ────────────────────────────────────────────────── #}
+      {% if requiere_doc_producido %}
+      <div class="mb-1">
+        <label class="form-label fw-semibold mb-1">Documento producido</label>
+        {# Modo ver #}
+        <div class="doc-modo-ver">
+          {% if tarea.documento_producido %}
+            {% set nombre_producido = tarea.documento_producido.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+              <i class="fas fa-file-export text-secondary"></i>
+              <span id="disp-doc-producido" class="fw-semibold">{{ nombre_producido }}</span>
+              <small class="text-secondary">
+                — {{ tarea.documento_producido.tipo_doc.nombre if tarea.documento_producido.tipo_doc else '' }}
+                {% if tarea.documento_producido.fecha_administrativa %}
+                  — {{ tarea.documento_producido.fecha_administrativa.strftime('%d/%m/%Y') }}
+                {% endif %}
+              </small>
+              <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_producido.id) }}"
+                 class="btn btn-sm btn-outline-secondary ms-auto"
+                 target="_blank" rel="noopener">
+                <i class="fas fa-download me-1"></i>Descargar
+              </a>
+            </div>
+          {% else %}
+            <span id="disp-doc-producido" class="fst-italic text-secondary small">Sin documento asociado</span>
+          {% endif %}
+        </div>
+        {# Modo editar #}
+        <div class="doc-modo-editar d-none">
+          <div id="sb-doc-producido"></div>
+        </div>
+      </div>
+      {% endif %}
+
+      {% endif %}{# /requiere_doc #}
+
     </div>
   </div>
 </div>
@@ -184,6 +259,17 @@
 
 {% block extra_js %}{{ super() }}
 <script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+<script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
+<script>
+window.TAREA_DOCS_CONFIG = {
+  requiereDocUsado:     {{ requiere_doc_usado | tojson }},
+  requiereDocProducido: {{ requiere_doc_producido | tojson }},
+  docUsadoId:      {{ tarea.documento_usado_id | tojson }},
+  docProducidoId:  {{ tarea.documento_producido_id | tojson }},
+  urlApiDocs: "{{ url_for('expedientes.pool_documentos_json', id=expediente.id) }}"
+};
+</script>
+<script src="{{ url_for('static', filename='js/tarea_documentos.js') }}"></script>
 {% endblock %}

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -11,6 +11,7 @@ from datetime import date
 from flask import Blueprint, jsonify, render_template, request
 from flask_login import login_required
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from app import db
 from app.models.expedientes import Expediente
 from app.models.solicitudes import Solicitud
@@ -401,9 +402,27 @@ def editar_tarea(tarea_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
+    expediente_id = tarea.tramite.fase.solicitud.expediente_id
+
     try:
         nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
         nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        # Documentos (nullable: string vacío → None)
+        doc_usado_raw     = request.form.get('documento_usado_id') or None
+        doc_producido_raw = request.form.get('documento_producido_id') or None
+        nuevo_doc_usado_id     = int(doc_usado_raw)     if doc_usado_raw     else None
+        nuevo_doc_producido_id = int(doc_producido_raw) if doc_producido_raw else None
+
+        # Validar que los documentos pertenecen al mismo expediente
+        for doc_id in filter(None, [nuevo_doc_usado_id, nuevo_doc_producido_id]):
+            doc = Documento.query.get(doc_id)
+            if not doc or doc.expediente_id != expediente_id:
+                return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
+
+        # Asignar documentos ANTES de los hooks para que el motor vea los nuevos valores
+        tarea.documento_usado_id     = nuevo_doc_usado_id
+        tarea.documento_producido_id = nuevo_doc_producido_id
 
         # Hook INICIAR (fecha_inicio: None → valor)
         res_eval = None
@@ -430,6 +449,9 @@ def editar_tarea(tarea_id):
                                documentos=documentos) if tarea_data else ''
         advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
         return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': 'Este documento ya está asignado como producido a otra tarea'}), 422
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500

--- a/app/static/js/tarea_documentos.js
+++ b/app/static/js/tarea_documentos.js
@@ -1,0 +1,121 @@
+// tarea_documentos.js — issue #166
+// Gestiona los SelectorBusqueda de documento_usado y documento_producido en la
+// vista de tarea (tramitacion_bc_tarea.html).
+//
+// Depende de: selector_busqueda.js, v3-breadcrumbs-edicion.js
+// Datos de entrada: window.TAREA_DOCS_CONFIG (inyectado por el template)
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  const cfg = window.TAREA_DOCS_CONFIG;
+  if (!cfg) return;
+
+  // Referencias a los botones de edición de C.1
+  const contenedor   = document.querySelector('[data-bc-editable]');
+  if (!contenedor) return;
+  const btn_editar   = contenedor.querySelector('.btn-editar-bc');
+  const btn_cancelar = contenedor.querySelector('.btn-cancelar-bc');
+  const btn_guardar  = contenedor.querySelector('.btn-guardar-bc');
+  const form         = contenedor.querySelector('form[data-url]');
+
+  if (!btn_editar || !form) return;
+
+  // ── Visibilidad de C.2 sincronizada con C.1 ───────────────────────────────
+  const bloques_ver    = document.querySelectorAll('#card-documentos .doc-modo-ver');
+  const bloques_editar = document.querySelectorAll('#card-documentos .doc-modo-editar');
+
+  function mostrar_ver() {
+    bloques_ver.forEach(el => el.classList.remove('d-none'));
+    bloques_editar.forEach(el => el.classList.add('d-none'));
+  }
+
+  function mostrar_editar() {
+    bloques_ver.forEach(el => el.classList.add('d-none'));
+    bloques_editar.forEach(el => el.classList.remove('d-none'));
+  }
+
+  // ── Instanciar SelectorBusqueda solo si el tipo de tarea lo requiere ──────
+  let sel_usado = null;
+  let sel_producido = null;
+
+  if (cfg.requiereDocUsado && document.getElementById('sb-doc-usado')) {
+    sel_usado = new SelectorBusqueda('#sb-doc-usado', [], {
+      placeholder: '— Seleccione documento de entrada —',
+      name: 'documento_usado_id'
+    });
+  }
+
+  if (cfg.requiereDocProducido && document.getElementById('sb-doc-producido')) {
+    sel_producido = new SelectorBusqueda('#sb-doc-producido', [], {
+      placeholder: '— Seleccione documento producido —',
+      name: 'documento_producido_id'
+    });
+  }
+
+  // ── Inyectar hidden inputs en el form de C.1 antes de que se construya el FormData ──
+  // capture:true garantiza que este handler se ejecuta antes que el de v3-breadcrumbs-edicion.js
+  btn_guardar.addEventListener('click', function () {
+    _inyectar_en_form('documento_usado_id',    sel_usado    ? (sel_usado.getValue()    || '') : '');
+    _inyectar_en_form('documento_producido_id', sel_producido ? (sel_producido.getValue() || '') : '');
+  }, true);
+
+  function _inyectar_en_form(name, value) {
+    let inp = form.querySelector('input[name="' + name + '"]');
+    if (!inp) {
+      inp = document.createElement('input');
+      inp.type = 'hidden';
+      inp.name = name;
+      form.appendChild(inp);
+    }
+    inp.value = value;
+  }
+
+  // ── Evento Editar: mostrar selectores + cargar opciones dinámicamente ─────
+  btn_editar.addEventListener('click', async function () {
+    mostrar_editar();
+    try {
+      const resp = await fetch(cfg.urlApiDocs);
+      const json = await resp.json();
+      if (json.ok) {
+        if (sel_usado)    sel_usado.setOpciones(json.docs);
+        if (sel_producido) sel_producido.setOpciones(json.docs);
+        // Preseleccionar el valor actual si existe
+        if (sel_usado    && cfg.docUsadoId)    sel_usado.setValue(String(cfg.docUsadoId), _texto_actual('disp-doc-usado'));
+        if (sel_producido && cfg.docProducidoId) sel_producido.setValue(String(cfg.docProducidoId), _texto_actual('disp-doc-producido'));
+      }
+    } catch (_e) {
+      // Silencioso: los selectores quedan vacíos; el usuario puede intentar guardar de nuevo
+    }
+  });
+
+  // ── Evento Cancelar ────────────────────────────────────────────────────────
+  btn_cancelar.addEventListener('click', mostrar_ver);
+
+  // ── Actualizar display tras guardar (CustomEvent 'bc:guardado' de v3-bc-edicion.js) ─
+  form.addEventListener('bc:guardado', function () {
+    mostrar_ver();
+
+    // Actualizar texto visible y guardar nuevos IDs en config para la próxima apertura
+    if (sel_usado) {
+      const id_nuevo = sel_usado.getValue();
+      const texto_nuevo = id_nuevo ? sel_usado._input.value : '';
+      cfg.docUsadoId = id_nuevo ? parseInt(id_nuevo) : null;
+      const span = document.getElementById('disp-doc-usado');
+      if (span) span.textContent = texto_nuevo || 'Sin documento asociado';
+    }
+    if (sel_producido) {
+      const id_nuevo = sel_producido.getValue();
+      const texto_nuevo = id_nuevo ? sel_producido._input.value : '';
+      cfg.docProducidoId = id_nuevo ? parseInt(id_nuevo) : null;
+      const span = document.getElementById('disp-doc-producido');
+      if (span) span.textContent = texto_nuevo || 'Sin documento asociado';
+    }
+  });
+
+  // ── Helper: obtiene el texto visible del span de display ──────────────────
+  function _texto_actual(span_id) {
+    const el = document.getElementById(span_id);
+    return el ? el.textContent.trim() : '';
+  }
+
+});

--- a/app/static/js/v3-breadcrumbs-edicion.js
+++ b/app/static/js/v3-breadcrumbs-edicion.js
@@ -63,6 +63,7 @@ document.addEventListener('DOMContentLoaded', function () {
       } else {
         _actualizar_display(datos);
         activar_modo_ver();
+        form.dispatchEvent(new CustomEvent('bc:guardado', { bubbles: false }));
         if (json.advertencia) {
           _mostrar_alert('warning', json.advertencia.mensaje);
         }


### PR DESCRIPTION
## Resumen

- Sustituye el card placeholder "próximamente" de la vista tarea por la sección documental completa (modo ver + modo editar)
- Nuevo endpoint JSON `/expedientes/<id>/documentos/json` para alimentar los SelectorBusqueda con el pool del expediente
- `editar_tarea()` acepta y persiste `documento_usado_id` y `documento_producido_id`, con validación de pertenencia al expediente y captura de `IntegrityError`
- Nuevo `tarea_documentos.js`: sincroniza visibilidad de C.2 con los botones de C.1, carga dinámica de opciones, inyección en `FormData` vía `capture:true`
- `v3-breadcrumbs-edicion.js` dispara `CustomEvent('bc:guardado')` tras guardar con éxito (no disruptivo para otros niveles ESFTT)

## Plan de pruebas

- [ ] Navegar a una tarea de tipo INCORPORAR o REDACTAR: aparece solo selector "Documento producido"
- [ ] Navegar a una tarea de tipo ANALISIS, FIRMAR, NOTIFICAR o PUBLICAR: aparecen ambos selectores
- [ ] Navegar a una tarea ESPERARPLAZO: mensaje "Este tipo de tarea no requiere documentos"
- [ ] Al pulsar Editar, los selectores se cargan con los documentos del pool del expediente
- [ ] Si ya hay documento asociado, aparece preseleccionado
- [ ] Guardar asigna los documentos correctamente (verificar en BD)
- [ ] Intentar finalizar una tarea INCORPORAR sin documento producido → motor bloquea
- [ ] Cancelar restaura el modo ver sin cambios

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
