### PR TITLE
Bugs responsive y UX segunda iteración seguimiento

### DIFF
--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -44,6 +44,16 @@
 
 {% block tabla_clase %}seguimiento-table{% endblock %}
 
+{% block extra_css %}
+<style>
+/* Bug #265.1: ocultar «Mostrando» a anchos intermedios donde los filtros de seguimiento
+   (4 selects) empujan el contador. A ≤767px el base CSS ya apila en columna. */
+@media (max-width: 1200px) and (min-width: 768px) {
+    .filters-row:has(#sel-ver) .pagination-info { display: none; }
+}
+</style>
+{% endblock %}
+
 {% block extra_js %}
 {{ super() }}
 <script>
@@ -192,19 +202,22 @@ class SeguimientoScroll extends ScrollInfinito {
         if (this.cursor !== 0) return;
         const contenedor = document.querySelector('.toast-container');
         if (!contenedor) return;
-        const toast = document.createElement('div');
-        toast.className = 'toast show align-items-center text-bg-info border-0';
-        toast.setAttribute('role', 'alert');
-        toast.innerHTML = `
-            <div class="d-flex">
-                <div class="toast-body">
-                    No tienes expedientes asignados. Usa «Todos» para ver el listado completo.
+        // Patrón estándar de toasts del proyecto (#265.2)
+        const el = document.createElement('div');
+        el.className = 'toast toast-info';
+        el.setAttribute('role', 'alert');
+        el.setAttribute('data-bs-autohide', 'true');
+        el.setAttribute('data-bs-delay', '6000');
+        el.innerHTML = `
+            <div class="d-flex align-items-center p-3">
+                <div class="flex-grow-1">
+                    <i class="fas fa-info-circle me-2"></i>No tienes expedientes asignados. Usa «Todos» para ver el listado completo.
                 </div>
-                <button type="button" class="btn-close btn-close-white me-2 m-auto"
-                        data-bs-dismiss="toast" aria-label="Cerrar"></button>
+                <button type="button" class="btn-close ms-3" data-bs-dismiss="toast" aria-label="Cerrar"></button>
             </div>`;
-        contenedor.appendChild(toast);
-        setTimeout(() => toast.remove(), 6000);
+        contenedor.appendChild(el);
+        new bootstrap.Toast(el).show();
+        el.addEventListener('hidden.bs.toast', () => el.remove());
     }
 }
 
@@ -219,6 +232,7 @@ const filtros = new FiltrosListado(scrollInfinito);
 
 // Reparte el espacio sobrante: TITULAR 40% / PROYECTO 60% (mínimo 100px cada uno)
 // CSS calc() no funciona con rem en table-layout:fixed → medimos el DOM.
+// Bug #265.5: saltar si ninguna columna flexible está visible; excluir cols ocultas de anchoFijo.
 function ajustarFlexiblesSeguimiento() {
     const tabla = document.querySelector('.seguimiento-table');
     if (!tabla) return;
@@ -228,12 +242,21 @@ function ajustarFlexiblesSeguimiento() {
     const thProyecto = ths[4];
     thTitular.style.width  = '';
     thProyecto.style.width = '';
+
+    const titularVisible  = getComputedStyle(thTitular).display  !== 'none';
+    const proyectoVisible = getComputedStyle(thProyecto).display !== 'none';
+    // Si ninguna columna flexible está visible, no hay nada que distribuir
+    if (!titularVisible && !proyectoVisible) return;
+
     const totalWidth = tabla.offsetWidth;
     let anchoFijo = 0;
-    ths.forEach((th, i) => { if (i !== 3 && i !== 4) anchoFijo += th.offsetWidth; });
+    ths.forEach((th, i) => {
+        if (i !== 3 && i !== 4 && getComputedStyle(th).display !== 'none') {
+            anchoFijo += th.offsetWidth;
+        }
+    });
     const sobrante = Math.max(0, totalWidth - anchoFijo);
     const MIN_PX = 100;
-    const proyectoVisible = getComputedStyle(thProyecto).display !== 'none';
     if (proyectoVisible) {
         thTitular.style.width  = Math.max(MIN_PX, sobrante * 0.4) + 'px';
         thProyecto.style.width = Math.max(MIN_PX, sobrante * 0.6) + 'px';
@@ -244,5 +267,9 @@ function ajustarFlexiblesSeguimiento() {
 requestAnimationFrame(ajustarFlexiblesSeguimiento);
 new ResizeObserver(ajustarFlexiblesSeguimiento)
     .observe(document.querySelector('.lista-scroll-container'));
+// Recalcular también cuando los media queries cambian la visibilidad de columnas (#265.5)
+[1100, 1000, 880, 760, 640].forEach(bp => {
+    window.matchMedia(`(max-width: ${bp}px)`).addEventListener('change', ajustarFlexiblesSeguimiento);
+});
 </script>
 {% endblock %}

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -44,15 +44,6 @@
 
 {% block tabla_clase %}seguimiento-table{% endblock %}
 
-{% block extra_css %}
-<style>
-/* Bug #265.1: ocultar «Mostrando» a anchos intermedios donde los filtros de seguimiento
-   (4 selects) empujan el contador. A ≤767px el base CSS ya apila en columna. */
-@media (max-width: 1200px) and (min-width: 768px) {
-    .filters-row:has(#sel-ver) .pagination-info { display: none; }
-}
-</style>
-{% endblock %}
 
 {% block extra_js %}
 {{ super() }}
@@ -216,7 +207,10 @@ class SeguimientoScroll extends ScrollInfinito {
                 <button type="button" class="btn-close ms-3" data-bs-dismiss="toast" aria-label="Cerrar"></button>
             </div>`;
         contenedor.appendChild(el);
-        new bootstrap.Toast(el).show();
+        const toastInstance = new bootstrap.Toast(el);
+        // data-bs-dismiss no funciona en toasts dinámicos — click explícito
+        el.querySelector('.btn-close').addEventListener('click', () => toastInstance.hide());
+        toastInstance.show();
         el.addEventListener('hidden.bs.toast', () => el.remove());
     }
 }

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -265,8 +265,8 @@ function ajustarFlexiblesSeguimiento() {
 requestAnimationFrame(ajustarFlexiblesSeguimiento);
 new ResizeObserver(ajustarFlexiblesSeguimiento)
     .observe(document.querySelector('.lista-scroll-container'));
-// Recalcular también cuando los media queries cambian la visibilidad de columnas (#265.5)
-[1100, 1000, 880, 760, 640].forEach(bp => {
+// Recalcular cuando los media queries ocultan/muestran las columnas flexibles (#265.5)
+[1100, 1000].forEach(bp => {
     window.matchMedia(`(max-width: ${bp}px)`).addEventListener('change', ajustarFlexiblesSeguimiento);
 });
 </script>

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -189,28 +189,32 @@ class SeguimientoScroll extends ScrollInfinito {
     }
 
     _mostrarToastSinExpedientes() {
-        // Solo mostrar en la primera carga (cursor=0) y si sigue sin resultados
+        // Solo mostrar en la primera carga y si no hay resultados
         if (this.cursor !== 0) return;
         const contenedor = document.querySelector('.toast-container');
         if (!contenedor) return;
-        // Patrón estándar de toasts del proyecto (#265.2)
-        const el = document.createElement('div');
-        el.className = 'toast toast-info';
-        el.setAttribute('role', 'alert');
-        el.setAttribute('data-bs-autohide', 'true');
-        el.setAttribute('data-bs-delay', '6000');
-        el.innerHTML = `
-            <div class="d-flex align-items-center p-3">
-                <div class="flex-grow-1">
-                    <i class="fas fa-info-circle me-2"></i>No tienes expedientes asignados. Usa «Todos» para ver el listado completo.
+        // Patrón pool_documentos: insertAdjacentHTML + showing + click en toast (#265.2)
+        const id = 'toast-seg-' + Date.now();
+        contenedor.insertAdjacentHTML('beforeend',
+            `<div id="${id}" class="toast toast-info" role="alert"
+                  aria-live="assertive" aria-atomic="true"
+                  data-bs-autohide="true" data-bs-delay="6000">
+                <div class="d-flex align-items-center p-3">
+                    <div class="flex-grow-1">
+                        <i class="fas fa-info-circle me-2"></i>
+                        <strong>Información:</strong> No tienes expedientes asignados. Usa «Todos» para ver el listado completo.
+                    </div>
+                    <button type="button" class="btn-close ms-3"
+                            data-bs-dismiss="toast" aria-label="Cerrar"></button>
                 </div>
-                <button type="button" class="btn-close ms-3" data-bs-dismiss="toast" aria-label="Cerrar"></button>
-            </div>`;
-        contenedor.appendChild(el);
-        const toastInstance = new bootstrap.Toast(el);
-        // data-bs-dismiss no funciona en toasts dinámicos — click explícito
-        el.querySelector('.btn-close').addEventListener('click', () => toastInstance.hide());
-        toastInstance.show();
+            </div>`);
+        const el = document.getElementById(id);
+        el.classList.add('showing');
+        const t = new bootstrap.Toast(el);
+        t.show();
+        setTimeout(() => el.classList.remove('showing'), 300);
+        el.addEventListener('hide.bs.toast', () => el.classList.add('hide'));
+        el.addEventListener('click', e => { if (!e.target.closest('.btn-close')) t.hide(); });
         el.addEventListener('hidden.bs.toast', () => el.remove());
     }
 }

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -447,12 +447,9 @@ table a.badge:hover {
     color: #664d03;
 }
 
-/* Responsive: ocultar columnas progresivamente (#263, #265)
- * Breakpoints espaciados ≥100px para que la ocultación sea progresiva y visible.
- * Cols fijas totales: AT(5.5)+SOL(9)+pistas×5(28.75)+ACC(4.5) = 47.75rem ≈ 764px
- *   +FECHA(5.25) = 53rem ≈ 848px
- *   +TITULAR(flex)
- *   +PROYECTO(flex) */
+/* Responsive: ocultar columnas flexibles (#263, #265)
+ * Solo se ocultan las columnas flexibles (PROYECTO y TITULAR).
+ * A partir de ahí las columnas fijas suman ~53rem y el scroll h trabaja. */
 @media (max-width: 1100px) {
     .seguimiento-table th:nth-child(5),
     .seguimiento-table td:nth-child(5) { display: none; } /* PROYECTO */
@@ -460,18 +457,4 @@ table a.badge:hover {
 @media (max-width: 1000px) {
     .seguimiento-table th:nth-child(4),
     .seguimiento-table td:nth-child(4) { display: none; } /* TITULAR */
-}
-@media (max-width: 880px) {
-    .seguimiento-table th:nth-child(3),
-    .seguimiento-table td:nth-child(3) { display: none; } /* FECHA */
-}
-@media (max-width: 760px) {
-    .seguimiento-table th:nth-child(7),
-    .seguimiento-table td:nth-child(7),
-    .seguimiento-table th:nth-child(8),
-    .seguimiento-table td:nth-child(8) { display: none; } /* CONSULTAS, MA */
-}
-@media (max-width: 640px) {
-    .seguimiento-table th:nth-child(9),
-    .seguimiento-table td:nth-child(9) { display: none; } /* IP */
 }

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -447,8 +447,12 @@ table a.badge:hover {
     color: #664d03;
 }
 
-/* Responsive: ocultar columnas progresivamente (#263)
- * Breakpoints calculados sobre espacio real disponible (cols fijas = 53rem ≈ 848px) */
+/* Responsive: ocultar columnas progresivamente (#263, #265)
+ * Breakpoints espaciados ≥100px para que la ocultación sea progresiva y visible.
+ * Cols fijas totales: AT(5.5)+SOL(9)+pistas×5(28.75)+ACC(4.5) = 47.75rem ≈ 764px
+ *   +FECHA(5.25) = 53rem ≈ 848px
+ *   +TITULAR(flex)
+ *   +PROYECTO(flex) */
 @media (max-width: 1100px) {
     .seguimiento-table th:nth-child(5),
     .seguimiento-table td:nth-child(5) { display: none; } /* PROYECTO */
@@ -457,13 +461,17 @@ table a.badge:hover {
     .seguimiento-table th:nth-child(4),
     .seguimiento-table td:nth-child(4) { display: none; } /* TITULAR */
 }
-@media (max-width: 991px) {
+@media (max-width: 880px) {
+    .seguimiento-table th:nth-child(3),
+    .seguimiento-table td:nth-child(3) { display: none; } /* FECHA */
+}
+@media (max-width: 760px) {
     .seguimiento-table th:nth-child(7),
     .seguimiento-table td:nth-child(7),
     .seguimiento-table th:nth-child(8),
     .seguimiento-table td:nth-child(8) { display: none; } /* CONSULTAS, MA */
 }
-@media (max-width: 767px) {
+@media (max-width: 640px) {
     .seguimiento-table th:nth-child(9),
     .seguimiento-table td:nth-child(9) { display: none; } /* IP */
 }

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -463,11 +463,11 @@
   cursor: pointer;
 }
 
-/* ===== INDICADOR PAGINACIÓN (derecha) ===== */
+/* ===== INDICADOR PAGINACIÓN — subtítulo bajo el h1 ===== */
 .pagination-info {
   color: var(--text-secondary);
-  font-size: 0.875rem;
-  white-space: nowrap;
+  font-size: 0.8rem;
+  margin-top: 0.2rem;
 }
 
 .pagination-info span {
@@ -604,7 +604,5 @@
     min-width: auto;
   }
   
-  .pagination-info {
-    text-align: center;
-  }
+  /* pagination-info es subtítulo del h1, no necesita override en mobile */
 }

--- a/app/templates/layout/lista_v2_base.html
+++ b/app/templates/layout/lista_v2_base.html
@@ -75,14 +75,20 @@
 
     <!-- Page Header -->
     <div class="page-header content-constrained">
-        <h1>
-            {% block page_icon %}<i class="fas fa-list"></i>{% endblock %}
-            {% block page_title_h1 %}{{ self.page_title() }}{% endblock %}
-        </h1>
+        <div>
+            <h1>
+                {% block page_icon %}<i class="fas fa-list"></i>{% endblock %}
+                {% block page_title_h1 %}{{ self.page_title() }}{% endblock %}
+            </h1>
+            <div class="pagination-info">
+                <i class="fas fa-filter filtro-indicador me-1"></i><span>0</span> de <span>0</span>
+                {% block entity_label_plural %}registros{% endblock %}
+            </div>
+        </div>
         {% block btn_nuevo %}{% endblock %}
     </div>
 
-    <!-- Filtros + Contador -->
+    <!-- Filtros -->
     <div class="filters-row content-constrained">
         <div class="filters">
             <input type="search"
@@ -92,11 +98,6 @@
             <button class="btn btn-outline-primary btn-limpiar" disabled>
                 <i class="fas fa-times"></i> Limpiar
             </button>
-        </div>
-
-        <div class="pagination-info">
-            <i class="fas fa-filter filtro-indicador me-1"></i>Mostrando <span>0</span> de <span>0</span>
-            {% block entity_label_plural %}registros{% endblock %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Cambios

- **Toast sin expedientes**: reescrito con el patrón estándar del proyecto (`insertAdjacentHTML` + id único + `showing`/`hide` clases + click listener en el toast), igual que `pool_documentos.html`.
- **Contador "Mostrando"**: movido como subtítulo bajo el `<h1>` en `lista_v2_base.html` (aplica a todas las vistas). Texto simplificado a `N de M entidades`, sin "Mostrando". Elimina el solapamiento con los filtros sin necesidad de media queries.
- **Responsive columnas**: solo se ocultan las columnas flexibles (PROYECTO ≤1100px, TITULAR ≤1000px). A partir de ahí las columnas fijas (~53rem) trabajan con scroll horizontal, sin breakpoints adicionales que no producían saltos visibles.
- **`ajustarFlexiblesSeguimiento`**: excluye columnas ocultas del cálculo de `anchoFijo`, retorna antes si no hay flexibles visibles, y usa `matchMedia` listeners en los 2 breakpoints activos.

Closes #265
