### PR TITLE
Panel tokens: sección campos de lista con snippet copiable

### DIFF
--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -47,7 +47,7 @@ CAMPOS_BASE = [
     {'campo': 'proyecto_emplazamiento', 'descripcion': 'Emplazamiento descriptivo'},
     {'campo': 'instrumento_ambiental',  'descripcion': 'Siglas del instrumento ambiental (AAI, AAU, EXENTO...)'},
     {'campo': 'responsable_nombre',     'descripcion': 'Nombre completo del tramitador asignado'},
-    {'campo': 'municipios',             'descripcion': 'Lista de municipios afectados (list[str], usar en bucle)'},
+    {'campo': 'municipios',             'descripcion': 'Lista de municipios afectados', 'tipo': 'lista'},
     {'campo': 'fecha_hoy',              'descripcion': 'Fecha actual en formato DD/MM/YYYY'},
 ]
 

--- a/app/modules/admin_plantillas/templates/admin_plantillas/_panel_tokens.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/_panel_tokens.html
@@ -22,7 +22,7 @@
             Sintaxis en la plantilla: <code class="bg-light px-1 rounded">{{ '{{campo}}' }}</code>
         </p>
         <div class="list-group list-group-flush mb-3">
-            {% for c in tokens.campos %}
+            {% for c in tokens.campos if c.get('tipo') != 'lista' %}
             <div class="list-group-item list-group-item-action py-2 px-2">
                 <div class="d-flex align-items-start gap-2">
                     <div class="flex-grow-1 min-w-0">
@@ -44,6 +44,46 @@
             {% endfor %}
         </div>
     </div>
+
+    {# ── Sección: Campos de lista (bucle de párrafo) ── #}
+    {% set campos_lista = tokens.campos | selectattr('tipo', 'equalto', 'lista') | list %}
+    {% if campos_lista %}
+    <div class="card-body pb-0 border-top pt-3">
+        <h6 class="mb-2 text-primary">
+            <i class="fas fa-list me-1"></i> Campos de lista
+        </h6>
+        <p class="small text-secondary mb-2">
+            Copia el bloque completo y pégalo en Word — los tres párrafos se crean solos.
+        </p>
+        <div class="list-group list-group-flush mb-3">
+            {% for c in campos_lista %}
+            {# data-token incluye &#10; (newline) para que Word cree 3 párrafos al pegar #}
+            {% set t_open  = '{%p for item in ' ~ c.campo ~ ' %}' %}
+            {% set t_item  = '{{item}}' %}
+            {% set t_close = '{%p endfor %}' %}
+            {% set snippet = t_open ~ '&#10;' ~ t_item ~ '&#10;' ~ t_close %}
+            <div class="list-group-item py-2 px-2">
+                <div class="d-flex align-items-start gap-2">
+                    <div class="flex-grow-1 min-w-0">
+                        <span class="text-secondary d-block" style="font-size:.8rem">{{ c.descripcion }}</span>
+                        <code class="d-block text-primary small mt-1 lh-base" style="white-space:pre-line">{{ t_open }}
+{{ t_item }}
+{{ t_close }}</code>
+                    </div>
+                    {% if not solo_lectura %}
+                    <button type="button"
+                            class="btn btn-sm btn-outline-primary flex-shrink-0 btn-copiar"
+                            data-token="{{ snippet }}"
+                            title="Copiar bloque de bucle (3 párrafos)">
+                        <i class="fas fa-copy"></i>
+                    </button>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
 
     {# ── Sección: Consultas nombradas (tablas dinámicas) ── #}
     <div class="card-body pb-0 border-top pt-3">


### PR DESCRIPTION
## Cambios

- `CAMPOS_BASE` — `municipios` marcado como `tipo: 'lista'`
- `_panel_tokens.html` — nueva sección "Campos de lista": muestra el snippet de bucle completo (`{%p for item in campo %}` / `{{item}}` / `{%p endfor %}`) y lo copia con saltos de línea reales (`&#10;`) para que al pegar en Word se generen los 3 párrafos separados automáticamente

Closes #189
