### PR TITLE
Refactorizar control de usuario en navbar con dropdown Bootstrap

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -92,6 +92,7 @@ def cambiar_rol(rol_id):
 
     session['rol_activo_id'] = rol.id
     session['rol_activo_nombre'] = rol.nombre
+    flash(f'Rol cambiado a {rol.nombre}.', 'info')
     return redirect(request.referrer or url_for('dashboard.index'))
 
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -81,6 +81,20 @@ def seleccionar_rol():
     return render_template('auth/seleccionar_rol.html', roles=current_user.roles)
 
 
+@bp.route('/cambiar-rol/<int:rol_id>')
+@login_required
+def cambiar_rol(rol_id):
+    """Cambia el rol activo desde el dropdown del navbar (GET directo)."""
+    rol = current_user.rol_por_id(rol_id)
+    if not rol:
+        flash('El rol seleccionado no está asignado a tu cuenta.', 'danger')
+        return redirect(url_for('dashboard.index'))
+
+    session['rol_activo_id'] = rol.id
+    session['rol_activo_nombre'] = rol.nombre
+    return redirect(request.referrer or url_for('dashboard.index'))
+
+
 @bp.route('/logout')
 @login_required
 def logout():

--- a/app/static/css/v2-layout.css
+++ b/app/static/css/v2-layout.css
@@ -361,3 +361,43 @@
     display: none;
   }
 }
+
+/* ── Dropdown de usuario ── */
+
+/* Botón trigger: blanco sobre fondo verde del header */
+.header-nav-row .user-menu .nav-user-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-inverse);
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.header-nav-row .user-menu .nav-user-btn:hover {
+  opacity: 0.85;
+}
+
+/* Items del dropdown: resetear color (la regla .user-menu a los pone en blanco) */
+.header-nav-row .user-menu .dropdown-menu .dropdown-item {
+  color: var(--gris-principal, #212529);
+}
+
+.header-nav-row .user-menu .dropdown-menu .dropdown-item:hover,
+.header-nav-row .user-menu .dropdown-menu .dropdown-item:focus {
+  background-color: var(--primary-lighter);
+  color: var(--primary);
+  opacity: 1;
+}
+
+.header-nav-row .user-menu .dropdown-menu .dropdown-item.text-danger {
+  color: var(--danger, #dc3545) !important;
+}
+
+.header-nav-row .user-menu .dropdown-menu .dropdown-item.text-danger:hover {
+  background-color: #f8d7da;
+  color: var(--danger, #dc3545) !important;
+}

--- a/app/static/css/v2-layout.css
+++ b/app/static/css/v2-layout.css
@@ -384,6 +384,7 @@
 /* Items del dropdown: resetear color (la regla .user-menu a los pone en blanco) */
 .header-nav-row .user-menu .dropdown-menu .dropdown-item {
   color: var(--gris-principal, #212529);
+  font-size: 0.875rem;
 }
 
 .header-nav-row .user-menu .dropdown-menu .dropdown-item:hover,

--- a/app/templates/auth/login_v0.html
+++ b/app/templates/auth/login_v0.html
@@ -96,17 +96,6 @@
                 <p>Introduce tus credenciales para acceder</p>
             </div>
             
-            <!-- Mensajes flash (errores/éxito) -->
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    {% for category, message in messages %}
-                    <div class="alert alert-{{ category }}" role="alert">
-                        {{ message }}
-                    </div>
-                    {% endfor %}
-                {% endif %}
-            {% endwith %}
-            
             <!-- Formulario -->
             <form method="POST" action="{{ url_for('auth.login') }}" class="login-form">
                 <!-- Campo: Siglas de Usuario -->

--- a/app/templates/layout/base_login.html
+++ b/app/templates/layout/base_login.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-components.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 
     {% block extra_css %}{% endblock %}
 </head>
@@ -44,8 +45,55 @@
     </div>
     <!-- Fin A -->
     
+    <!-- Sistema de notificaciones toast (flash messages de Flask) -->
+    <div class="toast-container position-fixed bottom-0 p-3">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                <div class="toast toast-{{ category }}" role="alert"
+                     aria-live="assertive" aria-atomic="true"
+                     data-bs-autohide="true" data-bs-delay="8000">
+                    <div class="d-flex align-items-center p-3">
+                        <div class="flex-grow-1">
+                            {% if category == 'success' %}
+                                <i class="fas fa-check-circle me-2"></i><strong>Correcto:</strong> {{ message }}
+                            {% elif category == 'danger' %}
+                                <i class="fas fa-exclamation-circle me-2"></i><strong>Error:</strong> {{ message }}
+                            {% elif category == 'warning' %}
+                                <i class="fas fa-exclamation-triangle me-2"></i><strong>Atención:</strong> {{ message }}
+                            {% elif category == 'info' %}
+                                <i class="fas fa-info-circle me-2"></i><strong>Información:</strong> {{ message }}
+                            {% endif %}
+                        </div>
+                        <button type="button" class="btn-close ms-3"
+                                data-bs-dismiss="toast" aria-label="Cerrar"></button>
+                    </div>
+                </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+    </div>
+
     <!-- Bootstrap JS bundle del CDN Junta (Bootstrap 5.3.3) Ref: #132 -->
     <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+            toastElList.forEach(function(toastEl) {
+                toastEl.classList.add('showing');
+                var toast = new bootstrap.Toast(toastEl);
+                toast.show();
+                setTimeout(function() { toastEl.classList.remove('showing'); }, 300);
+                toastEl.addEventListener('hide.bs.toast', function() {
+                    toastEl.classList.add('hide');
+                });
+                toastEl.addEventListener('click', function(e) {
+                    if (!e.target.closest('.btn-close')) { toast.hide(); }
+                });
+            });
+        });
+    </script>
 
     {% block extra_js %}{% endblock %}
 </body>

--- a/app/templates/layout/header.html
+++ b/app/templates/layout/header.html
@@ -58,7 +58,7 @@
     <div class="user-menu">
         {% if current_user.is_authenticated %}
         <div class="dropdown">
-            <button class="btn btn-link nav-user-btn dropdown-toggle" type="button"
+            <button class="nav-user-btn dropdown-toggle" type="button"
                     data-bs-toggle="dropdown" aria-expanded="false">
                 <i class="bi bi-person-circle"></i>
                 {{ current_user.nombre }}

--- a/app/templates/layout/header.html
+++ b/app/templates/layout/header.html
@@ -57,20 +57,48 @@
 
     <div class="user-menu">
         {% if current_user.is_authenticated %}
-            <span>
-                {{ current_user.nombre }} {{ current_user.apellido1 or '' }}
+        <div class="dropdown">
+            <button class="btn btn-link nav-user-btn dropdown-toggle" type="button"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="bi bi-person-circle"></i>
+                {{ current_user.nombre }}
                 {% if session.get('rol_activo_nombre') %}
-                    <small class="opacity-75">({{ session.rol_activo_nombre }})</small>
+                <span class="badge bg-primary ms-1">{{ session.rol_activo_nombre }}</span>
                 {% endif %}
-            </span>
-            {% if session.get('rol_activo_id') and current_user.roles | length > 1 %}
-            <a href="{{ url_for('auth.seleccionar_rol') }}" title="Cambiar rol activo">
-                <i class="fas fa-exchange-alt"></i> Cambiar rol
-            </a>
-            {% endif %}
-            <a href="{{ url_for('auth.logout') }}">
-                <i class="fas fa-sign-out-alt"></i> Salir
-            </a>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+                {# Lista de roles — solo si hay más de uno #}
+                {% if current_user.roles | length > 1 %}
+                    {% for rol in current_user.roles %}
+                    <li>
+                        {% if rol.id == session.get('rol_activo_id') %}
+                        <span class="dropdown-item disabled d-flex align-items-center gap-2">
+                            <i class="bi bi-check text-primary"></i> {{ rol.nombre }}
+                        </span>
+                        {% else %}
+                        <a class="dropdown-item ps-4" href="{{ url_for('auth.cambiar_rol', rol_id=rol.id) }}">
+                            {{ rol.nombre }}
+                        </a>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                    <li><hr class="dropdown-divider"></li>
+                {% endif %}
+                <li>
+                    <a class="dropdown-item d-flex align-items-center gap-2"
+                       href="{{ url_for('perfil.index') }}">
+                        <i class="bi bi-pencil"></i> Editar perfil
+                    </a>
+                </li>
+                <li><hr class="dropdown-divider"></li>
+                <li>
+                    <a class="dropdown-item d-flex align-items-center gap-2 text-danger"
+                       href="{{ url_for('auth.logout') }}">
+                        <i class="bi bi-box-arrow-right"></i> Cerrar sesión
+                    </a>
+                </li>
+            </ul>
+        </div>
         {% else %}
             <a href="{{ url_for('auth.login') }}">
                 <i class="fas fa-sign-in-alt"></i> Iniciar Sesión


### PR DESCRIPTION
## Cambios

- Reemplaza el control de usuario de la navbar por un dropdown Bootstrap nativo con `bi-person-circle` + nombre + badge de rol activo
- Los roles del usuario se listan directamente en el dropdown (sin pantalla intermedia); el rol activo aparece marcado con `bi-check`
- Nueva ruta `GET /auth/cambiar-rol/<rol_id>` para cambiar de rol desde el dropdown con toast de confirmación
- Flash messages del login (credenciales, cierre de sesión) migrados a toasts; eliminados los alerts inline de `login_v0.html`
- `base_login.html` incluye ahora el sistema de toasts (`custom.css` + JS de inicialización)
- Correcciones de color: botón trigger blanco sobre fondo verde, items del dropdown con color oscuro correcto
- Tamaño de letra del dropdown reducido a `0.875rem` para armonizar con el resto de la navbar

Closes #216
