### PR TITLE
Arquitectura escritos — Parte 1: BD, modelos y servicios

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -21,6 +21,8 @@ from app.models.tipos_solicitudes import TipoSolicitud
 from app.models.tipos_tareas import TipoTarea
 from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_documentos import TipoDocumento
+from app.models.consultas_nombradas import ConsultaNombrada
+from app.models.tipos_escritos import TipoEscrito
 
 # Modelo de metadata del sistema (issue #85)
 from app.models.tabla_metadata import TablaMetadata
@@ -70,6 +72,8 @@ __all__ = [
     'TipoTarea',
     'TipoTramite',
     'TipoDocumento',
+    'ConsultaNombrada',
+    'TipoEscrito',
     # Metadata del sistema
     'TablaMetadata',
     # Arquitectura Entidades (simplificada en issue #103)

--- a/app/models/consultas_nombradas.py
+++ b/app/models/consultas_nombradas.py
@@ -1,0 +1,74 @@
+from app import db
+
+
+class ConsultaNombrada(db.Model):
+    """
+    Catálogo de consultas SQL predefinidas para uso en plantillas .docx.
+
+    PROPÓSITO:
+        Permite que el supervisor inserte tablas dinámicas en plantillas sin
+        necesidad de escribir SQL. Referencia la consulta por nombre en el
+        marcador de plantilla: {%tr for row in municipios_afectados %}.
+
+        BDDAT ejecuta el SQL parametrizado y pasa el resultado como contexto
+        a python-docx-template.
+
+    CAMPOS:
+        nombre      — Slug estable usado en la plantilla (.docx) y en código.
+                      Debe ser snake_case: municipios_afectados, organismos_consultados.
+        descripcion — Texto legible mostrado al supervisor en el contextualizador.
+        sql         — SQL parametrizado. Parámetro esperado: :expediente_id
+        columnas    — [{campo, descripcion}] para mostrar al supervisor qué campos
+                      puede usar dentro del bloque de tabla (row.nombre, row.provincia...).
+        activo      — FALSE = oculta en UI pero conservada para histórico de plantillas.
+    """
+    __tablename__ = 'consultas_nombradas'
+    __table_args__ = (
+        db.UniqueConstraint('nombre', name='uq_consultas_nombradas_nombre'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    nombre = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Slug estable usado en plantillas: municipios_afectados'
+    )
+
+    descripcion = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Descripción legible para el supervisor en la UI'
+    )
+
+    sql = db.Column(
+        db.Text,
+        nullable=False,
+        comment='SQL parametrizado. Parámetro esperado: :expediente_id'
+    )
+
+    columnas = db.Column(
+        db.JSON,
+        nullable=False,
+        comment='[{campo, descripcion}] — columnas disponibles para el supervisor'
+    )
+
+    activo = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        server_default='true',
+        comment='FALSE = oculta en UI pero conservada para histórico'
+    )
+
+    def __repr__(self):
+        return f'<ConsultaNombrada {self.nombre}>'
+
+    def __str__(self):
+        return self.descripcion

--- a/app/models/tipos_escritos.py
+++ b/app/models/tipos_escritos.py
@@ -1,0 +1,141 @@
+from app import db
+
+
+class TipoEscrito(db.Model):
+    """
+    Catálogo de tipos de escritos administrativos generables.
+
+    PROPÓSITO:
+        Cada registro vincula una plantilla .docx con su contexto ESFTT
+        (tipo de solicitud, fase, trámite) y con el tipo de documento que se
+        creará en el pool del expediente al generar el escrito.
+
+    RELACIÓN CON tipos_documentos:
+        tipo_documento_id determina el TipoDocumento que se asignará al
+        Documento generado. Esto permite al motor de reglas evaluar el criterio
+        EXISTE_DOCUMENTO_TIPO sobre el expediente.
+
+    CONTEXTO ESFTT:
+        Las tres FKs (tipo_solicitud_id, tipo_fase_id, tipo_tramite_id) son
+        nullable. NULL significa "aplica a cualquier valor de esa dimensión".
+        Permite expresar plantillas transversales (ej: un requerimiento válido
+        para cualquier fase).
+
+    FILTROS_ADICIONALES:
+        JSONB vacío por ahora. Absorberá en el futuro variables de negocio
+        dinámicas (tipo de suelo, tensión, tecnología renovable, potencia...)
+        sin alterar el esquema de la tabla.
+
+    CAMPOS_CATALOGO:
+        [{campo, descripcion}] — Lista de campos disponibles para mostrar en la
+        UI del contextualizador. Ayuda al supervisor a copiar el token correcto
+        sin conocer el código Python.
+
+    CONTEXTO_CLASE:
+        Nombre de la clase Python del Context Builder (Capa 2).
+        NULL = solo se usa ContextoBaseExpediente (Capa 1).
+    """
+    __tablename__ = 'tipos_escritos'
+    __table_args__ = (
+        db.UniqueConstraint('codigo', name='uq_tipos_escritos_codigo'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    codigo = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Slug estable para referencias en código: REQUERIMIENTO_SUBSANACION'
+    )
+
+    nombre = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Nombre legible para la UI'
+    )
+
+    descripcion = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Descripción ampliada del tipo de escrito'
+    )
+
+    ruta_plantilla = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Ruta relativa a PLANTILLAS_BASE/plantillas/'
+    )
+
+    tipo_documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tipos_documentos.id', name='fk_tipos_escritos_tipo_documento'),
+        nullable=False,
+        comment='FK tipos_documentos — tipo que se asignará al documento generado'
+    )
+
+    contexto_clase = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Nombre de clase Python del Context Builder. NULL = solo Capa 1'
+    )
+
+    campos_catalogo = db.Column(
+        db.JSON,
+        nullable=True,
+        comment='[{campo, descripcion}] — campos disponibles para la UI del contextualizador'
+    )
+
+    tipo_solicitud_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tipos_solicitudes.id', name='fk_tipos_escritos_tipo_solicitud'),
+        nullable=True,
+        comment='FK tipos_solicitudes. NULL = aplica a cualquier tipo de solicitud'
+    )
+
+    tipo_fase_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tipos_fases.id', name='fk_tipos_escritos_tipo_fase'),
+        nullable=True,
+        comment='FK tipos_fases. NULL = aplica a cualquier fase'
+    )
+
+    tipo_tramite_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tipos_tramites.id', name='fk_tipos_escritos_tipo_tramite'),
+        nullable=True,
+        comment='FK tipos_tramites. NULL = aplica a cualquier trámite'
+    )
+
+    filtros_adicionales = db.Column(
+        db.JSON,
+        nullable=False,
+        default=dict,
+        server_default='{}',
+        comment='Variables de negocio futuras (tensión, tecnología...). Vacío por ahora.'
+    )
+
+    activo = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        server_default='true',
+        comment='FALSE = oculta en tarea REDACTAR pero conservada para histórico'
+    )
+
+    # Relaciones
+    tipo_documento = db.relationship('TipoDocumento', foreign_keys=[tipo_documento_id])
+    tipo_solicitud = db.relationship('TipoSolicitud', foreign_keys=[tipo_solicitud_id])
+    tipo_fase      = db.relationship('TipoFase',      foreign_keys=[tipo_fase_id])
+    tipo_tramite   = db.relationship('TipoTramite',   foreign_keys=[tipo_tramite_id])
+
+    def __repr__(self):
+        return f'<TipoEscrito {self.codigo}>'
+
+    def __str__(self):
+        return self.nombre

--- a/app/services/escritos.py
+++ b/app/services/escritos.py
@@ -1,0 +1,113 @@
+"""
+Servicio de contexto para generación de escritos administrativos.
+
+ARQUITECTURA DE CAPAS:
+    Capa 1 — ContextoBaseExpediente (este fichero):
+        Construye un dict plano con los datos directos del expediente.
+        Suficiente para la mayoría de escritos simples.
+
+    Capa 2 — Context Builders (app/services/context_builders/):
+        Clases Python que enriquecen el contexto base con datos calculados
+        o cruzados. Se crean cuando el primer tipo de escrito complejo los
+        requiera.
+
+USO:
+    from app.services.escritos import ContextoBaseExpediente
+
+    ctx = ContextoBaseExpediente(expediente).get_contexto()
+    # ctx es un dict plano listo para python-docx-template
+"""
+
+from datetime import date
+
+
+class ContextoBaseExpediente:
+    """
+    Capa 1 del sistema de generación de escritos.
+
+    Extrae del expediente un dict plano con los campos más habituales en
+    plantillas administrativas. Todos los valores son strings o None para
+    facilitar la inserción directa en Jinja2 sin conversiones adicionales.
+
+    CAMPOS DISPONIBLES EN EL CONTEXTO:
+        Expediente:
+            numero_at           — Número administrativo (AT-XXXX)
+            expediente_id       — ID técnico interno
+
+        Titular:
+            titular_nombre      — Nombre / Razón Social del titular
+            titular_nif         — NIF del titular
+            titular_direccion   — Dirección de notificación (si existe)
+
+        Proyecto:
+            proyecto_titulo     — Título del proyecto técnico
+            proyecto_finalidad  — Finalidad de la instalación
+            proyecto_emplazamiento — Emplazamiento descriptivo
+            instrumento_ambiental  — Siglas del instrumento (AAI, AAU, EXENTO...)
+
+        Responsable:
+            responsable_nombre  — Nombre completo del tramitador asignado
+
+        Municipios:
+            municipios          — Lista de nombres de municipios afectados (list[str])
+
+        Fecha:
+            fecha_hoy           — Fecha actual en formato DD/MM/YYYY
+    """
+
+    def __init__(self, expediente):
+        self._exp = expediente
+
+    def get_contexto(self) -> dict:
+        exp = self._exp
+        proyecto = exp.proyecto
+
+        ctx = {
+            # Expediente
+            'expediente_id':        exp.id,
+            'numero_at':            f'AT-{exp.numero_at}' if exp.numero_at else None,
+
+            # Titular
+            'titular_nombre':       exp.titular.nombre_completo if exp.titular else None,
+            'titular_nif':          exp.titular.nif            if exp.titular else None,
+            'titular_direccion':    self._direccion_titular(),
+
+            # Proyecto
+            'proyecto_titulo':         proyecto.titulo        if proyecto else None,
+            'proyecto_finalidad':      proyecto.finalidad     if proyecto else None,
+            'proyecto_emplazamiento':  proyecto.emplazamiento if proyecto else None,
+            'instrumento_ambiental':   proyecto.ia.siglas     if proyecto and proyecto.ia else None,
+
+            # Responsable
+            'responsable_nombre': (
+                exp.responsable.nombre_completo if exp.responsable else None
+            ),
+
+            # Municipios (lista de nombres para uso en plantilla simple)
+            'municipios': self._municipios(),
+
+            # Fecha
+            'fecha_hoy': date.today().strftime('%d/%m/%Y'),
+        }
+        return ctx
+
+    # ------------------------------------------------------------------
+    # Helpers privados
+    # ------------------------------------------------------------------
+
+    def _direccion_titular(self) -> str | None:
+        """Devuelve la dirección de notificación preferente del titular."""
+        if not self._exp.titular:
+            return None
+        direcciones = getattr(self._exp.titular, 'direcciones_notificacion', [])
+        preferente = next((d for d in direcciones if d.preferente), None)
+        if preferente:
+            return str(preferente)
+        return None
+
+    def _municipios(self) -> list[str]:
+        """Devuelve los nombres de municipios afectados por el proyecto."""
+        proyecto = self._exp.proyecto
+        if not proyecto:
+            return []
+        return [mp.municipio.nombre for mp in proyecto.municipios_afectados]

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -1,0 +1,123 @@
+"""
+Servicio de generación de escritos administrativos (.docx).
+
+RESPONSABILIDAD:
+    Orquesta las capas de contexto + python-docx-template para producir
+    un fichero .docx relleno a partir de una plantilla registrada en
+    tipos_escritos.
+
+FLUJO:
+    1. Carga la plantilla .docx desde PLANTILLAS_BASE
+    2. Construye el contexto: Capa 1 (ContextoBaseExpediente) + Capa 2 opcional
+    3. Ejecuta las consultas nombradas referenciadas en la plantilla
+    4. Renderiza con DocxTemplate (python-docx-template / Jinja2)
+    5. Devuelve bytes del .docx resultante
+
+USO:
+    from app.services.generador_escritos import generar_escrito
+
+    docx_bytes = generar_escrito(tipo_escrito, expediente, db_session)
+    # Guardar bytes en FILESYSTEM_BASE y registrar en pool del expediente
+
+DEPENDENCIA:
+    pip install python-docx-template
+"""
+
+import importlib
+import os
+
+from docxtpl import DocxTemplate
+
+from app.services.escritos import ContextoBaseExpediente
+
+
+def generar_escrito(tipo_escrito, expediente, db_session) -> bytes:
+    """
+    Genera el .docx relleno para el tipo_escrito y expediente dados.
+
+    Args:
+        tipo_escrito:  Instancia de TipoEscrito (plantilla + contexto registrado).
+        expediente:    Instancia de Expediente con relaciones cargadas.
+        db_session:    Sesión SQLAlchemy activa (para ejecutar consultas nombradas).
+
+    Returns:
+        bytes — Contenido del .docx generado, listo para guardar en disco.
+
+    Raises:
+        FileNotFoundError — Si la plantilla .docx no existe en PLANTILLAS_BASE.
+        RuntimeError      — Si el Context Builder especificado no se puede cargar.
+    """
+    plantilla_path = _ruta_plantilla(tipo_escrito.ruta_plantilla)
+
+    # Capa 1: contexto base del expediente
+    ctx = ContextoBaseExpediente(expediente).get_contexto()
+
+    # Capa 2: Context Builder opcional
+    if tipo_escrito.contexto_clase:
+        builder = _cargar_context_builder(tipo_escrito.contexto_clase)
+        ctx.update(builder(expediente, db_session).get_contexto())
+
+    # Consultas nombradas: se añaden al contexto con su nombre como clave
+    ctx.update(_ejecutar_consultas(tipo_escrito, expediente, db_session))
+
+    # Renderizado
+    tpl = DocxTemplate(plantilla_path)
+    tpl.render(ctx)
+
+    # Devolver bytes sin escribir a disco (la escritura es responsabilidad del caller)
+    import io
+    buffer = io.BytesIO()
+    tpl.save(buffer)
+    return buffer.getvalue()
+
+
+# ------------------------------------------------------------------
+# Helpers privados
+# ------------------------------------------------------------------
+
+def _ruta_plantilla(ruta_relativa: str) -> str:
+    """Resuelve la ruta absoluta de la plantilla dentro de PLANTILLAS_BASE."""
+    from flask import current_app
+    base = current_app.config['PLANTILLAS_BASE']
+    ruta = os.path.join(base, 'plantillas', ruta_relativa)
+    if not os.path.isfile(ruta):
+        raise FileNotFoundError(
+            f'Plantilla no encontrada: {ruta}. '
+            f'Comprueba PLANTILLAS_BASE y la ruta registrada en tipos_escritos.'
+        )
+    return ruta
+
+
+def _cargar_context_builder(nombre_clase: str):
+    """
+    Importa y devuelve la clase Context Builder por nombre.
+
+    Convenio de módulo: app.services.context_builders.<nombre_clase_en_snake>
+    Ejemplo: 'RequerimientoSubsanacion' → app.services.context_builders.requerimiento_subsanacion
+    """
+    import re
+    snake = re.sub(r'(?<!^)(?=[A-Z])', '_', nombre_clase).lower()
+    modulo_path = f'app.services.context_builders.{snake}'
+    try:
+        modulo = importlib.import_module(modulo_path)
+        return getattr(modulo, nombre_clase)
+    except (ModuleNotFoundError, AttributeError) as e:
+        raise RuntimeError(
+            f'No se pudo cargar el Context Builder "{nombre_clase}" '
+            f'desde {modulo_path}: {e}'
+        )
+
+
+def _ejecutar_consultas(tipo_escrito, expediente, db_session) -> dict:
+    """
+    Ejecuta las consultas nombradas referenciadas en la plantilla.
+
+    Por ahora devuelve un dict vacío: las consultas nombradas se detectarán
+    automáticamente al parsear la plantilla en una versión futura, o se
+    registrarán explícitamente en tipos_escritos cuando sea necesario.
+
+    TODO (Parte 2 o issue posterior):
+        - Parsear la plantilla para detectar {%tr for row in X %} y ejecutar
+          la consulta_nombrada con nombre X para cada bloque encontrado.
+    """
+    return {}

--- a/migrations/versions/20c5d1e9d782_tipos_escritos_y_consultas_nombradas.py
+++ b/migrations/versions/20c5d1e9d782_tipos_escritos_y_consultas_nombradas.py
@@ -1,0 +1,94 @@
+"""tipos_escritos y consultas_nombradas
+
+Revision ID: 20c5d1e9d782
+Revises: 45b0d1302dd4
+Create Date: 2026-03-14 16:59:08.440463
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = '20c5d1e9d782'
+down_revision = '45b0d1302dd4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ------------------------------------------------------------------
+    # consultas_nombradas
+    # Catálogo de consultas SQL predefinidas para uso en plantillas .docx.
+    # El supervisor referencia por nombre; BDDAT ejecuta el SQL parametrizado.
+    # ------------------------------------------------------------------
+    op.create_table(
+        'consultas_nombradas',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('nombre', sa.Text(), nullable=False,
+                  comment='Slug estable usado en plantillas: municipios_afectados'),
+        sa.Column('descripcion', sa.Text(), nullable=False,
+                  comment='Descripción legible para el supervisor en la UI'),
+        sa.Column('sql', sa.Text(), nullable=False,
+                  comment='SQL parametrizado. Parámetro esperado: :expediente_id'),
+        sa.Column('columnas', JSONB(), nullable=False,
+                  comment='[{campo, descripcion}] — columnas disponibles para el supervisor'),
+        sa.Column('activo', sa.Boolean(), nullable=False, server_default='true',
+                  comment='FALSE = oculta en UI pero conservada para histórico'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('nombre', name='uq_consultas_nombradas_nombre'),
+        schema='public'
+    )
+
+    # ------------------------------------------------------------------
+    # tipos_escritos
+    # Catálogo de tipos de escritos generables. Cada registro vincula
+    # una plantilla .docx con su contexto ESFTT y su tipo de documento.
+    # ------------------------------------------------------------------
+    op.create_table(
+        'tipos_escritos',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('codigo', sa.Text(), nullable=False,
+                  comment='Slug estable para referencias en código: REQUERIMIENTO_SUBSANACION'),
+        sa.Column('nombre', sa.Text(), nullable=False,
+                  comment='Nombre legible para la UI'),
+        sa.Column('descripcion', sa.Text(), nullable=True,
+                  comment='Descripción ampliada del tipo de escrito'),
+        sa.Column('ruta_plantilla', sa.Text(), nullable=False,
+                  comment='Ruta relativa a PLANTILLAS_BASE/plantillas/'),
+        sa.Column('tipo_documento_id', sa.Integer(), nullable=False,
+                  comment='FK tipos_documentos — tipo que se asignará al documento generado'),
+        sa.Column('contexto_clase', sa.Text(), nullable=True,
+                  comment='Nombre de clase Python del Context Builder. NULL = solo Capa 1 (ContextoBaseExpediente)'),
+        sa.Column('campos_catalogo', JSONB(), nullable=True,
+                  comment='[{campo, descripcion}] — campos disponibles para mostrar en UI del contextualizador'),
+        sa.Column('tipo_solicitud_id', sa.Integer(), nullable=True,
+                  comment='FK tipos_solicitudes. NULL = aplica a cualquier tipo de solicitud'),
+        sa.Column('tipo_fase_id', sa.Integer(), nullable=True,
+                  comment='FK tipos_fases. NULL = aplica a cualquier fase'),
+        sa.Column('tipo_tramite_id', sa.Integer(), nullable=True,
+                  comment='FK tipos_tramites. NULL = aplica a cualquier trámite'),
+        sa.Column('filtros_adicionales', JSONB(), nullable=False, server_default='{}',
+                  comment='Variables de negocio futuras (tensión, tecnología...). Vacío por ahora.'),
+        sa.Column('activo', sa.Boolean(), nullable=False, server_default='true',
+                  comment='FALSE = oculta en tarea REDACTAR pero conservada para histórico'),
+        sa.ForeignKeyConstraint(['tipo_documento_id'], ['public.tipos_documentos.id'],
+                                name='fk_tipos_escritos_tipo_documento'),
+        sa.ForeignKeyConstraint(['tipo_solicitud_id'], ['public.tipos_solicitudes.id'],
+                                name='fk_tipos_escritos_tipo_solicitud'),
+        sa.ForeignKeyConstraint(['tipo_fase_id'], ['public.tipos_fases.id'],
+                                name='fk_tipos_escritos_tipo_fase'),
+        sa.ForeignKeyConstraint(['tipo_tramite_id'], ['public.tipos_tramites.id'],
+                                name='fk_tipos_escritos_tipo_tramite'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('codigo', name='uq_tipos_escritos_codigo'),
+        schema='public'
+    )
+
+
+def downgrade():
+    op.drop_table('tipos_escritos', schema='public')
+    op.drop_table('consultas_nombradas', schema='public')


### PR DESCRIPTION
## Cambios

- Migración `20c5d1e9d782`: crea tablas `tipos_escritos` y `consultas_nombradas` con FKs nullable a tipos ESFTT y FK a `tipos_documentos`
- Modelo `TipoEscrito`: catálogo de plantillas .docx generables con contexto ESFTT, `campos_catalogo` JSONB y vínculo a `tipos_documentos`
- Modelo `ConsultaNombrada`: catálogo de consultas SQL predefinidas para uso en plantillas (el supervisor referencia por nombre, sin escribir SQL)
- Servicio `escritos.py`: `ContextoBaseExpediente` (Capa 1) — dict plano con datos del expediente listo para Jinja2
- Servicio `generador_escritos.py`: orquestador Capa 1 + Capa 2 (Context Builders opcionales) + python-docx-template → bytes del .docx

Parte 2 (UI admin del contextualizador) irá en rama separada.

Closes #189
