### PR TITLE
Dashboard: Mis Expedientes filtra por responsable, Tareas activa

### DIFF
--- a/app/modules/expedientes/templates/expedientes/listado_v2.html
+++ b/app/modules/expedientes/templates/expedientes/listado_v2.html
@@ -72,7 +72,10 @@
         tableClass:  '.expedientes-table',
         entityLabel: 'expedientes',
         detailUrl:   id => `/expedientes/${id}/tramitacion`,
-        columns
+        columns,
+        {% if request.args.get('responsable') %}
+        fixedParams: { responsable: '{{ request.args.get("responsable") }}' }
+        {% endif %}
     });
 
     const filtros = new FiltrosListado(scrollInfinito);

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -11,7 +11,7 @@ CAMBIOS v2.1: Añadido campo 'codigo' ("AT-{numero_at}") a serialización del li
 """
 
 from flask import Blueprint, request, jsonify, url_for
-from flask_login import login_required
+from flask_login import login_required, current_user
 from sqlalchemy.orm import joinedload
 from sqlalchemy import func, or_
 from app import db
@@ -95,6 +95,7 @@ def listar_expedientes():
             return jsonify({'error': 'Search debe tener al menos 2 caracteres'}), 400
 
         estado_filter = request.args.get('estado', '').strip()
+        responsable_filter = request.args.get('responsable', '').strip()
 
     except ValueError:
         return jsonify({'error': 'Parámetros numéricos inválidos'}), 400
@@ -140,6 +141,9 @@ def listar_expedientes():
         )
 
         query = query.filter(or_(*filtros_busqueda))
+
+    if responsable_filter == 'yo':
+        query = query.filter(Expediente.responsable_id == current_user.id)
 
     if estado_filter:
         estados_validos = ['borrador', 'tramitacion', 'finalizado', 'archivado']

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -23,4 +23,4 @@ def mis_expedientes():
     Redirección a listado de expedientes con filtro 'mis_expedientes=1'.
     Mantiene compatibilidad con enlaces del dashboard.
     """
-    return redirect(url_for('expedientes.listado_v2'))
+    return redirect(url_for('expedientes.listado_v2', responsable='yo'))

--- a/app/static/js/v2-scroll-infinito.js
+++ b/app/static/js/v2-scroll-infinito.js
@@ -55,12 +55,14 @@ class ScrollInfinito {
      * @param {string}   options.tableClass  - Selector CSS de la tabla. Default: '.expedientes-table'
      * @param {string}   options.entityLabel - Nombre de la entidad para mensajes. Default: 'expedientes'
      * @param {Function} options.detailUrl   - Función id => URL del detalle. Default: V3 expedientes
+     * @param {Object}   options.fixedParams - Parámetros fijos añadidos a cada petición. Default: {}
      */
     constructor(options = {}) {
         // Configuración base
         this.apiUrl      = options.apiUrl      || '/api/expedientes';
         this.limit       = options.limit       || 50;
         this.threshold   = options.threshold   || 0.8;
+        this.fixedParams = options.fixedParams || {};
 
         // Configuración genérica (nueva en v1.2)
         this.columns     = options.columns     || null;
@@ -119,7 +121,7 @@ class ScrollInfinito {
         this.showLoader();
 
         try {
-            const params = new URLSearchParams({ cursor: this.cursor, limit: this.limit });
+            const params = new URLSearchParams({ cursor: this.cursor, limit: this.limit, ...this.fixedParams });
             if (this.searchInput && this.searchInput.value.trim()) {
                 params.append('search', this.searchInput.value.trim());
             }

--- a/app/templates/dashboard/index_v1.html
+++ b/app/templates/dashboard/index_v1.html
@@ -39,7 +39,7 @@
             <i class="fas fa-folder-open"></i>
         </div>
         <h2 class="card-title">Expedientes</h2>
-        <p class="card-description">Listado con scroll infinito</p>
+        <p class="card-description">Consulta y gestión de expedientes</p>
     </a>
     {% endif %}
     
@@ -98,13 +98,13 @@
     
     <!-- Cards futuras (deshabilitadas) -->
     {% if 'TRAMITADOR' in user_roles or 'ADMINISTRATIVO' in user_roles or 'SUPERVISOR' in user_roles or 'ADMIN' in user_roles %}
-    <div class="dashboard-card disabled">
+    <a href="{{ url_for('expedientes.seguimiento') }}" class="dashboard-card">
         <div class="card-icon">
             <i class="fas fa-tasks"></i>
         </div>
         <h2 class="card-title">Tareas</h2>
-        <p class="card-description">Próximamente</p>
-    </div>
+        <p class="card-description">Cola de trabajo — solicitudes en tramitación</p>
+    </a>
     
     {# <div class="dashboard-card disabled"><div class="card-icon"><i class="fas fa-file-alt"></i></div><h2 class="card-title">Documentos</h2><p class="card-description">Búsqueda documental global — pendiente</p></div> #}
     {% endif %}


### PR DESCRIPTION
## Cambios

- `dashboard.py`: `mis_expedientes()` redirige a `listado_v2` con `?responsable=yo`
- `api_expedientes.py`: filtro `responsable=yo` aplica `WHERE responsable_id = current_user.id`
- `v2-scroll-infinito.js`: añadido soporte `fixedParams` para pasar parámetros fijos en cada petición a la API
- `listado_v2.html`: inyecta `fixedParams` con `responsable` cuando la URL lo incluye (vía Jinja2)
- `index_v1.html`: card Tareas activada apuntando a `/expedientes/seguimiento/`; subtítulo de card Expedientes actualizado

Closes #282
