### PR TITLE
Corregir bugs visuales y de layout en seguimiento (#263)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -1,9 +1,18 @@
 {% extends 'layout/lista_v2_base.html' %}
 
+{# Bug #263.5: breadcrumb con tercer nivel Seguimiento #}
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a>
+<span>›</span>
+<span>Seguimiento</span>
+{% endblock %}
+
 {% block page_title %}Seguimiento{% endblock %}
 {% block page_icon %}<i class="fas fa-tasks"></i>{% endblock %}
 {% block entity_label_plural %}solicitudes{% endblock %}
-{% block search_placeholder %}{% endblock %}
+{% block search_placeholder %}Buscar por Nº AT o titular...{% endblock %}
 
 {% block filtros_extra %}
 <select id="sel-ver" aria-label="Ver">
@@ -79,12 +88,15 @@ function renderFecha(val) {
 
 const renderFns = {
     'num_at': (val, item) => {
-        let html = `<strong>AT-${val}</strong>`;
+        // Bug #263.1: fondo amarillo en lugar de badge cuando hay múltiples solicitudes
+        const atStr = `AT-${val}`;
         if (item.at_count > 1) {
-            html += ` <span class="badge bg-warning text-dark ms-1"
-                           title="Este AT tiene ${item.at_count} solicitudes activas">×${item.at_count}</span>`;
+            return `<span class="num-at-multiples"
+                         title="Este AT tiene ${item.at_count} solicitudes activas simultáneas">
+                        <strong>${atStr}</strong>
+                    </span>`;
         }
-        return html;
+        return `<strong>${atStr}</strong>`;
     },
 
     'tipo_solicitud': (val, item) => {

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -88,15 +88,14 @@ function renderFecha(val) {
 
 const renderFns = {
     'num_at': (val, item) => {
-        // Bug #263.1: fondo amarillo en lugar de badge cuando hay múltiples solicitudes
         const atStr = `AT-${val}`;
         if (item.at_count > 1) {
-            return `<span class="num-at-multiples"
+            return `<span class="num-at-pill num-at-multiples"
                          title="Este AT tiene ${item.at_count} solicitudes activas simultáneas">
                         <strong>${atStr}</strong>
                     </span>`;
         }
-        return `<strong>${atStr}</strong>`;
+        return `<span class="num-at-pill"><strong>${atStr}</strong></span>`;
     },
 
     'tipo_solicitud': (val, item) => {
@@ -147,6 +146,9 @@ class SeguimientoScroll extends ScrollInfinito {
 
         try {
             const params = new URLSearchParams({ cursor: this.cursor, limit: this.limit });
+
+            const search = this.searchInput?.value.trim();
+            if (search) params.append('search', search);
 
             const ver = document.getElementById('sel-ver')?.value || 'mis';
             params.append('ver', ver);
@@ -214,6 +216,33 @@ const scrollInfinito = new SeguimientoScroll({
 });
 
 const filtros = new FiltrosListado(scrollInfinito);
-console.log('Seguimiento inicializado');
+
+// Reparte el espacio sobrante: TITULAR 40% / PROYECTO 60% (mínimo 100px cada uno)
+// CSS calc() no funciona con rem en table-layout:fixed → medimos el DOM.
+function ajustarFlexiblesSeguimiento() {
+    const tabla = document.querySelector('.seguimiento-table');
+    if (!tabla) return;
+    const ths = Array.from(tabla.querySelectorAll('thead th'));
+    if (ths.length < 5) return;
+    const thTitular  = ths[3];
+    const thProyecto = ths[4];
+    thTitular.style.width  = '';
+    thProyecto.style.width = '';
+    const totalWidth = tabla.offsetWidth;
+    let anchoFijo = 0;
+    ths.forEach((th, i) => { if (i !== 3 && i !== 4) anchoFijo += th.offsetWidth; });
+    const sobrante = Math.max(0, totalWidth - anchoFijo);
+    const MIN_PX = 100;
+    const proyectoVisible = getComputedStyle(thProyecto).display !== 'none';
+    if (proyectoVisible) {
+        thTitular.style.width  = Math.max(MIN_PX, sobrante * 0.4) + 'px';
+        thProyecto.style.width = Math.max(MIN_PX, sobrante * 0.6) + 'px';
+    } else {
+        thTitular.style.width  = Math.max(MIN_PX, sobrante) + 'px';
+    }
+}
+requestAnimationFrame(ajustarFlexiblesSeguimiento);
+new ResizeObserver(ajustarFlexiblesSeguimiento)
+    .observe(document.querySelector('.lista-scroll-container'));
 </script>
 {% endblock %}

--- a/app/routes/api_seguimiento.py
+++ b/app/routes/api_seguimiento.py
@@ -35,7 +35,7 @@ FECHA: 2026-03-27
 from flask import Blueprint, request, jsonify
 from flask_login import login_required, current_user
 from sqlalchemy.orm import joinedload
-from sqlalchemy import func
+from sqlalchemy import func, cast, String, or_
 
 from app import db
 from app.models.expedientes import Expediente
@@ -78,6 +78,7 @@ def listar_seguimiento():
     estado           = request.args.get('estado', 'EN_TRAMITE').strip()
     tipo_titular     = request.args.get('tipo_titular', '').strip()
     tipo_expediente_id_raw = request.args.get('tipo_expediente_id', '').strip()
+    search           = request.args.get('search', '').strip()
 
     if ver not in ('mis', 'todos'):
         return jsonify({'error': 'ver debe ser "mis" o "todos"'}), 400
@@ -106,6 +107,12 @@ def listar_seguimiento():
         filtros_base.append(Entidad.tipo_titular == tipo_titular)
     if tipo_expediente_id:
         filtros_base.append(Expediente.tipo_expediente_id == tipo_expediente_id)
+    if search:
+        num_at_str = search.upper().removeprefix('AT-').removeprefix('AT')
+        filtros_base.append(or_(
+            cast(Expediente.numero_at, String).ilike(f'%{num_at_str}%'),
+            Entidad.nombre_completo.ilike(f'%{search}%'),
+        ))
 
     # -------------------------------------------------------------------------
     # 3. Query principal con eager loading para evitar N+1 en serialización

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -349,20 +349,97 @@ table a.badge:hover {
     white-space: nowrap;
 }
 
-/* Tabla seguimiento: columnas cortas sin wrap */
+/* Tabla seguimiento: layout fijo + padding compacto (#263 bug #3)
+ * table-layout:fixed obliga al navegador a respetar los anchos declarados
+ * y NO distribuir el espacio sobrante entre todas las columnas. */
+.seguimiento-table {
+    table-layout: fixed;
+    width: 100%;
+    min-width: 0;
+}
+
 .seguimiento-table th,
 .seguimiento-table td {
     white-space: nowrap;
+    padding: 0.6rem 0.75rem;
+    overflow: hidden;
 }
 
-/* TITULAR y PROYECTO permiten truncado controlado */
+/* ── Columnas fijas IZQUIERDA: Nº AT, SOLICITUD, FECHA ── */
+.seguimiento-table th:nth-child(1),
+.seguimiento-table td:nth-child(1) { width: 5.5rem; }  /* Nº AT */
+
+.seguimiento-table th:nth-child(2),
+.seguimiento-table td:nth-child(2) { width: 9rem; }    /* SOLICITUD */
+
+.seguimiento-table th:nth-child(3),
+.seguimiento-table td:nth-child(3) { width: 6.5rem; }  /* FECHA */
+
+/* ── Columnas flexibles CENTRO: TITULAR y PROYECTO se reparten lo que sobra ──
+ * Con table-layout:fixed, las columnas sin ancho explícito se reparten el espacio
+ * restante en partes iguales → 50% cada una automáticamente. */
+
+/* TITULAR y PROYECTO: truncado con ellipsis llenando toda la celda */
 .seguimiento-table td:nth-child(4),
 .seguimiento-table td:nth-child(5) {
-    white-space: normal;
-    max-width: 220px;
+    white-space: nowrap; /* necesario para ellipsis en celdas flexibles */
+}
+.seguimiento-table .celda-ellipsis {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-/* Scroll horizontal si la pantalla es estrecha */
-.seguimiento-table {
-    min-width: 1100px;
+/* ── Columnas fijas DERECHA: pistas + acciones ── */
+.seguimiento-table th:nth-child(6),
+.seguimiento-table td:nth-child(6)  { width: 7rem; }   /* ANÁLISIS */
+
+.seguimiento-table th:nth-child(7),
+.seguimiento-table td:nth-child(7)  { width: 7rem; }   /* CONSULTAS */
+
+.seguimiento-table th:nth-child(8),
+.seguimiento-table td:nth-child(8)  { width: 6.5rem; } /* MA */
+
+.seguimiento-table th:nth-child(9),
+.seguimiento-table td:nth-child(9)  { width: 6.5rem; } /* IP */
+
+.seguimiento-table th:nth-child(10),
+.seguimiento-table td:nth-child(10) { width: 7.5rem; } /* RESOLUCIÓN */
+
+.seguimiento-table th:nth-child(11),
+.seguimiento-table td:nth-child(11) { width: 4.5rem; } /* Acciones */
+
+/* AT con múltiples solicitudes: fondo amarillo en lugar de badge (#263 bug #1) */
+.num-at-multiples {
+    display: inline-block;
+    background-color: #fff3cd;
+    color: #664d03;
+    border-radius: 0.25rem;
+    padding: 0.1em 0.4em;
+    border-left: 3px solid #ffc107;
+}
+
+/* Responsive seguimiento: ocultar columnas progresivamente (#263 bug #2)
+ * Orden de ocultación (menos → más importante): PROYECTO → TITULAR → CONSULTAS+MA → IP
+ * RESOLUCIÓN siempre visible */
+@media (max-width: 1400px) {
+    .seguimiento-table th:nth-child(5),
+    .seguimiento-table td:nth-child(5) { display: none; } /* PROYECTO */
+}
+@media (max-width: 1199px) {
+    .seguimiento-table th:nth-child(4),
+    .seguimiento-table td:nth-child(4) { display: none; } /* TITULAR */
+}
+@media (max-width: 991px) {
+    .seguimiento-table th:nth-child(7),
+    .seguimiento-table td:nth-child(7),
+    .seguimiento-table th:nth-child(8),
+    .seguimiento-table td:nth-child(8) { display: none; } /* CONSULTAS, MA */
+}
+@media (max-width: 767px) {
+    .seguimiento-table th:nth-child(9),
+    .seguimiento-table td:nth-child(9) { display: none; } /* IP */
 }

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -301,20 +301,27 @@ table a.badge:hover {
 
 /* ========================================
    Seguimiento — Pistas y celda SOLICITUD
-   Issue #262
+   Issue #262 / #263
    ======================================== */
 
-/* Pill de estado de pista (§4.1) */
+/* Variables de layout — un solo punto de cambio (#263) */
+:root {
+    --seg-pista-w:   5.75rem; /* ancho de cada columna de pista (ANÁLISIS…RESOLUCIÓN) */
+    /* Total cols fijas: AT(5.5)+SOL(9)+FECHA(5.25)+pistas×5(28.75)+ACC(4.5) = 53rem */
+    --seg-fixed-tot: 53rem;
+}
+
+/* Pill de estado de pista — display:block para rellenar toda la celda (#263) */
 .pista-celda {
-    display: inline-block;
+    display: block;
     padding: 0.2em 0.55em;
     border-radius: 0.25rem;
     font-size: 0.78rem;
     font-weight: 600;
-    min-width: 5.5rem;
     text-align: center;
     white-space: nowrap;
     letter-spacing: 0.02em;
+    overflow: hidden;
 }
 
 .pista-rojo     { background-color: #f8d7da; color: #721c24; }
@@ -349,9 +356,7 @@ table a.badge:hover {
     white-space: nowrap;
 }
 
-/* Tabla seguimiento: layout fijo + padding compacto (#263 bug #3)
- * table-layout:fixed obliga al navegador a respetar los anchos declarados
- * y NO distribuir el espacio sobrante entre todas las columnas. */
+/* Tabla seguimiento: layout fijo (#263) */
 .seguimiento-table {
     table-layout: fixed;
     width: 100%;
@@ -363,27 +368,34 @@ table a.badge:hover {
     white-space: nowrap;
     padding: 0.6rem 0.75rem;
     overflow: hidden;
+    border-right: 1px solid #dee2e6;
 }
+.seguimiento-table th:last-child,
+.seguimiento-table td:last-child { border-right: none; }
 
-/* ── Columnas fijas IZQUIERDA: Nº AT, SOLICITUD, FECHA ── */
+/* ── Columnas fijas IZQUIERDA ── */
 .seguimiento-table th:nth-child(1),
-.seguimiento-table td:nth-child(1) { width: 5.5rem; }  /* Nº AT */
+.seguimiento-table td:nth-child(1) {
+    width: 5.5rem;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+}  /* Nº AT */
 
 .seguimiento-table th:nth-child(2),
 .seguimiento-table td:nth-child(2) { width: 9rem; }    /* SOLICITUD */
 
 .seguimiento-table th:nth-child(3),
-.seguimiento-table td:nth-child(3) { width: 6.5rem; }  /* FECHA */
+.seguimiento-table td:nth-child(3) {
+    width: 5.25rem;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+    text-align: center;
+}  /* FECHA */
 
-/* ── Columnas flexibles CENTRO: TITULAR y PROYECTO se reparten lo que sobra ──
- * Con table-layout:fixed, las columnas sin ancho explícito se reparten el espacio
- * restante en partes iguales → 50% cada una automáticamente. */
-
-/* TITULAR y PROYECTO: truncado con ellipsis llenando toda la celda */
+/* ── Columnas flexibles CENTRO: TITULAR (40%) / PROYECTO (60%) gestionado por JS ── */
 .seguimiento-table td:nth-child(4),
-.seguimiento-table td:nth-child(5) {
-    white-space: nowrap; /* necesario para ellipsis en celdas flexibles */
-}
+.seguimiento-table td:nth-child(5) { white-space: nowrap; }
+
 .seguimiento-table .celda-ellipsis {
     display: block;
     width: 100%;
@@ -393,43 +405,55 @@ table a.badge:hover {
     white-space: nowrap;
 }
 
-/* ── Columnas fijas DERECHA: pistas + acciones ── */
-.seguimiento-table th:nth-child(6),
-.seguimiento-table td:nth-child(6)  { width: 7rem; }   /* ANÁLISIS */
-
-.seguimiento-table th:nth-child(7),
-.seguimiento-table td:nth-child(7)  { width: 7rem; }   /* CONSULTAS */
-
-.seguimiento-table th:nth-child(8),
-.seguimiento-table td:nth-child(8)  { width: 6.5rem; } /* MA */
-
-.seguimiento-table th:nth-child(9),
-.seguimiento-table td:nth-child(9)  { width: 6.5rem; } /* IP */
-
-.seguimiento-table th:nth-child(10),
-.seguimiento-table td:nth-child(10) { width: 7.5rem; } /* RESOLUCIÓN */
-
-.seguimiento-table th:nth-child(11),
-.seguimiento-table td:nth-child(11) { width: 4.5rem; } /* Acciones */
-
-/* AT con múltiples solicitudes: fondo amarillo en lugar de badge (#263 bug #1) */
-.num-at-multiples {
-    display: inline-block;
-    background-color: #fff3cd;
-    color: #664d03;
-    border-radius: 0.25rem;
-    padding: 0.1em 0.4em;
-    border-left: 3px solid #ffc107;
+/* ── Columnas fijas DERECHA: pistas — padding mínimo para que el pill llene la celda ── */
+.seguimiento-table th:nth-child(6),  .seguimiento-table td:nth-child(6),
+.seguimiento-table th:nth-child(7),  .seguimiento-table td:nth-child(7),
+.seguimiento-table th:nth-child(8),  .seguimiento-table td:nth-child(8),
+.seguimiento-table th:nth-child(9),  .seguimiento-table td:nth-child(9),
+.seguimiento-table th:nth-child(10), .seguimiento-table td:nth-child(10) {
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
 }
 
-/* Responsive seguimiento: ocultar columnas progresivamente (#263 bug #2)
- * Orden de ocultación (menos → más importante): PROYECTO → TITULAR → CONSULTAS+MA → IP
- * RESOLUCIÓN siempre visible */
-@media (max-width: 1400px) {
+.seguimiento-table th:nth-child(6),
+.seguimiento-table td:nth-child(6)  { width: var(--seg-pista-w); } /* ANÁLISIS */
+
+.seguimiento-table th:nth-child(7),
+.seguimiento-table td:nth-child(7)  { width: var(--seg-pista-w); } /* CONSULTAS */
+
+.seguimiento-table th:nth-child(8),
+.seguimiento-table td:nth-child(8)  { width: var(--seg-pista-w); } /* MA */
+
+.seguimiento-table th:nth-child(9),
+.seguimiento-table td:nth-child(9)  { width: var(--seg-pista-w); } /* IP */
+
+.seguimiento-table th:nth-child(10),
+.seguimiento-table td:nth-child(10) { width: var(--seg-pista-w); } /* RESOLUCIÓN */
+
+.seguimiento-table th:nth-child(11),
+.seguimiento-table td:nth-child(11) { width: 4.5rem; }             /* Acciones */
+
+/* Pill base Nº AT — mismo tamaño en todas las filas, solo cambia el color (#263) */
+.num-at-pill {
+    display: block;
+    padding: 0.2em 0.55em;
+    border-radius: 0.25rem;
+    text-align: center;
+    overflow: hidden;
+    background-color: transparent;
+}
+.num-at-multiples {
+    background-color: #fff3cd;
+    color: #664d03;
+}
+
+/* Responsive: ocultar columnas progresivamente (#263)
+ * Breakpoints calculados sobre espacio real disponible (cols fijas = 53rem ≈ 848px) */
+@media (max-width: 1100px) {
     .seguimiento-table th:nth-child(5),
     .seguimiento-table td:nth-child(5) { display: none; } /* PROYECTO */
 }
-@media (max-width: 1199px) {
+@media (max-width: 1000px) {
     .seguimiento-table th:nth-child(4),
     .seguimiento-table td:nth-child(4) { display: none; } /* TITULAR */
 }


### PR DESCRIPTION
## Cambios

- Breadcrumb actualizado: `Inicio › Expedientes › Seguimiento`
- Placeholder en campo de búsqueda
- Badge ×2 sustituido por pill `.num-at-pill` (fondo amarillo si at_count > 1, transparente si no)
- `table-layout:fixed` con anchos explícitos; variables CSS `--seg-pista-w` / `--seg-fixed-tot`
- Pills de pista `display:block` para rellenar toda la celda
- TITULAR/PROYECTO distribuidos al 40/60% vía JS con mínimo 100px
- Separadores verticales entre columnas
- Breakpoints responsive calibrados al espacio real disponible
- Búsqueda textual corregida: `search` incluido en `loadMore()` y procesado en la API

Closes #263
