### PR TITLE
[UI] #268 Nuevos componentes SelectorFiltro e InputFiltro

### DIFF
--- a/app/modules/expedientes/templates/expedientes/listado_v2.html
+++ b/app/modules/expedientes/templates/expedientes/listado_v2.html
@@ -13,13 +13,7 @@
 {% endblock %}
 
 {% block filtros_extra %}
-<select aria-label="Filtrar por estado">
-    <option value="">Estado: Todos</option>
-    <option value="tramitacion">En trámite</option>
-    <option value="finalizado">Resuelto</option>
-    <option value="archivado">Archivado</option>
-    <option value="borrador">Sin solicitudes</option>
-</select>
+<div id="sf-estado-exp"></div>
 {% endblock %}
 
 {% block tabla_clase %}expedientes-table{% endblock %}
@@ -27,6 +21,13 @@
 {% block extra_js %}
 {{ super() }}
 <script>
+    const sfEstadoExp = new SelectorFiltro('#sf-estado-exp', [
+        { v: 'tramitacion', t: 'En trámite' },
+        { v: 'finalizado',  t: 'Resuelto' },
+        { v: 'archivado',   t: 'Archivado' },
+        { v: 'borrador',    t: 'Sin solicitudes' }
+    ], { label: 'Estado' });
+
     // Columnas base desde metadata.json (serializables a JSON)
     const colsMeta = {{ columns | tojson }};
 

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -15,31 +15,10 @@
 {% block search_placeholder %}Buscar por Nº AT o titular...{% endblock %}
 
 {% block filtros_extra %}
-<select id="sel-ver" aria-label="Ver">
-    <option value="mis">Mis expedientes</option>
-    <option value="todos">Todos</option>
-</select>
-<select id="sel-estado" aria-label="Estado solicitud">
-    <option value="EN_TRAMITE">En trámite</option>
-    <option value="RESUELTA">Resuelta</option>
-    <option value="DESISTIDA">Desistida</option>
-    <option value="ARCHIVADA">Archivada</option>
-    <option value="todos">Todos los estados</option>
-</select>
-<select id="sel-tipo-titular" aria-label="Tipo de titular">
-    <option value="">Todos los titulares</option>
-    <option value="PROMOTOR">Promotor</option>
-    <option value="ORGANISMO_PUBLICO">Organismo público</option>
-    <option value="DISTRIBUIDOR_MENOR">Distribuidora menor</option>
-    <option value="GRAN_DISTRIBUIDORA">Gran distribuidora</option>
-    <option value="OTRO">Otro</option>
-</select>
-<select id="sel-tipo-expediente" aria-label="Tipo de expediente">
-    <option value="">Todos los tipos</option>
-    {% for te in tipos_expedientes %}
-    <option value="{{ te.id }}">{{ te.tipo }}</option>
-    {% endfor %}
-</select>
+<div id="sf-ver"></div>
+<div id="sf-estado"></div>
+<div id="sf-tipo-titular"></div>
+<div id="sf-tipo-expediente"></div>
 {% endblock %}
 
 {% block tabla_clase %}seguimiento-table{% endblock %}
@@ -48,6 +27,39 @@
 {% block extra_js %}
 {{ super() }}
 <script>
+// ===== SELECTORES DE FILTRO =====
+// Instanciados antes de las clases para que sus valores sean accesibles
+// en el closure de SeguimientoScroll.loadMore() y FiltrosSeguimiento.
+
+const sfVer = new SelectorFiltro('#sf-ver', [
+    { v: 'mis', t: 'Mis expedientes' }
+], { label: 'Ver' });
+// Ver (todos) = placeholder vacío → muestra todos; Mis expedientes = filtro activo
+sfVer.setValue('mis');  // la ruta empieza mostrando solo mis expedientes
+
+const sfEstado = new SelectorFiltro('#sf-estado', [
+    { v: 'EN_TRAMITE', t: 'En trámite' },
+    { v: 'RESUELTA',   t: 'Resuelta' },
+    { v: 'DESISTIDA',  t: 'Desistida' },
+    { v: 'ARCHIVADA',  t: 'Archivada' }
+], { label: 'Estado' });
+sfEstado.setValue('EN_TRAMITE');  // la ruta empieza filtrada por en trámite
+
+const sfTipoTitular = new SelectorFiltro('#sf-tipo-titular', [
+    { v: 'PROMOTOR',           t: 'Promotor' },
+    { v: 'ORGANISMO_PUBLICO',  t: 'Organismo público' },
+    { v: 'DISTRIBUIDOR_MENOR', t: 'Distribuidora menor' },
+    { v: 'GRAN_DISTRIBUIDORA', t: 'Gran distribuidora' },
+    { v: 'OTRO',               t: 'Otro' }
+], { label: 'Tipo titular' });
+
+const sfTipoExpediente = new SelectorFiltro('#sf-tipo-expediente', [
+    {% for te in tipos_expedientes %}
+    { v: '{{ te.id }}', t: {{ te.tipo | tojson }} }{% if not loop.last %},{% endif %}
+
+    {% endfor %}
+], { label: 'Tipo expediente' });
+
 const colsMeta = {{ columns | tojson }};
 
 // Mapas de texto y color por estado interno (§4.2 / §4.3)
@@ -151,16 +163,16 @@ class SeguimientoScroll extends ScrollInfinito {
             const search = this.searchInput?.value.trim();
             if (search) params.append('search', search);
 
-            const ver = document.getElementById('sel-ver')?.value || 'mis';
+            const ver = sfVer.getValue() || 'todos';
             params.append('ver', ver);
 
-            const estado = document.getElementById('sel-estado')?.value || 'EN_TRAMITE';
-            if (estado && estado !== 'todos') params.append('estado', estado);
+            const estado = sfEstado.getValue();
+            if (estado) params.append('estado', estado);
 
-            const tipoTitular = document.getElementById('sel-tipo-titular')?.value;
+            const tipoTitular = sfTipoTitular.getValue();
             if (tipoTitular) params.append('tipo_titular', tipoTitular);
 
-            const tipoExp = document.getElementById('sel-tipo-expediente')?.value;
+            const tipoExp = sfTipoExpediente.getValue();
             if (tipoExp) params.append('tipo_expediente_id', tipoExp);
 
             const response = await fetch(`${this.apiUrl}?${params}`);
@@ -226,7 +238,42 @@ const scrollInfinito = new SeguimientoScroll({
     columns,
 });
 
-const filtros = new FiltrosListado(scrollInfinito);
+// FiltrosSeguimiento extiende FiltrosListado para gestionar los dos filtros
+// que tienen valor por defecto (ver=mis, estado=EN_TRAMITE):
+//   - El indicador solo se activa cuando hay desviación de los defaults
+//   - El botón Limpiar restaura a los defaults en vez de dejar en blanco
+class FiltrosSeguimiento extends FiltrosListado {
+    // Los defaults de esta vista (no cuentan como "filtro extra" aplicado por el usuario)
+    static DEFAULTS = { ver: 'mis', estado: 'EN_TRAMITE' };
+
+    _actualizarIndicador() {
+        if (!this._filtersRow) return;
+        const hayExtra =
+            (this.searchInput && this.searchInput.value.trim()) ||
+            sfTipoTitular.getValue() ||
+            sfTipoExpediente.getValue() ||
+            sfVer.getValue()    !== FiltrosSeguimiento.DEFAULTS.ver ||
+            sfEstado.getValue() !== FiltrosSeguimiento.DEFAULTS.estado;
+        this._filtersRow.classList.toggle('filtros-activos', !!hayExtra);
+        if (this.btnLimpiar) this.btnLimpiar.disabled = !hayExtra;
+    }
+
+    _limpiar() {
+        this._limpiando = true;
+        if (this.searchInput) this.searchInput.value = '';
+        sfTipoTitular.clear();       // dispara 'change' → suprimido por _limpiando
+        sfTipoExpediente.clear();    // idem
+        // setValue no dispara evento DOM → no necesita supresión
+        sfVer.setValue(FiltrosSeguimiento.DEFAULTS.ver);
+        sfEstado.setValue(FiltrosSeguimiento.DEFAULTS.estado);
+        this._limpiando = false;
+        clearTimeout(this._timer);
+        this._actualizarIndicador();
+        this.scroll.reload();
+    }
+}
+
+const filtros = new FiltrosSeguimiento(scrollInfinito);
 
 // Reparte el espacio sobrante: TITULAR 40% / PROYECTO 60% (mínimo 100px cada uno)
 // CSS calc() no funciona con rem en table-layout:fixed → medimos el DOM.

--- a/app/static/css/input_filtro.css
+++ b/app/static/css/input_filtro.css
@@ -1,0 +1,98 @@
+/* input_filtro.css
+ * Estructura del componente InputFiltro.
+ * CERO colores, CERO tipografía: todo se hereda del tema Bootstrap (v2-theme.css).
+ * Prefijo de clases: if-
+ * Issue: nuevos componentes de filtro
+ */
+
+/* ===== CONTENEDOR ===== */
+
+.if-wrap {
+  display: inline-flex;
+  align-items: stretch;
+  position: relative;   /* necesario para posicionar el icono lupa */
+}
+
+/* ===== ICONO LUPA =====
+   Posicionado de forma absoluta dentro del input.
+   pointer-events:none para que los clics pasen al input. */
+
+.if-icon {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  transition: color 0.2s ease;
+  z-index: 1;
+}
+
+.if-wrap.if-activo .if-icon {
+  color: var(--primary);
+}
+
+/* ===== INPUT DE TEXTO ===== */
+
+.if-input {
+  flex: 1;
+  min-width: 160px;
+  /* padding-left ampliado para dejar espacio al icono lupa */
+  padding: 0.625rem 1rem 0.625rem 2.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  font-size: 0.875rem;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.if-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 0.25rem var(--focus-ring);
+}
+
+/* Estado activo: fondo corporativo sutil + borde primario + radio izquierdo para unir con × */
+.if-wrap.if-activo .if-input {
+  background: var(--primary-lighter);
+  border-color: var(--primary);
+  border-right-color: transparent;
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+
+/* ===== BOTÓN × ===== */
+
+.if-btn-x {
+  display: none;           /* visible solo cuando if-activo */
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.6rem;
+  border: 1px solid var(--border-color);
+  border-left: none;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  background: var(--bg-card);
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: background 0.2s ease, border-color 0.2s ease, opacity 0.15s ease;
+}
+
+.if-wrap.if-activo .if-btn-x {
+  display: flex;
+  background: var(--primary-lighter);
+  border-color: var(--primary);
+}
+
+.if-btn-x:hover {
+  opacity: 0.7;
+}
+
+/* ===== ESTADO DESHABILITADO ===== */
+
+.if-wrap.if-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}

--- a/app/static/css/selector_filtro.css
+++ b/app/static/css/selector_filtro.css
@@ -1,0 +1,79 @@
+/* selector_filtro.css
+ * Estructura del componente SelectorFiltro.
+ * CERO colores, CERO tipografía: todo se hereda del tema Bootstrap (v2-theme.css).
+ * Prefijo de clases: sf-
+ */
+
+/* ===== CONTENEDOR ===== */
+
+.sf-wrap {
+  display: inline-flex;
+  align-items: stretch;
+  transition: background 0.2s ease;
+}
+
+/* Estado activo: el COLOR va en el WRAPPER (div), no en el <select>.
+   Así el dropdown nativo abre con su fondo de sistema sin herencia de color. */
+.sf-wrap.sf-activo {
+  background: var(--primary-lighter);
+  border-radius: var(--border-radius);
+  overflow: hidden;   /* recorta el fondo del wrapper a los bordes redondeados */
+}
+
+/* ===== SELECT NATIVO =====
+   Hereda padding, border, font-size y color de `.filters select` (v2-components.css).
+   En estado activo: transparent para que se vea el fondo del wrapper. */
+
+.sf-wrap .sf-select {
+  flex: 1;
+  transition: border-color 0.2s ease;
+}
+
+.sf-wrap.sf-activo .sf-select {
+  background: transparent;           /* el dropdown nativo ignora esto */
+  border-color: var(--primary);
+  border-right-color: transparent;   /* se funde visualmente con el botón × */
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+
+/* outline se recalcula automáticamente cuando el select cambia de tamaño;
+   box-shadow no lo hace y queda "congelado" en el tamaño anterior */
+.sf-wrap .sf-select:focus {
+  outline: 0.25rem solid var(--focus-ring);
+  outline-offset: 0;
+  box-shadow: none;
+}
+
+/* ===== BOTÓN × ===== */
+
+.sf-btn-x {
+  display: none;           /* visible solo cuando sf-activo */
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.6rem;
+  border: 1px solid var(--border-color);
+  border-left: none;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  background: transparent; /* hereda el fondo del wrapper */
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  transition: opacity 0.15s ease;
+}
+
+.sf-wrap.sf-activo .sf-btn-x {
+  display: flex;
+  border-color: var(--primary);
+}
+
+.sf-btn-x:hover {
+  opacity: 0.7;
+}
+
+/* ===== ESTADO DESHABILITADO ===== */
+
+.sf-wrap.sf-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -443,12 +443,18 @@
   font-size: 0.875rem;
   background: var(--bg-card);
   color: var(--text-primary);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .filters input[type="search"] {
   flex: 1;
   min-width: 180px;
+}
+
+/* Estado activo del buscador: cambia fondo al tener texto (sin JS) */
+.filters input[type="search"]:not(:placeholder-shown) {
+  background: var(--primary-lighter);
+  border-color: var(--primary);
 }
 
 .filters input[type="search"]:focus,

--- a/app/static/js/input_filtro.js
+++ b/app/static/js/input_filtro.js
@@ -1,0 +1,125 @@
+/**
+ * InputFiltro — campo de texto para filtros con icono de lupa y estado activo
+ *
+ * Compañero de SelectorFiltro para filtros de texto. Compatible con
+ * FiltrosListado (requiere v2-filtros.js ≥ 2.2): el input interno
+ * (.if-input) es detectado y gestionado automáticamente.
+ *
+ * FICHEROS:
+ *   app/static/js/input_filtro.js
+ *   app/static/css/input_filtro.css
+ *
+ * USO:
+ *   new InputFiltro('#mi-div', {
+ *     placeholder: 'Filtrar por NIF...',
+ *     name: 'nif',                       // name del <input> para lectura en JS
+ *     onChange: (v) => {}                // opcional — llamado en cada tecla
+ *   });
+ *
+ * API PÚBLICA:
+ *   .getValue()     → string con el valor actual o ''
+ *   .setValue(v)    → establece el valor programáticamente (dispara onChange)
+ *   .clear()        → limpia el campo (dispara onChange con '')
+ *   .enable() / .disable()
+ *
+ * NOTA INTERNA:
+ *   El <input> expone ._ifInstance apuntando a esta instancia para que
+ *   FiltrosListado pueda actualizar el estado visual en _limpiar() sin
+ *   disparar eventos extra.
+ *
+ * VERSIÓN: 1.0
+ */
+class InputFiltro {
+    constructor(selector, config = {}) {
+        this._wrap = typeof selector === 'string'
+            ? document.querySelector(selector)
+            : selector;
+        if (!this._wrap) {
+            console.error('InputFiltro: elemento no encontrado', selector);
+            return;
+        }
+
+        this._placeholder = config.placeholder || 'Filtrar...';
+        this._name        = config.name        || '';
+        this._onChange    = config.onChange    || null;
+
+        this._build();
+        this._bindEvents();
+    }
+
+    _build() {
+        this._wrap.className = 'if-wrap';
+
+        // Icono lupa — decorativo, no interactivo
+        this._icon = document.createElement('span');
+        this._icon.className = 'if-icon';
+        this._icon.setAttribute('aria-hidden', 'true');
+        this._icon.innerHTML = '<i class="fas fa-search"></i>';
+
+        this._input = document.createElement('input');
+        this._input.type = 'text';
+        this._input.className = 'if-input';
+        this._input.placeholder = this._placeholder;
+        this._input.autocomplete = 'off';
+        if (this._name) this._input.name = this._name;
+
+        this._btnX = document.createElement('button');
+        this._btnX.type = 'button';
+        this._btnX.className = 'if-btn-x';
+        this._btnX.tabIndex = -1;
+        this._btnX.textContent = '×';
+        this._btnX.setAttribute('aria-label', 'Limpiar filtro');
+
+        this._wrap.appendChild(this._icon);
+        this._wrap.appendChild(this._input);
+        this._wrap.appendChild(this._btnX);
+
+        // Referencia inversa para que FiltrosListado pueda llamar _actualizarEstado()
+        this._input._ifInstance = this;
+
+        this._actualizarEstado();
+    }
+
+    _bindEvents() {
+        this._input.addEventListener('input', () => {
+            this._actualizarEstado();
+            if (this._onChange) this._onChange(this._input.value);
+        });
+
+        this._btnX.addEventListener('mousedown', e => e.preventDefault());
+        this._btnX.addEventListener('click', () => this.clear());
+    }
+
+    _actualizarEstado() {
+        this._wrap.classList.toggle('if-activo', !!this._input.value.trim());
+    }
+
+    getValue() {
+        return this._input.value;
+    }
+
+    setValue(v) {
+        this._input.value = v;
+        this._actualizarEstado();
+        if (this._onChange) this._onChange(v);
+    }
+
+    clear() {
+        this._input.value = '';
+        this._actualizarEstado();
+        this._input.focus();
+        if (this._onChange) this._onChange('');
+        // Notifica a FiltrosListado igual que haría un cambio manual del usuario
+        this._input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    enable() {
+        this._input.disabled = false;
+        this._wrap.classList.remove('if-disabled');
+    }
+
+    disable() {
+        this._input.disabled = true;
+        this._wrap.classList.add('if-disabled');
+    }
+}

--- a/app/static/js/selector_filtro.js
+++ b/app/static/js/selector_filtro.js
@@ -1,0 +1,152 @@
+/**
+ * SelectorFiltro — selector de filtro con etiqueta contextual y estado activo
+ *
+ * Wrapper sobre un <select> nativo. Compatible con FiltrosListado sin
+ * configuración adicional: el <select> interno es detectado automáticamente
+ * al estar dentro de .filters-row.
+ *
+ * FICHEROS:
+ *   app/static/js/selector_filtro.js
+ *   app/static/css/selector_filtro.css
+ *
+ * USO:
+ *   new SelectorFiltro('#mi-div', opciones, {
+ *     label: 'Tipo expediente',       // → muestra "Tipo expediente (todos)" vacío
+ *     name: 'tipo_expediente_id',     // name del <select> para que FiltrosListado lo lea
+ *     onChange: (v, t) => {}          // opcional
+ *   });
+ *
+ *   El array opciones tiene la forma [{ v: 'valor', t: 'texto visible' }, ...]
+ *
+ * API PÚBLICA:
+ *   .getValue()           → valor seleccionado o ''
+ *   .setValue(v)          → selecciona programáticamente (dispara onChange)
+ *   .clear()              → vuelve al estado "todos" (dispara onChange con v='')
+ *   .setOpciones(nuevas)  → reemplaza opciones sin disparar onChange
+ *   .enable() / .disable()
+ *
+ * NOTA INTERNA:
+ *   El <select> expone ._sfInstance apuntando a esta instancia para que
+ *   FiltrosListado pueda actualizar el estado visual en _limpiar() sin
+ *   disparar eventos extra.
+ *
+ * VERSIÓN: 1.0
+ */
+class SelectorFiltro {
+    constructor(selector, opciones, config = {}) {
+        this._wrap = typeof selector === 'string'
+            ? document.querySelector(selector)
+            : selector;
+        if (!this._wrap) {
+            console.error('SelectorFiltro: elemento no encontrado', selector);
+            return;
+        }
+
+        this._opciones = opciones || [];
+        this._label    = config.label    || 'Seleccione';
+        this._name     = config.name     || '';
+        this._onChange = config.onChange || null;
+
+        this._build();
+        this._bindEvents();
+    }
+
+    _build() {
+        this._wrap.className = 'sf-wrap';
+
+        this._select = document.createElement('select');
+        this._select.className = 'sf-select';
+        if (this._name) this._select.name = this._name;
+
+        // Primera opción: el estado "sin filtro"
+        const optTodos = document.createElement('option');
+        optTodos.value = '';
+        optTodos.textContent = `${this._label} (todos)`;
+        this._select.appendChild(optTodos);
+
+        this._opciones.forEach(op => {
+            const opt = document.createElement('option');
+            opt.value       = op.v;
+            opt.textContent = op.t;
+            this._select.appendChild(opt);
+        });
+
+        this._btnX = document.createElement('button');
+        this._btnX.type = 'button';
+        this._btnX.className = 'sf-btn-x';
+        this._btnX.tabIndex = -1;
+        this._btnX.textContent = '×';
+        this._btnX.setAttribute('aria-label', 'Limpiar filtro');
+
+        this._wrap.appendChild(this._select);
+        this._wrap.appendChild(this._btnX);
+
+        // Referencia inversa para que FiltrosListado pueda llamar _actualizarEstado()
+        this._select._sfInstance = this;
+
+        this._actualizarEstado();
+    }
+
+    _bindEvents() {
+        this._select.addEventListener('change', () => {
+            this._actualizarEstado();
+            if (this._onChange) {
+                const idx = this._select.selectedIndex;
+                this._onChange(this._select.value, this._select.options[idx]?.text || '');
+            }
+        });
+
+        // mousedown + preventDefault evita que el blur del select dispare antes de procesar
+        this._btnX.addEventListener('mousedown', e => e.preventDefault());
+        this._btnX.addEventListener('click', () => this.clear());
+    }
+
+    _actualizarEstado() {
+        this._wrap.classList.toggle('sf-activo', !!this._select.value);
+    }
+
+    getValue() {
+        return this._select.value;
+    }
+
+    setValue(v) {
+        this._select.value = v;
+        this._actualizarEstado();
+        if (this._onChange) {
+            const idx = this._select.selectedIndex;
+            this._onChange(v, this._select.options[idx]?.text || '');
+        }
+    }
+
+    clear() {
+        this._select.value = '';
+        this._actualizarEstado();
+        this._select.focus();
+        if (this._onChange) this._onChange('', '');
+        // Notifica a FiltrosListado igual que haría un cambio manual del usuario
+        this._select.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    setOpciones(nuevas) {
+        // Mantener solo la primera opción ("todos") y sustituir el resto
+        while (this._select.options.length > 1) this._select.remove(1);
+        nuevas.forEach(op => {
+            const opt = document.createElement('option');
+            opt.value       = op.v;
+            opt.textContent = op.t;
+            this._select.appendChild(opt);
+        });
+        this._select.value = '';
+        this._actualizarEstado();
+    }
+
+    enable() {
+        this._select.disabled = false;
+        this._wrap.classList.remove('sf-disabled');
+    }
+
+    disable() {
+        this._select.disabled = true;
+        this._wrap.classList.add('sf-disabled');
+    }
+}

--- a/app/static/js/v2-filtros.js
+++ b/app/static/js/v2-filtros.js
@@ -1,8 +1,9 @@
 /**
  * FiltrosListado — filtrado con debounce para listados V2
  *
- * Debounce automático en el input de búsqueda. Los selects disparan
- * recarga inmediata. btn-filtrar es opcional (dispara recarga manual).
+ * Debounce automático en el input de búsqueda y en los InputFiltro (.if-input).
+ * Los selects (incluidos los de SelectorFiltro) disparan recarga inmediata.
+ * btn-filtrar es opcional (dispara recarga manual).
  * btn-limpiar vacía todos los campos y recarga.
  * El icono .filtro-indicador se activa (verde) cuando hay filtros activos.
  *
@@ -10,7 +11,12 @@
  *   const filtros = new FiltrosListado(scrollInfinitoInstance);
  *   const filtros = new FiltrosListado(scrollInfinitoInstance, { delay: 300 });
  *
- * VERSIÓN: 2.1 — indicador de filtros activos (#206)
+ * COMPONENTES COMPATIBLES (detección automática en .filters-row):
+ *   - input[type="search"]  — buscador principal (debounce)
+ *   - select / .sf-select   — SelectorFiltro y selects nativos (inmediato)
+ *   - .if-input             — InputFiltro (debounce)
+ *
+ * VERSIÓN: 2.2 — soporte SelectorFiltro e InputFiltro
  */
 
 class FiltrosListado {
@@ -25,18 +31,21 @@ class FiltrosListado {
 
         this.searchInput  = document.querySelector('input[type="search"]');
         this.selects      = document.querySelectorAll('.filters-row select');
+        this.inputsFiltro = document.querySelectorAll('.filters-row .if-input');
         this.btnFiltrar   = document.querySelector('.btn-filtrar');
         this.btnLimpiar   = document.querySelector('.btn-limpiar');
         this._filtersRow  = document.querySelector('.filters-row');
 
-        this._timer = null;
+        this._timer     = null;
+        this._limpiando = false;   // suprime recargas durante _limpiar()
         this._init();
     }
 
     _init() {
-        // Debounce en campo de búsqueda
+        // Debounce en campo de búsqueda principal
         if (this.searchInput) {
             this.searchInput.addEventListener('input', () => {
+                if (this._limpiando) return;
                 clearTimeout(this._timer);
                 this._timer = setTimeout(() => {
                     this.scroll.reload();
@@ -45,11 +54,24 @@ class FiltrosListado {
             });
         }
 
-        // Selects: recarga inmediata al cambiar
+        // Selects (nativos y SelectorFiltro): recarga inmediata al cambiar
         this.selects.forEach(sel => {
             sel.addEventListener('change', () => {
+                if (this._limpiando) return;
                 this.scroll.reload();
                 this._actualizarIndicador();
+            });
+        });
+
+        // InputFiltro (.if-input): debounce igual que el buscador principal
+        this.inputsFiltro.forEach(inp => {
+            inp.addEventListener('input', () => {
+                if (this._limpiando) return;
+                clearTimeout(this._timer);
+                this._timer = setTimeout(() => {
+                    this.scroll.reload();
+                    this._actualizarIndicador();
+                }, this.delay);
             });
         });
 
@@ -75,14 +97,30 @@ class FiltrosListado {
     _actualizarIndicador() {
         if (!this._filtersRow) return;
         const hayFiltros = (this.searchInput && this.searchInput.value.trim())
-            || Array.from(this.selects).some(s => s.value);
+            || Array.from(this.selects).some(s => s.value)
+            || Array.from(this.inputsFiltro).some(inp => inp.value.trim());
         this._filtersRow.classList.toggle('filtros-activos', !!hayFiltros);
         if (this.btnLimpiar) this.btnLimpiar.disabled = !hayFiltros;
     }
 
     _limpiar() {
+        this._limpiando = true;
         if (this.searchInput) this.searchInput.value = '';
-        this.selects.forEach(sel => { sel.selectedIndex = 0; });
+
+        // Delegar en .clear() de SelectorFiltro (actualiza CSS + dispara change suprimido)
+        // o resetear directamente si es un select nativo sin instancia
+        this.selects.forEach(sel => {
+            if (sel._sfInstance) sel._sfInstance.clear();
+            else sel.selectedIndex = 0;
+        });
+
+        // Igual para InputFiltro
+        this.inputsFiltro.forEach(inp => {
+            if (inp._ifInstance) inp._ifInstance.clear();
+            else inp.value = '';
+        });
+
+        this._limpiando = false;
         clearTimeout(this._timer);
         this._actualizarIndicador();
         this.scroll.reload();

--- a/app/templates/layout/lista_v2_base.html
+++ b/app/templates/layout/lista_v2_base.html
@@ -138,9 +138,16 @@
 
 {% endblock %}
 
+{% block extra_css %}{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/selector_filtro.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/input_filtro.css') }}">
+{% endblock %}
+
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/v2-scroll-infinito.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v2-filtros.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v2-tabla-scroll-to-top.js') }}"></script>
+<script src="{{ url_for('static', filename='js/selector_filtro.js') }}"></script>
+<script src="{{ url_for('static', filename='js/input_filtro.js') }}"></script>
 {# Cada template hijo añade aquí su inicialización de ScrollInfinito con {{ super() }} #}
 {% endblock %}

--- a/docs/GUIA_COMPONENTES_INTERACTIVOS.md
+++ b/docs/GUIA_COMPONENTES_INTERACTIVOS.md
@@ -339,6 +339,182 @@ mostrar_toast('info',    'Ruta copiada al portapapeles.');
 
 ---
 
+---
+
+### SelectorFiltro
+
+Selector de filtro con etiqueta contextual y estado activo visual. Diseñado para
+usarse en la barra de filtros de los listados V2. Internamente usa un `<select>` nativo,
+por lo que `FiltrosListado` lo detecta y gestiona automáticamente.
+
+**Ficheros:**
+- `app/static/js/selector_filtro.js`
+- `app/static/css/selector_filtro.css`
+
+Cargados automáticamente en `lista_v2_base.html` — no hace falta incluirlos manualmente
+en templates que extiendan ese base.
+
+#### Uso en Jinja2
+
+```html
+{# En el bloque filtros_extra del template de listado #}
+{% block filtros_extra %}
+<div id="sf-tipo-exp"></div>
+{% endblock %}
+
+{% block extra_js %}
+{{ super() }}
+<script>
+  new SelectorFiltro('#sf-tipo-exp', {{ tipos_exp | tojson }}, {
+    label: 'Tipo expediente',
+    name: 'tipo_expediente_id'
+  });
+  const scrollInfinito = new ScrollInfinito({ ... });
+  const filtros = new FiltrosListado(scrollInfinito);
+</script>
+{% endblock %}
+```
+
+El array de opciones tiene la forma `[{ "v": "valor", "t": "texto visible" }, ...]`.
+
+#### Config
+
+| Opción | Tipo | Descripción |
+|---|---|---|
+| `label` | string | Texto de la etiqueta. El placeholder será `"Label (todos)"`. |
+| `name` | string | Atributo `name` del `<select>` nativo interno |
+| `onChange` | `(v, t) => {}` | Callback al seleccionar o limpiar. `v` = valor, `t` = texto. Se llama con `('', '')` al limpiar. |
+
+#### API pública
+
+```javascript
+const sf = new SelectorFiltro('#mi-div', opciones, config);
+
+sf.getValue()               // → valor seleccionado o ''
+sf.setValue('3')            // selecciona programáticamente (dispara onChange)
+sf.clear()                  // vuelve al estado "todos" (dispara onChange)
+sf.setOpciones(nuevas)      // reemplaza opciones y limpia — sin disparar onChange
+sf.enable() / sf.disable()
+```
+
+#### Comportamiento
+
+| Estado | Apariencia |
+|---|---|
+| Sin filtro | Fondo blanco, texto `"Label (todos)"`, sin botón × |
+| Con filtro | Fondo `var(--primary-lighter)` (#f7fbf8, verde muy claro — igual que hover de fila de tabla), borde `var(--primary)`, botón × visible |
+| Clic en × | Limpia la selección, devuelve el foco al select, dispara recarga del listado |
+| Btn Limpiar (FiltrosListado) | Resetea el select y actualiza el estado visual |
+
+#### Notas de implementación
+
+- El color de fondo activo se aplica al **wrapper** `.sf-wrap` (div), **no** al `<select>`.
+  El select usa `background: transparent` para que el dropdown nativo no herede el tinte verde.
+- El focus ring usa `outline` en vez de `box-shadow` para que se recalcule automáticamente
+  si el selector cambia de tamaño al elegir una opción más larga. Pendiente #268: el outline
+  desaparece al aparecer el botón `×`.
+- `clear()` despacha un evento `change` con `bubbles:true` para que `FiltrosListado` recargue
+  el listado, igual que haría una selección manual del usuario.
+- `FiltrosListado._limpiar()` usa el flag `_limpiando` para suprimir los eventos de cambio
+  durante el reset masivo y evitar recargas múltiples.
+
+#### Estructura HTML generada
+
+```html
+<div id="mi-div" class="sf-wrap [sf-activo]">
+  <select class="sf-select" name="tipo_expediente_id">
+    <option value="">Tipo expediente (todos)</option>
+    <option value="1">Legalización</option>
+    ...
+  </select>
+  <button class="sf-btn-x" tabindex="-1">×</button>
+</div>
+```
+
+---
+
+---
+
+### InputFiltro
+
+Campo de texto para filtros con icono de lupa y estado activo visual. Compañero de
+`SelectorFiltro`. Compatible con `FiltrosListado` (v2.2+): los inputs `.if-input`
+se detectan automáticamente y se gestionan con debounce.
+
+**Ficheros:**
+- `app/static/js/input_filtro.js`
+- `app/static/css/input_filtro.css`
+
+Cargados automáticamente en `lista_v2_base.html`.
+
+#### Uso en Jinja2
+
+```html
+{% block filtros_extra %}
+<div id="if-nif"></div>
+{% endblock %}
+
+{% block extra_js %}
+{{ super() }}
+<script>
+  new InputFiltro('#if-nif', {
+    placeholder: 'Filtrar por NIF...',
+    name: 'nif'
+  });
+  const scrollInfinito = new ScrollInfinito({ ... });
+  const filtros = new FiltrosListado(scrollInfinito);
+</script>
+{% endblock %}
+```
+
+#### Config
+
+| Opción | Tipo | Descripción |
+|---|---|---|
+| `placeholder` | string | Texto de ayuda mostrado en el input |
+| `name` | string | Atributo `name` del `<input>` interno |
+| `onChange` | `(v) => {}` | Callback en cada pulsación de tecla. `v` = valor actual. |
+
+#### API pública
+
+```javascript
+const inf = new InputFiltro('#mi-div', config);
+
+inf.getValue()          // → string con el valor actual o ''
+inf.setValue('12345')   // establece el valor (dispara onChange)
+inf.clear()             // limpia el campo (dispara onChange con '')
+inf.enable() / inf.disable()
+```
+
+#### Comportamiento
+
+| Estado | Apariencia |
+|---|---|
+| Vacío | Fondo blanco, icono lupa gris (`var(--text-secondary)`), sin botón × |
+| Con texto | Fondo `var(--primary-lighter)` (#f7fbf8, igual que `SelectorFiltro` y hover de fila), borde `var(--primary)`, lupa verde (`var(--primary)`), botón × visible |
+| Clic en × | Limpia el campo, devuelve el foco al input, dispara recarga del listado |
+| Btn Limpiar (FiltrosListado) | Vacía el input y actualiza el estado visual |
+
+#### Notas de implementación
+
+- El buscador principal (`input[type="search"]` en `lista_v2_base.html`) también muestra
+  estado activo con el mismo color, pero vía CSS puro: `.filters input[type="search"]:not(:placeholder-shown)`.
+  No requiere componente JS.
+- `clear()` despacha un evento `input` con `bubbles:true` para que `FiltrosListado`
+  inicie su debounce y recargue el listado.
+
+#### Estructura HTML generada
+
+```html
+<div id="mi-div" class="if-wrap [if-activo]">
+  <span class="if-icon" aria-hidden="true"><i class="fas fa-search"></i></span>
+  <input type="text" class="if-input" placeholder="Filtrar por NIF...">
+  <button class="if-btn-x" tabindex="-1">×</button>
+</div>
+```
+
+---
+
 ## Próximos componentes (pendientes)
 
 - `SelectorMultiple` — selección acumulable con badges (variante del anterior)


### PR DESCRIPTION
## Summary

- Nuevos componentes `SelectorFiltro` e `InputFiltro` para la barra de filtros de listados V2
- `FiltrosListado` v2.2 con soporte automático para ambos componentes
- Migración de seguimiento y listado de expedientes a los nuevos componentes
- Estado activo visual consistente en todos los controles de filtro (borde + fondo verde claro)

## Cambios

**Nuevos ficheros:**
- `app/static/js/selector_filtro.js` — wrapper sobre `<select>` nativo con placeholder contextual y estado activo
- `app/static/css/selector_filtro.css`
- `app/static/js/input_filtro.js` — campo de texto con lupa y estado activo
- `app/static/css/input_filtro.css`

**Modificados:**
- `app/static/js/v2-filtros.js` — v2.2: detecta `.if-input`, flag `_limpiando`, delega `.clear()` en instancias
- `app/templates/layout/lista_v2_base.html` — carga automática de los nuevos componentes
- `app/modules/expedientes/templates/expedientes/seguimiento.html` — 4 filtros migrados + `FiltrosSeguimiento` para defaults obligatorios
- `app/modules/expedientes/templates/expedientes/listado_v2.html` — filtro estado migrado
- `app/static/css/v2-components.css` — estado activo del buscador vía `:not(:placeholder-shown)`
- `docs/GUIA_COMPONENTES_INTERACTIVOS.md` — documentación de `SelectorFiltro` e `InputFiltro`

## Pendiente

- Fixes #268: focus ring del `SelectorFiltro` desaparece al aparecer el botón `×`

## Test plan

- [ ] Seguimiento: filtros muestran estado activo (verde claro) al seleccionar
- [ ] Seguimiento: `×` en cualquier filtro recarga el listado inmediatamente
- [ ] Seguimiento: Btn Limpiar deshabilitado en estado default (ver=mis + estado=EN_TRAMITE)
- [ ] Seguimiento: Btn Limpiar restaura defaults, no deja selectores en blanco
- [ ] Listado expedientes: filtro Estado funciona con SelectorFiltro
- [ ] Buscador principal: fondo verde claro al tener texto
- [ ] Ver (todos) en seguimiento muestra todos los expedientes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
