### PR TITLE
Reemplazar upload cliente por explorador de servidor en plantillas

### DIFF
--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -16,10 +16,10 @@ Endpoints AJAX (cascada ESFTT):
 - GET  /admin/plantillas/api/tipos-fase       — Tipos fase (filtrar=1: solo whitelist por sol)
 - GET  /admin/plantillas/api/tipos-tramite    — Tipos trámite (filtrar=1: solo whitelist por fase)
 - GET  /admin/plantillas/api/tokens           — Tokens Capa 1 (stub — Capa 2 en Fase 5)
+- GET  /admin/plantillas/api/fs               — Explorador de servidor restringido a PLANTILLAS_BASE/plantillas/
 """
 import os
 
-import werkzeug.utils
 from docx import Document as DocxDocument
 from docxtpl import DocxTemplate
 from flask import (Blueprint, abort, current_app, flash, jsonify, redirect,
@@ -118,28 +118,22 @@ def _validar_plantilla_docx(ruta_abs: str) -> str | None:
         return str(e)
 
 
-def _guardar_docx(archivo) -> str | None:
+def _path_seguro_plantillas(ruta_relativa: str) -> str | None:
     """
-    Guarda el fichero .docx subido en PLANTILLAS_BASE/plantillas/.
-    Devuelve el nombre de fichero (ruta_plantilla) o None si hay error.
+    Valida que ruta_relativa (con '/' como separador) no escape de PLANTILLAS_BASE/plantillas/.
+    Devuelve la ruta absoluta o None si hay path traversal.
     """
-    if not archivo or not archivo.filename:
-        return None
-
-    base = current_app.config.get('PLANTILLAS_BASE', '')
+    base = _plantillas_dir()
     if not base:
-        flash('PLANTILLAS_BASE no está configurado en el servidor.', 'danger')
         return None
-
-    filename = werkzeug.utils.secure_filename(archivo.filename)
-    if not filename.lower().endswith('.docx'):
-        flash('Solo se admiten ficheros .docx.', 'danger')
+    base_norm = os.path.normpath(os.path.abspath(base))
+    if ruta_relativa:
+        ruta_full = os.path.normpath(os.path.join(base, ruta_relativa.replace('/', os.sep)))
+    else:
+        ruta_full = base_norm
+    if ruta_full != base_norm and not ruta_full.startswith(base_norm + os.sep):
         return None
-
-    destino_dir = _plantillas_dir()
-    os.makedirs(destino_dir, exist_ok=True)
-    archivo.save(os.path.join(destino_dir, filename))
-    return filename
+    return ruta_full
 
 
 def _form_data_to_plantilla(plantilla: Plantilla) -> bool:
@@ -285,6 +279,39 @@ def api_tipos_tramite():
     ])
 
 
+@bp.route('/api/fs')
+@login_required
+@role_required('ADMIN', 'SUPERVISOR')
+def api_explorador_fs():
+    """
+    Explorador de ficheros del servidor restringido a PLANTILLAS_BASE/plantillas/.
+    GET ?ruta=<subruta>  →  JSON {ok, partes, directorios, ficheros}
+    Solo expone ficheros .docx y subdirectorios.
+    """
+    base = _plantillas_dir()
+    if not base or not os.path.isdir(base):
+        return jsonify({'ok': False, 'error': 'Directorio de plantillas no accesible'}), 503
+
+    ruta_rel = request.args.get('ruta', '').strip('/\\ ')
+    ruta_abs = _path_seguro_plantillas(ruta_rel)
+    if not ruta_abs or not os.path.isdir(ruta_abs):
+        return jsonify({'ok': False, 'error': 'Ruta no válida'}), 400
+
+    try:
+        dirs, files = [], []
+        for e in sorted(os.scandir(ruta_abs), key=lambda x: (not x.is_dir(), x.name.lower())):
+            rel = os.path.relpath(e.path, base).replace(os.sep, '/')
+            if e.is_dir(follow_symlinks=False):
+                dirs.append({'nombre': e.name, 'ruta': rel})
+            elif e.is_file(follow_symlinks=False) and e.name.lower().endswith('.docx'):
+                files.append({'nombre': e.name, 'ruta': rel, 'tamano': e.stat().st_size})
+    except PermissionError:
+        return jsonify({'ok': False, 'error': 'Sin permisos en esta carpeta'}), 403
+
+    partes = ruta_rel.split('/') if ruta_rel else []
+    return jsonify({'ok': True, 'partes': partes, 'directorios': dirs, 'ficheros': files})
+
+
 @bp.route('/api/tokens')
 @login_required
 @role_required('ADMIN', 'SUPERVISOR')
@@ -321,10 +348,9 @@ def listado():
 @role_required('ADMIN', 'SUPERVISOR')
 def nueva():
     if request.method == 'POST':
-        archivo = request.files.get('archivo_plantilla')
-        ruta = _guardar_docx(archivo)
-        if ruta is None and not archivo.filename:
-            flash('Debes subir el fichero .docx de la plantilla.', 'danger')
+        ruta_rel = request.form.get('ruta_plantilla', '').strip()
+        if not ruta_rel:
+            flash('Debes seleccionar el fichero .docx de la plantilla desde el servidor.', 'danger')
             return render_template(
                 'admin_plantillas/form.html',
                 modo='nueva', plantilla=None,
@@ -332,16 +358,25 @@ def nueva():
                 **_selects_context(),
             )
 
-        if ruta:
-            error_docx = _validar_plantilla_docx(os.path.join(_plantillas_dir(), ruta))
-            if error_docx:
-                flash(f'El fichero .docx tiene errores de sintaxis: {error_docx}', 'danger')
-                return render_template(
-                    'admin_plantillas/form.html',
-                    modo='nueva', plantilla=None,
-                    tokens=_build_tokens(),
-                    **_selects_context(),
-                )
+        ruta_abs = _path_seguro_plantillas(ruta_rel)
+        if not ruta_abs or not os.path.isfile(ruta_abs):
+            flash('La ruta del fichero seleccionado no es válida.', 'danger')
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='nueva', plantilla=None,
+                tokens=_build_tokens(),
+                **_selects_context(),
+            )
+
+        error_docx = _validar_plantilla_docx(ruta_abs)
+        if error_docx:
+            flash(f'El fichero .docx tiene errores de sintaxis: {error_docx}', 'danger')
+            return render_template(
+                'admin_plantillas/form.html',
+                modo='nueva', plantilla=None,
+                tokens=_build_tokens(),
+                **_selects_context(),
+            )
 
         p = Plantilla()
         if not _form_data_to_plantilla(p):
@@ -352,8 +387,8 @@ def nueva():
                 **_selects_context(),
             )
 
-        if ruta:
-            p.ruta_plantilla = ruta
+        # Almacenar solo el nombre de fichero (relativo a PLANTILLAS_BASE/plantillas/)
+        p.ruta_plantilla = os.path.basename(ruta_rel)
 
         db.session.add(p)
         try:
@@ -404,11 +439,20 @@ def editar(id):
     plantilla = Plantilla.query.get_or_404(id)
 
     if request.method == 'POST':
-        archivo = request.files.get('archivo_plantilla')
-        ruta = _guardar_docx(archivo)
+        ruta_rel = request.form.get('ruta_plantilla', '').strip()
 
-        if ruta:
-            error_docx = _validar_plantilla_docx(os.path.join(_plantillas_dir(), ruta))
+        if ruta_rel:
+            # El supervisor ha seleccionado un nuevo fichero en el servidor
+            ruta_abs = _path_seguro_plantillas(ruta_rel)
+            if not ruta_abs or not os.path.isfile(ruta_abs):
+                flash('La ruta del fichero seleccionado no es válida.', 'danger')
+                return render_template(
+                    'admin_plantillas/form.html',
+                    modo='editar', plantilla=plantilla,
+                    tokens=_build_tokens(plantilla),
+                    **_selects_context(),
+                )
+            error_docx = _validar_plantilla_docx(ruta_abs)
             if error_docx:
                 flash(f'El fichero .docx tiene errores de sintaxis: {error_docx}', 'danger')
                 return render_template(
@@ -426,8 +470,8 @@ def editar(id):
                 **_selects_context(),
             )
 
-        if ruta:
-            plantilla.ruta_plantilla = ruta
+        if ruta_rel:
+            plantilla.ruta_plantilla = os.path.basename(ruta_rel)
 
         try:
             db.session.commit()

--- a/app/modules/admin_plantillas/templates/admin_plantillas/form.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/form.html
@@ -281,7 +281,7 @@
 
             {# ── Columna derecha: panel de tokens ── #}
             <div class="col-lg-5">
-                <div class="sticky-top" style="top: 1rem">
+                <div class="sticky-top" style="top: 1rem; z-index: 100">
                     {% include 'admin_plantillas/_panel_tokens.html' %}
                 </div>
             </div>

--- a/app/modules/admin_plantillas/templates/admin_plantillas/form.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/form.html
@@ -34,7 +34,6 @@
 
 <div class="content-constrained py-4">
     <form method="POST"
-          enctype="multipart/form-data"
           action="{% if modo == 'editar' %}{{ url_for('admin_plantillas.editar', id=plantilla.id) }}{% else %}{{ url_for('admin_plantillas.nueva') }}{% endif %}">
 
         <div class="row g-4">
@@ -185,7 +184,7 @@
                 {# Bloque: Plantilla .docx #}
                 <div class="card mb-4">
                     <div class="card-header fw-semibold">
-                        <i class="fas fa-file-upload me-1"></i> Fichero de plantilla
+                        <i class="fas fa-server me-1"></i> Fichero de plantilla
                     </div>
                     <div class="card-body">
                         {% if modo == 'editar' and plantilla.ruta_plantilla %}
@@ -199,20 +198,31 @@
                                 </a>
                             </div>
                         </div>
-                        <label for="archivo_plantilla" class="form-label fw-semibold">
-                            Subir nueva versión <span class="text-secondary">(opcional)</span>
-                        </label>
+                        <div class="form-label fw-semibold">
+                            Cambiar fichero <span class="text-secondary">(opcional)</span>
+                        </div>
                         {% else %}
-                        <label for="archivo_plantilla" class="form-label fw-semibold">
+                        <div class="form-label fw-semibold">
                             Fichero .docx <span class="text-danger">*</span>
-                        </label>
+                        </div>
                         {% endif %}
-                        <input type="file" class="form-control" id="archivo_plantilla"
-                               name="archivo_plantilla" accept=".docx"
-                               {% if modo == 'nueva' %}required{% endif %}>
-                        <div class="form-text">
-                            Crea la plantilla en LibreOffice Writer usando los tokens del panel.
-                            Guárdala como .docx antes de subirla.
+
+                        {# Campo oculto con la ruta relativa seleccionada en el explorador #}
+                        <input type="hidden" id="ruta_plantilla" name="ruta_plantilla"
+                               value="">
+
+                        <div class="d-flex align-items-center gap-3">
+                            <button type="button" class="btn btn-outline-secondary"
+                                    onclick="abrirExploradorPlantillas()">
+                                <i class="fas fa-folder-open me-1"></i> Seleccionar del servidor
+                            </button>
+                            <span id="plantilla_nombre_label" class="text-secondary small fst-italic">
+                                Ningún archivo seleccionado
+                            </span>
+                        </div>
+                        <div class="form-text mt-2">
+                            Navega el servidor corporativo para seleccionar el fichero .docx de la plantilla.
+                            {% if modo == 'editar' %}Si no seleccionas ninguno, se conserva el fichero actual.{% endif %}
                         </div>
                     </div>
                 </div>
@@ -279,10 +289,158 @@
         </div>{# fin row #}
     </form>
 </div>
+
+{# ============================================================ #}
+{# Modal: Explorador de servidor restringido a PLANTILLAS_BASE  #}
+{# ============================================================ #}
+<div class="modal fade" id="modal-explorador-plantillas" tabindex="-1"
+     aria-labelledby="modal-exp-pl-label">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modal-exp-pl-label">
+          <i class="fas fa-server me-1"></i> Seleccionar plantilla del servidor
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <nav class="small mb-2" id="exp-pl-breadcrumb">
+          <span class="text-secondary">Cargando…</span>
+        </nav>
+        <div class="alert alert-danger d-none small py-2" id="exp-pl-error"></div>
+        <table class="table table-sm table-hover mb-0">
+          <tbody id="exp-pl-tbody"></tbody>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary"
+                data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary" id="exp-pl-btn-seleccionar"
+                disabled onclick="confirmarSeleccionPlantilla()">
+          <i class="fas fa-check me-1"></i> Seleccionar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% endblock %}
 
 {% block extra_js %}
 <script>
+    // -----------------------------------------------------------------------
+    // Explorador de plantillas del servidor
+    // -----------------------------------------------------------------------
+    (function () {
+        'use strict';
+
+        var URL_FS = "{{ url_for('admin_plantillas.api_explorador_fs') }}";
+        var _modal_bs = null;
+        var _seleccionado = null;   // {ruta, nombre}
+
+        document.addEventListener('DOMContentLoaded', function () {
+            var el = document.getElementById('modal-explorador-plantillas');
+            _modal_bs = new bootstrap.Modal(el);
+            el.addEventListener('show.bs.modal', function () {
+                _seleccionado = null;
+                document.getElementById('exp-pl-btn-seleccionar').disabled = true;
+                cargarCarpeta('');
+            });
+        });
+
+        window.abrirExploradorPlantillas = function () {
+            _modal_bs.show();
+        };
+
+        window.confirmarSeleccionPlantilla = function () {
+            if (!_seleccionado) return;
+            document.getElementById('ruta_plantilla').value = _seleccionado.ruta;
+            var label = document.getElementById('plantilla_nombre_label');
+            label.textContent = _seleccionado.nombre;
+            label.classList.remove('text-secondary', 'fst-italic');
+            label.classList.add('fw-semibold');
+            _modal_bs.hide();
+        };
+
+        function cargarCarpeta(ruta) {
+            var qs = ruta ? '?ruta=' + encodeURIComponent(ruta) : '';
+            fetch(URL_FS + qs)
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (!data.ok) {
+                        mostrarError(data.error || 'Error al cargar');
+                        return;
+                    }
+                    ocultarError();
+                    renderBreadcrumb(data.partes);
+                    renderTabla(data.directorios, data.ficheros);
+                    _seleccionado = null;
+                    document.getElementById('exp-pl-btn-seleccionar').disabled = true;
+                })
+                .catch(function () { mostrarError('Error de red'); });
+        }
+
+        function renderBreadcrumb(partes) {
+            var nav = document.getElementById('exp-pl-breadcrumb');
+            var html = '<a href="#" class="text-decoration-none" onclick="expPlNavegar(\'\');return false;">Inicio</a>';
+            var acum = [];
+            partes.forEach(function (p, i) {
+                acum.push(p);
+                var ruta = acum.join('/');
+                if (i === partes.length - 1) {
+                    html += ' / <span class="fw-semibold">' + p + '</span>';
+                } else {
+                    html += ' / <a href="#" class="text-decoration-none" onclick="expPlNavegar(\'' + ruta + '\');return false;">' + p + '</a>';
+                }
+            });
+            nav.innerHTML = html;
+        }
+
+        function renderTabla(dirs, files) {
+            var tbody = document.getElementById('exp-pl-tbody');
+            var html = '';
+            dirs.forEach(function (d) {
+                html += '<tr style="cursor:pointer" onclick="expPlNavegar(\'' + d.ruta.replace(/'/g, "\\'") + '\')">'
+                      + '<td><i class="fas fa-folder text-warning me-2"></i>' + d.nombre + '</td>'
+                      + '<td class="text-secondary small text-end">Carpeta</td>'
+                      + '</tr>';
+            });
+            files.forEach(function (f) {
+                var kb = (f.tamano / 1024).toFixed(1) + ' KB';
+                html += '<tr style="cursor:pointer" class="exp-pl-fila-doc" onclick="expPlSeleccionar(\'' + f.ruta.replace(/'/g, "\\'") + '\',\'' + f.nombre.replace(/'/g, "\\'") + '\')">'
+                      + '<td><i class="fas fa-file-word text-primary me-2"></i>' + f.nombre + '</td>'
+                      + '<td class="text-secondary small text-end">' + kb + '</td>'
+                      + '</tr>';
+            });
+            if (!html) {
+                html = '<tr><td colspan="2" class="text-secondary small text-center py-3">Carpeta vacía</td></tr>';
+            }
+            tbody.innerHTML = html;
+        }
+
+        window.expPlNavegar = function (ruta) { cargarCarpeta(ruta); };
+
+        window.expPlSeleccionar = function (ruta, nombre) {
+            // Resaltar fila activa
+            document.querySelectorAll('.exp-pl-fila-doc').forEach(function (tr) {
+                tr.classList.remove('table-active');
+            });
+            event.currentTarget.classList.add('table-active');
+            _seleccionado = {ruta: ruta, nombre: nombre};
+            document.getElementById('exp-pl-btn-seleccionar').disabled = false;
+        };
+
+        function mostrarError(msg) {
+            var el = document.getElementById('exp-pl-error');
+            el.textContent = msg;
+            el.classList.remove('d-none');
+        }
+
+        function ocultarError() {
+            document.getElementById('exp-pl-error').classList.add('d-none');
+        }
+    })();
+
     // Autoformato código: convierte a MAYÚSCULAS mientras escribe
     document.getElementById('codigo').addEventListener('input', function () {
         const pos = this.selectionStart;


### PR DESCRIPTION
## Cambios

- Reemplaza el `<input type="file">` del formulario de plantillas por un explorador de servidor restringido a `PLANTILLAS_BASE/plantillas/`, igual que hace el pool de documentos
- Añade endpoint `GET /admin/plantillas/api/fs` que lista directorios y ficheros `.docx` dentro de la ruta autorizada, con validación de path traversal
- El formulario ya no sube ficheros desde el cliente: envía la ruta relativa seleccionada y el servidor la registra directamente en `ruta_plantilla` sin mover ningún fichero
- Elimina `_guardar_docx()` y la dependencia de `werkzeug.utils`
- Corrige z-index del panel sticky de tokens para que no tape el dropdown del navbar

Closes #239
