### PR TITLE
Columnas dinámicas en metadata.json — Fase 3 frontend

### DIFF
--- a/app/modules/entidades/metadata.json
+++ b/app/modules/entidades/metadata.json
@@ -12,5 +12,14 @@
   "navigation": {
     "label": "Entidades",
     "route": "entidades.index"
+  },
+  "listado_v2": {
+    "columns": [
+      { "key": "nombre_completo", "label": "Nombre / Raz\u00f3n Social", "type": "text"     },
+      { "key": "nif",             "label": "NIF",                        "type": "text"     },
+      { "key": "roles",           "label": "Roles",                      "type": "text"     },
+      { "key": "activo",          "label": "Activo",                     "type": "bool"     },
+      { "key": "_acciones",       "label": "",                           "type": "acciones" }
+    ]
   }
 }

--- a/app/modules/entidades/routes.py
+++ b/app/modules/entidades/routes.py
@@ -22,6 +22,7 @@ from app import db
 from app.models.entidad import Entidad
 from app.models.autorizados_titular import AutorizadoTitular
 from app.models.direccion_notificacion import DireccionNotificacion
+from app.utils.metadata import cargar_metadata
 
 # template_folder apunta a app/modules/entidades/templates/
 bp = Blueprint('entidades', __name__,
@@ -37,7 +38,9 @@ bp = Blueprint('entidades', __name__,
 @login_required
 def index():
     """Vista listado de entidades. Sin datos de BD en Jinja2."""
-    return render_template('entidades/index.html')
+    meta = cargar_metadata('entidades')
+    columns = meta.get('listado_v2', {}).get('columns', [])
+    return render_template('entidades/index.html', columns=columns)
 
 
 # =============================================================================

--- a/app/modules/entidades/templates/entidades/index.html
+++ b/app/modules/entidades/templates/entidades/index.html
@@ -22,14 +22,6 @@
 
 {% block tabla_clase %}entidades-table{% endblock %}
 
-{% block thead_cols %}
-<th>Nombre / Razón Social</th>
-<th>NIF</th>
-<th>Roles</th>
-<th>Activo</th>
-<th></th>
-{% endblock %}
-
 {% block extra_js %}
 {{ super() }}
 <script>
@@ -38,13 +30,7 @@
         tableClass:  '.entidades-table',
         entityLabel: 'entidades',
         detailUrl:   id => `/entidades/${id}`,
-        columns: [
-            { key: 'nombre_completo', label: 'Nombre / Razón Social', type: 'text'     },
-            { key: 'nif',             label: 'NIF',                   type: 'text'     },
-            { key: 'roles',           label: 'Roles',                 type: 'text'     },
-            { key: 'activo',          label: 'Activo',                type: 'bool'     },
-            { key: '_acciones',       label: '',                      type: 'acciones' }
-        ]
+        columns:     {{ columns | tojson }}
     });
 
     const filtros = new FiltrosListado(scrollInfinito);

--- a/app/modules/expedientes/metadata.json
+++ b/app/modules/expedientes/metadata.json
@@ -12,5 +12,16 @@
   "navigation": {
     "label": "Expedientes",
     "route": "expedientes.listado_v2"
+  },
+  "listado_v2": {
+    "columns": [
+      { "key": "codigo",             "label": "N\u00b0 Expediente", "type": "text"   },
+      { "key": "titular",            "label": "Titular",            "type": "text"   },
+      { "key": "tipo_expediente",    "label": "Tipo",               "type": "text"   },
+      { "key": "responsable",        "label": "Responsable",        "type": "text"   },
+      { "key": "num_solicitudes",    "label": "Solicitudes",        "type": "custom" },
+      { "key": "estado_tramitacion", "label": "Estado",             "type": "custom" },
+      { "key": "_acciones",          "label": "",                   "type": "custom" }
+    ]
   }
 }

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -42,6 +42,7 @@ from app.utils.permisos import (
     puede_cambiar_responsable,
     verificar_acceso_expediente
 )
+from app.utils.metadata import cargar_metadata
 
 # template_folder apunta a app/modules/expedientes/templates/
 bp = Blueprint('expedientes', __name__,
@@ -68,7 +69,9 @@ def listado_v2():
     Nota: Esta ruta NO carga expedientes iniciales, solo renderiza
           la estructura HTML. Los datos se cargan vía AJAX.
     """
-    return render_template('expedientes/listado_v2.html')
+    meta = cargar_metadata('expedientes')
+    columns = meta.get('listado_v2', {}).get('columns', [])
+    return render_template('expedientes/listado_v2.html', columns=columns)
 
 
 @bp.route('/<int:id>/tramitacion_v3')

--- a/app/modules/expedientes/templates/expedientes/listado_v2.html
+++ b/app/modules/expedientes/templates/expedientes/listado_v2.html
@@ -24,70 +24,52 @@
 
 {% block tabla_clase %}expedientes-table{% endblock %}
 
-{% block thead_cols %}
-<th>N° Expediente</th>
-<th>Titular</th>
-<th>Tipo</th>
-<th>Responsable</th>
-<th>Solicitudes</th>
-<th>Estado</th>
-<th></th>
-{% endblock %}
-
 {% block extra_js %}
 {{ super() }}
 <script>
+    // Columnas base desde metadata.json (serializables a JSON)
+    const colsMeta = {{ columns | tojson }};
+
+    // renderFns para columnas custom — no serializables, definidas localmente
+    const renderFns = {
+        'num_solicitudes': (val, item) => {
+            const total = item.num_solicitudes || 0;
+            const activas = item.num_activas || 0;
+            if (total === 0) return '<span class="text-secondary">—</span>';
+            const badge = activas > 0
+                ? `<span class="badge bg-primary ms-1">${activas} activa${activas !== 1 ? 's' : ''}</span>`
+                : '';
+            return `${total}${badge}`;
+        },
+        'estado_tramitacion': (val) => {
+            const mapa = {
+                'SIN_SOLICITUDES': ['secondary', 'Sin solicitudes'],
+                'EN_TRAMITE':      ['primary',   'En trámite'],
+                'RESUELTO':        ['success',   'Resuelto']
+            };
+            const [cls, label] = mapa[val] || ['secondary', val || '—'];
+            return `<span class="badge bg-${cls}">${label}</span>`;
+        },
+        '_acciones': (val, item) =>
+            `<a href="/expedientes/${item.id}" class="btn btn-sm btn-outline-primary me-1">
+                <i class="fas fa-info-circle"></i> Detalle
+             </a>
+             <a href="${item.url_tramitacion}" class="btn btn-sm btn-primary">
+                <i class="fas fa-tasks"></i> Tramitar
+             </a>`
+    };
+
+    // Mezcla: inyectar renderFn en cada columna custom
+    const columns = colsMeta.map(col =>
+        renderFns[col.key] ? { ...col, renderFn: renderFns[col.key] } : col
+    );
+
     const scrollInfinito = new ScrollInfinito({
         apiUrl:      '{{ url_for("api.listar_expedientes") }}',
         tableClass:  '.expedientes-table',
         entityLabel: 'expedientes',
         detailUrl:   id => `/expedientes/${id}/tramitacion`,
-        columns: [
-            { key: 'codigo',          label: 'N° Expediente', type: 'text' },
-            { key: 'titular',         label: 'Titular',       type: 'text' },
-            { key: 'tipo_expediente', label: 'Tipo',          type: 'text' },
-            { key: 'responsable',     label: 'Responsable',   type: 'text' },
-            {
-                key: 'num_solicitudes',
-                label: 'Solicitudes',
-                type: 'custom',
-                renderFn: (val, item) => {
-                    const total = item.num_solicitudes || 0;
-                    const activas = item.num_activas || 0;
-                    if (total === 0) return '<span class="text-secondary">—</span>';
-                    const badge = activas > 0
-                        ? `<span class="badge bg-primary ms-1">${activas} activa${activas !== 1 ? 's' : ''}</span>`
-                        : '';
-                    return `${total}${badge}`;
-                }
-            },
-            {
-                key: 'estado_tramitacion',
-                label: 'Estado',
-                type: 'custom',
-                renderFn: (val) => {
-                    const mapa = {
-                        'SIN_SOLICITUDES': ['secondary', 'Sin solicitudes'],
-                        'EN_TRAMITE':      ['primary',   'En trámite'],
-                        'RESUELTO':        ['success',   'Resuelto']
-                    };
-                    const [cls, label] = mapa[val] || ['secondary', val || '—'];
-                    return `<span class="badge bg-${cls}">${label}</span>`;
-                }
-            },
-            {
-                key: '_acciones',
-                label: '',
-                type: 'custom',
-                renderFn: (val, item) =>
-                    `<a href="/expedientes/${item.id}" class="btn btn-sm btn-outline-primary me-1">
-                        <i class="fas fa-info-circle"></i> Detalle
-                     </a>
-                     <a href="${item.url_tramitacion}" class="btn btn-sm btn-primary">
-                        <i class="fas fa-tasks"></i> Tramitar
-                     </a>`
-            }
-        ]
+        columns
     });
 
     const filtros = new FiltrosListado(scrollInfinito);

--- a/app/modules/proyectos/metadata.json
+++ b/app/modules/proyectos/metadata.json
@@ -12,5 +12,15 @@
   "navigation": {
     "label": "Proyectos",
     "route": "proyectos.index"
+  },
+  "listado_v2": {
+    "columns": [
+      { "key": "expediente_codigo", "label": "N\u00b0 Expediente",      "type": "text"     },
+      { "key": "titulo",            "label": "T\u00edtulo del Proyecto", "type": "text"     },
+      { "key": "tipo_ia",           "label": "Instr. Ambiental",         "type": "text"     },
+      { "key": "responsable",       "label": "Responsable",              "type": "text"     },
+      { "key": "fecha",             "label": "Fecha",                    "type": "text"     },
+      { "key": "_acciones",         "label": "",                         "type": "acciones" }
+    ]
   }
 }

--- a/app/modules/proyectos/routes.py
+++ b/app/modules/proyectos/routes.py
@@ -17,6 +17,7 @@ from app.models.proyectos import Proyecto
 from app.models.expedientes import Expediente
 from app.models.usuarios import Usuario
 from app.models.tipos_ia import TipoIA
+from app.utils.metadata import cargar_metadata
 
 # template_folder apunta a app/modules/proyectos/templates/
 bp = Blueprint('proyectos', __name__,
@@ -33,7 +34,9 @@ bp = Blueprint('proyectos', __name__,
 def index():
     """Vista listado de proyectos. Pasa tipos_ia para poblar el filtro."""
     tipos_ia = TipoIA.query.order_by(TipoIA.siglas).all()
-    return render_template('proyectos/index.html', tipos_ia=tipos_ia)
+    meta = cargar_metadata('proyectos')
+    columns = meta.get('listado_v2', {}).get('columns', [])
+    return render_template('proyectos/index.html', tipos_ia=tipos_ia, columns=columns)
 
 
 # =============================================================================

--- a/app/modules/proyectos/templates/proyectos/index.html
+++ b/app/modules/proyectos/templates/proyectos/index.html
@@ -16,15 +16,6 @@
 
 {% block tabla_clase %}proyectos-table{% endblock %}
 
-{% block thead_cols %}
-<th>N° Expediente</th>
-<th>Título del Proyecto</th>
-<th>Instr. Ambiental</th>
-<th>Responsable</th>
-<th>Fecha</th>
-<th></th>
-{% endblock %}
-
 {% block extra_js %}
 {{ super() }}
 <script>
@@ -33,14 +24,7 @@
         tableClass:  '.proyectos-table',
         entityLabel: 'proyectos',
         detailUrl:   id => `/proyectos/${id}`,
-        columns: [
-            { key: 'expediente_codigo', label: 'N° Expediente',      type: 'text'     },
-            { key: 'titulo',            label: 'Título del Proyecto', type: 'text'     },
-            { key: 'tipo_ia',           label: 'Instr. Ambiental',    type: 'text'     },
-            { key: 'responsable',       label: 'Responsable',         type: 'text'     },
-            { key: 'fecha',             label: 'Fecha',               type: 'text'     },
-            { key: '_acciones',         label: '',                    type: 'acciones' }
-        ]
+        columns:     {{ columns | tojson }}
     });
 
     // ScrollInfinito lee el primer select de .filters-row como parámetro 'estado'.

--- a/app/templates/layout/lista_v2_base.html
+++ b/app/templates/layout/lista_v2_base.html
@@ -113,7 +113,13 @@
         <table class="expedientes-table {% block tabla_clase %}{% endblock %}">
             <thead>
                 <tr>
-                    {% block thead_cols %}{% endblock %}
+                    {% if columns is defined and columns %}
+                        {% for col in columns %}
+                            <th>{{ col.label }}</th>
+                        {% endfor %}
+                    {% else %}
+                        {% block thead_cols %}{% endblock %}
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>

--- a/app/utils/metadata.py
+++ b/app/utils/metadata.py
@@ -1,0 +1,22 @@
+"""
+Utilidad para leer metadata.json de los módulos.
+
+Uso:
+    from app.utils.metadata import cargar_metadata
+    meta = cargar_metadata('expedientes')
+    columns = meta.get('listado_v2', {}).get('columns', [])
+"""
+import json
+import os
+
+
+def cargar_metadata(modulo: str) -> dict:
+    """Lee el metadata.json del módulo dado. Devuelve {} si no existe o es inválido."""
+    ruta = os.path.join(
+        os.path.dirname(__file__), '..', 'modules', modulo, 'metadata.json'
+    )
+    try:
+        with open(os.path.abspath(ruta), encoding='utf-8') as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}


### PR DESCRIPTION
## Cambios

- Nuevo `app/utils/metadata.py`: helper `cargar_metadata(modulo)` para leer metadata.json de cualquier módulo
- `metadata.json` de expedientes, entidades y proyectos: añade sección `listado_v2.columns` con definición de columnas
- `lista_v2_base.html`: thead generado dinámicamente desde Jinja2 (con fallback backward-compatible para templates que no pasen `columns`)
- Templates de entidades y proyectos: columnas servidas vía `{{ columns | tojson }}` — sin duplicación
- Template de expedientes: mezcla JSON + renderFns locales para columnas `custom` no serializables

Closes #204
