### PR TITLE
Motor de generación de escritos .docx (Fase 5 #167)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,13 +67,14 @@ def create_app(config_name='development'):
     app.register_blueprint(wizard_expediente.bp)  # Issue #67
 
     # Registrar blueprints - APIs
-    from app.routes import api_expedientes, api_municipios, vista3, api_entidades, api_proyectos
+    from app.routes import api_expedientes, api_municipios, vista3, api_entidades, api_proyectos, api_escritos
 
     app.register_blueprint(api_expedientes.api_bp)          # usa 'api_bp'
     app.register_blueprint(api_municipios.bp)               # usa 'bp'
     app.register_blueprint(vista3.bp)                       # usa 'bp'
     app.register_blueprint(api_entidades.api_entidades_bp)  # usa 'api_entidades_bp' — Issue #61
     app.register_blueprint(api_proyectos.api_proyectos_bp)  # usa 'api_proyectos_bp' — Issue #123
+    app.register_blueprint(api_escritos.api_escritos_bp)    # usa 'api_escritos_bp' — Issue #167
 
     # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -483,6 +483,7 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
     codigo_tipo = tarea.tipo_tarea.codigo if tarea.tipo_tarea else ''
     requiere_doc_usado     = codigo_tipo in _TIPOS_REQUIEREN_DOC_USADO
     requiere_doc_producido = codigo_tipo in _TIPOS_REQUIEREN_DOC_PRODUCIDO
+    es_tarea_redactar      = (codigo_tipo == 'REDACTAR')
 
     return render_template(
         'expedientes/tramitacion_bc_tarea.html',
@@ -493,6 +494,7 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         tarea=tarea,
         requiere_doc_usado=requiere_doc_usado,
         requiere_doc_producido=requiere_doc_producido,
+        es_tarea_redactar=es_tarea_redactar,
     )
 
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -87,6 +87,14 @@
                 </a>
               </li>
               {% endif %}
+              {% if es_tarea_redactar %}
+              <li>
+                <a class="dropdown-item" href="#"
+                   data-bs-toggle="modal" data-bs-target="#modalGenerarEscrito">
+                  <i class="fas fa-file-word me-2 text-primary"></i> Generar escrito
+                </a>
+              </li>
+              {% endif %}
               <li><hr class="dropdown-divider"></li>
               <li>
                 <a class="dropdown-item text-danger" href="#"
@@ -254,6 +262,80 @@
   </div>
 </div>
 
+{% if es_tarea_redactar %}
+{# ── Modal Generar Escrito (#167 Fase 5) ───────────────────────────── #}
+<div class="modal fade" id="modalGenerarEscrito" tabindex="-1"
+     aria-labelledby="modalGenerarEscritoLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="modalGenerarEscritoLabel">
+          <i class="fas fa-file-word me-2 text-primary"></i>Generar escrito
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+
+        {# Paso 1: Selección de plantilla #}
+        <div id="ge-paso1">
+          <label class="form-label fw-semibold mb-1">Plantilla</label>
+          <div id="ge-selector-plantilla"></div>
+          <small class="text-secondary" id="ge-contador">Cargando plantillas...</small>
+        </div>
+
+        {# Paso 2: Preview y opciones (oculto hasta selección) #}
+        <div id="ge-paso2" class="d-none mt-3">
+          <hr>
+          <h6 class="fw-semibold mb-2">Datos del contexto</h6>
+          <div id="ge-preview-campos" class="row g-2 mb-3"></div>
+
+          <div class="row g-2 mb-3">
+            <div class="col-12">
+              <label class="form-label fw-semibold mb-1">Nombre del fichero</label>
+              <input type="text" class="form-control form-control-sm" id="ge-nombre-fichero">
+            </div>
+            <div class="col-12">
+              <label class="form-label fw-semibold mb-1">Ruta destino</label>
+              <input type="text" class="form-control form-control-sm" id="ge-ruta-destino" readonly>
+            </div>
+          </div>
+
+          <div class="d-flex flex-column gap-1">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="ge-check-pool" checked>
+              <label class="form-check-label" for="ge-check-pool">Registrar en pool del expediente</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="ge-check-doc-producido" checked>
+              <label class="form-check-label" for="ge-check-doc-producido">Asignar como documento producido</label>
+            </div>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="ge-check-abrir-carpeta">
+              <label class="form-check-label" for="ge-check-abrir-carpeta">Abrir carpeta tras generar</label>
+            </div>
+          </div>
+        </div>
+
+        {# Spinner durante generación #}
+        <div id="ge-spinner" class="d-none text-center py-4">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Generando...</span>
+          </div>
+          <p class="mt-2 text-secondary">Generando escrito...</p>
+        </div>
+
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary" id="ge-btn-generar" disabled>
+          <i class="fas fa-file-word me-1"></i> Generar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 </div>
 {% endblock %}
 
@@ -272,4 +354,8 @@ window.TAREA_DOCS_CONFIG = {
 };
 </script>
 <script src="{{ url_for('static', filename='js/tarea_documentos.js') }}"></script>
+{% if es_tarea_redactar %}
+<script>window.GE_CONFIG = { tareaId: {{ tarea.id }} };</script>
+<script src="{{ url_for('static', filename='js/generar_escrito.js') }}"></script>
+{% endif %}
 {% endblock %}

--- a/app/routes/api_escritos.py
+++ b/app/routes/api_escritos.py
@@ -229,7 +229,7 @@ def generar():
                 expediente_id=expediente.id,
                 url=ruta,
                 tipo_doc_id=plantilla.tipo_documento_id,
-                tipo_contenido='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                tipo_contenido='application/docx',
                 fecha_administrativa=None,
                 prioridad=0,
                 asunto=asunto,

--- a/app/routes/api_escritos.py
+++ b/app/routes/api_escritos.py
@@ -1,0 +1,258 @@
+"""API REST para generación de escritos administrativos (#167 Fase 5).
+
+ENDPOINTS:
+    1. GET  /api/escritos/plantillas?tarea_id=X — Plantillas ESFTT compatibles
+    2. GET  /api/escritos/preview?plantilla_id=X&tarea_id=Y — Preview del contexto
+    3. POST /api/escritos/generar — Genera el .docx y lo registra en pool
+"""
+
+import logging
+from datetime import date
+
+import jinja2
+from flask import Blueprint, request, jsonify, current_app
+from flask_login import login_required
+
+from app import db
+from app.models.plantillas import Plantilla
+from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.services.escritos import ContextoBaseExpediente
+from app.services.generador_escritos import (
+    generar_escrito,
+    componer_nombre_documento,
+    ruta_destino_documento,
+    guardar_docx,
+)
+from app.utils.permisos import puede_editar_expediente
+
+logger = logging.getLogger(__name__)
+
+api_escritos_bp = Blueprint('api_escritos', __name__, url_prefix='/api/escritos')
+
+
+# ------------------------------------------------------------------
+# Helpers internos
+# ------------------------------------------------------------------
+
+def _obtener_tarea_y_expediente(tarea_id):
+    """Obtiene tarea, sube por la cadena ESFTT y devuelve (tarea, expediente) o None."""
+    tarea = Tarea.query.get(tarea_id)
+    if not tarea:
+        return None, None
+    tramite = tarea.tramite
+    fase = tramite.fase if tramite else None
+    solicitud = fase.solicitud if fase else None
+    expediente = solicitud.expediente if solicitud else None
+    return tarea, expediente
+
+
+def _ids_esftt(tarea):
+    """Extrae los IDs ESFTT de la cadena tarea → tramite → fase → solicitud → expediente."""
+    tramite = tarea.tramite
+    fase = tramite.fase if tramite else None
+    solicitud = fase.solicitud if fase else None
+    expediente = solicitud.expediente if solicitud else None
+
+    return {
+        'te_id': expediente.tipo_expediente_id if expediente else None,
+        'ts_id': solicitud.tipo_solicitud_id if solicitud else None,
+        'tf_id': fase.tipo_fase_id if fase else None,
+        'tt_id': tramite.tipo_tramite_id if tramite else None,
+    }
+
+
+def _especificidad(plantilla):
+    """Cuenta campos ESFTT no-NULL (0-4) para ordenar por especificidad."""
+    return sum(1 for f in [
+        plantilla.tipo_expediente_id,
+        plantilla.tipo_solicitud_id,
+        plantilla.tipo_fase_id,
+        plantilla.tipo_tramite_id,
+    ] if f is not None)
+
+
+# ------------------------------------------------------------------
+# GET /api/escritos/plantillas?tarea_id=X
+# ------------------------------------------------------------------
+
+@api_escritos_bp.route('/plantillas')
+@login_required
+def listar_plantillas():
+    """Devuelve plantillas activas compatibles con el contexto ESFTT de la tarea."""
+    tarea_id = request.args.get('tarea_id', type=int)
+    if not tarea_id:
+        return jsonify(ok=False, error='Parámetro tarea_id requerido'), 400
+
+    tarea, expediente = _obtener_tarea_y_expediente(tarea_id)
+    if not tarea or not expediente:
+        return jsonify(ok=False, error='Tarea no encontrada'), 404
+
+    ids = _ids_esftt(tarea)
+
+    # Query NULL-comodín: NULL en plantilla = aplica a cualquier valor
+    plantillas = Plantilla.query.filter(
+        Plantilla.activo == True,
+        db.or_(Plantilla.tipo_expediente_id == None, Plantilla.tipo_expediente_id == ids['te_id']),
+        db.or_(Plantilla.tipo_solicitud_id == None, Plantilla.tipo_solicitud_id == ids['ts_id']),
+        db.or_(Plantilla.tipo_fase_id == None, Plantilla.tipo_fase_id == ids['tf_id']),
+        db.or_(Plantilla.tipo_tramite_id == None, Plantilla.tipo_tramite_id == ids['tt_id']),
+    ).all()
+
+    resultado = [{
+        'id': p.id,
+        'nombre': p.nombre,
+        'variante': p.variante,
+        'descripcion': p.descripcion,
+        'especificidad': _especificidad(p),
+    } for p in plantillas]
+
+    # Ordenar: más específicas primero
+    resultado.sort(key=lambda x: x['especificidad'], reverse=True)
+
+    return jsonify(ok=True, plantillas=resultado)
+
+
+# ------------------------------------------------------------------
+# GET /api/escritos/preview?plantilla_id=X&tarea_id=Y
+# ------------------------------------------------------------------
+
+@api_escritos_bp.route('/preview')
+@login_required
+def preview():
+    """Devuelve campos del contexto base, nombre propuesto y ruta destino."""
+    plantilla_id = request.args.get('plantilla_id', type=int)
+    tarea_id = request.args.get('tarea_id', type=int)
+    if not plantilla_id or not tarea_id:
+        return jsonify(ok=False, error='Parámetros plantilla_id y tarea_id requeridos'), 400
+
+    plantilla = Plantilla.query.get(plantilla_id)
+    if not plantilla:
+        return jsonify(ok=False, error='Plantilla no encontrada'), 404
+
+    tarea, expediente = _obtener_tarea_y_expediente(tarea_id)
+    if not tarea or not expediente:
+        return jsonify(ok=False, error='Tarea no encontrada'), 404
+
+    # Contexto base (campos para preview)
+    ctx = ContextoBaseExpediente(expediente).get_contexto()
+
+    # Nombre propuesto y ruta destino
+    nombre = componer_nombre_documento(tarea, plantilla)
+    try:
+        ruta = ruta_destino_documento(expediente, nombre)
+    except RuntimeError as e:
+        return jsonify(ok=False, error=str(e)), 503
+
+    return jsonify(ok=True, campos=ctx, nombre_propuesto=nombre, ruta_destino=ruta)
+
+
+# ------------------------------------------------------------------
+# POST /api/escritos/generar
+# ------------------------------------------------------------------
+
+@api_escritos_bp.route('/generar', methods=['POST'])
+@login_required
+def generar():
+    """Genera el .docx, lo guarda en disco y opcionalmente lo registra en el pool."""
+    data = request.get_json(silent=True) or {}
+    plantilla_id = data.get('plantilla_id')
+    tarea_id = data.get('tarea_id')
+    nombre_fichero = data.get('nombre_fichero', '').strip()
+    registrar_pool = data.get('registrar_pool', True)
+    asignar_doc_producido = data.get('asignar_doc_producido', True)
+
+    if not plantilla_id or not tarea_id:
+        return jsonify(ok=False, error='plantilla_id y tarea_id requeridos'), 400
+
+    plantilla = Plantilla.query.get(plantilla_id)
+    if not plantilla:
+        return jsonify(ok=False, error='Plantilla no encontrada'), 404
+
+    tarea, expediente = _obtener_tarea_y_expediente(tarea_id)
+    if not tarea or not expediente:
+        return jsonify(ok=False, error='Tarea no encontrada'), 404
+
+    # Verificar acceso edición
+    if not puede_editar_expediente(expediente):
+        return jsonify(ok=False, error='Sin permisos de edición sobre este expediente'), 403
+
+    # FILESYSTEM_BASE obligatorio
+    fs_base = current_app.config.get('FILESYSTEM_BASE', '')
+    if not fs_base:
+        return jsonify(ok=False, error='FILESYSTEM_BASE no configurado en el servidor'), 503
+
+    # Nombre y ruta
+    if not nombre_fichero:
+        nombre_fichero = componer_nombre_documento(tarea, plantilla)
+    ruta = ruta_destino_documento(expediente, nombre_fichero)
+
+    # B8: Si tarea.fecha_inicio es None → establecer fecha de hoy
+    if tarea.fecha_inicio is None:
+        tarea.fecha_inicio = date.today()
+
+    # Generar .docx
+    try:
+        docx_bytes = generar_escrito(plantilla, expediente, db.session)
+    except FileNotFoundError as e:
+        return jsonify(ok=False, error=f'Plantilla .docx no encontrada: {e}'), 404
+    except jinja2.TemplateSyntaxError as e:
+        return jsonify(ok=False, error=f'Error de sintaxis en plantilla: {e.message} (línea {e.lineno})'), 422
+    except jinja2.UndefinedError as e:
+        return jsonify(ok=False, error=f'Variable no definida en plantilla: {e.message}'), 422
+    except RuntimeError as e:
+        return jsonify(ok=False, error=str(e)), 500
+
+    # Guardar a disco
+    guardar_docx(docx_bytes, ruta)
+
+    doc_id = None
+
+    if registrar_pool:
+        # B6: Buscar doc existente por URL (regeneración) o crear nuevo
+        doc_existente = Documento.query.filter_by(
+            expediente_id=expediente.id,
+            url=ruta,
+        ).first()
+
+        if doc_existente:
+            doc = doc_existente
+            # Actualizar metadatos si cambian
+            doc.tipo_doc_id = plantilla.tipo_documento_id
+        else:
+            # Composición del asunto: nombre plantilla + variante
+            asunto = plantilla.nombre
+            if plantilla.variante:
+                asunto += f' — {plantilla.variante}'
+
+            doc = Documento(
+                expediente_id=expediente.id,
+                url=ruta,
+                tipo_doc_id=plantilla.tipo_documento_id,
+                tipo_contenido='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                fecha_administrativa=None,
+                prioridad=0,
+                asunto=asunto,
+            )
+            db.session.add(doc)
+
+        db.session.flush()  # Para obtener doc.id si es nuevo
+        doc_id = doc.id
+
+        if asignar_doc_producido:
+            tarea.documento_producido_id = doc_id
+
+    db.session.commit()
+
+    # URI para abrir carpeta en explorador (file:/// con barras normalizadas)
+    import os
+    carpeta = os.path.dirname(ruta)
+    uri_explorador = 'file:///' + carpeta.replace('\\', '/')
+
+    return jsonify(
+        ok=True,
+        nombre_fichero=nombre_fichero,
+        ruta=ruta,
+        doc_id=doc_id,
+        uri_explorador=uri_explorador,
+    )

--- a/app/services/escritos.py
+++ b/app/services/escritos.py
@@ -100,9 +100,9 @@ class ContextoBaseExpediente:
         if not self._exp.titular:
             return None
         direcciones = getattr(self._exp.titular, 'direcciones_notificacion', [])
-        preferente = next((d for d in direcciones if d.preferente), None)
-        if preferente:
-            return str(preferente)
+        activa = next((d for d in direcciones if d.activo), None)
+        if activa:
+            return str(activa)
         return None
 
     def _nombre_responsable(self) -> str | None:

--- a/app/services/escritos.py
+++ b/app/services/escritos.py
@@ -78,9 +78,9 @@ class ContextoBaseExpediente:
             'proyecto_emplazamiento':  proyecto.emplazamiento if proyecto else None,
             'instrumento_ambiental':   proyecto.ia.siglas     if proyecto and proyecto.ia else None,
 
-            # Responsable
+            # Responsable (Usuario no tiene nombre_completo, se construye aquí)
             'responsable_nombre': (
-                exp.responsable.nombre_completo if exp.responsable else None
+                self._nombre_responsable()
             ),
 
             # Municipios (lista de nombres para uso en plantilla simple)
@@ -104,6 +104,16 @@ class ContextoBaseExpediente:
         if preferente:
             return str(preferente)
         return None
+
+    def _nombre_responsable(self) -> str | None:
+        """Construye nombre completo del responsable (Usuario no tiene nombre_completo)."""
+        r = self._exp.responsable
+        if not r:
+            return None
+        partes = [r.nombre, r.apellido1]
+        if r.apellido2:
+            partes.append(r.apellido2)
+        return ' '.join(p for p in partes if p)
 
     def _municipios(self) -> list[str]:
         """Devuelve los nombres de municipios afectados por el proyecto."""

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -73,6 +73,10 @@ def generar_escrito(plantilla, expediente, db_session) -> bytes:
 
     # Renderizado
     tpl = DocxTemplate(plantilla_path)
+
+    # Fragmentos insertables: {{r NombreFragmento}} → tpl.new_subdoc(ruta)
+    ctx.update(_cargar_fragmentos(tpl, plantilla_path))
+
     tpl.render(ctx)
 
     # Devolver bytes sin escribir a disco (la escritura es responsabilidad del caller)
@@ -204,6 +208,43 @@ def _cargar_context_builder(nombre_clase: str):
             f'No se pudo cargar el Context Builder "{nombre_clase}" '
             f'desde {modulo_path}: {e}'
         )
+
+
+def _cargar_fragmentos(tpl, plantilla_path) -> dict:
+    """
+    Detecta etiquetas {{r NombreFragmento}} en el XML de la plantilla y carga
+    los subdocumentos correspondientes desde PLANTILLAS_BASE/fragmentos/.
+
+    python-docx-template requiere que el contexto contenga un objeto Subdoc
+    creado con tpl.new_subdoc(ruta) para cada {{r variable}}.
+    """
+    import zipfile
+
+    # Leer el XML del .docx para encontrar las etiquetas {{r ...}}
+    with zipfile.ZipFile(plantilla_path) as z:
+        xml = z.read('word/document.xml').decode('utf-8')
+
+    # Patrón: {{r nombre}} — captura el nombre del fragmento
+    nombres = re.findall(r'\{\{r\s+(\w+)\s*\}\}', xml)
+    if not nombres:
+        return {}
+
+    from flask import current_app
+    base = current_app.config['PLANTILLAS_BASE']
+    fragmentos_dir = os.path.join(base, 'fragmentos')
+
+    resultado = {}
+    for nombre in set(nombres):
+        ruta_frag = os.path.join(fragmentos_dir, nombre + '.docx')
+        if os.path.isfile(ruta_frag):
+            resultado[nombre] = tpl.new_subdoc(ruta_frag)
+        else:
+            logger.warning(
+                'Fragmento "%s.docx" referenciado en plantilla pero no encontrado en %s',
+                nombre, fragmentos_dir
+            )
+
+    return resultado
 
 
 def _ejecutar_consultas(plantilla, expediente, db_session) -> dict:

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -12,22 +12,34 @@ FLUJO:
     4. Renderiza con DocxTemplate (python-docx-template / Jinja2)
     5. Devuelve bytes del .docx resultante
 
+FUNCIONES PÚBLICAS ADICIONALES (Fase 5 #167):
+    componer_nombre_documento  — Nombre sistematizado para el .docx generado
+    ruta_destino_documento     — Ruta en FILESYSTEM_BASE/AT-XXXX/
+    guardar_docx               — Escribe bytes a disco (sobrescribe si existe)
+
 USO:
     from app.services.generador_escritos import generar_escrito
+    from app.services.generador_escritos import componer_nombre_documento, ruta_destino_documento, guardar_docx
 
     docx_bytes = generar_escrito(plantilla, expediente, db_session)
-    # Guardar bytes en FILESYSTEM_BASE y registrar en pool del expediente
+    nombre = componer_nombre_documento(tarea, plantilla)
+    ruta = ruta_destino_documento(expediente, nombre)
+    guardar_docx(docx_bytes, ruta)
 
 DEPENDENCIA:
     pip install python-docx-template
 """
 
 import importlib
+import logging
 import os
+import re
 
 from docxtpl import DocxTemplate
 
 from app.services.escritos import ContextoBaseExpediente
+
+logger = logging.getLogger(__name__)
 
 
 def generar_escrito(plantilla, expediente, db_session) -> bytes:
@@ -68,6 +80,93 @@ def generar_escrito(plantilla, expediente, db_session) -> bytes:
     buffer = io.BytesIO()
     tpl.save(buffer)
     return buffer.getvalue()
+
+
+# ------------------------------------------------------------------
+# Funciones públicas — nombre, ruta y guardado (Fase 5 #167)
+# ------------------------------------------------------------------
+
+# Caracteres no válidos en nombres de fichero Windows
+_CARACTERES_INVALIDOS = re.compile(r'[\\/:*?"<>|]')
+
+
+def componer_nombre_documento(tarea, plantilla) -> str:
+    """
+    Genera un nombre sistematizado para el .docx a partir de la cadena ESFTT.
+
+    Recorre tarea → tipo_tarea → tramite → tipo_tramite → fase → tipo_fase
+    → solicitud → tipo_solicitud → expediente, tomando nombre_en_plantilla
+    de cada nivel. NULL al final se omite; NULL en medio se reemplaza por "ANY".
+
+    Si plantilla.variante existe, se añade " V {variante}" al final.
+    Sufijo siempre .docx. Caracteres inválidos para fichero → '_'.
+    """
+    tramite = tarea.tramite
+    fase = tramite.fase if tramite else None
+    solicitud = fase.solicitud if fase else None
+    expediente = solicitud.expediente if solicitud else None
+
+    # Recoger nombre_en_plantilla de cada nivel (de más genérico a más específico)
+    partes_raw = [
+        getattr(tarea.tipo_tarea, 'nombre_en_plantilla', None) if tarea.tipo_tarea else None,
+        getattr(tramite.tipo_tramite, 'nombre_en_plantilla', None) if tramite and tramite.tipo_tramite else None,
+        getattr(fase.tipo_fase, 'nombre_en_plantilla', None) if fase and fase.tipo_fase else None,
+        getattr(solicitud.tipo_solicitud, 'nombre_en_plantilla', None) if solicitud and solicitud.tipo_solicitud else None,
+        f'AT-{expediente.numero_at}' if expediente and expediente.numero_at else None,
+    ]
+
+    # Recortar NULLs del final; reemplazar NULLs internos por "ANY"
+    while partes_raw and partes_raw[-1] is None:
+        partes_raw.pop()
+
+    partes = [p if p is not None else 'ANY' for p in partes_raw]
+
+    nombre = ' '.join(partes)
+
+    if plantilla.variante:
+        nombre += f' V {plantilla.variante}'
+
+    nombre += '.docx'
+
+    # Sanitizar caracteres inválidos para nombre de fichero
+    nombre = _CARACTERES_INVALIDOS.sub('_', nombre)
+
+    return nombre
+
+
+def ruta_destino_documento(expediente, nombre_fichero) -> str:
+    """
+    Calcula la ruta absoluta donde guardar el documento generado.
+
+    Estructura: FILESYSTEM_BASE / AT-{numero_at} / {nombre_fichero}
+    Crea el subdirectorio si no existe.
+
+    NOTA: Ruta hardcoded provisional. Se reemplazará por rutas configurables
+    en tablas maestras cuando se implemente esa decisión de arquitectura
+    (Bloque 2/8 del roadmap).
+    """
+    from flask import current_app
+    base = current_app.config.get('FILESYSTEM_BASE', '')
+    if not base:
+        raise RuntimeError('FILESYSTEM_BASE no está configurado')
+
+    carpeta_exp = f'AT-{expediente.numero_at}'
+    directorio = os.path.join(base, carpeta_exp)
+    os.makedirs(directorio, exist_ok=True)
+
+    return os.path.join(directorio, nombre_fichero)
+
+
+def guardar_docx(docx_bytes, ruta_destino) -> str:
+    """
+    Escribe bytes del .docx a disco. Sobrescribe si existe (regeneración B6).
+
+    Returns:
+        str — Ruta absoluta del fichero escrito.
+    """
+    with open(ruta_destino, 'wb') as f:
+        f.write(docx_bytes)
+    return ruta_destino
 
 
 # ------------------------------------------------------------------

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -79,11 +79,19 @@ def generar_escrito(plantilla, expediente, db_session) -> bytes:
 
     tpl.render(ctx)
 
+    # docxtpl/docxcompose genera <w:p> anidados (inválido en OOXML) al insertar subdocs.
+    # Word descarta silenciosamente el contenido anidado. Corrección necesaria.
+    # — Para el body: se puede corregir en memoria antes de save()
+    _elevar_parrafos_anidados(tpl.docx)
+
     # Devolver bytes sin escribir a disco (la escritura es responsabilidad del caller)
     import io
     buffer = io.BytesIO()
     tpl.save(buffer)
-    return buffer.getvalue()
+
+    # — Para cabeceras/pies: docxtpl los renderiza en Parts separados no accesibles
+    #   vía tpl.docx en memoria; hay que parchear el ZIP resultante.
+    return _corregir_anidados_en_zip(buffer.getvalue())
 
 
 # ------------------------------------------------------------------
@@ -210,6 +218,95 @@ def _cargar_context_builder(nombre_clase: str):
         )
 
 
+def _corregir_anidados_en_zip(docx_bytes: bytes) -> bytes:
+    """
+    Parchea el ZIP del .docx resultante para corregir <w:p> anidados en las
+    partes que docxtpl renderiza fuera del objeto Document en memoria:
+    cabeceras (word/header*.xml) y pies de página (word/footer*.xml).
+
+    Devuelve los bytes corregidos.
+    """
+    import zipfile
+    import io as _io
+    from lxml import etree
+
+    W = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
+    _PARTES = re.compile(r'^word/(header|footer)\d*\.xml$')
+
+    buf_in = _io.BytesIO(docx_bytes)
+    buf_out = _io.BytesIO()
+
+    with zipfile.ZipFile(buf_in, 'r') as zin, \
+         zipfile.ZipFile(buf_out, 'w', compression=zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if _PARTES.match(item.filename):
+                try:
+                    root = etree.fromstring(data)
+                    _elevar_en_contenedor(root, W)
+                    data = etree.tostring(root, xml_declaration=True,
+                                          encoding='UTF-8', standalone=True)
+                except Exception as e:
+                    logger.warning('No se pudo corregir %s: %s', item.filename, e)
+            zout.writestr(item, data)
+
+    return buf_out.getvalue()
+
+
+def _elevar_parrafos_anidados(doc) -> None:
+    """
+    Corrige párrafos anidados (<w:p> dentro de <w:p>) que genera docxtpl/docxcompose
+    al insertar subdocumentos. OOXML no permite anidamiento de párrafos: Word los
+    descarta silenciosamente al renderizar.
+
+    Procesa el body principal y los elementos de cabecera/pie de todas las secciones.
+    """
+    W = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
+
+    # Recoger todos los contenedores de párrafos: body + cabeceras + pies de página
+    contenedores = [doc.element.body]
+    for section in doc.sections:
+        for part in (section.header, section.footer,
+                     section.even_page_header, section.even_page_footer,
+                     section.first_page_header, section.first_page_footer):
+            try:
+                if part and not part.is_linked_to_previous:
+                    contenedores.append(part._element)
+            except Exception:
+                pass
+
+    for contenedor in contenedores:
+        _elevar_en_contenedor(contenedor, W)
+
+
+def _elevar_en_contenedor(contenedor, W: str) -> None:
+    """Eleva párrafos anidados dentro de un contenedor OOXML (body, hdr, ftr)."""
+    changed = True
+    while changed:
+        changed = False
+        for i, elem in enumerate(list(contenedor)):
+            if elem.tag != f'{W}p':
+                continue
+            nested = [c for c in list(elem) if c.tag == f'{W}p']
+            if not nested:
+                continue
+
+            insert_pos = i + 1
+            for nested_p in nested:
+                elem.remove(nested_p)
+                contenedor.insert(insert_pos, nested_p)
+                insert_pos += 1
+
+            texto_restante = ''.join(
+                (t.text or '') for t in elem.iter(f'{W}t')
+            ).strip()
+            if not texto_restante:
+                contenedor.remove(elem)
+
+            changed = True
+            break
+
+
 def _cargar_fragmentos(tpl, plantilla_path) -> dict:
     """
     Detecta etiquetas {{r NombreFragmento}} en el XML de la plantilla y carga
@@ -220,12 +317,15 @@ def _cargar_fragmentos(tpl, plantilla_path) -> dict:
     """
     import zipfile
 
-    # Leer el XML del .docx para encontrar las etiquetas {{r ...}}
+    # Escanear todos los XML relevantes: body, cabeceras y pies de página
+    _PARTES_ESCANEAR = re.compile(r'^word/(document|header\d*|footer\d*)\.xml$')
+    nombres = set()
     with zipfile.ZipFile(plantilla_path) as z:
-        xml = z.read('word/document.xml').decode('utf-8')
+        for nombre_parte in z.namelist():
+            if _PARTES_ESCANEAR.match(nombre_parte):
+                xml = z.read(nombre_parte).decode('utf-8', errors='replace')
+                nombres.update(re.findall(r'\{\{r\s+(\w+)\s*\}\}', xml))
 
-    # Patrón: {{r nombre}} — captura el nombre del fragmento
-    nombres = re.findall(r'\{\{r\s+(\w+)\s*\}\}', xml)
     if not nombres:
         return {}
 

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -208,10 +208,30 @@ def _cargar_context_builder(nombre_clase: str):
 
 def _ejecutar_consultas(plantilla, expediente, db_session) -> dict:
     """
-    Ejecuta las consultas nombradas referenciadas en la plantilla.
+    Ejecuta TODAS las ConsultaNombrada activas con :expediente_id y las pasa
+    al contexto. Las no referenciadas en la plantilla se ignoran por Jinja2.
 
-    Por ahora devuelve un dict vacío. La implementación completa se hará
-    en Fase 5 (#167): parsear la plantilla para detectar {%tr for row in X %}
-    y ejecutar la consulta_nombrada con nombre X para cada bloque encontrado.
+    Estrategia simple: ejecutar todas es más barato que parsear el .docx
+    buscando etiquetas {%tr for row in X %}. Si una consulta falla, se
+    registra un warning y se pasa como lista vacía (no rompe la generación).
     """
-    return {}
+    from app.models.consultas_nombradas import ConsultaNombrada
+    from sqlalchemy import text
+
+    resultado = {}
+
+    for cn in ConsultaNombrada.query.filter_by(activo=True).all():
+        try:
+            rows = db_session.execute(
+                text(cn.sql),
+                {'expediente_id': expediente.id}
+            ).mappings().all()
+            resultado[cn.nombre] = [dict(r) for r in rows]
+        except Exception as e:
+            logger.warning(
+                'Consulta nombrada "%s" (id=%s) falló para expediente %s: %s',
+                cn.nombre, cn.id, expediente.id, e
+            )
+            resultado[cn.nombre] = []
+
+    return resultado

--- a/app/static/js/generar_escrito.js
+++ b/app/static/js/generar_escrito.js
@@ -1,0 +1,246 @@
+/**
+ * generar_escrito.js — Flujo de generación de escritos desde tarea REDACTAR (#167 Fase 5)
+ *
+ * Depende de:
+ *   - SelectorBusqueda (selector_busqueda.js) — ya cargado en el template
+ *   - window.GE_CONFIG = { tareaId: Number }  — inyectado por el template
+ *   - Bootstrap 5 (Modal, Toast)
+ *
+ * Flujo:
+ *   1. Modal show → GET /api/escritos/plantillas → poblar SelectorBusqueda
+ *   2. Selección → GET /api/escritos/preview → mostrar paso 2
+ *   3. Click "Generar" → POST /api/escritos/generar → toast + reload
+ */
+(function () {
+  'use strict';
+
+  var config = window.GE_CONFIG;
+  if (!config || !config.tareaId) return;
+
+  // ── Elementos del DOM ──────────────────────────────────────────────
+  var modal_el      = document.getElementById('modalGenerarEscrito');
+  var paso1         = document.getElementById('ge-paso1');
+  var paso2         = document.getElementById('ge-paso2');
+  var spinner       = document.getElementById('ge-spinner');
+  var contador      = document.getElementById('ge-contador');
+  var preview_grid  = document.getElementById('ge-preview-campos');
+  var input_nombre  = document.getElementById('ge-nombre-fichero');
+  var input_ruta    = document.getElementById('ge-ruta-destino');
+  var check_pool    = document.getElementById('ge-check-pool');
+  var check_doc     = document.getElementById('ge-check-doc-producido');
+  var check_abrir   = document.getElementById('ge-check-abrir-carpeta');
+  var btn_generar   = document.getElementById('ge-btn-generar');
+
+  if (!modal_el) return;
+
+  // ── Estado ─────────────────────────────────────────────────────────
+  var plantilla_id_seleccionada = null;
+  var selector = null;
+
+  // ── Toast helper ───────────────────────────────────────────────────
+  function mostrar_toast(tipo, mensaje) {
+    var iconos    = { success: 'fa-check-circle', danger: 'fa-exclamation-circle',
+                      warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
+    var etiquetas = { success: 'Correcto', danger: 'Error',
+                      warning: 'Atención',  info: 'Información' };
+    var id   = 'toast-js-' + Date.now();
+    var html =
+      '<div id="' + id + '" class="toast toast-' + tipo + '" role="alert"' +
+      ' aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">' +
+      '<div class="d-flex align-items-center p-3"><div class="flex-grow-1">' +
+      '<i class="fas ' + (iconos[tipo] || iconos.info) + ' me-2"></i>' +
+      '<strong>' + (etiquetas[tipo] || 'Aviso') + ':</strong> ' + mensaje +
+      '</div><button type="button" class="btn-close ms-3"' +
+      ' data-bs-dismiss="toast" aria-label="Cerrar"></button></div></div>';
+    var container = document.querySelector('.toast-container');
+    if (!container) return;
+    container.insertAdjacentHTML('beforeend', html);
+    var el = document.getElementById(id);
+    el.classList.add('showing');
+    var t = new bootstrap.Toast(el);
+    t.show();
+    setTimeout(function () { el.classList.remove('showing'); }, 300);
+    el.addEventListener('hide.bs.toast', function () { el.classList.add('hide'); });
+    el.addEventListener('click', function (e) {
+      if (!e.target.closest('.btn-close')) { t.hide(); }
+    });
+    el.addEventListener('hidden.bs.toast', function () { el.remove(); });
+  }
+
+  // ── Inicializar SelectorBusqueda ───────────────────────────────────
+  selector = new SelectorBusqueda('#ge-selector-plantilla', [], {
+    placeholder: '— Seleccione una plantilla —',
+    name: 'plantilla_id',
+    onChange: function (v, t) {
+      plantilla_id_seleccionada = v ? parseInt(v, 10) : null;
+      btn_generar.disabled = !plantilla_id_seleccionada;
+
+      if (plantilla_id_seleccionada) {
+        cargar_preview(plantilla_id_seleccionada);
+      } else {
+        paso2.classList.add('d-none');
+      }
+    }
+  });
+
+  // ── Evento: modal se abre → cargar plantillas ─────────────────────
+  modal_el.addEventListener('show.bs.modal', function () {
+    resetear_modal();
+    cargar_plantillas();
+  });
+
+  function resetear_modal() {
+    plantilla_id_seleccionada = null;
+    btn_generar.disabled = true;
+    paso2.classList.add('d-none');
+    spinner.classList.add('d-none');
+    paso1.classList.remove('d-none');
+    btn_generar.classList.remove('d-none');
+    selector.clear();
+    preview_grid.innerHTML = '';
+    input_nombre.value = '';
+    input_ruta.value = '';
+    check_pool.checked = true;
+    check_doc.checked = true;
+    check_abrir.checked = false;
+  }
+
+  // ── Cargar plantillas ESFTT compatibles ────────────────────────────
+  function cargar_plantillas() {
+    contador.textContent = 'Cargando plantillas...';
+    fetch('/api/escritos/plantillas?tarea_id=' + config.tareaId)
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok) {
+          contador.textContent = 'Error: ' + (data.error || 'desconocido');
+          return;
+        }
+        var opciones = data.plantillas.map(function (p) {
+          var texto = p.nombre;
+          if (p.variante) texto += ' — ' + p.variante;
+          texto += ' (' + p.especificidad + '/4)';
+          return { v: String(p.id), t: texto };
+        });
+        selector.setOpciones(opciones);
+        var n = data.plantillas.length;
+        contador.textContent = n + ' plantilla' + (n !== 1 ? 's' : '') + ' disponible' + (n !== 1 ? 's' : '');
+      })
+      .catch(function (err) {
+        contador.textContent = 'Error al cargar plantillas';
+        console.error('GE: error cargando plantillas', err);
+      });
+  }
+
+  // ── Cargar preview ─────────────────────────────────────────────────
+  function cargar_preview(pid) {
+    fetch('/api/escritos/preview?plantilla_id=' + pid + '&tarea_id=' + config.tareaId)
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok) {
+          mostrar_toast('danger', data.error || 'Error al cargar preview');
+          return;
+        }
+
+        // Mostrar campos del contexto en grid
+        var campos = data.campos || {};
+        var html = '';
+        var labels = {
+          numero_at: 'N.o AT',
+          titular_nombre: 'Titular',
+          titular_nif: 'NIF titular',
+          proyecto_titulo: 'Proyecto',
+          responsable_nombre: 'Responsable',
+          fecha_hoy: 'Fecha'
+        };
+        var claves_mostrar = ['numero_at', 'titular_nombre', 'titular_nif',
+                              'proyecto_titulo', 'responsable_nombre', 'fecha_hoy'];
+        for (var i = 0; i < claves_mostrar.length; i++) {
+          var k = claves_mostrar[i];
+          var label = labels[k] || k;
+          var valor = campos[k] || '—';
+          html += '<div class="col-md-6"><small class="fw-semibold">' + label +
+                  ':</small> <small>' + escapeHtml(String(valor)) + '</small></div>';
+        }
+        preview_grid.innerHTML = html;
+
+        input_nombre.value = data.nombre_propuesto || '';
+        input_ruta.value = data.ruta_destino || '';
+
+        paso2.classList.remove('d-none');
+      })
+      .catch(function (err) {
+        mostrar_toast('danger', 'Error de conexión al cargar preview');
+        console.error('GE: error preview', err);
+      });
+  }
+
+  // ── Click "Generar" ────────────────────────────────────────────────
+  btn_generar.addEventListener('click', function () {
+    if (!plantilla_id_seleccionada) return;
+
+    btn_generar.disabled = true;
+    paso1.classList.add('d-none');
+    paso2.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    btn_generar.classList.add('d-none');
+
+    var body = {
+      plantilla_id: plantilla_id_seleccionada,
+      tarea_id: config.tareaId,
+      nombre_fichero: input_nombre.value.trim(),
+      registrar_pool: check_pool.checked,
+      asignar_doc_producido: check_doc.checked,
+      abrir_carpeta: check_abrir.checked
+    };
+
+    fetch('/api/escritos/generar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        if (!data.ok) {
+          // Error: mostrar toast, volver al estado anterior
+          spinner.classList.add('d-none');
+          paso1.classList.remove('d-none');
+          paso2.classList.remove('d-none');
+          btn_generar.classList.remove('d-none');
+          btn_generar.disabled = false;
+          mostrar_toast('danger', data.error || 'Error desconocido al generar');
+          return;
+        }
+
+        // OK: cerrar modal, toast success
+        var bsModal = bootstrap.Modal.getInstance(modal_el);
+        if (bsModal) bsModal.hide();
+
+        mostrar_toast('success', 'Escrito generado: ' + escapeHtml(data.nombre_fichero));
+
+        // Abrir carpeta si el usuario lo pidió
+        if (check_abrir.checked && data.uri_explorador) {
+          window.open(data.uri_explorador, '_blank');
+        }
+
+        // Recargar para reflejar cambios (doc_producido, fecha_inicio)
+        setTimeout(function () { location.reload(); }, 1000);
+      })
+      .catch(function (err) {
+        spinner.classList.add('d-none');
+        paso1.classList.remove('d-none');
+        paso2.classList.remove('d-none');
+        btn_generar.classList.remove('d-none');
+        btn_generar.disabled = false;
+        mostrar_toast('danger', 'Error de conexión al generar escrito');
+        console.error('GE: error generación', err);
+      });
+  });
+
+  // ── Utilidad escape HTML ───────────────────────────────────────────
+  function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(text));
+    return div.innerHTML;
+  }
+
+})();

--- a/docs/fuentesIA/ARQUITECTURA_DOCUMENTOS.md
+++ b/docs/fuentesIA/ARQUITECTURA_DOCUMENTOS.md
@@ -1,6 +1,6 @@
 # ARQUITECTURA — Subsistema Documental
 
-> **Sesión de diseño:** 2026-03-04 | **Actualizado:** 2026-03-05
+> **Sesión de diseño:** 2026-03-04 | **Actualizado:** 2026-03-18
 > Decisiones tomadas antes de entrar en M1 sistema documental (#166) y M2 generación escritos (#167).
 > Documentos relacionados: `MOTOR_REGLAS_arquitectura.md`, `GUIA_CONTEXT_BUILDERS.md`, `ROADMAP.md`
 
@@ -148,28 +148,63 @@ El motor delegará via nuevo `tipo_criterio = 'PLAZO_ESTADO'`:
 
 Ver detalle completo en `docs/fuentesIA/GUIA_CONTEXT_BUILDERS.md`.
 
-### Tabla `tipos_escritos`
+### Tabla `plantillas` (renombrada desde `tipos_escritos` en #167 Fase 2)
+
+Modelo: `app/models/plantillas.py`
 
 ```
-tipos_escritos
-  id                SERIAL PK
-  codigo            TEXT UNIQUE NOT NULL
-  nombre            TEXT NOT NULL
-  descripcion       TEXT
-  plantilla_url     TEXT            ← ruta al .docx plantilla
-  contexto_clase    TEXT NULL       ← nombre clase Python; NULL = solo capa base
-  campos_catalogo   JSONB NULL      ← {campo: descripcion_legible} para la UI
-  activo            BOOLEAN DEFAULT TRUE
+plantillas
+  id                    SERIAL PK
+  codigo                TEXT UNIQUE NOT NULL      ← slug estable (REQUERIMIENTO_SUBSANACION)
+  nombre                TEXT NOT NULL             ← nombre legible para la UI
+  descripcion           TEXT NULL
+  ruta_plantilla        TEXT NOT NULL             ← ruta relativa a PLANTILLAS_BASE/plantillas/
+  variante              TEXT NULL                 ← distingue plantillas del mismo contexto (Favorable, Denegatoria)
+  tipo_documento_id     FK tipos_documentos NOT NULL  ← tipo que se asignará al Documento generado
+  tipo_expediente_id    FK tipos_expedientes NULL ← NULL = aplica a cualquier tipo de expediente
+  tipo_solicitud_id     FK tipos_solicitudes NULL ← NULL = aplica a cualquier solicitud
+  tipo_fase_id          FK tipos_fases NULL       ← NULL = aplica a cualquier fase
+  tipo_tramite_id       FK tipos_tramites NULL    ← NULL = aplica a cualquier trámite
+  contexto_clase        TEXT NULL                 ← nombre clase Python; NULL = solo capa base
+  filtros_adicionales   JSONB DEFAULT '{}'        ← variables de negocio futuras (tensión, tecnología…)
+  activo                BOOLEAN DEFAULT TRUE      ← FALSE = oculta en REDACTAR, conservada para histórico
+```
+
+**Cambios respecto al diseño original (`tipos_escritos`):**
+- Renombrada a `plantillas` por claridad semántica
+- Añadidas 4 FKs ESFTT nullable (tipo_expediente, tipo_solicitud, tipo_fase, tipo_tramite) para filtrado por contexto de tarea — NULL = comodín
+- `plantilla_url` → `ruta_plantilla` (relativa a `PLANTILLAS_BASE/plantillas/`)
+- Añadido `tipo_documento_id` (NOT NULL): tipo semántico que se asigna al Documento generado
+- Añadido `variante`: texto libre para distinguir escritos del mismo contexto ESFTT
+- Añadido `filtros_adicionales`: JSON extensible para criterios futuros
+- Eliminado `campos_catalogo`: reemplazado por `consultas_nombradas` (tabla independiente)
+
+### Tabla `consultas_nombradas` (nueva, #167 Fase 3)
+
+Modelo: `app/models/consultas_nombradas.py`
+
+Consultas SQL predefinidas para tablas dinámicas en plantillas .docx.
+El supervisor referencia la consulta por nombre en el marcador: `{%tr for row in municipios_afectados %}`.
+
+```
+consultas_nombradas
+  id          SERIAL PK
+  nombre      TEXT UNIQUE NOT NULL     ← slug usado en plantilla (municipios_afectados)
+  descripcion TEXT NOT NULL            ← texto legible para supervisor en UI
+  sql         TEXT NOT NULL            ← SQL parametrizado con :expediente_id
+  columnas    JSONB NOT NULL           ← [{campo, descripcion}] para UI supervisor
+  activo      BOOLEAN DEFAULT TRUE
 ```
 
 ### Capa 1 — Contexto base (autoservicio Supervisor)
 
-`app/services/escritos.py` → `ContextoBaseExpediente.get_contexto(expediente_id)`
+`app/services/escritos.py` → `ContextoBaseExpediente(expediente).get_contexto()`
 
-Devuelve diccionario plano con todos los campos simples del expediente:
-titular, proyecto, tipo, municipio, tensión, instrumento ambiental, fecha_hoy, etc.
+Devuelve diccionario plano con los campos directos del expediente:
+numero_at, titular (nombre/NIF/dirección), proyecto (título/finalidad/emplazamiento),
+instrumento ambiental, responsable, municipios, fecha_hoy.
 
-El Supervisor prepara plantilla .docx con `{{campo}}` y la registra en `tipos_escritos`
+El Supervisor prepara plantilla .docx con `{{campo}}` y la registra en `plantillas`
 sin intervención del gestor de sistemas.
 
 ### Capa 2 — Context Builder (con soporte técnico/AI)
@@ -177,7 +212,24 @@ sin intervención del gestor de sistemas.
 Para escritos con campos calculados o cruzados. Clase Python que enriquece el contexto base.
 Ver `GUIA_CONTEXT_BUILDERS.md` para crear uno nuevo.
 
-**Issue:** #189 (M2)
+### Capa 3 — Consultas nombradas (autoservicio Supervisor)
+
+Tablas dinámicas ejecutadas sobre el expediente. Se ejecutan todas las activas y se pasan
+al contexto Jinja2; las no referenciadas en la plantilla se ignoran silenciosamente.
+Si una consulta falla, se pasa como lista vacía (log warning, no rompe generación).
+
+### Motor de generación (Fase 5 #167)
+
+`app/services/generador_escritos.py` orquesta el flujo:
+1. Carga plantilla .docx desde `PLANTILLAS_BASE/plantillas/`
+2. Capa 1: `ContextoBaseExpediente`
+3. Capa 2: Context Builder opcional (`plantilla.contexto_clase`)
+4. Capa 3: Consultas nombradas activas
+5. Renderiza con `python-docx-template` (Jinja2)
+
+API REST: `app/routes/api_escritos.py` — endpoints `/api/escritos/plantillas`, `/preview`, `/generar`.
+
+**Issue:** #167
 
 ---
 
@@ -188,8 +240,10 @@ Ver `GUIA_CONTEXT_BUILDERS.md` para crear uno nuevo.
 | Extensión de `Documento` | Particularización N:M | Herencia SQLAlchemy |
 | Estado de consultas | Service layer (seguimiento.py) | Event Sourcing / campo persistido |
 | Plazos en motor | Servicio separado (plazos.py) | Criterios temporales en condiciones_regla |
-| Escritos simples | Contexto base + plantilla .docx | Hardcoded por tipo |
-| Escritos complejos | Context Builder por tipo | Motor genérico de descubrimiento semántico |
+| Escritos simples | Contexto base + plantilla .docx (tabla `plantillas`) | Hardcoded por tipo |
+| Escritos complejos | Context Builder por tipo + consultas nombradas | Motor genérico de descubrimiento semántico |
+| Catálogo de escritos | `plantillas` con 4 FKs ESFTT nullable (comodín) | `tipos_escritos` sin filtrado por contexto |
+| Tablas dinámicas en plantillas | `consultas_nombradas` (SQL + :expediente_id) | `campos_catalogo` JSONB en tipos_escritos |
 | Campo `origen` | Eliminado; procedencia en tablas cualificadoras | Campo libre en Documento |
 | Campo `nombre_display` | Eliminado; deducible de URL | Campo editable por usuario |
 | `fecha_administrativa` | Nullable (dos semánticas de NULL documentadas) | NOT NULL con fecha placeholder |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.18.1
+docxcompose==2.0.2
 docxtpl==0.20.2
 lxml==6.0.2
 python-docx==1.2.0


### PR DESCRIPTION
## Cambios

Motor completo de generación de escritos administrativos (.docx) desde una tarea REDACTAR.

**Servicio de generación (`generador_escritos.py`)**
- Helpers públicos: `componer_nombre_documento`, `ruta_destino_documento`, `guardar_docx`
- `_ejecutar_consultas()`: ejecuta todas las `ConsultaNombrada` activas con `:expediente_id`
- `_cargar_fragmentos()`: detecta `{{r Nombre}}` en body, cabeceras y pies; carga subdocumentos desde `PLANTILLAS_BASE/fragmentos/`
- `_elevar_parrafos_anidados()` + `_corregir_anidados_en_zip()`: corrigen párrafos anidados inválidos (bug docxtpl/docxcompose) en body y en cabeceras/pies de página

**Contexto base (`escritos.py`)**
- Corregido `AttributeError`: `responsable.nombre_completo` → concatenación de `nombre + apellido1 + apellido2`
- Corregido `AttributeError`: `DireccionNotificacion.preferente` → `.activo`

**API REST (`api_escritos.py`)**
- `GET /api/escritos/plantillas?tarea_id=X` — plantillas compatibles con contexto ESFTT (filtro NULL-comodín)
- `GET /api/escritos/preview?plantilla_id=X&tarea_id=Y` — preview de campos, nombre propuesto y ruta destino
- `POST /api/escritos/generar` — genera .docx, guarda en disco, registra en pool (B6 regeneración), asigna `documento_producido_id` (B8 fecha_inicio)

**UI (template + JS)**
- Botón "Generar escrito" en dropdown de acciones de tarea REDACTAR
- Modal en dos pasos: selección de plantilla (SelectorBusqueda) + preview/confirmación
- `generar_escrito.js`: flujo fetch completo con spinner, toast y apertura de carpeta

**Fixes y docs**
- `tipo_contenido='application/docx'` (evita desbordamiento VARCHAR(50))
- `docxcompose==2.0.2` añadido a `requirements.txt`
- `ARQUITECTURA_DOCUMENTOS.md` actualizado: esquema `plantillas`, `consultas_nombradas`, motor de 3 capas

Closes #167
