### PR TITLE
UI admin plantillas escritos — Parte 2 (#189)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ Ver referencia completa: `docs/fuentesIA/ANTI_BLOQUEOS_BASH.md`
 
 Resumen de patrones obligatorios:
 - **`$()` y backticks:** NUNCA — separar en llamadas Bash secuenciales
-- **`sed -i`:** usar tool `Edit`
+- **`sed -i`:** usar tool `Edit` — nunca sed para escribir ficheros
+- **Newlines en comandos Bash:** NUNCA saltos de línea dentro del cuerpo de un comando (heredocs, `python -c "..."` multilínea, etc.) → escribir el contenido con `Write` a `docs_prueba/temp/` y pasarlo como fichero
 - **`git commit` / `gh pr create` con texto largo:** `Write` a `docs_prueba/temp/` → pasar como fichero
 - **`git -C /ruta`:** SIEMPRE en vez de `cd /ruta && git`
 - **Ficheros temporales:** SIEMPRE en `D:\BDDAT\docs_prueba\temp\` (allowlisted, gitignored)

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,10 @@ class Config:
     # Desarrollo: cualquier carpeta local (p.ej. D:/BDDAT/docs_prueba)
     # Producción: W:\ALTA TENSION\Expedientes  o  \\HACACL0102\energia\ALTA TENSION\Expedientes
     FILESYSTEM_BASE = os.environ.get('FILESYSTEM_BASE') or ''
+    # Raíz de plantillas .docx para generación de escritos.
+    # Estructura: PLANTILLAS_BASE/plantillas/ y PLANTILLAS_BASE/fragmentos/
+    # Desarrollo: p.ej. D:/BDDAT/docs_prueba/plantillas_escritos
+    PLANTILLAS_BASE = os.environ.get('PLANTILLAS_BASE') or ''
 
 class DevelopmentConfig(Config):
     """Desarrollo"""

--- a/app/modules/admin_plantillas/__init__.py
+++ b/app/modules/admin_plantillas/__init__.py
@@ -1,0 +1,2 @@
+# Módulo admin_plantillas — inicialización vacía.
+# El blueprint se define en routes.py.

--- a/app/modules/admin_plantillas/metadata.json
+++ b/app/modules/admin_plantillas/metadata.json
@@ -1,0 +1,16 @@
+{
+  "module": "admin_plantillas",
+  "name": "Plantillas de escritos",
+  "icon": "fa-file-word",
+  "order": 80,
+  "permissions": {
+    "list":   ["ADMIN", "SUPERVISOR"],
+    "create": ["ADMIN", "SUPERVISOR"],
+    "edit":   ["ADMIN", "SUPERVISOR"],
+    "delete": ["ADMIN"]
+  },
+  "navigation": {
+    "label": "Plantillas",
+    "route": "admin_plantillas.listado"
+  }
+}

--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -248,7 +248,11 @@ def nueva():
 def detalle(id):
     tipo = TipoEscrito.query.get_or_404(id)
     tokens = _build_tokens(tipo)
-    return render_template('admin_plantillas/detalle.html', tipo=tipo, tokens=tokens)
+    # Ruta absoluta en disco para que el supervisor pueda abrirla directamente
+    d = _plantillas_dir()
+    ruta_absoluta = os.path.join(d, tipo.ruta_plantilla).replace('/', '\\') if d else None
+    return render_template('admin_plantillas/detalle.html', tipo=tipo, tokens=tokens,
+                           ruta_absoluta=ruta_absoluta)
 
 
 @bp.route('/<int:id>/editar', methods=['GET', 'POST'])

--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -1,0 +1,321 @@
+"""
+Blueprint para administración de plantillas de escritos administrativos.
+
+Rutas:
+- GET  /admin/plantillas/             — Listado de tipos_escritos
+- GET  /admin/plantillas/nueva/       — Formulario alta nueva plantilla
+- POST /admin/plantillas/nueva/       — Guardar nueva plantilla
+- GET  /admin/plantillas/<id>/        — Detalle (solo lectura) + panel tokens
+- GET  /admin/plantillas/<id>/editar  — Formulario edición pre-rellenado
+- POST /admin/plantillas/<id>/editar  — Guardar cambios
+- GET  /admin/plantillas/<id>/descargar — Descarga del .docx registrado
+- POST /admin/plantillas/<id>/activar — Activar/desactivar plantilla
+"""
+import json
+import os
+
+import werkzeug.utils
+from flask import (Blueprint, abort, current_app, flash, redirect,
+                   render_template, request, send_file, url_for)
+from flask_login import login_required
+
+from app import db
+from app.decorators import role_required
+from app.models.consultas_nombradas import ConsultaNombrada
+from app.models.tipos_documentos import TipoDocumento
+from app.models.tipos_escritos import TipoEscrito
+from app.models.tipos_fases import TipoFase
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.tipos_tramites import TipoTramite
+
+bp = Blueprint(
+    'admin_plantillas',
+    __name__,
+    url_prefix='/admin/plantillas',
+    template_folder='templates',
+)
+
+# Campos fijos del ContextoBaseExpediente — siempre disponibles en cualquier plantilla
+CAMPOS_BASE = [
+    {'campo': 'numero_at',              'descripcion': 'Número administrativo (AT-XXXX)'},
+    {'campo': 'expediente_id',          'descripcion': 'ID técnico interno del expediente'},
+    {'campo': 'titular_nombre',         'descripcion': 'Nombre / Razón Social del titular'},
+    {'campo': 'titular_nif',            'descripcion': 'NIF del titular'},
+    {'campo': 'titular_direccion',      'descripcion': 'Dirección de notificación preferente'},
+    {'campo': 'proyecto_titulo',        'descripcion': 'Título del proyecto técnico'},
+    {'campo': 'proyecto_finalidad',     'descripcion': 'Finalidad de la instalación'},
+    {'campo': 'proyecto_emplazamiento', 'descripcion': 'Emplazamiento descriptivo'},
+    {'campo': 'instrumento_ambiental',  'descripcion': 'Siglas del instrumento ambiental (AAI, AAU, EXENTO...)'},
+    {'campo': 'responsable_nombre',     'descripcion': 'Nombre completo del tramitador asignado'},
+    {'campo': 'municipios',             'descripcion': 'Lista de municipios afectados (list[str], usar en bucle)'},
+    {'campo': 'fecha_hoy',              'descripcion': 'Fecha actual en formato DD/MM/YYYY'},
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _plantillas_dir():
+    """Directorio absoluto de plantillas .docx."""
+    base = current_app.config.get('PLANTILLAS_BASE', '')
+    return os.path.join(base, 'plantillas') if base else ''
+
+
+def _fragmentos_dir():
+    """Directorio absoluto de fragmentos .docx."""
+    base = current_app.config.get('PLANTILLAS_BASE', '')
+    return os.path.join(base, 'fragmentos') if base else ''
+
+
+def _listar_fragmentos() -> list[str]:
+    """Devuelve nombres de fichero .docx en PLANTILLAS_BASE/fragmentos/."""
+    d = _fragmentos_dir()
+    if not d or not os.path.isdir(d):
+        return []
+    return sorted(f for f in os.listdir(d) if f.lower().endswith('.docx'))
+
+
+def _build_tokens(tipo_escrito=None) -> dict:
+    """
+    Construye el contexto de tokens para el panel del supervisor.
+
+    campos:    CAMPOS_BASE + campos_catalogo del tipo (si existe y tiene context builder)
+    consultas: ConsultaNombrada activas (ordenadas por nombre)
+    fragmentos: ficheros .docx en PLANTILLAS_BASE/fragmentos/
+    """
+    campos = list(CAMPOS_BASE)
+    if tipo_escrito and tipo_escrito.campos_catalogo:
+        campos = campos + tipo_escrito.campos_catalogo
+
+    consultas = (
+        ConsultaNombrada.query
+        .filter_by(activo=True)
+        .order_by(ConsultaNombrada.nombre)
+        .all()
+    )
+    fragmentos = _listar_fragmentos()
+
+    return {'campos': campos, 'consultas': consultas, 'fragmentos': fragmentos}
+
+
+def _guardar_docx(archivo) -> str | None:
+    """
+    Guarda el fichero .docx subido en PLANTILLAS_BASE/plantillas/.
+    Devuelve el nombre de fichero (ruta_plantilla) o None si hay error.
+    """
+    if not archivo or not archivo.filename:
+        return None
+
+    base = current_app.config.get('PLANTILLAS_BASE', '')
+    if not base:
+        flash('PLANTILLAS_BASE no está configurado en el servidor.', 'danger')
+        return None
+
+    filename = werkzeug.utils.secure_filename(archivo.filename)
+    if not filename.lower().endswith('.docx'):
+        flash('Solo se admiten ficheros .docx.', 'danger')
+        return None
+
+    destino_dir = _plantillas_dir()
+    os.makedirs(destino_dir, exist_ok=True)
+    archivo.save(os.path.join(destino_dir, filename))
+    return filename
+
+
+def _form_data_to_tipo(tipo: TipoEscrito) -> bool:
+    """
+    Rellena los campos de un TipoEscrito desde request.form.
+    Devuelve False si hay errores de validación (con flash).
+    """
+    codigo = request.form.get('codigo', '').strip().upper()
+    nombre = request.form.get('nombre', '').strip()
+
+    if not codigo:
+        flash('El código es obligatorio.', 'danger')
+        return False
+    if not nombre:
+        flash('El nombre es obligatorio.', 'danger')
+        return False
+
+    tipo_documento_id = request.form.get('tipo_documento_id') or None
+    if not tipo_documento_id:
+        flash('El tipo de documento es obligatorio.', 'danger')
+        return False
+
+    # campos_catalogo viene como JSON en textarea
+    campos_raw = request.form.get('campos_catalogo', '').strip()
+    campos_catalogo = None
+    if campos_raw:
+        try:
+            campos_catalogo = json.loads(campos_raw)
+            if not isinstance(campos_catalogo, list):
+                raise ValueError
+        except (ValueError, json.JSONDecodeError):
+            flash('El catálogo de campos adicionales no es JSON válido (debe ser una lista).', 'danger')
+            return False
+
+    tipo.codigo = codigo
+    tipo.nombre = nombre
+    tipo.descripcion = request.form.get('descripcion', '').strip() or None
+    tipo.tipo_documento_id = int(tipo_documento_id)
+    tipo.tipo_solicitud_id  = int(request.form['tipo_solicitud_id']) if request.form.get('tipo_solicitud_id') else None
+    tipo.tipo_fase_id       = int(request.form['tipo_fase_id'])      if request.form.get('tipo_fase_id')      else None
+    tipo.tipo_tramite_id    = int(request.form['tipo_tramite_id'])   if request.form.get('tipo_tramite_id')   else None
+    tipo.contexto_clase     = request.form.get('contexto_clase', '').strip() or None
+    tipo.campos_catalogo    = campos_catalogo
+    tipo.activo             = 'activo' in request.form
+    return True
+
+
+def _selects_context():
+    """Devuelve los querysets para los selects del formulario."""
+    return {
+        'tipos_solicitud':  TipoSolicitud.query.order_by(TipoSolicitud.siglas).all(),
+        'tipos_fase':       TipoFase.query.order_by(TipoFase.nombre).all(),
+        'tipos_tramite':    TipoTramite.query.order_by(TipoTramite.nombre).all(),
+        'tipos_documento':  TipoDocumento.query.order_by(TipoDocumento.nombre).all(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rutas
+# ---------------------------------------------------------------------------
+
+@bp.route('/')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def listado():
+    tipos = TipoEscrito.query.order_by(TipoEscrito.nombre).all()
+    return render_template('admin_plantillas/listado.html', tipos=tipos)
+
+
+@bp.route('/nueva/', methods=['GET', 'POST'])
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def nueva():
+    if request.method == 'POST':
+        archivo = request.files.get('archivo_plantilla')
+        ruta = _guardar_docx(archivo)
+        if ruta is None and not archivo.filename:
+            flash('Debes subir el fichero .docx de la plantilla.', 'danger')
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='nueva', tipo=None,
+                tokens=_build_tokens(),
+                **_selects_context(),
+            )
+
+        tipo = TipoEscrito()
+        if not _form_data_to_tipo(tipo):
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='nueva', tipo=None,
+                tokens=_build_tokens(),
+                **_selects_context(),
+            )
+
+        if ruta:
+            tipo.ruta_plantilla = ruta
+
+        db.session.add(tipo)
+        try:
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error al guardar: {e}', 'danger')
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='nueva', tipo=None,
+                tokens=_build_tokens(),
+                **_selects_context(),
+            )
+
+        flash(f'Plantilla «{tipo.nombre}» registrada correctamente.', 'success')
+        return redirect(url_for('admin_plantillas.detalle', id=tipo.id))
+
+    return render_template(
+        'admin_plantillas/form.html',
+        modo='nueva', tipo=None,
+        tokens=_build_tokens(),
+        **_selects_context(),
+    )
+
+
+@bp.route('/<int:id>/')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def detalle(id):
+    tipo = TipoEscrito.query.get_or_404(id)
+    tokens = _build_tokens(tipo)
+    return render_template('admin_plantillas/detalle.html', tipo=tipo, tokens=tokens)
+
+
+@bp.route('/<int:id>/editar', methods=['GET', 'POST'])
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def editar(id):
+    tipo = TipoEscrito.query.get_or_404(id)
+
+    if request.method == 'POST':
+        archivo = request.files.get('archivo_plantilla')
+        ruta = _guardar_docx(archivo)
+
+        if not _form_data_to_tipo(tipo):
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='editar', tipo=tipo,
+                tokens=_build_tokens(tipo),
+                **_selects_context(),
+            )
+
+        if ruta:
+            tipo.ruta_plantilla = ruta
+
+        try:
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Error al guardar: {e}', 'danger')
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='editar', tipo=tipo,
+                tokens=_build_tokens(tipo),
+                **_selects_context(),
+            )
+
+        flash(f'Plantilla «{tipo.nombre}» actualizada correctamente.', 'success')
+        return redirect(url_for('admin_plantillas.detalle', id=tipo.id))
+
+    return render_template(
+        'admin_plantillas/form.html',
+        modo='editar', tipo=tipo,
+        tokens=_build_tokens(tipo),
+        **_selects_context(),
+    )
+
+
+@bp.route('/<int:id>/descargar')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def descargar(id):
+    tipo = TipoEscrito.query.get_or_404(id)
+    d = _plantillas_dir()
+    if not d:
+        abort(503, 'PLANTILLAS_BASE no configurado.')
+    ruta_abs = os.path.join(d, tipo.ruta_plantilla)
+    if not os.path.isfile(ruta_abs):
+        abort(404, f'Fichero no encontrado: {tipo.ruta_plantilla}')
+    return send_file(ruta_abs, as_attachment=True, download_name=tipo.ruta_plantilla)
+
+
+@bp.route('/<int:id>/activar', methods=['POST'])
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def activar(id):
+    tipo = TipoEscrito.query.get_or_404(id)
+    tipo.activo = not tipo.activo
+    db.session.commit()
+    estado = 'activada' if tipo.activo else 'desactivada'
+    flash(f'Plantilla «{tipo.nombre}» {estado}.', 'success')
+    return redirect(url_for('admin_plantillas.detalle', id=tipo.id))

--- a/app/modules/admin_plantillas/templates/admin_plantillas/_panel_tokens.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/_panel_tokens.html
@@ -1,0 +1,200 @@
+{#
+  Panel de tokens disponibles para plantillas .docx.
+  Variables esperadas en contexto:
+    tokens.campos     — list[{campo, descripcion}]
+    tokens.consultas  — list[ConsultaNombrada]
+    tokens.fragmentos — list[str] (nombres de fichero .docx)
+  solo_lectura (opcional) — Si True, no muestra botones Copiar
+#}
+{% set solo_lectura = solo_lectura | default(false) %}
+
+<div class="card border-primary">
+    <div class="card-header bg-primary text-white fw-semibold">
+        <i class="fas fa-tags me-1"></i> Tokens disponibles
+    </div>
+
+    {# ── Sección: Campos simples ── #}
+    <div class="card-body pb-0">
+        <h6 class="mb-2 text-primary">
+            <i class="fas fa-cube me-1"></i> Campos simples
+        </h6>
+        <p class="small text-secondary mb-2">
+            Sintaxis en la plantilla: <code class="bg-light px-1 rounded">{{ '{{campo}}' }}</code>
+        </p>
+        <div class="list-group list-group-flush mb-3">
+            {% for c in tokens.campos %}
+            <div class="list-group-item list-group-item-action py-2 px-2">
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1 min-w-0">
+                        <code class="d-block text-primary small">{{ '{{' }}{{ c.campo }}{{ '}}' }}</code>
+                        <span class="text-secondary" style="font-size:.8rem">{{ c.descripcion }}</span>
+                    </div>
+                    {% if not solo_lectura %}
+                    <button type="button"
+                            class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                            data-token="{{ '{{' }}{{ c.campo }}{{ '}}' }}"
+                            title="Copiar token">
+                        <i class="fas fa-copy"></i>
+                    </button>
+                    {% endif %}
+                </div>
+            </div>
+            {% else %}
+            <div class="list-group-item text-secondary small">Sin campos disponibles.</div>
+            {% endfor %}
+        </div>
+    </div>
+
+    {# ── Sección: Consultas nombradas (tablas dinámicas) ── #}
+    <div class="card-body pb-0 border-top pt-3">
+        <h6 class="mb-2 text-primary">
+            <i class="fas fa-table me-1"></i> Consultas nombradas
+        </h6>
+        <p class="small text-secondary mb-2">
+            Sintaxis: <code class="bg-light px-1 rounded">{{ '{%tr for row in nombre %}' }}</code> … <code class="bg-light px-1 rounded">{{ '{%tr endfor %}' }}</code>
+        </p>
+        {% if tokens.consultas %}
+        <div class="accordion accordion-flush" id="acordeon-consultas">
+            {% for cn in tokens.consultas %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="hcn-{{ cn.id }}">
+                    <button class="accordion-button collapsed py-2 px-2 small"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#ccn-{{ cn.id }}"
+                            aria-expanded="false">
+                        <code class="text-primary me-2">{{ cn.nombre }}</code>
+                        <span class="text-secondary">{{ cn.descripcion }}</span>
+                    </button>
+                </h2>
+                <div id="ccn-{{ cn.id }}" class="accordion-collapse collapse"
+                     aria-labelledby="hcn-{{ cn.id }}"
+                     data-bs-parent="#acordeon-consultas">
+                    <div class="accordion-body py-2 px-2">
+                        {# Token de apertura del bucle #}
+                        <div class="d-flex align-items-center gap-2 mb-1">
+                            <code class="small flex-grow-1 text-primary">{{ '{%tr for row in ' }}{{ cn.nombre }}{{ ' %}' }}</code>
+                            {% if not solo_lectura %}
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                                    data-token="{{ '{%tr for row in ' }}{{ cn.nombre }}{{ ' %}' }}"
+                                    title="Copiar apertura de bucle">
+                                <i class="fas fa-copy"></i>
+                            </button>
+                            {% endif %}
+                        </div>
+                        {# Columnas disponibles #}
+                        {% if cn.columnas %}
+                        <div class="small text-secondary mb-2 ps-1">
+                            Columnas disponibles dentro del bucle:
+                        </div>
+                        {% for col in cn.columnas %}
+                        <div class="d-flex align-items-center gap-2 mb-1 ps-2">
+                            <code class="small flex-grow-1">{{ '{{row.' }}{{ col.campo }}{{ '}}' }}</code>
+                            <span class="text-secondary small me-auto">{{ col.descripcion }}</span>
+                            {% if not solo_lectura %}
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                                    data-token="{{ '{{row.' }}{{ col.campo }}{{ '}}' }}"
+                                    title="Copiar campo de fila">
+                                <i class="fas fa-copy"></i>
+                            </button>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                        {% endif %}
+                        {# Token de cierre #}
+                        <div class="d-flex align-items-center gap-2 mt-1">
+                            <code class="small flex-grow-1 text-primary">{{ '{%tr endfor %}' }}</code>
+                            {% if not solo_lectura %}
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                                    data-token="{{ '{%tr endfor %}' }}"
+                                    title="Copiar cierre de bucle">
+                                <i class="fas fa-copy"></i>
+                            </button>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-secondary small">No hay consultas nombradas registradas.</p>
+        {% endif %}
+    </div>
+
+    {# ── Sección: Fragmentos .docx ── #}
+    <div class="card-body pb-3 border-top pt-3">
+        <h6 class="mb-2 text-primary">
+            <i class="fas fa-file-import me-1"></i> Fragmentos insertables
+        </h6>
+        <p class="small text-secondary mb-2">
+            Sintaxis: <code class="bg-light px-1 rounded">{{ '{{r nombre_sin_extension}}' }}</code>
+        </p>
+        {% if tokens.fragmentos %}
+        <div class="list-group list-group-flush">
+            {% for frag in tokens.fragmentos %}
+            {% set nombre_sin_ext = frag[:-5] if frag.endswith('.docx') else frag %}
+            <div class="list-group-item list-group-item-action py-2 px-2">
+                <div class="d-flex align-items-center gap-2">
+                    <div class="flex-grow-1 min-w-0">
+                        <code class="d-block text-primary small">{{ '{{r ' }}{{ nombre_sin_ext }}{{ '}}' }}</code>
+                        <span class="text-secondary" style="font-size:.8rem">{{ frag }}</span>
+                    </div>
+                    {% if not solo_lectura %}
+                    <button type="button"
+                            class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                            data-token="{{ '{{r ' }}{{ nombre_sin_ext }}{{ '}}' }}"
+                            title="Copiar token fragmento">
+                        <i class="fas fa-copy"></i>
+                    </button>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-secondary small mb-0">
+            No se encontraron fragmentos en <code>PLANTILLAS_BASE/fragmentos/</code>.
+            {% if not solo_lectura %}
+            Coloca ficheros .docx en esa carpeta para verlos aquí.
+            {% endif %}
+        </p>
+        {% endif %}
+    </div>
+</div>
+
+{% if not solo_lectura %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.btn-copiar').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            const token = btn.dataset.token;
+            navigator.clipboard.writeText(token).then(function () {
+                const icon = btn.querySelector('i');
+                icon.className = 'fas fa-check text-success';
+                setTimeout(function () {
+                    icon.className = 'fas fa-copy';
+                }, 1500);
+            }).catch(function () {
+                // Fallback para contextos sin clipboard API (HTTP sin TLS)
+                const tmp = document.createElement('textarea');
+                tmp.value = token;
+                tmp.style.position = 'fixed';
+                tmp.style.opacity = '0';
+                document.body.appendChild(tmp);
+                tmp.focus();
+                tmp.select();
+                document.execCommand('copy');
+                document.body.removeChild(tmp);
+                const icon = btn.querySelector('i');
+                icon.className = 'fas fa-check text-success';
+                setTimeout(function () { icon.className = 'fas fa-copy'; }, 1500);
+            });
+        });
+    });
+});
+</script>
+{% endif %}

--- a/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
@@ -99,14 +99,26 @@
                 <div class="card-header fw-semibold">
                     <i class="fas fa-file-word me-1"></i> Fichero de plantilla
                 </div>
-                <div class="card-body d-flex align-items-center gap-3">
-                    <i class="fas fa-file-word fa-2x text-primary"></i>
-                    <div>
-                        <div class="fw-semibold">{{ tipo.ruta_plantilla }}</div>
-                        <a href="{{ url_for('admin_plantillas.descargar', id=tipo.id) }}"
-                           class="btn btn-sm btn-outline-primary mt-2">
-                            <i class="fas fa-download me-1"></i> Descargar .docx
-                        </a>
+                <div class="card-body">
+                    <div class="d-flex align-items-start gap-3">
+                        <i class="fas fa-file-word fa-2x text-primary flex-shrink-0 mt-1"></i>
+                        <div class="flex-grow-1 min-w-0">
+                            <div class="fw-semibold mb-2">{{ tipo.ruta_plantilla }}</div>
+                            {% if ruta_absoluta %}
+                            <div class="input-group input-group-sm">
+                                <input type="text" class="form-control font-monospace"
+                                       id="ruta-abs" value="{{ ruta_absoluta }}" readonly>
+                                <button class="btn btn-outline-secondary" type="button"
+                                        id="btn-copiar-ruta"
+                                        title="Pega esta ruta en la barra del Explorador de Windows">
+                                    <i class="fas fa-copy me-1"></i> Copiar ruta
+                                </button>
+                            </div>
+                            <div class="form-text">
+                                Pega la ruta en la barra del Explorador de Windows para ir directamente al fichero.
+                            </div>
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -172,4 +184,18 @@
 
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+{% if ruta_absoluta %}
+<script>
+document.getElementById('btn-copiar-ruta').addEventListener('click', function () {
+    navigator.clipboard.writeText(document.getElementById('ruta-abs').value).then(function () {
+        const btn = document.getElementById('btn-copiar-ruta');
+        btn.innerHTML = '<i class="fas fa-check text-success me-1"></i> Copiada';
+        setTimeout(function () { btn.innerHTML = '<i class="fas fa-copy me-1"></i> Copiar ruta'; }, 2000);
+    });
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
@@ -1,0 +1,175 @@
+{% extends 'layout/base_fullwidth.html' %}
+
+{% block title %}{{ tipo.nombre }} — Plantillas — BDDAT{% endblock %}
+
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<a href="{{ url_for('admin_plantillas.listado') }}">Plantillas de escritos</a>
+<span>›</span>
+<span>{{ tipo.nombre }}</span>
+{% endblock %}
+
+{% block content %}
+<div class="lista-cabecera">
+    <div class="page-header content-constrained">
+        <h1>
+            <i class="fas fa-file-word me-1"></i>
+            {{ tipo.nombre }}
+            {% if tipo.activo %}
+                <span class="badge bg-success fs-6 ms-2">Activa</span>
+            {% else %}
+                <span class="badge bg-secondary fs-6 ms-2">Inactiva</span>
+            {% endif %}
+        </h1>
+        <div class="d-flex gap-2">
+            <a href="{{ url_for('admin_plantillas.listado') }}" class="btn btn-outline-primary">
+                <i class="fas fa-arrow-left me-1"></i> Volver
+            </a>
+            <a href="{{ url_for('admin_plantillas.editar', id=tipo.id) }}" class="btn btn-primary">
+                <i class="fas fa-edit me-1"></i> Editar
+            </a>
+        </div>
+    </div>
+</div>
+
+<div class="content-constrained py-4">
+    <div class="row g-4">
+
+        {# ── Columna izquierda: datos ── #}
+        <div class="col-lg-7">
+
+            {# Bloque: Identificación #}
+            <div class="card mb-4">
+                <div class="card-header fw-semibold">
+                    <i class="fas fa-tag me-1"></i> Identificación
+                </div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Código</dt>
+                        <dd class="col-sm-8"><code>{{ tipo.codigo }}</code></dd>
+
+                        <dt class="col-sm-4">Nombre</dt>
+                        <dd class="col-sm-8">{{ tipo.nombre }}</dd>
+
+                        <dt class="col-sm-4">Descripción</dt>
+                        <dd class="col-sm-8">{{ tipo.descripcion or '—' }}</dd>
+
+                        <dt class="col-sm-4">Tipo documento</dt>
+                        <dd class="col-sm-8">
+                            {% if tipo.tipo_documento %}
+                                <code>{{ tipo.tipo_documento.codigo }}</code> — {{ tipo.tipo_documento.nombre }}
+                            {% else %}—{% endif %}
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+
+            {# Bloque: Contexto ESFTT #}
+            <div class="card mb-4">
+                <div class="card-header fw-semibold">
+                    <i class="fas fa-sitemap me-1"></i> Contexto ESFTT
+                </div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Tipo solicitud</dt>
+                        <dd class="col-sm-8">
+                            {% if tipo.tipo_solicitud %}
+                                {{ tipo.tipo_solicitud.siglas }} — {{ tipo.tipo_solicitud.descripcion }}
+                            {% else %}<span class="text-secondary">Cualquiera</span>{% endif %}
+                        </dd>
+
+                        <dt class="col-sm-4">Fase</dt>
+                        <dd class="col-sm-8">
+                            {% if tipo.tipo_fase %}{{ tipo.tipo_fase.nombre }}
+                            {% else %}<span class="text-secondary">Cualquiera</span>{% endif %}
+                        </dd>
+
+                        <dt class="col-sm-4">Trámite</dt>
+                        <dd class="col-sm-8">
+                            {% if tipo.tipo_tramite %}{{ tipo.tipo_tramite.nombre }}
+                            {% else %}<span class="text-secondary">Cualquiera</span>{% endif %}
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+
+            {# Bloque: Plantilla .docx #}
+            <div class="card mb-4">
+                <div class="card-header fw-semibold">
+                    <i class="fas fa-file-word me-1"></i> Fichero de plantilla
+                </div>
+                <div class="card-body d-flex align-items-center gap-3">
+                    <i class="fas fa-file-word fa-2x text-primary"></i>
+                    <div>
+                        <div class="fw-semibold">{{ tipo.ruta_plantilla }}</div>
+                        <a href="{{ url_for('admin_plantillas.descargar', id=tipo.id) }}"
+                           class="btn btn-sm btn-outline-primary mt-2">
+                            <i class="fas fa-download me-1"></i> Descargar .docx
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            {# Bloque: Context Builder #}
+            {% if tipo.contexto_clase or tipo.campos_catalogo %}
+            <div class="card mb-4">
+                <div class="card-header fw-semibold">
+                    <i class="fas fa-code me-1"></i> Context Builder (Capa 2)
+                </div>
+                <div class="card-body">
+                    {% if tipo.contexto_clase %}
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Clase</dt>
+                        <dd class="col-sm-8"><code>{{ tipo.contexto_clase }}</code></dd>
+                    </dl>
+                    {% endif %}
+                    {% if tipo.campos_catalogo %}
+                    <div class="mt-2">
+                        <div class="fw-semibold small mb-1">Campos adicionales:</div>
+                        <table class="table table-sm table-bordered small mb-0">
+                            <thead class="table-light">
+                                <tr><th>Campo</th><th>Descripción</th></tr>
+                            </thead>
+                            <tbody>
+                                {% for c in tipo.campos_catalogo %}
+                                <tr>
+                                    <td><code>{{ c.campo }}</code></td>
+                                    <td>{{ c.descripcion }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+
+            {# Acción desactivar/activar #}
+            <form method="POST" action="{{ url_for('admin_plantillas.activar', id=tipo.id) }}">
+                <button type="submit" class="btn {% if tipo.activo %}btn-outline-danger{% else %}btn-outline-success{% endif %}">
+                    <i class="fas {% if tipo.activo %}fa-toggle-off{% else %}fa-toggle-on{% endif %} me-1"></i>
+                    {% if tipo.activo %}Desactivar plantilla{% else %}Activar plantilla{% endif %}
+                </button>
+            </form>
+
+        </div>{# fin col-lg-7 #}
+
+        {# ── Columna derecha: panel de tokens (solo lectura) ── #}
+        <div class="col-lg-5">
+            <div class="sticky-top" style="top: 1rem">
+                {% set solo_lectura = true %}
+                {% include 'admin_plantillas/_panel_tokens.html' %}
+                <div class="mt-2 text-center">
+                    <a href="{{ url_for('admin_plantillas.editar', id=tipo.id) }}"
+                       class="btn btn-sm btn-outline-primary">
+                        <i class="fas fa-edit me-1"></i> Editar para copiar tokens
+                    </a>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/app/modules/admin_plantillas/templates/admin_plantillas/form.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/form.html
@@ -1,0 +1,273 @@
+{% extends 'layout/base_fullwidth.html' %}
+
+{% block title %}
+{% if modo == 'editar' %}Editar plantilla — {{ tipo.nombre }}{% else %}Nueva plantilla{% endif %} — BDDAT
+{% endblock %}
+
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<a href="{{ url_for('admin_plantillas.listado') }}">Plantillas de escritos</a>
+{% if modo == 'editar' %}
+<span>›</span>
+<a href="{{ url_for('admin_plantillas.detalle', id=tipo.id) }}">{{ tipo.nombre }}</a>
+<span>›</span>
+<span>Editar</span>
+{% else %}
+<span>›</span>
+<span>Nueva plantilla</span>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="lista-cabecera">
+    <div class="page-header content-constrained">
+        <h1>
+            <i class="fas fa-file-word"></i>
+            {% if modo == 'editar' %}Editar plantilla{% else %}Nueva plantilla{% endif %}
+        </h1>
+        <a href="{{ url_for('admin_plantillas.listado') }}" class="btn btn-outline-primary">
+            <i class="fas fa-arrow-left me-1"></i> Volver
+        </a>
+    </div>
+</div>
+
+<div class="content-constrained py-4">
+    <form method="POST"
+          enctype="multipart/form-data"
+          action="{% if modo == 'editar' %}{{ url_for('admin_plantillas.editar', id=tipo.id) }}{% else %}{{ url_for('admin_plantillas.nueva') }}{% endif %}">
+
+        <div class="row g-4">
+
+            {# ── Columna izquierda: formulario ── #}
+            <div class="col-lg-7">
+
+                {# Bloque: Identificación #}
+                <div class="card mb-4">
+                    <div class="card-header fw-semibold">
+                        <i class="fas fa-tag me-1"></i> Identificación
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label for="nombre" class="form-label fw-semibold">Nombre <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="nombre" name="nombre"
+                                   value="{{ tipo.nombre if tipo else '' }}"
+                                   placeholder="Requerimiento de subsanación"
+                                   required>
+                            <div class="form-text">Nombre legible que verán tramitadores y supervisores.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="codigo" class="form-label fw-semibold">Código <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control font-monospace" id="codigo" name="codigo"
+                                   value="{{ tipo.codigo if tipo else '' }}"
+                                   placeholder="REQUERIMIENTO_SUBSANACION"
+                                   pattern="[A-Z0-9_]+"
+                                   title="Solo mayúsculas, números y guiones bajos"
+                                   required>
+                            <div class="form-text">Slug estable en MAYÚSCULAS_CON_GUIONES. Se usará en código.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="descripcion" class="form-label fw-semibold">Descripción</label>
+                            <textarea class="form-control" id="descripcion" name="descripcion"
+                                      rows="2"
+                                      placeholder="Requerimiento al titular para subsanación de documentación técnica">{{ tipo.descripcion if tipo and tipo.descripcion else '' }}</textarea>
+                        </div>
+
+                        <div class="mb-0">
+                            <label for="tipo_documento_id" class="form-label fw-semibold">
+                                Tipo de documento resultante <span class="text-danger">*</span>
+                            </label>
+                            <select class="form-select" id="tipo_documento_id" name="tipo_documento_id" required>
+                                <option value="">— Seleccionar —</option>
+                                {% for td in tipos_documento %}
+                                <option value="{{ td.id }}"
+                                    {% if tipo and tipo.tipo_documento_id == td.id %}selected{% endif %}>
+                                    {{ td.codigo }} — {{ td.nombre }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                            <div class="form-text">
+                                El documento generado se registrará en el pool del expediente con este tipo.
+                                Permite al motor de reglas detectar su existencia.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {# Bloque: Contexto ESFTT #}
+                <div class="card mb-4">
+                    <div class="card-header fw-semibold">
+                        <i class="fas fa-sitemap me-1"></i> Contexto ESFTT
+                        <span class="badge bg-secondary ms-2" style="font-weight:400">Todos los campos son opcionales</span>
+                    </div>
+                    <div class="card-body">
+                        <p class="text-secondary small mb-3">
+                            Deja en blanco los campos que no apliquen.
+                            <strong>Vacío = aplica a cualquier valor</strong> de esa dimensión.
+                        </p>
+
+                        <div class="mb-3">
+                            <label for="tipo_solicitud_id" class="form-label fw-semibold">Tipo de solicitud</label>
+                            <select class="form-select" id="tipo_solicitud_id" name="tipo_solicitud_id">
+                                <option value="">— Cualquier solicitud —</option>
+                                {% for ts in tipos_solicitud %}
+                                <option value="{{ ts.id }}"
+                                    {% if tipo and tipo.tipo_solicitud_id == ts.id %}selected{% endif %}>
+                                    {{ ts.siglas }} — {{ ts.descripcion }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="tipo_fase_id" class="form-label fw-semibold">Fase</label>
+                            <select class="form-select" id="tipo_fase_id" name="tipo_fase_id">
+                                <option value="">— Cualquier fase —</option>
+                                {% for tf in tipos_fase %}
+                                <option value="{{ tf.id }}"
+                                    {% if tipo and tipo.tipo_fase_id == tf.id %}selected{% endif %}>
+                                    {{ tf.nombre }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+
+                        <div class="mb-0">
+                            <label for="tipo_tramite_id" class="form-label fw-semibold">Trámite</label>
+                            <select class="form-select" id="tipo_tramite_id" name="tipo_tramite_id">
+                                <option value="">— Cualquier trámite —</option>
+                                {% for tt in tipos_tramite %}
+                                <option value="{{ tt.id }}"
+                                    {% if tipo and tipo.tipo_tramite_id == tt.id %}selected{% endif %}>
+                                    {{ tt.nombre }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+
+                {# Bloque: Plantilla .docx #}
+                <div class="card mb-4">
+                    <div class="card-header fw-semibold">
+                        <i class="fas fa-file-upload me-1"></i> Fichero de plantilla
+                    </div>
+                    <div class="card-body">
+                        {% if modo == 'editar' and tipo.ruta_plantilla %}
+                        <div class="alert alert-info d-flex align-items-center gap-2 mb-3">
+                            <i class="fas fa-file-word fa-lg"></i>
+                            <div>
+                                Plantilla actual: <strong>{{ tipo.ruta_plantilla }}</strong>
+                                <a href="{{ url_for('admin_plantillas.descargar', id=tipo.id) }}"
+                                   class="ms-2 small">
+                                    <i class="fas fa-download me-1"></i>Descargar
+                                </a>
+                            </div>
+                        </div>
+                        <label for="archivo_plantilla" class="form-label fw-semibold">
+                            Subir nueva versión <span class="text-secondary">(opcional)</span>
+                        </label>
+                        {% else %}
+                        <label for="archivo_plantilla" class="form-label fw-semibold">
+                            Fichero .docx <span class="text-danger">*</span>
+                        </label>
+                        {% endif %}
+                        <input type="file" class="form-control" id="archivo_plantilla"
+                               name="archivo_plantilla" accept=".docx"
+                               {% if modo == 'nueva' %}required{% endif %}>
+                        <div class="form-text">
+                            Crea la plantilla en LibreOffice Writer usando los tokens del panel.
+                            Guárdala como .docx antes de subirla.
+                        </div>
+                    </div>
+                </div>
+
+                {# Bloque: Contexto Python avanzado #}
+                <div class="card mb-4">
+                    <div class="card-header fw-semibold">
+                        <i class="fas fa-code me-1"></i> Contexto Python avanzado
+                        <span class="badge bg-secondary ms-2" style="font-weight:400">Opcional — Capa 2</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label for="contexto_clase" class="form-label fw-semibold">Clase Context Builder</label>
+                            <input type="text" class="form-control font-monospace"
+                                   id="contexto_clase" name="contexto_clase"
+                                   value="{{ tipo.contexto_clase if tipo and tipo.contexto_clase else '' }}"
+                                   placeholder="RequerimientoSubsanacion">
+                            <div class="form-text">
+                                Nombre de clase Python en <code>app/services/context_builders/</code>.
+                                Dejar vacío si la plantilla solo usa campos base (Capa 1).
+                            </div>
+                        </div>
+
+                        <div class="mb-0">
+                            <label for="campos_catalogo" class="form-label fw-semibold">
+                                Campos adicionales del Context Builder
+                            </label>
+                            <textarea class="form-control font-monospace" id="campos_catalogo"
+                                      name="campos_catalogo" rows="5"
+                                      placeholder='[{"campo": "importe_tasas", "descripcion": "Importe en euros de las tasas calculadas"}]'>{{ tipo.campos_catalogo | tojson(indent=2) if tipo and tipo.campos_catalogo else '' }}</textarea>
+                            <div class="form-text">
+                                JSON: lista de <code>{"campo": "...", "descripcion": "..."}</code>.
+                                Estos campos aparecerán en el panel de tokens para copiarlos fácilmente.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {# Bloque: Estado #}
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox"
+                                   id="activo" name="activo" role="switch"
+                                   {% if tipo is none or tipo.activo %}checked{% endif %}>
+                            <label class="form-check-label fw-semibold" for="activo">
+                                Plantilla activa
+                            </label>
+                        </div>
+                        <div class="form-text">
+                            Las plantillas inactivas no se muestran en la tarea REDACTAR,
+                            pero se conservan para histórico.
+                        </div>
+                    </div>
+                </div>
+
+                {# Botones de acción #}
+                <div class="d-flex gap-2 mb-5">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save me-1"></i>
+                        {% if modo == 'editar' %}Guardar cambios{% else %}Registrar plantilla{% endif %}
+                    </button>
+                    <a href="{{ url_for('admin_plantillas.listado') }}" class="btn btn-outline-secondary">
+                        Cancelar
+                    </a>
+                </div>
+
+            </div>{# fin col-lg-7 #}
+
+            {# ── Columna derecha: panel de tokens ── #}
+            <div class="col-lg-5">
+                <div class="sticky-top" style="top: 1rem">
+                    {% include 'admin_plantillas/_panel_tokens.html' %}
+                </div>
+            </div>
+
+        </div>{# fin row #}
+    </form>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    // Autoformato código: convierte a MAYÚSCULAS mientras escribe
+    document.getElementById('codigo').addEventListener('input', function () {
+        const pos = this.selectionStart;
+        this.value = this.value.toUpperCase().replace(/[^A-Z0-9_]/g, '_');
+        this.setSelectionRange(pos, pos);
+    });
+</script>
+{% endblock %}

--- a/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
@@ -1,0 +1,82 @@
+{% extends 'layout/base_fullwidth.html' %}
+
+{% block title %}Plantillas de escritos — BDDAT{% endblock %}
+
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<span>Plantillas de escritos</span>
+{% endblock %}
+
+{% block content %}
+<div class="lista-cabecera">
+    <div class="page-header content-constrained">
+        <h1><i class="fas fa-file-word"></i> Plantillas de escritos</h1>
+        <a href="{{ url_for('admin_plantillas.nueva') }}" class="btn btn-primary">
+            <i class="fas fa-plus me-1"></i> Nueva plantilla
+        </a>
+    </div>
+</div>
+
+<div class="content-constrained py-4">
+    <div class="card tabla-bloque">
+        <table class="expedientes-table">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Código</th>
+                    <th>Tipo documento</th>
+                    <th>Solicitud</th>
+                    <th>Fase</th>
+                    <th>Trámite</th>
+                    <th>Estado</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for t in tipos %}
+                <tr>
+                    <td>
+                        <a href="{{ url_for('admin_plantillas.detalle', id=t.id) }}" class="fw-semibold">
+                            {{ t.nombre }}
+                        </a>
+                        {% if t.descripcion %}
+                        <div class="small text-secondary">{{ t.descripcion }}</div>
+                        {% endif %}
+                    </td>
+                    <td><code>{{ t.codigo }}</code></td>
+                    <td>{{ t.tipo_documento.nombre if t.tipo_documento else '—' }}</td>
+                    <td>{{ t.tipo_solicitud.siglas if t.tipo_solicitud else '<span class="text-secondary">Cualquiera</span>'|safe }}</td>
+                    <td>{{ t.tipo_fase.nombre if t.tipo_fase else '<span class="text-secondary">Cualquiera</span>'|safe }}</td>
+                    <td>{{ t.tipo_tramite.nombre if t.tipo_tramite else '<span class="text-secondary">Cualquiera</span>'|safe }}</td>
+                    <td>
+                        {% if t.activo %}
+                            <span class="badge bg-success">Activa</span>
+                        {% else %}
+                            <span class="badge bg-secondary">Inactiva</span>
+                        {% endif %}
+                    </td>
+                    <td class="text-end">
+                        <a href="{{ url_for('admin_plantillas.detalle', id=t.id) }}"
+                           class="btn btn-sm btn-outline-primary me-1">
+                            <i class="fas fa-info-circle"></i>
+                        </a>
+                        <a href="{{ url_for('admin_plantillas.editar', id=t.id) }}"
+                           class="btn btn-sm btn-outline-secondary">
+                            <i class="fas fa-edit"></i>
+                        </a>
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="8" class="text-center text-secondary py-4">
+                        No hay plantillas registradas.
+                        <a href="{{ url_for('admin_plantillas.nueva') }}">Crear la primera</a>.
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Cambios

- Nuevo módulo `admin_plantillas` auto-descubierto por `ModuleRegistry` (metadata.json + routes.py)
- 4 pantallas de administración: listado, nueva, detalle y editar plantillas `.docx`
- Panel de tokens lateral con botón "Copiar" (clipboard API): campos base de `ContextoBaseExpediente`, consultas nombradas activas y fragmentos `.docx` de `PLANTILLAS_BASE/fragmentos/`
- Upload de fichero `.docx` al registrar/editar una plantilla
- Vista detalle muestra ruta absoluta en disco con botón "Copiar ruta"
- Acceso restringido a roles `ADMIN` y `SUPERVISOR`
- Añade `PLANTILLAS_BASE` a `app/config.py` (variable de entorno)
- Actualiza `CLAUDE.md` con patrones anti-bloqueo Bash (`sed -i`, newlines en comandos)

Closes #189
