### PR TITLE
Implementar vista /expedientes/seguimiento/

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,14 +67,15 @@ def create_app(config_name='development'):
     app.register_blueprint(wizard_expediente.bp)  # Issue #67
 
     # Registrar blueprints - APIs
-    from app.routes import api_expedientes, api_municipios, vista3, api_entidades, api_proyectos, api_escritos
+    from app.routes import api_expedientes, api_municipios, vista3, api_entidades, api_proyectos, api_escritos, api_seguimiento
 
-    app.register_blueprint(api_expedientes.api_bp)          # usa 'api_bp'
-    app.register_blueprint(api_municipios.bp)               # usa 'bp'
-    app.register_blueprint(vista3.bp)                       # usa 'bp'
-    app.register_blueprint(api_entidades.api_entidades_bp)  # usa 'api_entidades_bp' — Issue #61
-    app.register_blueprint(api_proyectos.api_proyectos_bp)  # usa 'api_proyectos_bp' — Issue #123
-    app.register_blueprint(api_escritos.api_escritos_bp)    # usa 'api_escritos_bp' — Issue #167
+    app.register_blueprint(api_expedientes.api_bp)                  # usa 'api_bp'
+    app.register_blueprint(api_municipios.bp)                       # usa 'bp'
+    app.register_blueprint(vista3.bp)                               # usa 'bp'
+    app.register_blueprint(api_entidades.api_entidades_bp)          # usa 'api_entidades_bp' — Issue #61
+    app.register_blueprint(api_proyectos.api_proyectos_bp)          # usa 'api_proyectos_bp' — Issue #123
+    app.register_blueprint(api_escritos.api_escritos_bp)            # usa 'api_escritos_bp' — Issue #167
+    app.register_blueprint(api_seguimiento.api_seguimiento_bp)      # usa 'api_seguimiento_bp' — Issue #262
 
     # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry

--- a/app/modules/expedientes/metadata.json
+++ b/app/modules/expedientes/metadata.json
@@ -23,5 +23,20 @@
       { "key": "estado_tramitacion", "label": "Estado",             "type": "custom" },
       { "key": "_acciones",          "label": "Acciones",           "type": "custom" }
     ]
+  },
+  "seguimiento": {
+    "columns": [
+      { "key": "num_at",               "label": "N\u00ba AT",      "type": "custom" },
+      { "key": "tipo_solicitud",       "label": "SOLICITUD",        "type": "custom" },
+      { "key": "fecha_solicitud",      "label": "FECHA",            "type": "custom" },
+      { "key": "titular_nombre",       "label": "TITULAR",          "type": "custom" },
+      { "key": "proyecto_descripcion", "label": "PROYECTO",         "type": "custom" },
+      { "key": "pista_SOL",            "label": "AN\u00c1LISIS",   "type": "custom" },
+      { "key": "pista_CONSULTAS",      "label": "CONSULTAS",        "type": "custom" },
+      { "key": "pista_MA",             "label": "MA",               "type": "custom" },
+      { "key": "pista_IP",             "label": "IP",               "type": "custom" },
+      { "key": "pista_RES",            "label": "RESOLUCI\u00d3N",  "type": "custom" },
+      { "key": "_acciones",            "label": "",                 "type": "custom" }
+    ]
   }
 }

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -43,11 +43,31 @@ from app.utils.permisos import (
     verificar_acceso_expediente
 )
 from app.utils.metadata import cargar_metadata
+from app.models.tipos_expedientes import TipoExpediente
 
 # template_folder apunta a app/modules/expedientes/templates/
 bp = Blueprint('expedientes', __name__,
                url_prefix='/expedientes',
                template_folder='templates')
+
+
+@bp.route('/seguimiento/')
+@login_required
+def seguimiento():
+    """
+    Listado inteligente de seguimiento: cola de trabajo multi-pista.
+
+    Cada fila es una solicitud EN_TRAMITE (o con el estado seleccionado).
+    El estado de cada pista se deduce dinámicamente vía API /api/expedientes/seguimiento.
+    """
+    meta = cargar_metadata('expedientes')
+    columns = meta.get('seguimiento', {}).get('columns', [])
+    tipos_expedientes = TipoExpediente.query.order_by(TipoExpediente.tipo).all()
+    return render_template(
+        'expedientes/seguimiento.html',
+        columns=columns,
+        tipos_expedientes=tipos_expedientes,
+    )
 
 
 @bp.route('/')

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -1,0 +1,207 @@
+{% extends 'layout/lista_v2_base.html' %}
+
+{% block page_title %}Seguimiento{% endblock %}
+{% block page_icon %}<i class="fas fa-tasks"></i>{% endblock %}
+{% block entity_label_plural %}solicitudes{% endblock %}
+{% block search_placeholder %}{% endblock %}
+
+{% block filtros_extra %}
+<select id="sel-ver" aria-label="Ver">
+    <option value="mis">Mis expedientes</option>
+    <option value="todos">Todos</option>
+</select>
+<select id="sel-estado" aria-label="Estado solicitud">
+    <option value="EN_TRAMITE">En trámite</option>
+    <option value="RESUELTA">Resuelta</option>
+    <option value="DESISTIDA">Desistida</option>
+    <option value="ARCHIVADA">Archivada</option>
+    <option value="todos">Todos los estados</option>
+</select>
+<select id="sel-tipo-titular" aria-label="Tipo de titular">
+    <option value="">Todos los titulares</option>
+    <option value="PROMOTOR">Promotor</option>
+    <option value="ORGANISMO_PUBLICO">Organismo público</option>
+    <option value="DISTRIBUIDOR_MENOR">Distribuidora menor</option>
+    <option value="GRAN_DISTRIBUIDORA">Gran distribuidora</option>
+    <option value="OTRO">Otro</option>
+</select>
+<select id="sel-tipo-expediente" aria-label="Tipo de expediente">
+    <option value="">Todos los tipos</option>
+    {% for te in tipos_expedientes %}
+    <option value="{{ te.id }}">{{ te.tipo }}</option>
+    {% endfor %}
+</select>
+{% endblock %}
+
+{% block tabla_clase %}seguimiento-table{% endblock %}
+
+{% block extra_js %}
+{{ super() }}
+<script>
+const colsMeta = {{ columns | tojson }};
+
+// Mapas de texto y color por estado interno (§4.2 / §4.3)
+const TEXTO_ESTADO = {
+    'PENDIENTE_TRAMITAR':  'TRAMITAR',
+    'PENDIENTE_ESTUDIO':   'ESTUDIAR',
+    'PENDIENTE_REDACTAR':  'REDACTAR',
+    'PENDIENTE_FIRMA':     'FIRMAR',
+    'PENDIENTE_NOTIFICAR': 'NOTIFICAR',
+    'PENDIENTE_PUBLICAR':  'PUBLICAR',
+    'PENDIENTE_SUBSANAR':  'SUBSANAR',
+    'PENDIENTE_PLAZOS':    'PLAZOS',
+    'PENDIENTE_CERRAR':    'CERRAR',
+    'FIN':                 'FIN',
+};
+const COLOR_CLASE = {
+    'rojo':     'pista-rojo',
+    'amarillo': 'pista-amarillo',
+    'azul':     'pista-azul',
+    'gris':     'pista-gris',
+    'naranja':  'pista-naranja',
+    'verde':    'pista-verde',
+};
+
+function renderPista(ep) {
+    if (!ep) return '';
+    const texto   = TEXTO_ESTADO[ep.codigo] || ep.codigo;
+    const clase   = COLOR_CLASE[ep.color]   || '';
+    const counter = ep.count > 1 ? ` (${ep.count})` : '';
+    return `<span class="pista-celda ${clase}">${texto}${counter}</span>`;
+}
+
+function renderFecha(val) {
+    if (!val) return '—';
+    // +T12:00:00 para evitar desfase de zona horaria
+    const d = new Date(val + 'T12:00:00');
+    return d.toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+const renderFns = {
+    'num_at': (val, item) => {
+        let html = `<strong>AT-${val}</strong>`;
+        if (item.at_count > 1) {
+            html += ` <span class="badge bg-warning text-dark ms-1"
+                           title="Este AT tiene ${item.at_count} solicitudes activas">×${item.at_count}</span>`;
+        }
+        return html;
+    },
+
+    'tipo_solicitud': (val, item) => {
+        const clase   = item.color_solicitud ? `solicitud-${item.color_solicitud}` : '';
+        const tooltip = item.estado_solicitud || '';
+        return `<span class="tipo-solicitud-celda ${clase}" title="${tooltip}">${val || '—'}</span>`;
+    },
+
+    'fecha_solicitud': (val) => renderFecha(val),
+
+    'titular_nombre': (val, item) => {
+        let clase = '';
+        if      (item.tipo_titular === 'PROMOTOR')         clase = 'titular-promotor';
+        else if (item.tipo_titular === 'ORGANISMO_PUBLICO') clase = 'titular-organismo';
+        else if (item.tipo_titular === 'GRAN_DISTRIBUIDORA') clase = 'titular-gran-dist';
+        const texto = val || '—';
+        return `<span class="celda-ellipsis ${clase}" title="${texto}">${texto}</span>`;
+    },
+
+    'proyecto_descripcion': (val) => {
+        const texto = val || '—';
+        return `<span class="celda-ellipsis" title="${texto}">${texto}</span>`;
+    },
+
+    'pista_SOL':       (val) => renderPista(val),
+    'pista_CONSULTAS': (val) => renderPista(val),
+    'pista_MA':        (val) => renderPista(val),
+    'pista_IP':        (val) => renderPista(val),
+    'pista_RES':       (val) => renderPista(val),
+
+    '_acciones': (val, item) =>
+        `<a href="/expedientes/${item.expediente_id}/tramitacion/solicitud/${item.id}"
+             class="btn-accion-ver">
+            <i class="fas fa-eye"></i> Ver
+         </a>`,
+};
+
+const columns = colsMeta.map(col =>
+    renderFns[col.key] ? { ...col, renderFn: renderFns[col.key] } : col
+);
+
+// Subclase que inyecta los filtros del seguimiento en cada petición
+class SeguimientoScroll extends ScrollInfinito {
+    async loadMore() {
+        if (this.loading || !this.hasMore) return;
+        this.loading = true;
+        this.showLoader();
+
+        try {
+            const params = new URLSearchParams({ cursor: this.cursor, limit: this.limit });
+
+            const ver = document.getElementById('sel-ver')?.value || 'mis';
+            params.append('ver', ver);
+
+            const estado = document.getElementById('sel-estado')?.value || 'EN_TRAMITE';
+            if (estado && estado !== 'todos') params.append('estado', estado);
+
+            const tipoTitular = document.getElementById('sel-tipo-titular')?.value;
+            if (tipoTitular) params.append('tipo_titular', tipoTitular);
+
+            const tipoExp = document.getElementById('sel-tipo-expediente')?.value;
+            if (tipoExp) params.append('tipo_expediente_id', tipoExp);
+
+            const response = await fetch(`${this.apiUrl}?${params}`);
+            if (!response.ok) throw new Error(`Error ${response.status}: ${response.statusText}`);
+
+            const data = await response.json();
+            this.cursor         = data.next_cursor;
+            this.hasMore        = data.has_more;
+            this.totalAvailable = data.total || null;
+
+            this.renderItems(data.data);
+            this.totalLoaded += data.data.length;
+            this.updatePaginationInfo();
+
+            if (this.totalLoaded === 0 && ver === 'mis') {
+                this._mostrarToastSinExpedientes();
+            }
+
+        } catch (error) {
+            console.error('Error cargando seguimiento:', error);
+            this.showError('Error al cargar el seguimiento. Inténtalo de nuevo.');
+        } finally {
+            this.loading = false;
+            this.hideLoader();
+        }
+    }
+
+    _mostrarToastSinExpedientes() {
+        // Solo mostrar en la primera carga (cursor=0) y si sigue sin resultados
+        if (this.cursor !== 0) return;
+        const contenedor = document.querySelector('.toast-container');
+        if (!contenedor) return;
+        const toast = document.createElement('div');
+        toast.className = 'toast show align-items-center text-bg-info border-0';
+        toast.setAttribute('role', 'alert');
+        toast.innerHTML = `
+            <div class="d-flex">
+                <div class="toast-body">
+                    No tienes expedientes asignados. Usa «Todos» para ver el listado completo.
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto"
+                        data-bs-dismiss="toast" aria-label="Cerrar"></button>
+            </div>`;
+        contenedor.appendChild(toast);
+        setTimeout(() => toast.remove(), 6000);
+    }
+}
+
+const scrollInfinito = new SeguimientoScroll({
+    apiUrl:      '{{ url_for("api_seguimiento.listar_seguimiento") }}',
+    tableClass:  '.seguimiento-table',
+    entityLabel: 'solicitudes',
+    columns,
+});
+
+const filtros = new FiltrosListado(scrollInfinito);
+console.log('Seguimiento inicializado');
+</script>
+{% endblock %}

--- a/app/routes/api_seguimiento.py
+++ b/app/routes/api_seguimiento.py
@@ -1,0 +1,209 @@
+"""API REST para el listado de seguimiento de solicitudes.
+
+ENDPOINT:
+    GET /api/expedientes/seguimiento — Listado paginado de solicitudes con estado de pistas.
+
+    Params:
+        cursor           (int,    default 0)           — Paginación por cursor
+        limit            (int,    default 50, max 100) — Solicitudes por página
+        ver              (str,    default "mis")        — "mis" | "todos"
+        estado           (str,    default "EN_TRAMITE") — Estado BD o "todos"
+        tipo_titular     (str,    opcional)             — Filtra por tipo de titular
+        tipo_expediente_id (int,  opcional)             — Filtra por tipo de expediente
+
+    Respuesta JSON:
+        {
+            "data": [{
+                "id": 1, "expediente_id": 5, "num_at": 1234, "at_count": 2,
+                "tipo_solicitud": "AAP_AAC", "fecha_solicitud": "2025-01-15",
+                "estado_solicitud": "EN_TRAMITE", "color_solicitud": "",
+                "titular_nombre": "...", "tipo_titular": "PROMOTOR",
+                "proyecto_descripcion": "...",
+                "pista_SOL": {"codigo": "PENDIENTE_ESTUDIO", "color": "rojo", "count": 1},
+                "pista_CONSULTAS": null, "pista_MA": null, "pista_IP": null,
+                "pista_RES": {"codigo": "PENDIENTE_TRAMITAR", "color": "rojo", "count": 1}
+            }, ...],
+            "next_cursor": 5,
+            "has_more": true,
+            "total": null
+        }
+
+VERSIÓN: 1.0
+FECHA: 2026-03-27
+"""
+
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from sqlalchemy.orm import joinedload
+from sqlalchemy import func
+
+from app import db
+from app.models.expedientes import Expediente
+from app.models.solicitudes import Solicitud
+from app.models.entidad import Entidad
+from app.services.seguimiento import estado_solicitud, fin_total
+
+api_seguimiento_bp = Blueprint('api_seguimiento', __name__, url_prefix='/api')
+
+# Estados válidos para el filtro
+_ESTADOS_VALIDOS = {'EN_TRAMITE', 'RESUELTA', 'DESISTIDA', 'ARCHIVADA', 'todos'}
+# Tipos de titular válidos
+_TIPOS_TITULAR_VALIDOS = {'GRAN_DISTRIBUIDORA', 'DISTRIBUIDOR_MENOR', 'PROMOTOR', 'ORGANISMO_PUBLICO', 'OTRO'}
+
+
+@api_seguimiento_bp.route('/expedientes/seguimiento', methods=['GET'])
+@login_required
+def listar_seguimiento():
+    """
+    GET /api/expedientes/seguimiento — Listado paginado de solicitudes con estado de pistas.
+
+    Cada fila representa una solicitud (no un expediente): un AT puede aparecer varias
+    veces si tiene múltiples solicitudes activas simultáneas (at_count > 1).
+    """
+    # -------------------------------------------------------------------------
+    # 1. Parsear y validar parámetros
+    # -------------------------------------------------------------------------
+    try:
+        cursor = int(request.args.get('cursor', 0))
+        if cursor < 0:
+            return jsonify({'error': 'cursor debe ser >= 0'}), 400
+
+        limit = int(request.args.get('limit', 50))
+        limit = min(max(limit, 1), 100)
+
+    except ValueError:
+        return jsonify({'error': 'Parámetros numéricos inválidos'}), 400
+
+    ver              = request.args.get('ver', 'mis').strip()
+    estado           = request.args.get('estado', 'EN_TRAMITE').strip()
+    tipo_titular     = request.args.get('tipo_titular', '').strip()
+    tipo_expediente_id_raw = request.args.get('tipo_expediente_id', '').strip()
+
+    if ver not in ('mis', 'todos'):
+        return jsonify({'error': 'ver debe ser "mis" o "todos"'}), 400
+    if estado not in _ESTADOS_VALIDOS:
+        return jsonify({'error': f'estado inválido. Válidos: {", ".join(sorted(_ESTADOS_VALIDOS))}'}), 400
+    if tipo_titular and tipo_titular not in _TIPOS_TITULAR_VALIDOS:
+        return jsonify({'error': f'tipo_titular inválido'}), 400
+
+    tipo_expediente_id = None
+    if tipo_expediente_id_raw:
+        try:
+            tipo_expediente_id = int(tipo_expediente_id_raw)
+        except ValueError:
+            return jsonify({'error': 'tipo_expediente_id debe ser entero'}), 400
+
+    # -------------------------------------------------------------------------
+    # 2. Construir filtros base (reutilizados para la query principal y at_count)
+    # -------------------------------------------------------------------------
+    filtros_base = []
+
+    if ver == 'mis':
+        filtros_base.append(Expediente.responsable_id == current_user.id)
+    if estado != 'todos':
+        filtros_base.append(Solicitud.estado == estado)
+    if tipo_titular:
+        filtros_base.append(Entidad.tipo_titular == tipo_titular)
+    if tipo_expediente_id:
+        filtros_base.append(Expediente.tipo_expediente_id == tipo_expediente_id)
+
+    # -------------------------------------------------------------------------
+    # 3. Query principal con eager loading para evitar N+1 en serialización
+    # -------------------------------------------------------------------------
+    query = (
+        db.session.query(Solicitud)
+        .join(Expediente, Solicitud.expediente_id == Expediente.id)
+        .join(Entidad, Expediente.titular_id == Entidad.id, isouter=True)
+        .options(
+            joinedload(Solicitud.expediente).joinedload(Expediente.titular),
+            joinedload(Solicitud.expediente).joinedload(Expediente.proyecto),
+            joinedload(Solicitud.tipo_solicitud),
+        )
+        .filter(*filtros_base)
+    )
+
+    if cursor > 0:
+        query = query.filter(Solicitud.id > cursor)
+
+    query = query.order_by(Solicitud.id.asc())
+    solicitudes_raw = query.limit(limit + 1).all()
+
+    has_more = len(solicitudes_raw) > limit
+    solicitudes = solicitudes_raw[:limit]
+
+    next_cursor = solicitudes[-1].id if solicitudes else cursor
+
+    # -------------------------------------------------------------------------
+    # 4. at_count: cuántas solicitudes tiene cada expediente bajo los filtros
+    #    activos (sin cursor, para reflejar el total real por AT)
+    # -------------------------------------------------------------------------
+    exp_ids_pagina = list({s.expediente_id for s in solicitudes})
+    at_counts: dict[int, int] = {}
+    if exp_ids_pagina:
+        rows = (
+            db.session.query(
+                Solicitud.expediente_id,
+                func.count(Solicitud.id).label('cnt')
+            )
+            .join(Expediente, Solicitud.expediente_id == Expediente.id)
+            .join(Entidad, Expediente.titular_id == Entidad.id, isouter=True)
+            .filter(
+                Solicitud.expediente_id.in_(exp_ids_pagina),
+                *filtros_base  # mismos filtros, sin cursor
+            )
+            .group_by(Solicitud.expediente_id)
+            .all()
+        )
+        at_counts = {row.expediente_id: row.cnt for row in rows}
+
+    # -------------------------------------------------------------------------
+    # 5. Calcular estado de pistas y serializar
+    # -------------------------------------------------------------------------
+    data = []
+    for sol in solicitudes:
+        estados = estado_solicitud(sol.id)
+        es_fin = fin_total(estados)
+
+        if sol.estado != 'EN_TRAMITE':
+            color_solicitud = 'verde'
+        elif es_fin:
+            color_solicitud = 'naranja'
+        else:
+            color_solicitud = ''
+
+        expediente = sol.expediente
+        titular = expediente.titular if expediente else None
+        proyecto = expediente.proyecto if expediente else None
+
+        data.append({
+            'id':                    sol.id,
+            'expediente_id':         expediente.id if expediente else None,
+            'num_at':                expediente.numero_at if expediente else None,
+            'at_count':              at_counts.get(expediente.id, 1) if expediente else 1,
+            'tipo_solicitud':        sol.tipo_solicitud.siglas if sol.tipo_solicitud else '—',
+            'fecha_solicitud':       sol.fecha_solicitud.isoformat() if sol.fecha_solicitud else None,
+            'estado_solicitud':      sol.estado,
+            'color_solicitud':       color_solicitud,
+            'titular_nombre':        titular.nombre_completo if titular else '—',
+            'tipo_titular':          titular.tipo_titular if titular else None,
+            'proyecto_descripcion':  proyecto.descripcion if proyecto else '—',
+            'pista_SOL':             _ser_pista(estados.get('SOL')),
+            'pista_CONSULTAS':       _ser_pista(estados.get('CONSULTAS')),
+            'pista_MA':              _ser_pista(estados.get('MA')),
+            'pista_IP':              _ser_pista(estados.get('IP')),
+            'pista_RES':             _ser_pista(estados.get('RES')),
+        })
+
+    return jsonify({
+        'data':        data,
+        'next_cursor': next_cursor,
+        'has_more':    has_more,
+        'total':       None,  # costoso de calcular; el cliente lo infiere de has_more
+    })
+
+
+def _ser_pista(ep) -> dict | None:
+    """Serializa un EstadoPista a dict JSON; None si la pista es N/A."""
+    if ep is None:
+        return None
+    return {'codigo': ep.codigo, 'color': ep.color, 'count': ep.count}

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -298,3 +298,71 @@ table a.badge:hover {
     color: #fff;
     text-decoration: none;
 }
+
+/* ========================================
+   Seguimiento — Pistas y celda SOLICITUD
+   Issue #262
+   ======================================== */
+
+/* Pill de estado de pista (§4.1) */
+.pista-celda {
+    display: inline-block;
+    padding: 0.2em 0.55em;
+    border-radius: 0.25rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    min-width: 5.5rem;
+    text-align: center;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+}
+
+.pista-rojo     { background-color: #f8d7da; color: #721c24; }
+.pista-amarillo { background-color: #fff3cd; color: #664d03; }
+.pista-azul     { background-color: #cfe2ff; color: #084298; }
+.pista-gris     { background-color: #e2e3e5; color: #41464b; }
+.pista-naranja  { background-color: #ffe5d0; color: #7d3f00; }
+.pista-verde    { background-color: #d1e7dd; color: #0a3622; }
+
+/* Columna SOLICITUD — color según estado global (§2) */
+.tipo-solicitud-celda {
+    display: inline-block;
+    padding: 0.15em 0.4em;
+    border-radius: 0.2rem;
+    font-weight: 500;
+    font-size: 0.82rem;
+}
+.tipo-solicitud-celda.solicitud-naranja { background-color: #ffe5d0; color: #7d3f00; }
+.tipo-solicitud-celda.solicitud-verde   { background-color: #d1e7dd; color: #0a3622; }
+
+/* Columna TITULAR — diferenciación por tipo_titular (§7.3) */
+.titular-promotor  { font-weight: 700; }
+.titular-organismo { font-weight: 700; color: #0d6efd; }
+.titular-gran-dist { color: #6c757d; }
+
+/* Ellipsis para TITULAR y PROYECTO */
+.celda-ellipsis {
+    display: block;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Tabla seguimiento: columnas cortas sin wrap */
+.seguimiento-table th,
+.seguimiento-table td {
+    white-space: nowrap;
+}
+
+/* TITULAR y PROYECTO permiten truncado controlado */
+.seguimiento-table td:nth-child(4),
+.seguimiento-table td:nth-child(5) {
+    white-space: normal;
+    max-width: 220px;
+}
+
+/* Scroll horizontal si la pantalla es estrecha */
+.seguimiento-table {
+    min-width: 1100px;
+}


### PR DESCRIPTION
## Cambios

- `app/routes/api_seguimiento.py` — nuevo endpoint `GET /api/expedientes/seguimiento`: listado paginado de solicitudes con estado de pistas calculado por `seguimiento.py`. Filtros: `ver` (mis/todos), `estado`, `tipo_titular`, `tipo_expediente_id`. Campo `at_count` detecta ATs con múltiples solicitudes activas simultáneas.
- `app/modules/expedientes/templates/expedientes/seguimiento.html` — template con `SeguimientoScroll` (subclase de `ScrollInfinito`) que inyecta filtros extra en cada petición. `renderFns` para pistas (colores por estado), titular (diferenciación por tipo) y `num_at` (indicador de duplicidad).
- `app/modules/expedientes/routes.py` — ruta `GET /expedientes/seguimiento/` que pasa columnas del metadata y `tipos_expedientes` para los selects de filtro.
- `app/modules/expedientes/metadata.json` — sección `seguimiento` con columnas: `num_at`, `tipo_solicitud`, `fecha_solicitud`, `titular_nombre`, `proyecto_descripcion`, pistas `SOL/CONSULTAS/MA/IP/RES` y `_acciones`.
- `app/static/css/custom.css` — clases `.pista-{color}`, `.tipo-solicitud-celda`, `.titular-{tipo}`, `.celda-ellipsis` y ajustes de tabla `.seguimiento-table`.
- `app/__init__.py` — registro del blueprint `api_seguimiento_bp`.

Verificado contra seed T01–T11: estados de pista, badge ×2 en AT-1004, color naranja en T10 (fin_total), celdas vacías N/A en T11.

Closes #262
