### PR TITLE
Fase 4 #167: selectores en cascada ESFTT + validación .docx

### DIFF
--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -1,7 +1,7 @@
 """
 Blueprint para administración de plantillas de escritos administrativos.
 
-Rutas:
+Rutas de formulario:
 - GET  /admin/plantillas/             — Listado de plantillas
 - GET  /admin/plantillas/nueva/       — Formulario alta nueva plantilla
 - POST /admin/plantillas/nueva/       — Guardar nueva plantilla
@@ -10,18 +10,28 @@ Rutas:
 - POST /admin/plantillas/<id>/editar  — Guardar cambios
 - GET  /admin/plantillas/<id>/descargar — Descarga del .docx registrado
 - POST /admin/plantillas/<id>/activar — Activar/desactivar plantilla
+
+Endpoints AJAX (cascada ESFTT):
+- GET  /admin/plantillas/api/tipos-solicitud  — Tipos solicitud (filtrar=1: solo whitelist por exp)
+- GET  /admin/plantillas/api/tipos-fase       — Tipos fase (filtrar=1: solo whitelist por sol)
+- GET  /admin/plantillas/api/tipos-tramite    — Tipos trámite (filtrar=1: solo whitelist por fase)
+- GET  /admin/plantillas/api/tokens           — Tokens Capa 1 (stub — Capa 2 en Fase 5)
 """
 import os
 
 import werkzeug.utils
-from flask import (Blueprint, abort, current_app, flash, redirect,
+from docxtpl import DocxTemplate
+from flask import (Blueprint, abort, current_app, flash, jsonify, redirect,
                    render_template, request, send_file, url_for)
 from flask_login import login_required
 
 from app import db
 from app.decorators import role_required
 from app.models.consultas_nombradas import ConsultaNombrada
+from app.models.expedientes_solicitudes import ExpedienteSolicitud
+from app.models.fases_tramites import FaseTramite
 from app.models.plantillas import Plantilla
+from app.models.solicitudes_fases import SolicitudFase
 from app.models.tipos_documentos import TipoDocumento
 from app.models.tipos_expedientes import TipoExpediente
 from app.models.tipos_fases import TipoFase
@@ -92,6 +102,15 @@ def _build_tokens(plantilla=None) -> dict:
     )
     fragmentos = _listar_fragmentos()
     return {'campos': list(CAMPOS_BASE), 'consultas': consultas, 'fragmentos': fragmentos}
+
+
+def _validar_plantilla_docx(ruta_abs: str) -> str | None:
+    """Intenta parsear el .docx con DocxTemplate. Devuelve mensaje de error o None si ok."""
+    try:
+        DocxTemplate(ruta_abs)
+        return None
+    except Exception as e:
+        return str(e)
 
 
 def _guardar_docx(archivo) -> str | None:
@@ -170,6 +189,117 @@ def _selects_context():
 
 
 # ---------------------------------------------------------------------------
+# Endpoints AJAX (cascada ESFTT)
+# ---------------------------------------------------------------------------
+
+@bp.route('/api/tipos-solicitud')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def api_tipos_solicitud():
+    """
+    Devuelve tipos de solicitud disponibles.
+    Si filtrar=1 y tipo_expediente_id dado: solo los de la whitelist expedientes_solicitudes.
+    Sin filtro: todos.
+    """
+    tipo_expediente_id = request.args.get('tipo_expediente_id', type=int)
+    filtrar = request.args.get('filtrar') == '1'
+
+    if filtrar and tipo_expediente_id:
+        tipos = (
+            TipoSolicitud.query
+            .join(ExpedienteSolicitud,
+                  ExpedienteSolicitud.tipo_solicitud_id == TipoSolicitud.id)
+            .filter(ExpedienteSolicitud.tipo_expediente_id == tipo_expediente_id)
+            .order_by(TipoSolicitud.siglas)
+            .all()
+        )
+    else:
+        tipos = TipoSolicitud.query.order_by(TipoSolicitud.siglas).all()
+
+    return jsonify([
+        {'id': t.id, 'texto': f'{t.siglas} — {t.descripcion}'}
+        for t in tipos
+    ])
+
+
+@bp.route('/api/tipos-fase')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def api_tipos_fase():
+    """
+    Devuelve tipos de fase disponibles.
+    Si filtrar=1 y tipo_solicitud_id dado: solo los de la whitelist solicitudes_fases.
+    """
+    tipo_solicitud_id = request.args.get('tipo_solicitud_id', type=int)
+    filtrar = request.args.get('filtrar') == '1'
+
+    if filtrar and tipo_solicitud_id:
+        tipos = (
+            TipoFase.query
+            .join(SolicitudFase,
+                  SolicitudFase.tipo_fase_id == TipoFase.id)
+            .filter(SolicitudFase.tipo_solicitud_id == tipo_solicitud_id)
+            .order_by(TipoFase.nombre)
+            .all()
+        )
+    else:
+        tipos = TipoFase.query.order_by(TipoFase.nombre).all()
+
+    return jsonify([
+        {'id': t.id, 'texto': t.nombre}
+        for t in tipos
+    ])
+
+
+@bp.route('/api/tipos-tramite')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def api_tipos_tramite():
+    """
+    Devuelve tipos de trámite disponibles.
+    Si filtrar=1 y tipo_fase_id dado: solo los de la whitelist fases_tramites.
+    """
+    tipo_fase_id = request.args.get('tipo_fase_id', type=int)
+    filtrar = request.args.get('filtrar') == '1'
+
+    if filtrar and tipo_fase_id:
+        tipos = (
+            TipoTramite.query
+            .join(FaseTramite,
+                  FaseTramite.tipo_tramite_id == TipoTramite.id)
+            .filter(FaseTramite.tipo_fase_id == tipo_fase_id)
+            .order_by(TipoTramite.nombre)
+            .all()
+        )
+    else:
+        tipos = TipoTramite.query.order_by(TipoTramite.nombre).all()
+
+    return jsonify([
+        {'id': t.id, 'texto': t.nombre}
+        for t in tipos
+    ])
+
+
+@bp.route('/api/tokens')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def api_tokens():
+    """
+    Stub para refresco dinámico de tokens (Capa 2 — Fase 5+).
+    Hoy devuelve siempre los tokens de Capa 1 independientemente del contexto ESFTT.
+    """
+    tokens = _build_tokens()
+    return jsonify({
+        'campos': tokens['campos'],
+        'consultas': [
+            {'nombre': c.nombre, 'descripcion': getattr(c, 'descripcion', '')}
+            for c in tokens['consultas']
+        ],
+        'fragmentos': tokens['fragmentos'],
+    })
+
+
+# ---------------------------------------------------------------------------
 # Rutas
 # ---------------------------------------------------------------------------
 
@@ -196,6 +326,17 @@ def nueva():
                 tokens=_build_tokens(),
                 **_selects_context(),
             )
+
+        if ruta:
+            error_docx = _validar_plantilla_docx(os.path.join(_plantillas_dir(), ruta))
+            if error_docx:
+                flash(f'El fichero .docx tiene errores de sintaxis: {error_docx}', 'danger')
+                return render_template(
+                    'admin_plantillas/form.html',
+                    modo='nueva', plantilla=None,
+                    tokens=_build_tokens(),
+                    **_selects_context(),
+                )
 
         p = Plantilla()
         if not _form_data_to_plantilla(p):
@@ -260,6 +401,17 @@ def editar(id):
     if request.method == 'POST':
         archivo = request.files.get('archivo_plantilla')
         ruta = _guardar_docx(archivo)
+
+        if ruta:
+            error_docx = _validar_plantilla_docx(os.path.join(_plantillas_dir(), ruta))
+            if error_docx:
+                flash(f'El fichero .docx tiene errores de sintaxis: {error_docx}', 'danger')
+                return render_template(
+                    'admin_plantillas/form.html',
+                    modo='editar', plantilla=plantilla,
+                    tokens=_build_tokens(plantilla),
+                    **_selects_context(),
+                )
 
         if not _form_data_to_plantilla(plantilla):
             return render_template(

--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -20,6 +20,7 @@ Endpoints AJAX (cascada ESFTT):
 import os
 
 import werkzeug.utils
+from docx import Document as DocxDocument
 from docxtpl import DocxTemplate
 from flask import (Blueprint, abort, current_app, flash, jsonify, redirect,
                    render_template, request, send_file, url_for)
@@ -105,9 +106,13 @@ def _build_tokens(plantilla=None) -> dict:
 
 
 def _validar_plantilla_docx(ruta_abs: str) -> str | None:
-    """Intenta parsear el .docx con DocxTemplate. Devuelve mensaje de error o None si ok."""
+    """
+    Valida que el fichero sea un .docx bien formado (ZIP con estructura OOXML).
+    DocxTemplate.__init__ no abre el fichero — se usa python-docx Document() que sí lo hace.
+    Devuelve mensaje de error o None si ok.
+    """
     try:
-        DocxTemplate(ruta_abs)
+        DocxDocument(ruta_abs)
         return None
     except Exception as e:
         return str(e)

--- a/app/modules/admin_plantillas/templates/admin_plantillas/form.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/form.html
@@ -109,14 +109,23 @@
 
                 {# Bloque: Contexto ESFTT #}
                 <div class="card mb-4">
-                    <div class="card-header fw-semibold">
-                        <i class="fas fa-sitemap me-1"></i> Contexto ESFTT
-                        <span class="badge bg-secondary ms-2" style="font-weight:400">Todos los campos son opcionales</span>
+                    <div class="card-header fw-semibold d-flex align-items-center justify-content-between flex-wrap gap-2">
+                        <span><i class="fas fa-sitemap me-1"></i> Contexto ESFTT
+                            <span class="badge bg-secondary ms-2" style="font-weight:400">Todos los campos son opcionales</span>
+                        </span>
+                        <div class="form-check form-switch mb-0">
+                            <input class="form-check-input" type="checkbox" role="switch"
+                                   id="toggle-solo-aplicables">
+                            <label class="form-check-label small fw-normal" for="toggle-solo-aplicables">
+                                Solo aplicables al contexto
+                            </label>
+                        </div>
                     </div>
                     <div class="card-body">
                         <p class="text-secondary small mb-3">
                             Deja en blanco los campos que no apliquen.
                             <strong>Vacío = aplica a cualquier valor</strong> de esa dimensión.
+                            Activa el filtro para ver solo las opciones válidas según la whitelist ESFTT.
                         </p>
 
                         <div class="mb-3">
@@ -280,5 +289,84 @@
         this.value = this.value.toUpperCase().replace(/[^A-Z0-9_]/g, '_');
         this.setSelectionRange(pos, pos);
     });
+
+    // -----------------------------------------------------------------------
+    // Selectores en cascada ESFTT
+    // -----------------------------------------------------------------------
+    const URL_SOL  = "{{ url_for('admin_plantillas.api_tipos_solicitud') }}";
+    const URL_FASE = "{{ url_for('admin_plantillas.api_tipos_fase') }}";
+    const URL_TRAM = "{{ url_for('admin_plantillas.api_tipos_tramite') }}";
+
+    const selExp  = document.getElementById('tipo_expediente_id');
+    const selSol  = document.getElementById('tipo_solicitud_id');
+    const selFase = document.getElementById('tipo_fase_id');
+    const selTram = document.getElementById('tipo_tramite_id');
+    const toggle  = document.getElementById('toggle-solo-aplicables');
+
+    function filtrarActivo() { return toggle.checked; }
+
+    async function fetchOpciones(url, params) {
+        const qs = new URLSearchParams(params).toString();
+        const resp = await fetch(url + (qs ? '?' + qs : ''));
+        if (!resp.ok) return null;
+        return resp.json();
+    }
+
+    function reconstruirSelect(sel, opciones, placeholder) {
+        const valActual = sel.value;
+        sel.innerHTML = '<option value="">' + placeholder + '</option>';
+        for (const d of opciones) {
+            const opt = document.createElement('option');
+            opt.value = d.id;
+            opt.textContent = d.texto;
+            if (String(d.id) === String(valActual)) opt.selected = true;
+            sel.appendChild(opt);
+        }
+    }
+
+    // Actualiza los tres selectores dependientes a partir del nivel indicado.
+    // desde=1 → recalcula S, F y T; desde=2 → recalcula F y T; desde=3 → recalcula T.
+    async function actualizarCascada(desde) {
+        const filtrar = filtrarActivo() ? '1' : '0';
+
+        if (desde <= 1) {
+            const params = (filtrar === '1' && selExp.value)
+                ? { tipo_expediente_id: selExp.value, filtrar: '1' }
+                : {};
+            const data = await fetchOpciones(URL_SOL, params);
+            if (data) reconstruirSelect(selSol, data, '— Cualquier solicitud —');
+        }
+
+        if (desde <= 2) {
+            const params = (filtrar === '1' && selSol.value)
+                ? { tipo_solicitud_id: selSol.value, filtrar: '1' }
+                : {};
+            const data = await fetchOpciones(URL_FASE, params);
+            if (data) reconstruirSelect(selFase, data, '— Cualquier fase —');
+        }
+
+        if (desde <= 3) {
+            const params = (filtrar === '1' && selFase.value)
+                ? { tipo_fase_id: selFase.value, filtrar: '1' }
+                : {};
+            const data = await fetchOpciones(URL_TRAM, params);
+            if (data) reconstruirSelect(selTram, data, '— Cualquier trámite —');
+        }
+    }
+
+    // Al cambiar E: si toggle ON, recascada desde S
+    selExp.addEventListener('change', () => {
+        if (filtrarActivo()) actualizarCascada(1);
+    });
+    // Al cambiar S: si toggle ON, recascada desde F
+    selSol.addEventListener('change', () => {
+        if (filtrarActivo()) actualizarCascada(2);
+    });
+    // Al cambiar F: si toggle ON, recascada desde T
+    selFase.addEventListener('change', () => {
+        if (filtrarActivo()) actualizarCascada(3);
+    });
+    // Al cambiar toggle: recascada completa (filtrar=1 aplica filtro, filtrar=0 restaura todo)
+    toggle.addEventListener('change', () => actualizarCascada(1));
 </script>
 {% endblock %}


### PR DESCRIPTION
## Cambios

- Endpoints AJAX de cascada ESFTT en admin plantillas:
  - `GET /admin/plantillas/api/tipos-solicitud` — todos o filtrado por whitelist `expedientes_solicitudes`
  - `GET /admin/plantillas/api/tipos-fase` — todos o filtrado por whitelist `solicitudes_fases`
  - `GET /admin/plantillas/api/tipos-tramite` — todos o filtrado por whitelist `fases_tramites`
  - `GET /admin/plantillas/api/tokens` — stub Capa 1 para refresco dinámico futuro (Fase 5)
- Toggle "Solo aplicables al contexto" en bloque ESFTT del formulario (defecto=OFF)
- JS cascada E→S→F→T: filtra opciones vía AJAX cuando toggle=ON; restaura todo al desactivar
- Validación del fichero .docx al registrar/editar plantilla usando `python-docx Document()`;
  error claro si el fichero no es un ZIP OOXML válido, sin guardar en BD
- Filtro `tipos_documento origen!=EXTERNO` ya aplicado en Fase 2 (sin cambios nuevos)

Closes #167
