### PR TITLE
Integrar selección de rol en el formulario de login

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -12,12 +12,42 @@ def login():
     Tras validar credenciales:
       - 0 roles  → denegar acceso
       - 1 rol    → guardar en sesión y redirigir al dashboard
-      - 2+ roles → redirigir al selector de rol activo
+      - 2+ roles → re-renderizar el formulario con <select> de roles (segunda pasada)
+    Segunda pasada (rol_id presente en el POST):
+      - Recuperar usuario de session['pending_login_id']
+      - Validar que el rol pertenece al usuario
+      - Guardar en sesión y redirigir al dashboard
     """
     if request.method == 'POST':
+        rol_id = request.form.get('rol_id')
+
+        # Segunda pasada: el usuario ya validó credenciales y ahora elige rol
+        if rol_id and 'pending_login_id' in session:
+            from app.models.usuarios import Rol
+            usuario = Usuario.query.get(session.pop('pending_login_id'))
+            if not usuario:
+                flash('La sesión ha expirado. Vuelve a introducir tus credenciales.', 'warning')
+                return redirect(url_for('auth.login'))
+
+            try:
+                rol = usuario.rol_por_id(int(rol_id))
+            except (ValueError, AttributeError):
+                rol = None
+
+            if not rol:
+                flash('El rol seleccionado no está asignado a tu cuenta.', 'danger')
+                return render_template('auth/login_v0.html', roles=usuario.roles)
+
+            login_user(usuario)
+            session['rol_activo_id'] = rol.id
+            session['rol_activo_nombre'] = rol.nombre
+            flash(f'Bienvenido, {usuario.nombre}! Trabajando como {rol.nombre}.', 'success')
+            next_page = session.pop('next_after_rol', None) or request.args.get('next')
+            return redirect(next_page if next_page else url_for('dashboard.index'))
+
+        # Primera pasada: validar credenciales
         siglas = request.form.get('siglas')
         password = request.form.get('password')
-
         usuario = Usuario.query.filter_by(siglas=siglas).first()
 
         if usuario and usuario.check_password(password):
@@ -29,9 +59,8 @@ def login():
                 flash('Tu cuenta no tiene ningún rol asignado. Contacta con el administrador.', 'danger')
                 return redirect(url_for('auth.login'))
 
-            login_user(usuario)
-
             if len(usuario.roles) == 1:
+                login_user(usuario)
                 rol = usuario.roles[0]
                 session['rol_activo_id'] = rol.id
                 session['rol_activo_nombre'] = rol.nombre
@@ -39,11 +68,12 @@ def login():
                 next_page = request.args.get('next')
                 return redirect(next_page if next_page else url_for('dashboard.index'))
             else:
-                # Guardar next para redirigir tras elegir rol
+                # Guardar usuario pendiente y next en sesión para la segunda pasada
+                session['pending_login_id'] = usuario.id
                 next_page = request.args.get('next')
                 if next_page:
                     session['next_after_rol'] = next_page
-                return redirect(url_for('auth.seleccionar_rol'))
+                return render_template('auth/login_v0.html', roles=usuario.roles)
         else:
             flash('Siglas o contraseña incorrectos.', 'danger')
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -73,7 +73,8 @@ def login():
                 next_page = request.args.get('next')
                 if next_page:
                     session['next_after_rol'] = next_page
-                return render_template('auth/login_v0.html', roles=usuario.roles)
+                return render_template('auth/login_v0.html', roles=usuario.roles,
+                                       siglas=usuario.siglas)
         else:
             flash('Siglas o contraseña incorrectos.', 'danger')
 

--- a/app/templates/auth/login_v0.html
+++ b/app/templates/auth/login_v0.html
@@ -133,6 +133,22 @@
                     >
                 </div>
                 
+                {% if roles %}
+                <!-- Selección de rol (solo usuarios con múltiples roles) -->
+                <div class="form-group">
+                    <label for="rol_id" class="form-label">
+                        <i class="fas fa-user-tag"></i>
+                        Rol de trabajo
+                    </label>
+                    <select class="form-select" id="rol_id" name="rol_id" required>
+                        {% for rol in roles %}
+                        <option value="{{ rol.id }}">{{ rol.nombre }}</option>
+                        {% endfor %}
+                    </select>
+                    <div class="form-text">Selecciona el rol con el que deseas trabajar en esta sesión.</div>
+                </div>
+                {% endif %}
+
                 <!-- Botón Entrar -->
                 <button type="submit" class="btn-login">
                     <i class="fas fa-sign-in-alt"></i>

--- a/app/templates/auth/login_v0.html
+++ b/app/templates/auth/login_v0.html
@@ -98,43 +98,14 @@
             
             <!-- Formulario -->
             <form method="POST" action="{{ url_for('auth.login') }}" class="login-form">
-                <!-- Campo: Siglas de Usuario -->
-                <div class="form-group">
-                    <label for="siglas" class="form-label">
-                        <i class="fas fa-user"></i>
-                        Siglas de Usuario
-                    </label>
-                    <input 
-                        type="text" 
-                        class="form-control" 
-                        id="siglas" 
-                        name="siglas" 
-                        placeholder="Ej: ADMIN, CLOPEZ..." 
-                        required 
-                        autofocus
-                        autocomplete="username"
-                    >
-                </div>
-                
-                <!-- Campo: Contraseña -->
-                <div class="form-group">
-                    <label for="password" class="form-label">
-                        <i class="fas fa-lock"></i>
-                        Contraseña
-                    </label>
-                    <input 
-                        type="password" 
-                        class="form-control" 
-                        id="password" 
-                        name="password" 
-                        placeholder="Introduce tu contraseña" 
-                        required
-                        autocomplete="current-password"
-                    >
-                </div>
-                
                 {% if roles %}
-                <!-- Selección de rol (solo usuarios con múltiples roles) -->
+                <!-- Segunda pasada: credenciales ya verificadas, solo elegir rol -->
+                <div class="text-center mb-3 p-3 rounded"
+                     style="background: var(--primary-lighter);">
+                    <i class="fas fa-check-circle me-1" style="color: var(--primary);"></i>
+                    <strong style="color: var(--primary);">{{ siglas }}</strong>
+                    <span class="text-secondary small d-block mt-1">Credenciales verificadas</span>
+                </div>
                 <div class="form-group">
                     <label for="rol_id" class="form-label">
                         <i class="fas fa-user-tag"></i>
@@ -146,6 +117,39 @@
                         {% endfor %}
                     </select>
                     <div class="form-text">Selecciona el rol con el que deseas trabajar en esta sesión.</div>
+                </div>
+                {% else %}
+                <!-- Primera pasada: introducir credenciales -->
+                <div class="form-group">
+                    <label for="siglas" class="form-label">
+                        <i class="fas fa-user"></i>
+                        Siglas de Usuario
+                    </label>
+                    <input
+                        type="text"
+                        class="form-control"
+                        id="siglas"
+                        name="siglas"
+                        placeholder="Ej: ADMIN, CLOPEZ..."
+                        required
+                        autofocus
+                        autocomplete="username"
+                    >
+                </div>
+                <div class="form-group">
+                    <label for="password" class="form-label">
+                        <i class="fas fa-key"></i>
+                        Contraseña
+                    </label>
+                    <input
+                        type="password"
+                        class="form-control"
+                        id="password"
+                        name="password"
+                        placeholder="Introduce tu contraseña"
+                        required
+                        autocomplete="current-password"
+                    >
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
## Cambios

- Elimina la pantalla intermedia `/auth/seleccionar-rol` del flujo de login
- Implementa lógica de dos pasadas en `auth.login()`: primera pasada valida credenciales, segunda pasada (con `rol_id`) establece la sesión
- El usuario pendiente se guarda en `session['pending_login_id']` entre pasadas
- En la segunda pasada el formulario muestra un banner de credenciales verificadas con las siglas del usuario, sustituyendo los campos de credenciales
- Cambia icono del campo contraseña de `fa-lock` a `fa-key`
- Usuarios con un solo rol no ven ningún cambio en el flujo

Closes #221
