### PR TITLE
Mostrar nota de tarea como tooltip en celda de pista

### DIFF
--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -89,7 +89,8 @@ function renderPista(ep) {
     const texto   = TEXTO_ESTADO[ep.codigo] || ep.codigo;
     const clase   = COLOR_CLASE[ep.color]   || '';
     const counter = ep.count > 1 ? ` (${ep.count})` : '';
-    return `<span class="pista-celda ${clase}">${texto}${counter}</span>`;
+    const tooltip = ep.nota ? ` data-bs-toggle="tooltip" title="${ep.nota.replace(/"/g, '&quot;')}"` : '';
+    return `<span class="pista-celda ${clase}"${tooltip}>${texto}${counter}</span>`;
 }
 
 function renderFecha(val) {
@@ -186,6 +187,11 @@ class SeguimientoScroll extends ScrollInfinito {
             this.renderItems(data.data);
             this.totalLoaded += data.data.length;
             this.updatePaginationInfo();
+
+            // Inicializar tooltips Bootstrap en los elementos recién renderizados
+            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+                if (!bootstrap.Tooltip.getInstance(el)) new bootstrap.Tooltip(el);
+            });
 
             if (this.totalLoaded === 0 && ver === 'mis') {
                 this._mostrarToastSinExpedientes();

--- a/app/routes/api_seguimiento.py
+++ b/app/routes/api_seguimiento.py
@@ -213,4 +213,4 @@ def _ser_pista(ep) -> dict | None:
     """Serializa un EstadoPista a dict JSON; None si la pista es N/A."""
     if ep is None:
         return None
-    return {'codigo': ep.codigo, 'color': ep.color, 'count': ep.count}
+    return {'codigo': ep.codigo, 'color': ep.color, 'count': ep.count, 'nota': ep.nota}

--- a/app/services/seguimiento.py
+++ b/app/services/seguimiento.py
@@ -83,6 +83,7 @@ class EstadoPista:
     codigo: str    # p.ej. 'PENDIENTE_ESTUDIO'
     color: str     # p.ej. 'rojo'
     count: int = 1 # elementos en el estado de mayor prioridad (para contador visible)
+    nota: Optional[str] = None  # notas de la tarea activa (para tooltip en seguimiento)
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +122,8 @@ def estado_solicitud(solicitud_id: int) -> dict[str, Optional[EstadoPista]]:
         fases_abiertas = [f for f in fases if f.fecha_fin is None]
         acc = _acumular([_estado_fase(f, pista) for f in fases_abiertas])
         ganador, count = _mayor_prioridad(acc)
-        result[pista] = EstadoPista(ganador, COLOR[ganador], count)
+        nota = _nota_activa(fases_abiertas)
+        result[pista] = EstadoPista(ganador, COLOR[ganador], count, nota)
 
     return result
 
@@ -274,6 +276,21 @@ def _parse_plazo_dias(notas: Optional[str]) -> Optional[int]:
         return None
     m = re.search(r'PLAZO_DIAS=(\d+)', notas)
     return int(m.group(1)) if m else None
+
+
+def _nota_activa(fases_abiertas) -> Optional[str]:
+    """
+    Devuelve las notas de la primera tarea abierta encontrada en las fases abiertas.
+    Se usa para poblar el tooltip en el listado de seguimiento.
+    """
+    for fase in fases_abiertas:
+        for tramite in sorted(fase.tramites, key=lambda t: t.id):
+            if tramite.fecha_fin is not None:
+                continue
+            for tarea in tramite.tareas:
+                if tarea.fecha_fin is None and tarea.notas:
+                    return tarea.notas
+    return None
 
 
 def _acumular(resultados: list[tuple[str, int]]) -> dict[str, int]:


### PR DESCRIPTION
## Cambios

- `seguimiento.py`: `EstadoPista` gana campo `nota: Optional[str]`; nuevo helper `_nota_activa()` devuelve las notas de la primera tarea abierta; `estado_solicitud()` lo propaga al `EstadoPista` ganador
- `api_seguimiento.py`: `_ser_pista()` incluye `nota` en el dict serializado
- `seguimiento.html`: `renderPista()` añade `data-bs-toggle="tooltip"` cuando `nota` no está vacío; tooltips Bootstrap se inicializan tras cada `renderItems()`

Closes #280
