### PR TITLE
Migrar filtros de entidades y proyectos a SelectorFiltro

### DIFF
--- a/app/modules/entidades/templates/entidades/index.html
+++ b/app/modules/entidades/templates/entidades/index.html
@@ -13,11 +13,7 @@
 {% endblock %}
 
 {% block filtros_extra %}
-<select aria-label="Filtrar por estado">
-    <option value="">Activo: Todos</option>
-    <option value="true">Activas</option>
-    <option value="false">Inactivas</option>
-</select>
+<div id="sf-activo"></div>
 {% endblock %}
 
 {% block tabla_clase %}entidades-table{% endblock %}
@@ -25,6 +21,11 @@
 {% block extra_js %}
 {{ super() }}
 <script>
+    new SelectorFiltro('#sf-activo', [
+        { v: 'true',  t: 'Activas'   },
+        { v: 'false', t: 'Inactivas' }
+    ], { label: 'Activo', name: 'activo' });
+
     const scrollInfinito = new ScrollInfinito({
         apiUrl:      '{{ url_for("api_entidades.listar_entidades") }}',
         tableClass:  '.entidades-table',

--- a/app/modules/proyectos/routes.py
+++ b/app/modules/proyectos/routes.py
@@ -34,7 +34,7 @@ bp = Blueprint('proyectos', __name__,
 def index():
     """Vista listado de proyectos. Pasa tipos_ia para poblar el filtro."""
     tipos_ia = TipoIA.query.order_by(TipoIA.siglas).all()
-    tipos_ia_opts = [{"v": str(ia.id), "t": f"{ia.siglas} — {ia.nombre}"} for ia in tipos_ia]
+    tipos_ia_opts = [{"v": str(ia.id), "t": f"{ia.siglas} — {ia.descripcion}"} for ia in tipos_ia]
     meta = cargar_metadata('proyectos')
     columns = meta.get('listado_v2', {}).get('columns', [])
     return render_template('proyectos/index.html',

--- a/app/modules/proyectos/routes.py
+++ b/app/modules/proyectos/routes.py
@@ -34,9 +34,11 @@ bp = Blueprint('proyectos', __name__,
 def index():
     """Vista listado de proyectos. Pasa tipos_ia para poblar el filtro."""
     tipos_ia = TipoIA.query.order_by(TipoIA.siglas).all()
+    tipos_ia_opts = [{"v": str(ia.id), "t": f"{ia.siglas} — {ia.nombre}"} for ia in tipos_ia]
     meta = cargar_metadata('proyectos')
     columns = meta.get('listado_v2', {}).get('columns', [])
-    return render_template('proyectos/index.html', tipos_ia=tipos_ia, columns=columns)
+    return render_template('proyectos/index.html',
+                           tipos_ia_opts=tipos_ia_opts, columns=columns)
 
 
 # =============================================================================

--- a/app/modules/proyectos/templates/proyectos/index.html
+++ b/app/modules/proyectos/templates/proyectos/index.html
@@ -6,12 +6,7 @@
 {% block search_placeholder %}Buscar por título o número AT...{% endblock %}
 
 {% block filtros_extra %}
-<select id="filtro-tipo-ia" aria-label="Filtrar por instrumento ambiental">
-    <option value="">Instr. ambiental: Todos</option>
-    {% for ia in tipos_ia %}
-    <option value="{{ ia.id }}">{{ ia.siglas }} — {{ ia.nombre }}</option>
-    {% endfor %}
-</select>
+<div id="sf-tipo-ia"></div>
 {% endblock %}
 
 {% block tabla_clase %}proyectos-table{% endblock %}
@@ -19,6 +14,11 @@
 {% block extra_js %}
 {{ super() }}
 <script>
+    new SelectorFiltro('#sf-tipo-ia', {{ tipos_ia_opts | tojson }}, {
+        label: 'Instr. ambiental',
+        name:  'tipo_ia'
+    });
+
     const scrollInfinito = new ScrollInfinito({
         apiUrl:      '{{ url_for("api_proyectos.listar_proyectos") }}',
         tableClass:  '.proyectos-table',
@@ -27,7 +27,7 @@
         columns:     {{ columns | tojson }}
     });
 
-    // ScrollInfinito lee el primer select de .filters-row como parámetro 'estado'.
+    // ScrollInfinito lee el primer select de .filters-row y lo envía como 'estado'.
     // La API de proyectos acepta 'estado' como alias de 'tipo_ia'.
     const filtros = new FiltrosListado(scrollInfinito);
 </script>

--- a/docs/GUIA_COMPONENTES_INTERACTIVOS.md
+++ b/docs/GUIA_COMPONENTES_INTERACTIVOS.md
@@ -32,6 +32,92 @@ Complementa `GUIA_VISTAS_BOOTSTRAP.md` (que cubre layout y vistas).
 
 ---
 
+## Toasts programáticos
+
+Sistema de notificaciones para uso desde JavaScript. Definido en `app/static/css/custom.css`
+y el contenedor vive en `app/templates/layout/base_fullwidth.html`.
+
+**No confundir con los flash messages de Flask**, que se inyectan en Jinja al renderizar
+la página. Los toasts programáticos se muestran como respuesta a acciones AJAX ya resueltas.
+
+### CSS (custom.css)
+
+Cuatro clases disponibles: `.toast-success`, `.toast-danger`, `.toast-warning`, `.toast-info`.
+Cada una aplica color de fondo sutil, texto oscuro y un botón de cierre con el filtro de color
+correspondiente. Sobreescribe el estilo base de Bootstrap.
+
+### Estructura HTML
+
+```html
+<div class="toast toast-success" role="alert"
+     aria-live="assertive" aria-atomic="true"
+     data-bs-autohide="true" data-bs-delay="5000">
+  <div class="d-flex align-items-center p-3">
+    <div class="flex-grow-1">
+      <i class="fas fa-check-circle me-2"></i>
+      <strong>Correcto:</strong> El mensaje aquí.
+    </div>
+    <button type="button" class="btn-close ms-3"
+            data-bs-dismiss="toast" aria-label="Cerrar"></button>
+  </div>
+</div>
+```
+
+| Tipo | Clase | Icono FA | Etiqueta |
+|------|-------|----------|----------|
+| `success` | `.toast-success` | `fa-check-circle` | Correcto |
+| `danger` | `.toast-danger` | `fa-exclamation-circle` | Error |
+| `warning` | `.toast-warning` | `fa-exclamation-triangle` | Atención |
+| `info` | `.toast-info` | `fa-info-circle` | Información |
+
+### Función JS reutilizable
+
+Copiar esta función en cualquier `<script>` que necesite mostrar toasts.
+Inyecta el elemento en el `.toast-container` ya presente en el base template
+y replica el ciclo de vida (clases `showing`/`hide`, autodestrucción).
+
+```javascript
+function mostrar_toast(tipo, mensaje) {
+  var iconos    = { success: 'fa-check-circle', danger: 'fa-exclamation-circle',
+                    warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
+  var etiquetas = { success: 'Correcto', danger: 'Error',
+                    warning: 'Atención',  info: 'Información' };
+  var id   = 'toast-js-' + Date.now();
+  var html =
+    '<div id="' + id + '" class="toast toast-' + tipo + '" role="alert"' +
+    ' aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">' +
+    '<div class="d-flex align-items-center p-3"><div class="flex-grow-1">' +
+    '<i class="fas ' + (iconos[tipo] || iconos.info) + ' me-2"></i>' +
+    '<strong>' + (etiquetas[tipo] || 'Aviso') + ':</strong> ' + mensaje +
+    '</div><button type="button" class="btn-close ms-3"' +
+    ' data-bs-dismiss="toast" aria-label="Cerrar"></button></div></div>';
+
+  var container = document.querySelector('.toast-container');
+  container.insertAdjacentHTML('beforeend', html);
+  var el = document.getElementById(id);
+  el.classList.add('showing');
+  var t = new bootstrap.Toast(el);
+  t.show();
+  setTimeout(function () { el.classList.remove('showing'); }, 300);
+  el.addEventListener('hide.bs.toast', function () { el.classList.add('hide'); });
+  el.addEventListener('click', function (e) {
+    if (!e.target.closest('.btn-close')) { t.hide(); }
+  });
+  el.addEventListener('hidden.bs.toast', function () { el.remove(); });
+}
+```
+
+### Uso
+
+```javascript
+mostrar_toast('success', 'Cambios guardados correctamente.');
+mostrar_toast('danger',  'Error al conectar con el servidor.');
+mostrar_toast('warning', 'El documento no tiene fecha administrativa.');
+mostrar_toast('info',    'Ruta copiada al portapapeles.');
+```
+
+---
+
 ## Catálogo
 
 ### SelectorBusqueda
@@ -173,8 +259,6 @@ fetch('/api/provincias')
 
 ---
 
----
-
 ### EntradaFecha
 
 Campo de texto con parser inteligente de fechas. Acepta formatos abreviados y normaliza
@@ -251,96 +335,6 @@ ef.disable()
 
 ---
 
----
-
-## Toasts programáticos
-
-Sistema de notificaciones para uso desde JavaScript. Definido en `app/static/css/custom.css`
-y el contenedor vive en `app/templates/layout/base_fullwidth.html`.
-
-**No confundir con los flash messages de Flask**, que se inyectan en Jinja al renderizar
-la página. Los toasts programáticos se muestran como respuesta a acciones AJAX ya resueltas.
-
-### CSS (custom.css)
-
-Cuatro clases disponibles: `.toast-success`, `.toast-danger`, `.toast-warning`, `.toast-info`.
-Cada una aplica color de fondo sutil, texto oscuro y un botón de cierre con el filtro de color
-correspondiente. Sobreescribe el estilo base de Bootstrap.
-
-### Estructura HTML
-
-```html
-<div class="toast toast-success" role="alert"
-     aria-live="assertive" aria-atomic="true"
-     data-bs-autohide="true" data-bs-delay="5000">
-  <div class="d-flex align-items-center p-3">
-    <div class="flex-grow-1">
-      <i class="fas fa-check-circle me-2"></i>
-      <strong>Correcto:</strong> El mensaje aquí.
-    </div>
-    <button type="button" class="btn-close ms-3"
-            data-bs-dismiss="toast" aria-label="Cerrar"></button>
-  </div>
-</div>
-```
-
-| Tipo | Clase | Icono FA | Etiqueta |
-|------|-------|----------|----------|
-| `success` | `.toast-success` | `fa-check-circle` | Correcto |
-| `danger` | `.toast-danger` | `fa-exclamation-circle` | Error |
-| `warning` | `.toast-warning` | `fa-exclamation-triangle` | Atención |
-| `info` | `.toast-info` | `fa-info-circle` | Información |
-
-### Función JS reutilizable
-
-Copiar esta función en cualquier `<script>` que necesite mostrar toasts.
-Inyecta el elemento en el `.toast-container` ya presente en el base template
-y replica el ciclo de vida (clases `showing`/`hide`, autodestrucción).
-
-```javascript
-function mostrar_toast(tipo, mensaje) {
-  var iconos    = { success: 'fa-check-circle', danger: 'fa-exclamation-circle',
-                    warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
-  var etiquetas = { success: 'Correcto', danger: 'Error',
-                    warning: 'Atención',  info: 'Información' };
-  var id   = 'toast-js-' + Date.now();
-  var html =
-    '<div id="' + id + '" class="toast toast-' + tipo + '" role="alert"' +
-    ' aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="5000">' +
-    '<div class="d-flex align-items-center p-3"><div class="flex-grow-1">' +
-    '<i class="fas ' + (iconos[tipo] || iconos.info) + ' me-2"></i>' +
-    '<strong>' + (etiquetas[tipo] || 'Aviso') + ':</strong> ' + mensaje +
-    '</div><button type="button" class="btn-close ms-3"' +
-    ' data-bs-dismiss="toast" aria-label="Cerrar"></button></div></div>';
-
-  var container = document.querySelector('.toast-container');
-  container.insertAdjacentHTML('beforeend', html);
-  var el = document.getElementById(id);
-  el.classList.add('showing');
-  var t = new bootstrap.Toast(el);
-  t.show();
-  setTimeout(function () { el.classList.remove('showing'); }, 300);
-  el.addEventListener('hide.bs.toast', function () { el.classList.add('hide'); });
-  el.addEventListener('click', function (e) {
-    if (!e.target.closest('.btn-close')) { t.hide(); }
-  });
-  el.addEventListener('hidden.bs.toast', function () { el.remove(); });
-}
-```
-
-### Uso
-
-```javascript
-mostrar_toast('success', 'Cambios guardados correctamente.');
-mostrar_toast('danger',  'Error al conectar con el servidor.');
-mostrar_toast('warning', 'El documento no tiene fecha administrativa.');
-mostrar_toast('info',    'Ruta copiada al portapapeles.');
-```
-
----
-
----
-
 ### SelectorFiltro
 
 Selector de filtro con etiqueta contextual y estado activo visual. Diseñado para
@@ -410,9 +404,8 @@ sf.enable() / sf.disable()
 
 - El color de fondo activo se aplica al **wrapper** `.sf-wrap` (div), **no** al `<select>`.
   El select usa `background: transparent` para que el dropdown nativo no herede el tinte verde.
-- El focus ring usa `outline` en vez de `box-shadow` para que se recalcule automáticamente
-  si el selector cambia de tamaño al elegir una opción más larga. Pendiente #268: el outline
-  desaparece al aparecer el botón `×`.
+- El focus ring usa `:focus-within` en el wrapper en vez de `outline` en el `<select>`:
+  el wrapper no sufre el layout shift al aparecer el botón `×` (fix #268).
 - `clear()` despacha un evento `change` con `bubbles:true` para que `FiltrosListado` recargue
   el listado, igual que haría una selección manual del usuario.
 - `FiltrosListado._limpiar()` usa el flag `_limpiando` para suprimir los eventos de cambio
@@ -430,8 +423,6 @@ sf.enable() / sf.disable()
   <button class="sf-btn-x" tabindex="-1">×</button>
 </div>
 ```
-
----
 
 ---
 


### PR DESCRIPTION
## Cambios

- Migrar filtro de entidades (`/entidades/`) de `<select>` nativo a `SelectorFiltro` con opciones estáticas (Activas/Inactivas)
- Migrar filtro de proyectos (`/proyectos/`) de `<select>` nativo a `SelectorFiltro` con opciones dinámicas
- Añadir `tipos_ia_opts` en `proyectos/routes.py` formateado como `[{v, t}]` para `tojson`
- Fix: usar `ia.descripcion` en lugar de `ia.nombre` (atributo inexistente en `TipoIA`)
- Reorganizar `GUIA_COMPONENTES_INTERACTIVOS.md`: mover `## Toasts programáticos` antes de `## Catálogo`, eliminar dobles separadores y actualizar nota de fix #268
