### PR TITLE
Protocolo URI bddat-explorador:// para abrir plantillas en Explorador de Windows

### DIFF
--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -251,8 +251,11 @@ def detalle(id):
     # Ruta absoluta en disco para que el supervisor pueda abrirla directamente
     d = _plantillas_dir()
     ruta_absoluta = os.path.join(d, tipo.ruta_plantilla).replace('/', '\\') if d else None
+    # El ':' de la letra de unidad (D:) se codifica como %3A para evitar que el
+    # navegador lo interprete como separador host:puerto en la autoridad de la URI.
+    uri_explorador = ('bddat-explorador://' + ruta_absoluta.replace('\\', '/').replace(':', '%3A')) if ruta_absoluta else None
     return render_template('admin_plantillas/detalle.html', tipo=tipo, tokens=tokens,
-                           ruta_absoluta=ruta_absoluta)
+                           ruta_absoluta=ruta_absoluta, uri_explorador=uri_explorador)
 
 
 @bp.route('/<int:id>/editar', methods=['GET', 'POST'])

--- a/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
@@ -114,8 +114,16 @@
                                     <i class="fas fa-copy me-1"></i> Copiar ruta
                                 </button>
                             </div>
-                            <div class="form-text">
-                                Pega la ruta en la barra del Explorador de Windows para ir directamente al fichero.
+                            <div class="mt-2 d-flex align-items-center gap-2">
+                                {% if uri_explorador %}
+                                <a href="{{ uri_explorador }}" class="btn btn-sm btn-outline-success"
+                                   title="Requiere tener instalado el protocolo bddat-explorador:// en este PC">
+                                    <i class="fas fa-folder-open me-1"></i> Abrir en Explorador
+                                </a>
+                                {% endif %}
+                                <span class="form-text mb-0">
+                                    O pega la ruta en la barra del Explorador de Windows.
+                                </span>
                             </div>
                             {% endif %}
                         </div>

--- a/scripts/cliente/bddat-explorador-handler.ps1
+++ b/scripts/cliente/bddat-explorador-handler.ps1
@@ -1,0 +1,9 @@
+param([string]$Uri)
+# Extraer la ruta quitando el esquema del protocolo personalizado
+$path = $Uri -replace '^bddat-explorador://', ''
+# URL-decode por si hay caracteres codificados (%20, etc.)
+$path = [System.Uri]::UnescapeDataString($path)
+# Convertir slashes a backslashes de Windows (soporta rutas locales y UNC)
+$path = $path.Replace('/', '\')
+# Abrir el Explorador de Windows seleccionando el fichero
+Start-Process explorer.exe -ArgumentList "/select,`"$path`""

--- a/scripts/cliente/install.bat
+++ b/scripts/cliente/install.bat
@@ -1,0 +1,4 @@
+@echo off
+echo Instalando protocolo bddat-explorador://...
+powershell -ExecutionPolicy Bypass -File "%~dp0install.ps1"
+pause

--- a/scripts/cliente/install.ps1
+++ b/scripts/cliente/install.ps1
@@ -1,0 +1,29 @@
+# Instalador del protocolo URI bddat-explorador://
+# No requiere privilegios de administrador (usa HKEY_CURRENT_USER)
+# Instala los scripts en %LOCALAPPDATA%\bddat-tools\
+
+$installDir = "$env:LOCALAPPDATA\bddat-tools"
+$handlerSrc = Join-Path $PSScriptRoot "bddat-explorador-handler.ps1"
+$handlerDst = Join-Path $installDir "bddat-explorador-handler.ps1"
+
+# Crear directorio de instalacion
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+# Copiar el handler
+Copy-Item -Path $handlerSrc -Destination $handlerDst -Force
+
+# Construir el comando que el registro ejecutara al activarse la URI
+$command = "`"powershell.exe`" -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$handlerDst`" `"%1`""
+
+# Registrar el protocolo en HKEY_CURRENT_USER (sin admin)
+$regBase = "HKCU:\SOFTWARE\Classes\bddat-explorador"
+New-Item -Path $regBase -Force | Out-Null
+Set-ItemProperty -Path $regBase -Name "(Default)" -Value "BDDAT Explorador de Plantillas"
+Set-ItemProperty -Path $regBase -Name "URL Protocol" -Value ""
+New-Item -Path "$regBase\shell\open\command" -Force | Out-Null
+Set-ItemProperty -Path "$regBase\shell\open\command" -Name "(Default)" -Value $command
+
+Write-Host ""
+Write-Host "Protocolo bddat-explorador:// instalado correctamente." -ForegroundColor Green
+Write-Host "Handler en: $handlerDst" -ForegroundColor Cyan
+Write-Host ""


### PR DESCRIPTION
## Cambios

- `scripts/cliente/install.bat` + `install.ps1` — instalador del protocolo URI en el PC cliente (sin privilegios de admin, usa `HKEY_CURRENT_USER`)
- `scripts/cliente/bddat-explorador-handler.ps1` — handler que recibe la URI, decodifica la ruta y abre `explorer.exe /select` en el fichero
- `routes.py` — genera `uri_explorador` con el colon de unidad codificado como `%3A` (evita que el navegador lo interprete como separador `host:puerto`)
- `detalle.html` — botón "Abrir en Explorador" junto al input de ruta absoluta

Closes #231
