### PR TITLE
Añadir tipo_titular a Entidad

### DIFF
--- a/app/models/entidad.py
+++ b/app/models/entidad.py
@@ -81,6 +81,14 @@ class Entidad(db.Model):
         comment='Puede publicar anuncios/notificaciones. Ej: diputaciones, ayuntamientos'
     )
     
+    tipo_titular = db.Column(
+        db.String(30),
+        nullable=True,
+        comment='Categoría del administrado cuando actúa como titular. '
+                'NULL para entidades sin rol_titular. '
+                'Valores: GRAN_DISTRIBUIDORA | DISTRIBUIDOR_MENOR | PROMOTOR | ORGANISMO_PUBLICO | OTRO'
+    )
+
     # === CONTACTO GENERAL ===
     email = db.Column(
         db.String(120), 

--- a/docs/ANALISIS_LISTADO_INTELIGENTE.md
+++ b/docs/ANALISIS_LISTADO_INTELIGENTE.md
@@ -267,7 +267,7 @@ Además del filtro por `tipo_titular`, el listado necesita filtros que no tienen
 ## 9. Próximos pasos
 
 1. ~~Revisar y aprobar este análisis (especialmente §8)~~ — en curso
-2. ~~Migración `tipo_titular` en `Entidad`~~ — **DECIDIDA** (§8). Pendiente de ejecutar: `flask db revision` manual, campo `tipo_titular VARCHAR(30) nullable` con default `'OTRO'`, poblar entidades existentes.
+2. ~~Migración `tipo_titular` en `Entidad`~~ — **HECHO** (issue #169). Migración `f77b09ef7c1e`, campo `tipo_titular VARCHAR(30) nullable`. Titulares existentes poblados con `'OTRO'` hasta revisión manual.
 3. ~~Crear script `docs_prueba/seed_listado.py` con los escenarios de §6~~ — hecho
 4. ~~**Limpieza BD ADMISION_TRAMITE**~~ — **HECHO** (issue #257). JSON actualizado a v5.6. Scripts promovidos a `scripts/`. Sin migración Alembic — los maestros FTT nunca se insertan por migración, siempre por `reset_maestros_ftt.py`.
 5. ~~Terminar decisiones §8 pendientes~~ — en curso. Quedan diferidos: `tecnologia` en `Proyecto` y presentación de `Notas`.

--- a/migrations/versions/f77b09ef7c1e_tipo_titular_en_entidades.py
+++ b/migrations/versions/f77b09ef7c1e_tipo_titular_en_entidades.py
@@ -1,0 +1,38 @@
+"""tipo_titular en entidades
+
+Revision ID: f77b09ef7c1e
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-26 20:30:51.173427
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f77b09ef7c1e'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('entidades',
+        sa.Column(
+            'tipo_titular',
+            sa.String(30),
+            nullable=True,
+            comment='Categoría del administrado cuando actúa como titular. '
+                    'NULL para entidades sin rol_titular. '
+                    'Valores: GRAN_DISTRIBUIDORA | DISTRIBUIDOR_MENOR | PROMOTOR | ORGANISMO_PUBLICO | OTRO'
+        ),
+        schema='public'
+    )
+    # Entidades titulares existentes quedan como OTRO hasta revisión manual
+    op.execute(
+        "UPDATE public.entidades SET tipo_titular = 'OTRO' WHERE rol_titular = TRUE"
+    )
+
+
+def downgrade():
+    op.drop_column('entidades', 'tipo_titular', schema='public')

--- a/scripts/seed_listado.py
+++ b/scripts/seed_listado.py
@@ -206,8 +206,8 @@ with app.app_context():
     limpiar()
 
     # Entidades de prueba
-    e_dist = Entidad(nombre_completo='Gran Distribuidora Eléctrica S.A.', rol_titular=True, activo=True)
-    e_prom = Entidad(nombre_completo='Promotor Solar Sur S.L.', rol_titular=True, activo=True)
+    e_dist = Entidad(nombre_completo='Gran Distribuidora Eléctrica S.A.', rol_titular=True, activo=True, tipo_titular='GRAN_DISTRIBUIDORA')
+    e_prom = Entidad(nombre_completo='Promotor Solar Sur S.L.', rol_titular=True, activo=True, tipo_titular='PROMOTOR')
     db.session.add_all([e_dist, e_prom])
     db.session.flush()
 


### PR DESCRIPTION
## Cambios

- Añade campo `tipo_titular VARCHAR(30) nullable` a `Entidad` con valores `GRAN_DISTRIBUIDORA | DISTRIBUIDOR_MENOR | PROMOTOR | ORGANISMO_PUBLICO | OTRO`
- Migración `f77b09ef7c1e`: `ADD COLUMN` + `UPDATE` para poblar titulares existentes con `'OTRO'`
- Actualiza `scripts/seed_listado.py`: entidades de prueba con `tipo_titular` real (`GRAN_DISTRIBUIDORA` y `PROMOTOR`)
- Marca el paso 2 de `ANALISIS_LISTADO_INTELIGENTE.md §9` como hecho

Closes #169
