### PR TITLE
Revisión visual vista bc tramitación

### DIFF
--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -84,7 +84,7 @@
         <div class="card tabla-bloque">
           <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
             <span class="fw-semibold">
-              <i class="fas fa-file-contract me-1"></i> Solicitudes
+              <i class="fas fa-file-contract fs-5 bc-icon-solicitud me-1"></i> Solicitudes
               <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
             </span>
             <button class="btn btn-sm btn-primary"

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base_fullwidth.html' %}
+{% extends 'layout/base_bc.html' %}
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} - BDDAT{% endblock %}
 
@@ -12,103 +12,19 @@
 <span>Tramitación</span>
 {% endblock %}
 
-{% block extra_css %}{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
-{% endblock %}
-
-{% from 'macros/page_header.html' import page_header %}
-
-{% block content %}
-<div class="bc-view">
-
-<!-- C.1: Encabezado homogéneo — expediente + navegación + datos secundarios -->
-<div class="lista-cabecera">
-  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
-    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-info-circle me-1"></i> Detalle
-    </a>
-    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-file-alt me-1"></i> Pool de Docs
-    </a>
-  {% endcall %}
-  <div class="page-subheader content-constrained">
-    <div class="page-subheader-data">
-      <div class="subheader-item">
-        <strong>Titular:</strong>
-        {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
-      </div>
-      <div class="subheader-item">
-        <strong>Responsable:</strong>
-        {{ expediente.responsable.siglas if expediente.responsable else '—' }}
-      </div>
-      <div class="subheader-item">
-        <strong>Tipo:</strong>
-        {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
-      </div>
-    </div>
+{% block bc_content %}
+<div class="card tabla-bloque">
+  <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+    <span class="fw-semibold">
+      <i class="fas fa-file-contract fs-5 bc-icon-solicitud me-1"></i> Solicitudes
+      <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+    </span>
+    <button class="btn btn-sm btn-primary"
+            data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
+      <i class="fas fa-plus me-1"></i> Nueva solicitud
+    </button>
   </div>
-</div>
-
-<!-- C.2: Tabs Solicitudes / Diagrama -->
-<div class="lista-scroll-container">
-  <div class="content-constrained pt-2 pb-3">
-
-    <!-- Nav tabs -->
-    <ul class="nav nav-tabs mb-3" id="bc-tabs" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="tab-solicitudes" data-bs-toggle="tab"
-                data-bs-target="#panel-solicitudes" type="button" role="tab"
-                aria-controls="panel-solicitudes" aria-selected="true">
-          <i class="fas fa-file-contract me-1"></i> Solicitudes
-          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
-        </button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-diagrama" data-bs-toggle="tab"
-                data-bs-target="#panel-diagrama" type="button" role="tab"
-                aria-controls="panel-diagrama" aria-selected="false">
-          <i class="fas fa-project-diagram me-1"></i> Diagrama
-        </button>
-      </li>
-    </ul>
-
-    <!-- Contenido tabs -->
-    <div class="tab-content" id="bc-tabs-content">
-
-      <!-- Tab Solicitudes -->
-      <div class="tab-pane fade show active" id="panel-solicitudes" role="tabpanel"
-           aria-labelledby="tab-solicitudes">
-        <div class="card tabla-bloque">
-          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-            <span class="fw-semibold">
-              <i class="fas fa-file-contract fs-5 bc-icon-solicitud me-1"></i> Solicitudes
-              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-            </span>
-            <button class="btn btn-sm btn-primary"
-                    data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
-              <i class="fas fa-plus me-1"></i> Nueva solicitud
-            </button>
-          </div>
-          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
-        </div>
-      </div>
-
-      <!-- Tab Diagrama (placeholder — issue #285) -->
-      <div class="tab-pane fade" id="panel-diagrama" role="tabpanel"
-           aria-labelledby="tab-diagrama">
-        <div class="card">
-          <div class="card-body text-center py-5 text-secondary">
-            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
-            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
-          </div>
-        </div>
-      </div>
-
-    </div>{# /tab-content #}
-  </div>
+  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
 <!-- Modal Nueva Solicitud -->
@@ -156,12 +72,9 @@
     </div>
   </div>
 </div>
-
-</div>
 {% endblock %}
 
-{% block extra_js %}{{ super() }}
-<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-crear.js') }}"></script>
 <script>
   const _ef_fecha_sol = new EntradaFecha('#ef-fecha-sol-bc', { name: 'fecha_solicitud' });

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -52,22 +52,62 @@
   </div>
 </div>
 
-<!-- C.2: Listado de Solicitudes (scrollable) -->
+<!-- C.2: Tabs Solicitudes / Diagrama -->
 <div class="lista-scroll-container">
-  <div class="content-constrained py-3">
-    <div class="card tabla-bloque">
-      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-        <span class="fw-semibold">
+  <div class="content-constrained pt-2 pb-3">
+
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs mb-3" id="bc-tabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="tab-solicitudes" data-bs-toggle="tab"
+                data-bs-target="#panel-solicitudes" type="button" role="tab"
+                aria-controls="panel-solicitudes" aria-selected="true">
           <i class="fas fa-file-contract me-1"></i> Solicitudes
-          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-        </span>
-        <button class="btn btn-sm btn-primary"
-                data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
-          <i class="fas fa-plus me-1"></i> Nueva solicitud
+          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
         </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-diagrama" data-bs-toggle="tab"
+                data-bs-target="#panel-diagrama" type="button" role="tab"
+                aria-controls="panel-diagrama" aria-selected="false">
+          <i class="fas fa-project-diagram me-1"></i> Diagrama
+        </button>
+      </li>
+    </ul>
+
+    <!-- Contenido tabs -->
+    <div class="tab-content" id="bc-tabs-content">
+
+      <!-- Tab Solicitudes -->
+      <div class="tab-pane fade show active" id="panel-solicitudes" role="tabpanel"
+           aria-labelledby="tab-solicitudes">
+        <div class="card tabla-bloque">
+          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+            <span class="fw-semibold">
+              <i class="fas fa-file-contract me-1"></i> Solicitudes
+              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+            </span>
+            <button class="btn btn-sm btn-primary"
+                    data-bs-toggle="modal" data-bs-target="#modal-nueva-solicitud-bc">
+              <i class="fas fa-plus me-1"></i> Nueva solicitud
+            </button>
+          </div>
+          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+        </div>
       </div>
-      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
-    </div>
+
+      <!-- Tab Diagrama (placeholder — issue #285) -->
+      <div class="tab-pane fade" id="panel-diagrama" role="tabpanel"
+           aria-labelledby="tab-diagrama">
+        <div class="card">
+          <div class="card-body text-center py-5 text-secondary">
+            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+          </div>
+        </div>
+      </div>
+
+    </div>{# /tab-content #}
   </div>
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -1,4 +1,5 @@
-{% extends 'layout/base_fullwidth.html' %}
+{% extends 'layout/base_bc.html' %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} — Fase - BDDAT{% endblock %}
 
@@ -18,233 +19,168 @@
 <span>{{ fase.tipo_fase.label_bc if fase.tipo_fase else 'Fase #' ~ fase.id }}</span>
 {% endblock %}
 
-{% block extra_css %}{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
-{% endblock %}
+{% block bc_content %}
 
-{% from 'macros/page_header.html' import page_header %}
-{% from 'macros/bc_cards.html' import bc_card_compacto %}
+{# Card compacto: Solicitud #}
+{{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+    'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+    url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
 
-{% block content %}
-<div class="bc-view">
+{# Estado de la fase deducido de fechas #}
+{% if fase.fecha_fin %}
+  {% set fase_badge_class = 'bg-success' %}
+  {% set fase_badge_label = 'Finalizada' %}
+{% elif fase.fecha_inicio %}
+  {% set fase_badge_class = 'bg-primary' %}
+  {% set fase_badge_label = 'En curso' %}
+{% else %}
+  {% set fase_badge_class = 'bg-secondary' %}
+  {% set fase_badge_label = 'Planificada' %}
+{% endif %}
 
-<!-- C.1 -->
-<div class="lista-cabecera">
-  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
-    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-info-circle me-1"></i> Detalle
-    </a>
-    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-file-alt me-1"></i> Pool de Docs
-    </a>
-  {% endcall %}
-  <div class="content-constrained pb-3">
+{# Card activo: Fase #}
+<div class="card bc-card-nodo mb-3" data-bc-editable>
 
-  {# Cards compactos de niveles superiores #}
-  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
-      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
-  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
-      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
-      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
-
-  {# Estado de la fase deducido de fechas #}
-  {% if fase.fecha_fin %}
-    {% set fase_badge_class = 'bg-success' %}
-    {% set fase_badge_label = 'Finalizada' %}
-  {% elif fase.fecha_inicio %}
-    {% set fase_badge_class = 'bg-primary' %}
-    {% set fase_badge_label = 'En curso' %}
-  {% else %}
-    {% set fase_badge_class = 'bg-secondary' %}
-    {% set fase_badge_label = 'Planificada' %}
-  {% endif %}
-
-  <div class="card bc-card-nodo" data-bc-editable>
-
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="fw-semibold d-flex align-items-center gap-2">
-        <i class="fas fa-layer-group fs-5 bc-icon-fase"></i>
-        <span>Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}</span>
-        <span class="badge {{ fase_badge_class }} ms-1">{{ fase_badge_label }}</span>
-      </span>
-      <div class="bc-acciones-bar">
-        {# Modo ver #}
-        <div data-modo-ver class="d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
-            <i class="fas fa-edit me-1"></i> Editar
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span class="fw-semibold d-flex align-items-center gap-2">
+      <i class="fas fa-layer-group fs-5 bc-icon-fase"></i>
+      <span>Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}</span>
+      <span class="badge {{ fase_badge_class }} ms-1">{{ fase_badge_label }}</span>
+    </span>
+    <div class="bc-acciones-bar">
+      <div data-modo-ver class="d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+          <i class="fas fa-edit me-1"></i> Editar
+        </button>
+        <div class="dropdown">
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                  data-bs-toggle="dropdown" aria-expanded="false">
+            Acciones
           </button>
-          <div class="dropdown">
-            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                    data-bs-toggle="dropdown" aria-expanded="false">
-              Acciones
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-              {% if not fase.fecha_inicio %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="iniciar"
-                   data-url="{{ url_for('vista3.iniciar_fase', fase_id=fase.id) }}">
-                  <i class="fas fa-play me-2 text-success"></i> Iniciar
-                </a>
-              </li>
-              {% endif %}
-              {% if fase.fecha_inicio and not fase.fecha_fin %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="finalizar"
-                   data-url="{{ url_for('vista3.finalizar_fase', fase_id=fase.id) }}">
-                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
-                </a>
-              </li>
-              {% endif %}
-              <li><hr class="dropdown-divider"></li>
-              <li>
-                <a class="dropdown-item text-danger" href="#"
-                   data-accion="borrar"
-                   data-url="{{ url_for('vista3.borrar_fase', fase_id=fase.id) }}"
-                   data-redirect="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
-                  <i class="fas fa-trash me-2"></i> Borrar
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        {# Modo editar #}
-        <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
-            <i class="fas fa-save me-1"></i> Guardar
-          </button>
-          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
-            Cancelar
-          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% if not fase.fecha_inicio %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="iniciar"
+                 data-url="{{ url_for('vista3.iniciar_fase', fase_id=fase.id) }}">
+                <i class="fas fa-play me-2 text-success"></i> Iniciar
+              </a>
+            </li>
+            {% endif %}
+            {% if fase.fecha_inicio and not fase.fecha_fin %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="finalizar"
+                 data-url="{{ url_for('vista3.finalizar_fase', fase_id=fase.id) }}">
+                <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+              </a>
+            </li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item text-danger" href="#"
+                 data-accion="borrar"
+                 data-url="{{ url_for('vista3.borrar_fase', fase_id=fase.id) }}"
+                 data-redirect="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
+                <i class="fas fa-trash me-2"></i> Borrar
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
-    </div>
-
-    <div class="card-body card-body-tinted py-2">
-
-      {# Modo ver #}
-      <div data-modo-ver class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio" class="bc-fecha-valor">
-            {{- fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin" class="bc-fecha-valor">
-            {{- fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>Resultado:</strong>
-          <span id="disp-resultado_fase_id">
-            {{- fase.resultado_fase.nombre if fase.resultado_fase else '—' -}}
-          </span>
-        </div>
+      <div data-modo-editar class="d-none d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+          Cancelar
+        </button>
       </div>
-
-      {# Modo editar #}
-      <form data-modo-editar class="d-none row g-2 pt-1"
-            data-url="{{ url_for('vista3.editar_fase', fase_id=fase.id) }}">
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">Tipo</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ fase.tipo_fase.nombre if fase.tipo_fase else '—' }}"
-                 data-bs-toggle="tooltip" title="El tipo se establece al crear la fase">
-        </div>
-        <div class="col-md-2">
-          <label class="form-label fw-semibold mb-1">F. Inicio</label>
-          <div id="ef-fecha_inicio"
-               data-ef-name="fecha_inicio"
-               data-ef-value="{{ fase.fecha_inicio.isoformat() if fase.fecha_inicio else '' }}">
-          </div>
-        </div>
-        <div class="col-md-2">
-          <label class="form-label fw-semibold mb-1">F. Fin</label>
-          <div id="ef-fecha_fin"
-               data-ef-name="fecha_fin"
-               data-ef-value="{{ fase.fecha_fin.isoformat() if fase.fecha_fin else '' }}">
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">Resultado</label>
-          <select class="form-select form-select-sm" name="resultado_fase_id">
-            <option value="">— Sin resultado —</option>
-            {% for r in resultados_fase %}
-            <option value="{{ r.id }}"
-                    {% if fase.resultado_fase_id == r.id %}selected{% endif %}>
-              {{ r.nombre }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-12">
-          <label class="form-label fw-semibold mb-1">Observaciones</label>
-          <textarea class="form-control form-control-sm" name="observaciones"
-                    rows="2">{{ fase.observaciones or '' }}</textarea>
-        </div>
-      </form>
-
-      {# Mensajes de error/advertencia del motor de reglas #}
-      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
-
     </div>
   </div>
-  </div>{# /content-constrained #}
-</div>{# /lista-cabecera #}
 
-<!-- C.2: Tabs Trámites / Diagrama -->
-<div class="lista-scroll-container">
-  <div class="content-constrained pt-2 pb-3">
+  <div class="card-body card-body-tinted py-2">
 
-    <ul class="nav nav-tabs mb-3" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" data-bs-toggle="tab"
-                data-bs-target="#panel-tramites" type="button" role="tab" aria-selected="true">
-          <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
-          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
-        </button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" data-bs-toggle="tab"
-                data-bs-target="#panel-diagrama-fase" type="button" role="tab" aria-selected="false">
-          <i class="fas fa-project-diagram me-1"></i> Diagrama
-        </button>
-      </li>
-    </ul>
-
-    <div class="tab-content">
-      <div class="tab-pane fade show active" id="panel-tramites" role="tabpanel">
-        <div class="card tabla-bloque">
-          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-            <span class="fw-semibold">
-              <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
-              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-            </span>
-            <button class="btn btn-sm btn-primary"
-                    data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
-              <i class="fas fa-plus me-1"></i> Nuevo trámite
-            </button>
-          </div>
-          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
-        </div>
+    <div data-modo-ver class="row g-2 bc-meta">
+      <div class="col-auto">
+        <strong>F. Inicio:</strong>
+        <span id="disp-fecha_inicio" class="bc-fecha-valor">
+          {{- fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else '—' -}}
+        </span>
       </div>
-      <div class="tab-pane fade" id="panel-diagrama-fase" role="tabpanel">
-        <div class="card">
-          <div class="card-body text-center py-5 text-secondary">
-            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
-            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
-          </div>
-        </div>
+      <div class="col-auto">
+        <strong>F. Fin:</strong>
+        <span id="disp-fecha_fin" class="bc-fecha-valor">
+          {{- fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else '—' -}}
+        </span>
+      </div>
+      <div class="col-auto">
+        <strong>Resultado:</strong>
+        <span id="disp-resultado_fase_id">
+          {{- fase.resultado_fase.nombre if fase.resultado_fase else '—' -}}
+        </span>
       </div>
     </div>
 
+    <form data-modo-editar class="d-none row g-2 pt-1"
+          data-url="{{ url_for('vista3.editar_fase', fase_id=fase.id) }}">
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">Tipo</label>
+        <input type="text" class="form-control form-control-sm" readonly
+               value="{{ fase.tipo_fase.nombre if fase.tipo_fase else '—' }}"
+               data-bs-toggle="tooltip" title="El tipo se establece al crear la fase">
+      </div>
+      <div class="col-md-2">
+        <label class="form-label fw-semibold mb-1">F. Inicio</label>
+        <div id="ef-fecha_inicio"
+             data-ef-name="fecha_inicio"
+             data-ef-value="{{ fase.fecha_inicio.isoformat() if fase.fecha_inicio else '' }}">
+        </div>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label fw-semibold mb-1">F. Fin</label>
+        <div id="ef-fecha_fin"
+             data-ef-name="fecha_fin"
+             data-ef-value="{{ fase.fecha_fin.isoformat() if fase.fecha_fin else '' }}">
+        </div>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">Resultado</label>
+        <select class="form-select form-select-sm" name="resultado_fase_id">
+          <option value="">— Sin resultado —</option>
+          {% for r in resultados_fase %}
+          <option value="{{ r.id }}"
+                  {% if fase.resultado_fase_id == r.id %}selected{% endif %}>
+            {{ r.nombre }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-1">Observaciones</label>
+        <textarea class="form-control form-control-sm" name="observaciones"
+                  rows="2">{{ fase.observaciones or '' }}</textarea>
+      </div>
+    </form>
+
+    <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
   </div>
+</div>
+
+{# Lista de Trámites #}
+<div class="card tabla-bloque">
+  <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+    <span class="fw-semibold">
+      <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
+      <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+    </span>
+    <button class="btn btn-sm btn-primary"
+            data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
+      <i class="fas fa-plus me-1"></i> Nuevo trámite
+    </button>
+  </div>
+  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
 <!-- Modal Nuevo Trámite -->
@@ -286,11 +222,9 @@
   </div>
 </div>
 
-</div>
 {% endblock %}
 
-{% block extra_js %}{{ super() }}
-<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-crear.js') }}"></script>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -204,7 +204,7 @@
     <div class="card tabla-bloque">
       <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
         <span class="fw-semibold">
-          <i class="fas fa-clipboard-list me-1"></i> Trámites
+          <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
           <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
         </span>
         <button class="btn btn-sm btn-primary"

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -24,6 +24,7 @@
 {% endblock %}
 
 {% from 'macros/page_header.html' import page_header %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block content %}
 <div class="bc-view">
@@ -41,12 +42,33 @@
     </a>
   {% endcall %}
   <div class="content-constrained pb-3">
+
+  {# Cards compactos de niveles superiores #}
+  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
+      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
+  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
+
+  {# Estado de la fase deducido de fechas #}
+  {% if fase.fecha_fin %}
+    {% set fase_badge_class = 'bg-success' %}
+    {% set fase_badge_label = 'Finalizada' %}
+  {% elif fase.fecha_inicio %}
+    {% set fase_badge_class = 'bg-primary' %}
+    {% set fase_badge_label = 'En curso' %}
+  {% else %}
+    {% set fase_badge_class = 'bg-secondary' %}
+    {% set fase_badge_label = 'Planificada' %}
+  {% endif %}
+
   <div class="card bc-card-nodo" data-bc-editable>
 
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-layer-group me-2"></i>
-        Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span class="fw-semibold d-flex align-items-center gap-2">
+        <i class="fas fa-layer-group fs-5 bc-icon-fase"></i>
+        <span>Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}</span>
+        <span class="badge {{ fase_badge_class }} ms-1">{{ fase_badge_label }}</span>
       </span>
       <div class="bc-acciones-bar">
         {# Modo ver #}
@@ -108,13 +130,13 @@
       <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio">
+          <span id="disp-fecha_inicio" class="bc-fecha-valor">
             {{- fase.fecha_inicio.strftime('%d/%m/%Y') if fase.fecha_inicio else '—' -}}
           </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin">
+          <span id="disp-fecha_fin" class="bc-fecha-valor">
             {{- fase.fecha_fin.strftime('%d/%m/%Y') if fase.fecha_fin else '—' -}}
           </span>
         </div>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -198,22 +198,52 @@
   </div>{# /content-constrained #}
 </div>{# /lista-cabecera #}
 
-<!-- C.2: Listado de Trámites (scrollable) -->
+<!-- C.2: Tabs Trámites / Diagrama -->
 <div class="lista-scroll-container">
-  <div class="content-constrained py-3">
-    <div class="card tabla-bloque">
-      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-        <span class="fw-semibold">
+  <div class="content-constrained pt-2 pb-3">
+
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" data-bs-toggle="tab"
+                data-bs-target="#panel-tramites" type="button" role="tab" aria-selected="true">
           <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
-          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-        </span>
-        <button class="btn btn-sm btn-primary"
-                data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
-          <i class="fas fa-plus me-1"></i> Nuevo trámite
+          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
         </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab"
+                data-bs-target="#panel-diagrama-fase" type="button" role="tab" aria-selected="false">
+          <i class="fas fa-project-diagram me-1"></i> Diagrama
+        </button>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="panel-tramites" role="tabpanel">
+        <div class="card tabla-bloque">
+          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+            <span class="fw-semibold">
+              <i class="fas fa-clipboard-list fs-5 bc-icon-tramite me-1"></i> Trámites
+              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+            </span>
+            <button class="btn btn-sm btn-primary"
+                    data-bs-toggle="modal" data-bs-target="#modal-nuevo-tramite-bc">
+              <i class="fas fa-plus me-1"></i> Nuevo trámite
+            </button>
+          </div>
+          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+        </div>
       </div>
-      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+      <div class="tab-pane fade" id="panel-diagrama-fase" role="tabpanel">
+        <div class="card">
+          <div class="card-body text-center py-5 text-secondary">
+            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+          </div>
+        </div>
+      </div>
     </div>
+
   </div>
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -20,6 +20,7 @@
 {% endblock %}
 
 {% from 'macros/page_header.html' import page_header %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block content %}
 <div class="bc-view">
@@ -37,13 +38,25 @@
     </a>
   {% endcall %}
   <div class="content-constrained pb-3">
+
+  {# Cards compactos de niveles superiores #}
+  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
+      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
+
   <div class="card bc-card-nodo" data-bc-editable>
 
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-file-alt me-2"></i>
-        Solicitud:
-        {{ solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id }}
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span class="fw-semibold d-flex align-items-center gap-2">
+        <i class="fas fa-file-alt fs-5 bc-icon-solicitud"></i>
+        <span>Solicitud:
+        {{ solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id }}</span>
+        <span class="badge
+          {% if solicitud.estado == 'EN_TRAMITE' %}bg-primary
+          {% elif solicitud.estado == 'RESUELTA' %}bg-success
+          {% elif solicitud.estado == 'DESISTIDA' %}bg-warning text-dark
+          {% else %}bg-secondary{% endif %} ms-1">
+          {{ solicitud.estado | replace('_', ' ') | title }}
+        </span>
       </span>
       <div class="bc-acciones-bar">
         {# Modo ver: botones Editar + Acciones #}
@@ -105,13 +118,13 @@
       <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Solicitud:</strong>
-          <span id="disp-fecha_solicitud">
+          <span id="disp-fecha_solicitud" class="bc-fecha-valor">
             {{- solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '—' -}}
           </span>
         </div>
         <div class="col-auto">
           <strong>F. Resolución:</strong>
-          <span id="disp-fecha_fin">
+          <span id="disp-fecha_fin" class="bc-fecha-valor">
             {{- solicitud.fecha_fin.strftime('%d/%m/%Y') if solicitud.fecha_fin else '—' -}}
           </span>
         </div>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -186,7 +186,7 @@
     <div class="card tabla-bloque">
       <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
         <span class="fw-semibold">
-          <i class="fas fa-sitemap me-1"></i> Fases
+          <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
           <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
         </span>
         <button class="btn btn-sm btn-primary"

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -180,22 +180,52 @@
   </div>{# /content-constrained #}
 </div>{# /lista-cabecera #}
 
-<!-- C.2: Listado de Fases (scrollable) -->
+<!-- C.2: Tabs Fases / Diagrama -->
 <div class="lista-scroll-container">
-  <div class="content-constrained py-3">
-    <div class="card tabla-bloque">
-      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-        <span class="fw-semibold">
+  <div class="content-constrained pt-2 pb-3">
+
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" data-bs-toggle="tab"
+                data-bs-target="#panel-fases" type="button" role="tab" aria-selected="true">
           <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
-          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-        </span>
-        <button class="btn btn-sm btn-primary"
-                data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
-          <i class="fas fa-plus me-1"></i> Nueva fase
+          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
         </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab"
+                data-bs-target="#panel-diagrama-sol" type="button" role="tab" aria-selected="false">
+          <i class="fas fa-project-diagram me-1"></i> Diagrama
+        </button>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="panel-fases" role="tabpanel">
+        <div class="card tabla-bloque">
+          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+            <span class="fw-semibold">
+              <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
+              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+            </span>
+            <button class="btn btn-sm btn-primary"
+                    data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
+              <i class="fas fa-plus me-1"></i> Nueva fase
+            </button>
+          </div>
+          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+        </div>
       </div>
-      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+      <div class="tab-pane fade" id="panel-diagrama-sol" role="tabpanel">
+        <div class="card">
+          <div class="card-body text-center py-5 text-secondary">
+            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+          </div>
+        </div>
+      </div>
     </div>
+
   </div>
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base_fullwidth.html' %}
+{% extends 'layout/base_bc.html' %}
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} — Solicitud - BDDAT{% endblock %}
 
@@ -14,219 +14,152 @@
 <span>{{ solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else "Solicitud #" ~ solicitud.id }}</span>
 {% endblock %}
 
-{% block extra_css %}{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
-{% endblock %}
+{% block bc_content %}
 
-{% from 'macros/page_header.html' import page_header %}
-{% from 'macros/bc_cards.html' import bc_card_compacto %}
+{# Card activo: Solicitud #}
+<div class="card bc-card-nodo mb-3" data-bc-editable>
 
-{% block content %}
-<div class="bc-view">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span class="fw-semibold d-flex align-items-center gap-2">
+      <i class="fas fa-file-alt fs-5 bc-icon-solicitud"></i>
+      <span>Solicitud:
+      {{ solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id }}</span>
+      <span class="badge
+        {% if solicitud.estado == 'EN_TRAMITE' %}bg-primary
+        {% elif solicitud.estado == 'RESUELTA' %}bg-success
+        {% elif solicitud.estado == 'DESISTIDA' %}bg-warning text-dark
+        {% else %}bg-secondary{% endif %} ms-1">
+        {{ solicitud.estado | replace('_', ' ') | title }}
+      </span>
+    </span>
+    <div class="bc-acciones-bar">
+      <div data-modo-ver class="d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+          <i class="fas fa-edit me-1"></i> Editar
+        </button>
+        <div class="dropdown">
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                  data-bs-toggle="dropdown" aria-expanded="false">
+            Acciones
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% if not solicitud.fecha_solicitud %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="iniciar"
+                 data-url="{{ url_for('vista3.iniciar_solicitud', sol_id=solicitud.id) }}">
+                <i class="fas fa-play me-2 text-success"></i> Iniciar
+              </a>
+            </li>
+            {% endif %}
+            {% if solicitud.fecha_solicitud and not solicitud.fecha_fin %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="finalizar"
+                 data-url="{{ url_for('vista3.finalizar_solicitud', sol_id=solicitud.id) }}">
+                <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+              </a>
+            </li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item text-danger" href="#"
+                 data-accion="borrar"
+                 data-url="{{ url_for('vista3.borrar_solicitud', sol_id=solicitud.id) }}"
+                 data-redirect="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">
+                <i class="fas fa-trash me-2"></i> Borrar
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div data-modo-editar class="d-none d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+          Cancelar
+        </button>
+      </div>
+    </div>
+  </div>
 
-<!-- C.1 -->
-<div class="lista-cabecera">
-  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
-    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-info-circle me-1"></i> Detalle
-    </a>
-    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-file-alt me-1"></i> Pool de Docs
-    </a>
-  {% endcall %}
-  <div class="content-constrained pb-3">
+  <div class="card-body card-body-tinted py-2">
 
-  {# Cards compactos de niveles superiores #}
-  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
-      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
-
-  <div class="card bc-card-nodo" data-bc-editable>
-
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="fw-semibold d-flex align-items-center gap-2">
-        <i class="fas fa-file-alt fs-5 bc-icon-solicitud"></i>
-        <span>Solicitud:
-        {{ solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id }}</span>
-        <span class="badge
+    <div data-modo-ver class="row g-2 bc-meta">
+      <div class="col-auto">
+        <strong>F. Solicitud:</strong>
+        <span id="disp-fecha_solicitud" class="bc-fecha-valor">
+          {{- solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '—' -}}
+        </span>
+      </div>
+      <div class="col-auto">
+        <strong>F. Resolución:</strong>
+        <span id="disp-fecha_fin" class="bc-fecha-valor">
+          {{- solicitud.fecha_fin.strftime('%d/%m/%Y') if solicitud.fecha_fin else '—' -}}
+        </span>
+      </div>
+      <div class="col-auto">
+        <strong>Estado:</strong>
+        <span id="disp-estado" class="badge
           {% if solicitud.estado == 'EN_TRAMITE' %}bg-primary
           {% elif solicitud.estado == 'RESUELTA' %}bg-success
           {% elif solicitud.estado == 'DESISTIDA' %}bg-warning text-dark
-          {% else %}bg-secondary{% endif %} ms-1">
+          {% else %}bg-secondary{% endif %}">
           {{ solicitud.estado | replace('_', ' ') | title }}
         </span>
-      </span>
-      <div class="bc-acciones-bar">
-        {# Modo ver: botones Editar + Acciones #}
-        <div data-modo-ver class="d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
-            <i class="fas fa-edit me-1"></i> Editar
-          </button>
-          <div class="dropdown">
-            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                    data-bs-toggle="dropdown" aria-expanded="false">
-              Acciones
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-              {% if not solicitud.fecha_solicitud %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="iniciar"
-                   data-url="{{ url_for('vista3.iniciar_solicitud', sol_id=solicitud.id) }}">
-                  <i class="fas fa-play me-2 text-success"></i> Iniciar
-                </a>
-              </li>
-              {% endif %}
-              {% if solicitud.fecha_solicitud and not solicitud.fecha_fin %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="finalizar"
-                   data-url="{{ url_for('vista3.finalizar_solicitud', sol_id=solicitud.id) }}">
-                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
-                </a>
-              </li>
-              {% endif %}
-              <li><hr class="dropdown-divider"></li>
-              <li>
-                <a class="dropdown-item text-danger" href="#"
-                   data-accion="borrar"
-                   data-url="{{ url_for('vista3.borrar_solicitud', sol_id=solicitud.id) }}"
-                   data-redirect="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">
-                  <i class="fas fa-trash me-2"></i> Borrar
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        {# Modo editar: botones Guardar + Cancelar #}
-        <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
-            <i class="fas fa-save me-1"></i> Guardar
-          </button>
-          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
-            Cancelar
-          </button>
-        </div>
       </div>
     </div>
 
-    <div class="card-body card-body-tinted py-2">
-
-      {# Modo ver: resumen de metadatos #}
-      <div data-modo-ver class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>F. Solicitud:</strong>
-          <span id="disp-fecha_solicitud" class="bc-fecha-valor">
-            {{- solicitud.fecha_solicitud.strftime('%d/%m/%Y') if solicitud.fecha_solicitud else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>F. Resolución:</strong>
-          <span id="disp-fecha_fin" class="bc-fecha-valor">
-            {{- solicitud.fecha_fin.strftime('%d/%m/%Y') if solicitud.fecha_fin else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>Estado:</strong>
-          <span id="disp-estado" class="badge
-            {% if solicitud.estado == 'EN_TRAMITE' %}bg-primary
-            {% elif solicitud.estado == 'RESUELTA' %}bg-success
-            {% elif solicitud.estado == 'DESISTIDA' %}bg-warning text-dark
-            {% else %}bg-secondary{% endif %}">
-            {{ solicitud.estado | replace('_', ' ') | title }}
-          </span>
+    <form data-modo-editar class="d-none row g-2 pt-1"
+          data-url="{{ url_for('vista3.editar_solicitud', sol_id=solicitud.id) }}">
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Solicitud</label>
+        <div id="ef-fecha_solicitud"
+             data-ef-name="fecha_solicitud"
+             data-ef-value="{{ solicitud.fecha_solicitud.isoformat() if solicitud.fecha_solicitud else '' }}">
         </div>
       </div>
-
-      {# Modo editar: formulario #}
-      <form data-modo-editar class="d-none row g-2 pt-1"
-            data-url="{{ url_for('vista3.editar_solicitud', sol_id=solicitud.id) }}">
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Solicitud</label>
-          <div id="ef-fecha_solicitud"
-               data-ef-name="fecha_solicitud"
-               data-ef-value="{{ solicitud.fecha_solicitud.isoformat() if solicitud.fecha_solicitud else '' }}">
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Resolución</label>
-          <div id="ef-fecha_fin"
-               data-ef-name="fecha_fin"
-               data-ef-value="{{ solicitud.fecha_fin.isoformat() if solicitud.fecha_fin else '' }}">
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">Estado</label>
-          <select class="form-select form-select-sm" name="estado">
-            {% for val, label in [('EN_TRAMITE','En trámite'),('RESUELTA','Resuelta'),('DESISTIDA','Desistida'),('ARCHIVADA','Archivada')] %}
-            <option value="{{ val }}" {% if solicitud.estado == val %}selected{% endif %}>{{ label }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-12">
-          <label class="form-label fw-semibold mb-1">Observaciones</label>
-          <textarea class="form-control form-control-sm" name="observaciones"
-                    rows="2">{{ solicitud.observaciones or '' }}</textarea>
-        </div>
-      </form>
-
-      {# Mensajes de error/advertencia del motor de reglas #}
-      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
-
-    </div>
-  </div>
-  </div>{# /content-constrained #}
-</div>{# /lista-cabecera #}
-
-<!-- C.2: Tabs Fases / Diagrama -->
-<div class="lista-scroll-container">
-  <div class="content-constrained pt-2 pb-3">
-
-    <ul class="nav nav-tabs mb-3" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" data-bs-toggle="tab"
-                data-bs-target="#panel-fases" type="button" role="tab" aria-selected="true">
-          <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
-          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
-        </button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" data-bs-toggle="tab"
-                data-bs-target="#panel-diagrama-sol" type="button" role="tab" aria-selected="false">
-          <i class="fas fa-project-diagram me-1"></i> Diagrama
-        </button>
-      </li>
-    </ul>
-
-    <div class="tab-content">
-      <div class="tab-pane fade show active" id="panel-fases" role="tabpanel">
-        <div class="card tabla-bloque">
-          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-            <span class="fw-semibold">
-              <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
-              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-            </span>
-            <button class="btn btn-sm btn-primary"
-                    data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
-              <i class="fas fa-plus me-1"></i> Nueva fase
-            </button>
-          </div>
-          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Resolución</label>
+        <div id="ef-fecha_fin"
+             data-ef-name="fecha_fin"
+             data-ef-value="{{ solicitud.fecha_fin.isoformat() if solicitud.fecha_fin else '' }}">
         </div>
       </div>
-      <div class="tab-pane fade" id="panel-diagrama-sol" role="tabpanel">
-        <div class="card">
-          <div class="card-body text-center py-5 text-secondary">
-            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
-            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
-          </div>
-        </div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">Estado</label>
+        <select class="form-select form-select-sm" name="estado">
+          {% for val, label in [('EN_TRAMITE','En trámite'),('RESUELTA','Resuelta'),('DESISTIDA','Desistida'),('ARCHIVADA','Archivada')] %}
+          <option value="{{ val }}" {% if solicitud.estado == val %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
       </div>
-    </div>
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-1">Observaciones</label>
+        <textarea class="form-control form-control-sm" name="observaciones"
+                  rows="2">{{ solicitud.observaciones or '' }}</textarea>
+      </div>
+    </form>
+
+    <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
 
   </div>
+</div>
+
+{# Lista de Fases #}
+<div class="card tabla-bloque">
+  <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+    <span class="fw-semibold">
+      <i class="fas fa-sitemap fs-5 bc-icon-fase me-1"></i> Fases
+      <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+    </span>
+    <button class="btn btn-sm btn-primary"
+            data-bs-toggle="modal" data-bs-target="#modal-nueva-fase-bc">
+      <i class="fas fa-plus me-1"></i> Nueva fase
+    </button>
+  </div>
+  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
 <!-- Modal Nueva Fase -->
@@ -268,11 +201,9 @@
   </div>
 </div>
 
-</div>
 {% endblock %}
 
-{% block extra_js %}{{ super() }}
-<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-crear.js') }}"></script>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -1,4 +1,5 @@
-{% extends 'layout/base_fullwidth.html' %}
+{% extends 'layout/base_bc.html' %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} — Tarea - BDDAT{% endblock %}
 
@@ -26,290 +27,222 @@
 <span>{{ tarea.tipo_tarea.label_bc if tarea.tipo_tarea else 'Tarea #' ~ tarea.id }}</span>
 {% endblock %}
 
-{% block extra_css %}{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
+{% block extra_css_bc %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/selector_busqueda.css') }}">
 {% endblock %}
 
-{% from 'macros/page_header.html' import page_header %}
-{% from 'macros/bc_cards.html' import bc_card_compacto %}
+{% block bc_content %}
 
-{% block content %}
-<div class="bc-view">
+{# Cards compactos de niveles superiores #}
+{{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+    'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+    url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
+{{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
+    'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
+    url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
+{{ bc_card_compacto('fas fa-tasks', 'bc-icon-tramite',
+    'Trámite: ' ~ (tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id),
+    url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id)) }}
 
-<!-- C.1 -->
-<div class="lista-cabecera">
-  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
-    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-info-circle me-1"></i> Detalle
-    </a>
-    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-file-alt me-1"></i> Pool de Docs
-    </a>
-  {% endcall %}
-  <div class="content-constrained pb-3">
+{# Card activo: Tarea #}
+<div class="card bc-card-nodo mb-3" data-bc-editable>
 
-  {# Cards compactos de niveles superiores #}
-  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
-      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
-  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
-      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
-      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
-  {{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
-      'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
-      url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
-  {{ bc_card_compacto('fas fa-tasks', 'bc-icon-tramite',
-      'Trámite: ' ~ (tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id),
-      url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id)) }}
-
-  <div class="card bc-card-nodo" data-bc-editable>
-
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="fw-semibold d-flex align-items-center gap-2">
-        <i class="fas fa-check-square fs-5 bc-icon-tarea"></i>
-        <span>Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}</span>
-      </span>
-      <div class="bc-acciones-bar">
-        {# Modo ver #}
-        <div data-modo-ver class="d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
-            <i class="fas fa-edit me-1"></i> Editar
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span class="fw-semibold d-flex align-items-center gap-2">
+      <i class="fas fa-check-square fs-5 bc-icon-tarea"></i>
+      <span>Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}</span>
+    </span>
+    <div class="bc-acciones-bar">
+      <div data-modo-ver class="d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+          <i class="fas fa-edit me-1"></i> Editar
+        </button>
+        <div class="dropdown">
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                  data-bs-toggle="dropdown" aria-expanded="false">
+            Acciones
           </button>
-          <div class="dropdown">
-            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                    data-bs-toggle="dropdown" aria-expanded="false">
-              Acciones
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-              {% if not tarea.fecha_inicio %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="iniciar"
-                   data-url="{{ url_for('vista3.iniciar_tarea', tarea_id=tarea.id) }}">
-                  <i class="fas fa-play me-2 text-success"></i> Iniciar
-                </a>
-              </li>
-              {% endif %}
-              {% if tarea.fecha_inicio and not tarea.fecha_fin %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="finalizar"
-                   data-url="{{ url_for('vista3.finalizar_tarea', tarea_id=tarea.id) }}">
-                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
-                </a>
-              </li>
-              {% endif %}
-              {% if es_tarea_redactar %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-bs-toggle="modal" data-bs-target="#modalGenerarEscrito">
-                  <i class="fas fa-file-word me-2 text-primary"></i> Generar escrito
-                </a>
-              </li>
-              {% endif %}
-              <li><hr class="dropdown-divider"></li>
-              <li>
-                <a class="dropdown-item text-danger" href="#"
-                   data-accion="borrar"
-                   data-url="{{ url_for('vista3.borrar_tarea', tarea_id=tarea.id) }}"
-                   data-redirect="{{ url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id) }}">
-                  <i class="fas fa-trash me-2"></i> Borrar
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        {# Modo editar #}
-        <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
-            <i class="fas fa-save me-1"></i> Guardar
-          </button>
-          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
-            Cancelar
-          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% if not tarea.fecha_inicio %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="iniciar"
+                 data-url="{{ url_for('vista3.iniciar_tarea', tarea_id=tarea.id) }}">
+                <i class="fas fa-play me-2 text-success"></i> Iniciar
+              </a>
+            </li>
+            {% endif %}
+            {% if tarea.fecha_inicio and not tarea.fecha_fin %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="finalizar"
+                 data-url="{{ url_for('vista3.finalizar_tarea', tarea_id=tarea.id) }}">
+                <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+              </a>
+            </li>
+            {% endif %}
+            {% if es_tarea_redactar %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-bs-toggle="modal" data-bs-target="#modalGenerarEscrito">
+                <i class="fas fa-file-word me-2 text-primary"></i> Generar escrito
+              </a>
+            </li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item text-danger" href="#"
+                 data-accion="borrar"
+                 data-url="{{ url_for('vista3.borrar_tarea', tarea_id=tarea.id) }}"
+                 data-redirect="{{ url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id) }}">
+                <i class="fas fa-trash me-2"></i> Borrar
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
-    </div>
-
-    <div class="card-body card-body-tinted py-2">
-
-      {# Modo ver #}
-      <div data-modo-ver class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio" class="bc-fecha-valor">
-            {{- tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin" class="bc-fecha-valor">
-            {{- tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' -}}
-          </span>
-        </div>
+      <div data-modo-editar class="d-none d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+          Cancelar
+        </button>
       </div>
-
-      {# Modo editar #}
-      <form data-modo-editar class="d-none row g-2 pt-1"
-            data-url="{{ url_for('vista3.editar_tarea', tarea_id=tarea.id) }}">
-        <div class="col-md-4">
-          <label class="form-label fw-semibold mb-1">Tipo</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '—' }}"
-                 data-bs-toggle="tooltip" title="El tipo se establece al crear la tarea">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Inicio</label>
-          <div id="ef-fecha_inicio"
-               data-ef-name="fecha_inicio"
-               data-ef-value="{{ tarea.fecha_inicio.isoformat() if tarea.fecha_inicio else '' }}">
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Fin</label>
-          <div id="ef-fecha_fin"
-               data-ef-name="fecha_fin"
-               data-ef-value="{{ tarea.fecha_fin.isoformat() if tarea.fecha_fin else '' }}">
-          </div>
-        </div>
-        <div class="col-12">
-          <label class="form-label fw-semibold mb-1">Notas</label>
-          <textarea class="form-control form-control-sm" name="notas"
-                    rows="2">{{ tarea.notas or '' }}</textarea>
-        </div>
-      </form>
-
-      {# Mensajes de error/advertencia del motor de reglas #}
-      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
-
     </div>
   </div>
-  </div>{# /content-constrained #}
-</div>{# /lista-cabecera #}
 
-<!-- C.2: Tabs Documentos / Diagrama -->
-<div class="lista-scroll-container">
-  <div class="content-constrained pt-2 pb-3">
+  <div class="card-body card-body-tinted py-2">
 
-    <ul class="nav nav-tabs mb-3" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" data-bs-toggle="tab"
-                data-bs-target="#panel-documentos" type="button" role="tab" aria-selected="true">
-          <i class="fas fa-file-alt me-1"></i> Documentos
-        </button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" data-bs-toggle="tab"
-                data-bs-target="#panel-diagrama-tarea" type="button" role="tab" aria-selected="false">
-          <i class="fas fa-project-diagram me-1"></i> Diagrama
-        </button>
-      </li>
-    </ul>
-
-    <div class="tab-content">
-      <div class="tab-pane fade show active" id="panel-documentos" role="tabpanel">
-  <div id="card-documentos">
-  <div class="card">
-    <div class="card-header card-header-accent">
-      <h6 class="mb-0 fw-semibold"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
+    <div data-modo-ver class="row g-2 bc-meta">
+      <div class="col-auto">
+        <strong>F. Inicio:</strong>
+        <span id="disp-fecha_inicio" class="bc-fecha-valor">
+          {{- tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' -}}
+        </span>
+      </div>
+      <div class="col-auto">
+        <strong>F. Fin:</strong>
+        <span id="disp-fecha_fin" class="bc-fecha-valor">
+          {{- tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' -}}
+        </span>
+      </div>
     </div>
-    <div class="card-body card-body-tinted py-3">
 
-      {% if not requiere_doc_usado and not doc_usado_opcional and not requiere_doc_producido %}
-      <p class="text-secondary mb-0 fst-italic small">Este tipo de tarea no requiere documentos.</p>
-
-      {% else %}
-
-      {# ── Documento usado ────────────────────────────────────────────────────── #}
-      {% if requiere_doc_usado or doc_usado_opcional %}
-      <div class="mb-3">
-        <label class="form-label fw-semibold mb-1">Documento de entrada{% if doc_usado_opcional %} <span class="text-secondary fw-normal small">(opcional)</span>{% endif %}</label>
-        {# Modo ver #}
-        <div class="doc-modo-ver">
-          {% if tarea.documento_usado %}
-            {% set nombre_usado = tarea.documento_usado.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
-            <div class="d-flex align-items-center gap-2 flex-wrap">
-              <i class="fas fa-file-import text-secondary"></i>
-              <span id="disp-doc-usado" class="fw-semibold">{{ nombre_usado }}</span>
-              <small class="text-secondary">
-                — {{ tarea.documento_usado.tipo_doc.nombre if tarea.documento_usado.tipo_doc else '' }}
-                {% if tarea.documento_usado.fecha_administrativa %}
-                  — {{ tarea.documento_usado.fecha_administrativa.strftime('%d/%m/%Y') }}
-                {% endif %}
-              </small>
-              <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_usado.id) }}"
-                 class="btn btn-sm btn-outline-secondary ms-auto"
-                 target="_blank" rel="noopener">
-                <i class="fas fa-download me-1"></i>Descargar
-              </a>
-            </div>
-          {% else %}
-            <span id="disp-doc-usado" class="fst-italic text-secondary small">Sin documento asociado</span>
-          {% endif %}
-        </div>
-        {# Modo editar #}
-        <div class="doc-modo-editar d-none">
-          <div id="sb-doc-usado"></div>
+    <form data-modo-editar class="d-none row g-2 pt-1"
+          data-url="{{ url_for('vista3.editar_tarea', tarea_id=tarea.id) }}">
+      <div class="col-md-4">
+        <label class="form-label fw-semibold mb-1">Tipo</label>
+        <input type="text" class="form-control form-control-sm" readonly
+               value="{{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '—' }}"
+               data-bs-toggle="tooltip" title="El tipo se establece al crear la tarea">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Inicio</label>
+        <div id="ef-fecha_inicio"
+             data-ef-name="fecha_inicio"
+             data-ef-value="{{ tarea.fecha_inicio.isoformat() if tarea.fecha_inicio else '' }}">
         </div>
       </div>
-      {% endif %}
-
-      {# ── Documento producido ────────────────────────────────────────────────── #}
-      {% if requiere_doc_producido %}
-      <div class="mb-1">
-        <label class="form-label fw-semibold mb-1">Documento producido</label>
-        {# Modo ver #}
-        <div class="doc-modo-ver">
-          {% if tarea.documento_producido %}
-            {% set nombre_producido = tarea.documento_producido.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
-            <div class="d-flex align-items-center gap-2 flex-wrap">
-              <i class="fas fa-file-export text-secondary"></i>
-              <span id="disp-doc-producido" class="fw-semibold">{{ nombre_producido }}</span>
-              <small class="text-secondary">
-                — {{ tarea.documento_producido.tipo_doc.nombre if tarea.documento_producido.tipo_doc else '' }}
-                {% if tarea.documento_producido.fecha_administrativa %}
-                  — {{ tarea.documento_producido.fecha_administrativa.strftime('%d/%m/%Y') }}
-                {% endif %}
-              </small>
-              <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_producido.id) }}"
-                 class="btn btn-sm btn-outline-secondary ms-auto"
-                 target="_blank" rel="noopener">
-                <i class="fas fa-download me-1"></i>Descargar
-              </a>
-            </div>
-          {% else %}
-            <span id="disp-doc-producido" class="fst-italic text-secondary small">Sin documento asociado</span>
-          {% endif %}
-        </div>
-        {# Modo editar #}
-        <div class="doc-modo-editar d-none">
-          <div id="sb-doc-producido"></div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Fin</label>
+        <div id="ef-fecha_fin"
+             data-ef-name="fecha_fin"
+             data-ef-value="{{ tarea.fecha_fin.isoformat() if tarea.fecha_fin else '' }}">
         </div>
       </div>
-      {% endif %}
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-1">Notas</label>
+        <textarea class="form-control form-control-sm" name="notas"
+                  rows="2">{{ tarea.notas or '' }}</textarea>
+      </div>
+    </form>
 
-      {% endif %}{# /requiere_doc #}
+    <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
 
-    </div>
   </div>
-  </div>{# /card-documentos #}
-      </div>{# /tab-pane panel-documentos #}
+</div>
 
-      <div class="tab-pane fade" id="panel-diagrama-tarea" role="tabpanel">
-        <div class="card">
-          <div class="card-body text-center py-5 text-secondary">
-            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
-            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+{# Documentos #}
+<div class="card" id="card-documentos">
+  <div class="card-header card-header-accent">
+    <h6 class="mb-0 fw-semibold"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
+  </div>
+  <div class="card-body card-body-tinted py-3">
+
+    {% if not requiere_doc_usado and not doc_usado_opcional and not requiere_doc_producido %}
+    <p class="text-secondary mb-0 fst-italic small">Este tipo de tarea no requiere documentos.</p>
+
+    {% else %}
+
+    {# ── Documento usado ────────────────────────────────────────────────────── #}
+    {% if requiere_doc_usado or doc_usado_opcional %}
+    <div class="mb-3">
+      <label class="form-label fw-semibold mb-1">Documento de entrada{% if doc_usado_opcional %} <span class="text-secondary fw-normal small">(opcional)</span>{% endif %}</label>
+      <div class="doc-modo-ver">
+        {% if tarea.documento_usado %}
+          {% set nombre_usado = tarea.documento_usado.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
+          <div class="d-flex align-items-center gap-2 flex-wrap">
+            <i class="fas fa-file-import text-secondary"></i>
+            <span id="disp-doc-usado" class="fw-semibold">{{ nombre_usado }}</span>
+            <small class="text-secondary">
+              — {{ tarea.documento_usado.tipo_doc.nombre if tarea.documento_usado.tipo_doc else '' }}
+              {% if tarea.documento_usado.fecha_administrativa %}
+                — {{ tarea.documento_usado.fecha_administrativa.strftime('%d/%m/%Y') }}
+              {% endif %}
+            </small>
+            <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_usado.id) }}"
+               class="btn btn-sm btn-outline-secondary ms-auto"
+               target="_blank" rel="noopener">
+              <i class="fas fa-download me-1"></i>Descargar
+            </a>
           </div>
-        </div>
+        {% else %}
+          <span id="disp-doc-usado" class="fst-italic text-secondary small">Sin documento asociado</span>
+        {% endif %}
       </div>
+      <div class="doc-modo-editar d-none">
+        <div id="sb-doc-usado"></div>
+      </div>
+    </div>
+    {% endif %}
 
-    </div>{# /tab-content #}
-  </div>{# /content-constrained #}
-</div>{# /lista-scroll-container #}
+    {# ── Documento producido ────────────────────────────────────────────────── #}
+    {% if requiere_doc_producido %}
+    <div class="mb-1">
+      <label class="form-label fw-semibold mb-1">Documento producido</label>
+      <div class="doc-modo-ver">
+        {% if tarea.documento_producido %}
+          {% set nombre_producido = tarea.documento_producido.url.replace('\\', '/').rsplit('/', 1)[-1].split('?')[0].split('#')[0] %}
+          <div class="d-flex align-items-center gap-2 flex-wrap">
+            <i class="fas fa-file-export text-secondary"></i>
+            <span id="disp-doc-producido" class="fw-semibold">{{ nombre_producido }}</span>
+            <small class="text-secondary">
+              — {{ tarea.documento_producido.tipo_doc.nombre if tarea.documento_producido.tipo_doc else '' }}
+              {% if tarea.documento_producido.fecha_administrativa %}
+                — {{ tarea.documento_producido.fecha_administrativa.strftime('%d/%m/%Y') }}
+              {% endif %}
+            </small>
+            <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=tarea.documento_producido.id) }}"
+               class="btn btn-sm btn-outline-secondary ms-auto"
+               target="_blank" rel="noopener">
+              <i class="fas fa-download me-1"></i>Descargar
+            </a>
+          </div>
+        {% else %}
+          <span id="disp-doc-producido" class="fst-italic text-secondary small">Sin documento asociado</span>
+        {% endif %}
+      </div>
+      <div class="doc-modo-editar d-none">
+        <div id="sb-doc-producido"></div>
+      </div>
+    </div>
+    {% endif %}
+
+    {% endif %}{# /requiere_doc #}
+
+  </div>
+</div>
 
 {% if es_tarea_redactar %}
 {# ── Modal Generar Escrito (#167 Fase 5) ───────────────────────────── #}
@@ -324,20 +257,15 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
       </div>
       <div class="modal-body">
-
-        {# Paso 1: Selección de plantilla #}
         <div id="ge-paso1">
           <label class="form-label fw-semibold mb-1">Plantilla</label>
           <div id="ge-selector-plantilla"></div>
           <small class="text-secondary" id="ge-contador">Cargando plantillas...</small>
         </div>
-
-        {# Paso 2: Preview y opciones (oculto hasta selección) #}
         <div id="ge-paso2" class="d-none mt-3">
           <hr>
           <h6 class="fw-semibold mb-2">Datos del contexto</h6>
           <div id="ge-preview-campos" class="row g-2 mb-3"></div>
-
           <div class="row g-2 mb-3">
             <div class="col-12">
               <label class="form-label fw-semibold mb-1">Nombre del fichero</label>
@@ -348,7 +276,6 @@
               <input type="text" class="form-control form-control-sm" id="ge-ruta-destino" readonly>
             </div>
           </div>
-
           <div class="d-flex flex-column gap-1">
             <div class="form-check">
               <input class="form-check-input" type="checkbox" id="ge-check-pool" checked>
@@ -364,15 +291,12 @@
             </div>
           </div>
         </div>
-
-        {# Spinner durante generación #}
         <div id="ge-spinner" class="d-none text-center py-4">
           <div class="spinner-border text-primary" role="status">
             <span class="visually-hidden">Generando...</span>
           </div>
           <p class="mt-2 text-secondary">Generando escrito...</p>
         </div>
-
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
@@ -385,11 +309,9 @@
 </div>
 {% endif %}
 
-</div>
 {% endblock %}
 
-{% block extra_js %}{{ super() }}
-<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}
 <script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -190,8 +190,28 @@
   </div>{# /content-constrained #}
 </div>{# /lista-cabecera #}
 
-<!-- C.2: Documentos (scrollable) -->
-<div class="lista-scroll-container p-3" id="card-documentos">
+<!-- C.2: Tabs Documentos / Diagrama -->
+<div class="lista-scroll-container">
+  <div class="content-constrained pt-2 pb-3">
+
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" data-bs-toggle="tab"
+                data-bs-target="#panel-documentos" type="button" role="tab" aria-selected="true">
+          <i class="fas fa-file-alt me-1"></i> Documentos
+        </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab"
+                data-bs-target="#panel-diagrama-tarea" type="button" role="tab" aria-selected="false">
+          <i class="fas fa-project-diagram me-1"></i> Diagrama
+        </button>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="panel-documentos" role="tabpanel">
+  <div id="card-documentos">
   <div class="card">
     <div class="card-header card-header-accent">
       <h6 class="mb-0 fw-semibold"><i class="fas fa-file-alt me-2"></i>Documentos</h6>
@@ -275,7 +295,21 @@
 
     </div>
   </div>
-</div>
+  </div>{# /card-documentos #}
+      </div>{# /tab-pane panel-documentos #}
+
+      <div class="tab-pane fade" id="panel-diagrama-tarea" role="tabpanel">
+        <div class="card">
+          <div class="card-body text-center py-5 text-secondary">
+            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+          </div>
+        </div>
+      </div>
+
+    </div>{# /tab-content #}
+  </div>{# /content-constrained #}
+</div>{# /lista-scroll-container #}
 
 {% if es_tarea_redactar %}
 {# ── Modal Generar Escrito (#167 Fase 5) ───────────────────────────── #}

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -33,6 +33,7 @@
 {% endblock %}
 
 {% from 'macros/page_header.html' import page_header %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block content %}
 <div class="bc-view">
@@ -50,12 +51,26 @@
     </a>
   {% endcall %}
   <div class="content-constrained pb-3">
+
+  {# Cards compactos de niveles superiores #}
+  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
+      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
+  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
+  {{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
+      'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
+      url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
+  {{ bc_card_compacto('fas fa-tasks', 'bc-icon-tramite',
+      'Trámite: ' ~ (tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id),
+      url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id)) }}
+
   <div class="card bc-card-nodo" data-bc-editable>
 
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-check-square me-2"></i>
-        Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span class="fw-semibold d-flex align-items-center gap-2">
+        <i class="fas fa-check-square fs-5 bc-icon-tarea"></i>
+        <span>Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}</span>
       </span>
       <div class="bc-acciones-bar">
         {# Modo ver #}
@@ -125,13 +140,13 @@
       <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio">
+          <span id="disp-fecha_inicio" class="bc-fecha-valor">
             {{- tarea.fecha_inicio.strftime('%d/%m/%Y') if tarea.fecha_inicio else '—' -}}
           </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin">
+          <span id="disp-fecha_fin" class="bc-fecha-valor">
             {{- tarea.fecha_fin.strftime('%d/%m/%Y') if tarea.fecha_fin else '—' -}}
           </span>
         </div>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -1,4 +1,5 @@
-{% extends 'layout/base_fullwidth.html' %}
+{% extends 'layout/base_bc.html' %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block title %}Tramitación AT-{{ expediente.numero_at }} — Trámite - BDDAT{% endblock %}
 
@@ -22,218 +23,153 @@
 <span>{{ tramite.tipo_tramite.label_bc if tramite.tipo_tramite else 'Trámite #' ~ tramite.id }}</span>
 {% endblock %}
 
-{% block extra_css %}{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
-{% endblock %}
+{% block bc_content %}
 
-{% from 'macros/page_header.html' import page_header %}
-{% from 'macros/bc_cards.html' import bc_card_compacto %}
+{# Cards compactos de niveles superiores #}
+{{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+    'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+    url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
+{{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
+    'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
+    url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
 
-{% block content %}
-<div class="bc-view">
+{# Estado del trámite deducido de fechas #}
+{% if tramite.fecha_fin %}
+  {% set tram_badge_class = 'bg-success' %}
+  {% set tram_badge_label = 'Finalizado' %}
+{% elif tramite.fecha_inicio %}
+  {% set tram_badge_class = 'bg-primary' %}
+  {% set tram_badge_label = 'En curso' %}
+{% else %}
+  {% set tram_badge_class = 'bg-secondary' %}
+  {% set tram_badge_label = 'Planificado' %}
+{% endif %}
 
-<!-- C.1 -->
-<div class="lista-cabecera">
-  {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
-    <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-info-circle me-1"></i> Detalle
-    </a>
-    <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
-       class="btn btn-sm btn-outline-primary">
-      <i class="fas fa-file-alt me-1"></i> Pool de Docs
-    </a>
-  {% endcall %}
-  <div class="content-constrained pb-3">
+{# Card activo: Trámite #}
+<div class="card bc-card-nodo mb-3" data-bc-editable>
 
-  {# Cards compactos de niveles superiores #}
-  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
-      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
-  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
-      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
-      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
-  {{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
-      'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
-      url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
-
-  {# Estado del trámite deducido de fechas #}
-  {% if tramite.fecha_fin %}
-    {% set tram_badge_class = 'bg-success' %}
-    {% set tram_badge_label = 'Finalizado' %}
-  {% elif tramite.fecha_inicio %}
-    {% set tram_badge_class = 'bg-primary' %}
-    {% set tram_badge_label = 'En curso' %}
-  {% else %}
-    {% set tram_badge_class = 'bg-secondary' %}
-    {% set tram_badge_label = 'Planificado' %}
-  {% endif %}
-
-  <div class="card bc-card-nodo" data-bc-editable>
-
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <span class="fw-semibold d-flex align-items-center gap-2">
-        <i class="fas fa-tasks fs-5 bc-icon-tramite"></i>
-        <span>Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id }}</span>
-        <span class="badge {{ tram_badge_class }} ms-1">{{ tram_badge_label }}</span>
-      </span>
-      <div class="bc-acciones-bar">
-        {# Modo ver #}
-        <div data-modo-ver class="d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
-            <i class="fas fa-edit me-1"></i> Editar
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span class="fw-semibold d-flex align-items-center gap-2">
+      <i class="fas fa-tasks fs-5 bc-icon-tramite"></i>
+      <span>Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id }}</span>
+      <span class="badge {{ tram_badge_class }} ms-1">{{ tram_badge_label }}</span>
+    </span>
+    <div class="bc-acciones-bar">
+      <div data-modo-ver class="d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-outline-primary btn-editar-bc">
+          <i class="fas fa-edit me-1"></i> Editar
+        </button>
+        <div class="dropdown">
+          <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                  data-bs-toggle="dropdown" aria-expanded="false">
+            Acciones
           </button>
-          <div class="dropdown">
-            <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                    data-bs-toggle="dropdown" aria-expanded="false">
-              Acciones
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-              {% if not tramite.fecha_inicio %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="iniciar"
-                   data-url="{{ url_for('vista3.iniciar_tramite', tram_id=tramite.id) }}">
-                  <i class="fas fa-play me-2 text-success"></i> Iniciar
-                </a>
-              </li>
-              {% endif %}
-              {% if tramite.fecha_inicio and not tramite.fecha_fin %}
-              <li>
-                <a class="dropdown-item" href="#"
-                   data-accion="finalizar"
-                   data-url="{{ url_for('vista3.finalizar_tramite', tram_id=tramite.id) }}">
-                  <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
-                </a>
-              </li>
-              {% endif %}
-              <li><hr class="dropdown-divider"></li>
-              <li>
-                <a class="dropdown-item text-danger" href="#"
-                   data-accion="borrar"
-                   data-url="{{ url_for('vista3.borrar_tramite', tram_id=tramite.id) }}"
-                   data-redirect="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
-                  <i class="fas fa-trash me-2"></i> Borrar
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        {# Modo editar #}
-        <div data-modo-editar class="d-none d-flex gap-1">
-          <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
-            <i class="fas fa-save me-1"></i> Guardar
-          </button>
-          <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
-            Cancelar
-          </button>
+          <ul class="dropdown-menu dropdown-menu-end">
+            {% if not tramite.fecha_inicio %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="iniciar"
+                 data-url="{{ url_for('vista3.iniciar_tramite', tram_id=tramite.id) }}">
+                <i class="fas fa-play me-2 text-success"></i> Iniciar
+              </a>
+            </li>
+            {% endif %}
+            {% if tramite.fecha_inicio and not tramite.fecha_fin %}
+            <li>
+              <a class="dropdown-item" href="#"
+                 data-accion="finalizar"
+                 data-url="{{ url_for('vista3.finalizar_tramite', tram_id=tramite.id) }}">
+                <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
+              </a>
+            </li>
+            {% endif %}
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <a class="dropdown-item text-danger" href="#"
+                 data-accion="borrar"
+                 data-url="{{ url_for('vista3.borrar_tramite', tram_id=tramite.id) }}"
+                 data-redirect="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
+                <i class="fas fa-trash me-2"></i> Borrar
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
-    </div>
-
-    <div class="card-body card-body-tinted py-2">
-
-      {# Modo ver #}
-      <div data-modo-ver class="row g-2 bc-meta">
-        <div class="col-auto">
-          <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio" class="bc-fecha-valor">
-            {{- tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else '—' -}}
-          </span>
-        </div>
-        <div class="col-auto">
-          <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin" class="bc-fecha-valor">
-            {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
-          </span>
-        </div>
+      <div data-modo-editar class="d-none d-flex gap-1">
+        <button type="button" class="btn btn-sm btn-primary btn-guardar-bc">
+          <i class="fas fa-save me-1"></i> Guardar
+        </button>
+        <button type="button" class="btn btn-sm btn-outline-secondary btn-cancelar-bc">
+          Cancelar
+        </button>
       </div>
-
-      {# Modo editar #}
-      <form data-modo-editar class="d-none row g-2 pt-1"
-            data-url="{{ url_for('vista3.editar_tramite', tram_id=tramite.id) }}">
-        <div class="col-md-4">
-          <label class="form-label fw-semibold mb-1">Tipo</label>
-          <input type="text" class="form-control form-control-sm" readonly
-                 value="{{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '—' }}"
-                 data-bs-toggle="tooltip" title="El tipo se establece al crear el trámite">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Inicio</label>
-          <div id="ef-fecha_inicio"
-               data-ef-name="fecha_inicio"
-               data-ef-value="{{ tramite.fecha_inicio.isoformat() if tramite.fecha_inicio else '' }}">
-          </div>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label fw-semibold mb-1">F. Fin</label>
-          <div id="ef-fecha_fin"
-               data-ef-name="fecha_fin"
-               data-ef-value="{{ tramite.fecha_fin.isoformat() if tramite.fecha_fin else '' }}">
-          </div>
-        </div>
-        <div class="col-12">
-          <label class="form-label fw-semibold mb-1">Observaciones</label>
-          <textarea class="form-control form-control-sm" name="observaciones"
-                    rows="2">{{ tramite.observaciones or '' }}</textarea>
-        </div>
-      </form>
-
-      {# Mensajes de error/advertencia del motor de reglas #}
-      <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
-
     </div>
   </div>
-  </div>{# /content-constrained #}
-</div>{# /lista-cabecera #}
 
-<!-- C.2: Tabs Tareas / Diagrama -->
-<div class="lista-scroll-container">
-  <div class="content-constrained pt-2 pb-3">
+  <div class="card-body card-body-tinted py-2">
 
-    <ul class="nav nav-tabs mb-3" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" data-bs-toggle="tab"
-                data-bs-target="#panel-tareas" type="button" role="tab" aria-selected="true">
-          <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
-          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
-        </button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" data-bs-toggle="tab"
-                data-bs-target="#panel-diagrama-tram" type="button" role="tab" aria-selected="false">
-          <i class="fas fa-project-diagram me-1"></i> Diagrama
-        </button>
-      </li>
-    </ul>
-
-    <div class="tab-content">
-      <div class="tab-pane fade show active" id="panel-tareas" role="tabpanel">
-        <div class="card tabla-bloque">
-          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-            <span class="fw-semibold">
-              <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
-              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-            </span>
-            <button class="btn btn-sm btn-primary"
-                    data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
-              <i class="fas fa-plus me-1"></i> Nueva tarea
-            </button>
-          </div>
-          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
-        </div>
+    <div data-modo-ver class="row g-2 bc-meta">
+      <div class="col-auto">
+        <strong>F. Inicio:</strong>
+        <span id="disp-fecha_inicio" class="bc-fecha-valor">
+          {{- tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else '—' -}}
+        </span>
       </div>
-      <div class="tab-pane fade" id="panel-diagrama-tram" role="tabpanel">
-        <div class="card">
-          <div class="card-body text-center py-5 text-secondary">
-            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
-            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
-          </div>
-        </div>
+      <div class="col-auto">
+        <strong>F. Fin:</strong>
+        <span id="disp-fecha_fin" class="bc-fecha-valor">
+          {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
+        </span>
       </div>
     </div>
 
+    <form data-modo-editar class="d-none row g-2 pt-1"
+          data-url="{{ url_for('vista3.editar_tramite', tram_id=tramite.id) }}">
+      <div class="col-md-4">
+        <label class="form-label fw-semibold mb-1">Tipo</label>
+        <input type="text" class="form-control form-control-sm" readonly
+               value="{{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '—' }}"
+               data-bs-toggle="tooltip" title="El tipo se establece al crear el trámite">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Inicio</label>
+        <div id="ef-fecha_inicio"
+             data-ef-name="fecha_inicio"
+             data-ef-value="{{ tramite.fecha_inicio.isoformat() if tramite.fecha_inicio else '' }}">
+        </div>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label fw-semibold mb-1">F. Fin</label>
+        <div id="ef-fecha_fin"
+             data-ef-name="fecha_fin"
+             data-ef-value="{{ tramite.fecha_fin.isoformat() if tramite.fecha_fin else '' }}">
+        </div>
+      </div>
+      <div class="col-12">
+        <label class="form-label fw-semibold mb-1">Observaciones</label>
+        <textarea class="form-control form-control-sm" name="observaciones"
+                  rows="2">{{ tramite.observaciones or '' }}</textarea>
+      </div>
+    </form>
+
+    <div id="alert-edicion" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
   </div>
+</div>
+
+{# Lista de Tareas #}
+<div class="card tabla-bloque">
+  <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+    <span class="fw-semibold">
+      <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
+      <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+    </span>
+    <button class="btn btn-sm btn-primary"
+            data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
+      <i class="fas fa-plus me-1"></i> Nueva tarea
+    </button>
+  </div>
+  {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
 </div>
 
 <!-- Modal Nueva Tarea -->
@@ -275,11 +211,9 @@
   </div>
 </div>
 
-</div>
 {% endblock %}
 
-{% block extra_js %}{{ super() }}
-<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-crear.js') }}"></script>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -187,22 +187,52 @@
   </div>{# /content-constrained #}
 </div>{# /lista-cabecera #}
 
-<!-- C.2: Listado de Tareas (scrollable) -->
+<!-- C.2: Tabs Tareas / Diagrama -->
 <div class="lista-scroll-container">
-  <div class="content-constrained py-3">
-    <div class="card tabla-bloque">
-      <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
-        <span class="fw-semibold">
+  <div class="content-constrained pt-2 pb-3">
+
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" data-bs-toggle="tab"
+                data-bs-target="#panel-tareas" type="button" role="tab" aria-selected="true">
           <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
-          <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
-        </span>
-        <button class="btn btn-sm btn-primary"
-                data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
-          <i class="fas fa-plus me-1"></i> Nueva tarea
+          <span class="badge bg-primary ms-1">{{ hijos | length }}</span>
         </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" data-bs-toggle="tab"
+                data-bs-target="#panel-diagrama-tram" type="button" role="tab" aria-selected="false">
+          <i class="fas fa-project-diagram me-1"></i> Diagrama
+        </button>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+      <div class="tab-pane fade show active" id="panel-tareas" role="tabpanel">
+        <div class="card tabla-bloque">
+          <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
+            <span class="fw-semibold">
+              <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
+              <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
+            </span>
+            <button class="btn btn-sm btn-primary"
+                    data-bs-toggle="modal" data-bs-target="#modal-nueva-tarea-bc">
+              <i class="fas fa-plus me-1"></i> Nueva tarea
+            </button>
+          </div>
+          {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+        </div>
       </div>
-      {% include 'vistas/vista3_bc/_tabla_hijos.html' %}
+      <div class="tab-pane fade" id="panel-diagrama-tram" role="tabpanel">
+        <div class="card">
+          <div class="card-body text-center py-5 text-secondary">
+            <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+            <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+          </div>
+        </div>
+      </div>
     </div>
+
   </div>
 </div>
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -28,6 +28,7 @@
 {% endblock %}
 
 {% from 'macros/page_header.html' import page_header %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
 
 {% block content %}
 <div class="bc-view">
@@ -45,12 +46,36 @@
     </a>
   {% endcall %}
   <div class="content-constrained pb-3">
+
+  {# Cards compactos de niveles superiores #}
+  {{ bc_card_compacto('fas fa-folder-open', '', 'Expediente AT-' ~ expediente.numero_at,
+      url_for('expedientes.tramitacion_bc', exp_id=expediente.id)) }}
+  {{ bc_card_compacto('fas fa-file-alt', 'bc-icon-solicitud',
+      'Solicitud: ' ~ (solicitud.tipo_solicitud.siglas if solicitud.tipo_solicitud else '#' ~ solicitud.id),
+      url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id)) }}
+  {{ bc_card_compacto('fas fa-layer-group', 'bc-icon-fase',
+      'Fase: ' ~ (fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id),
+      url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id)) }}
+
+  {# Estado del trámite deducido de fechas #}
+  {% if tramite.fecha_fin %}
+    {% set tram_badge_class = 'bg-success' %}
+    {% set tram_badge_label = 'Finalizado' %}
+  {% elif tramite.fecha_inicio %}
+    {% set tram_badge_class = 'bg-primary' %}
+    {% set tram_badge_label = 'En curso' %}
+  {% else %}
+    {% set tram_badge_class = 'bg-secondary' %}
+    {% set tram_badge_label = 'Planificado' %}
+  {% endif %}
+
   <div class="card bc-card-nodo" data-bc-editable>
 
-    <div class="card-header card-header-accent d-flex justify-content-between align-items-center">
-      <span class="fw-semibold">
-        <i class="fas fa-tasks me-2"></i>
-        Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id }}
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span class="fw-semibold d-flex align-items-center gap-2">
+        <i class="fas fa-tasks fs-5 bc-icon-tramite"></i>
+        <span>Trámite: {{ tramite.tipo_tramite.nombre if tramite.tipo_tramite else '#' ~ tramite.id }}</span>
+        <span class="badge {{ tram_badge_class }} ms-1">{{ tram_badge_label }}</span>
       </span>
       <div class="bc-acciones-bar">
         {# Modo ver #}
@@ -112,13 +137,13 @@
       <div data-modo-ver class="row g-2 bc-meta">
         <div class="col-auto">
           <strong>F. Inicio:</strong>
-          <span id="disp-fecha_inicio">
+          <span id="disp-fecha_inicio" class="bc-fecha-valor">
             {{- tramite.fecha_inicio.strftime('%d/%m/%Y') if tramite.fecha_inicio else '—' -}}
           </span>
         </div>
         <div class="col-auto">
           <strong>F. Fin:</strong>
-          <span id="disp-fecha_fin">
+          <span id="disp-fecha_fin" class="bc-fecha-valor">
             {{- tramite.fecha_fin.strftime('%d/%m/%Y') if tramite.fecha_fin else '—' -}}
           </span>
         </div>

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -193,7 +193,7 @@
     <div class="card tabla-bloque">
       <div class="card-header card-header-accent d-flex justify-content-between align-items-center py-2">
         <span class="fw-semibold">
-          <i class="fas fa-tasks me-1"></i> Tareas
+          <i class="fas fa-tasks fs-5 bc-icon-tarea me-1"></i> Tareas
           <span class="badge bg-primary ms-2">{{ hijos | length }}</span>
         </span>
         <button class="btn btn-sm btn-primary"

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -12,8 +12,9 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
 }
 
-/* Cabecera blanca — el color queda exclusivamente en el icono de nivel */
-.bc-card-nodo .card-header {
+/* Cabecera blanca en toda la vista bc — el color queda exclusivamente en el icono */
+.bc-view .card-header,
+.bc-view .card-header-accent {
     background-color: #fff;
     border-bottom: 1px solid rgba(0, 0, 0, 0.125);
     color: var(--bs-body-color);

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -12,14 +12,59 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
 }
 
-/* Texto de metadatos dentro del card de nodo (fechas, estado) */
-.bc-meta {
-    font-size: 0.85rem;
-    color: var(--bs-secondary-color, #6c757d);
+/* Cabecera blanca — el color queda exclusivamente en el icono de nivel */
+.bc-card-nodo .card-header {
+    background-color: #fff;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    color: var(--bs-body-color);
 }
 
-.bc-meta strong {
+/* Iconos de nivel SFTT — color identificativo por nivel (#274) */
+.bc-icon-solicitud { color: #3b7dd8; }
+.bc-icon-fase      { color: #d97706; }
+.bc-icon-tramite   { color: #7c3aed; }
+.bc-icon-tarea     { color: #16a34a; }
+
+/* Texto de metadatos dentro del card de nodo (fechas, estado) */
+.bc-meta {
+    /* Sin reducción de tamaño ni gris — las fechas son dato operacional principal */
+    font-size: 1rem;
     color: var(--bs-body-color);
+}
+
+/* Valor de fecha en negrita para máximo peso visual */
+.bc-fecha-valor {
+    font-weight: 600;
+}
+
+/* ── Cards compactos apilados (breadcrumb visual, #274) ──────────────────── */
+
+.bc-card-compacto {
+    text-decoration: none;
+    color: var(--bs-body-color);
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: var(--bs-border-radius);
+    background-color: #fff;
+    padding: 0.4rem 0.75rem;
+    margin-bottom: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.12s ease;
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.bc-card-compacto:hover {
+    background-color: #f8f9fa;
+    color: var(--bs-body-color);
+    text-decoration: none;
+}
+
+.bc-card-compacto .bc-compacto-label {
+    font-weight: 500;
+    flex: 1;
 }
 
 /* ── Indicadores de estado en tabla de hijos ────────────────────────────── */

--- a/app/templates/layout/base_bc.html
+++ b/app/templates/layout/base_bc.html
@@ -1,0 +1,107 @@
+{#
+  base_bc.html — Layout compartido para todas las vistas de tramitación bc (#274)
+
+  Bloques que los templates hijo deben/pueden definir:
+    title        — título de página (obligatorio)
+    breadcrumb   — migas de pan (obligatorio)
+    bc_content   — contenido del tab "Expediente" (obligatorio)
+    extra_css_bc — CSS adicional específico del nivel (opcional)
+    extra_js_bc  — JS adicional específico del nivel (opcional)
+
+  Variables de contexto requeridas en todas las rutas bc:
+    expediente — objeto Expediente (siempre disponible)
+#}
+{% extends 'layout/base_fullwidth.html' %}
+
+{% from 'macros/page_header.html' import page_header %}
+{% from 'macros/bc_cards.html' import bc_card_compacto %}
+
+{% block extra_css %}{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/v3-breadcrumbs.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/entrada_fecha.css') }}">
+{% block extra_css_bc %}{% endblock %}
+{% endblock %}
+
+{% block content %}
+<div class="bc-view">
+
+  <!-- Header fijo: siempre visible en todos los niveles -->
+  <div class="lista-cabecera">
+    {% call page_header('Expediente', 'fas fa-folder-open', title_accent='AT-' ~ expediente.numero_at) %}
+      <a href="{{ url_for('expedientes.detalle', id=expediente.id) }}"
+         class="btn btn-sm btn-outline-primary">
+        <i class="fas fa-info-circle me-1"></i> Detalle
+      </a>
+      <a href="{{ url_for('expedientes.pool_documentos', id=expediente.id) }}"
+         class="btn btn-sm btn-outline-primary">
+        <i class="fas fa-file-alt me-1"></i> Pool de Docs
+      </a>
+    {% endcall %}
+    <div class="page-subheader content-constrained">
+      <div class="page-subheader-data">
+        <div class="subheader-item">
+          <strong>Titular:</strong>
+          {{ expediente.titular.nombre_completo if expediente.titular else '—' }}
+        </div>
+        <div class="subheader-item">
+          <strong>Responsable:</strong>
+          {{ expediente.responsable.siglas if expediente.responsable else '—' }}
+        </div>
+        <div class="subheader-item">
+          <strong>Tipo:</strong>
+          {{ expediente.tipo_expediente.tipo if expediente.tipo_expediente else '—' }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Tabs permanentes: Expediente | Diagrama -->
+  <div class="lista-scroll-container">
+    <div class="content-constrained pt-2 pb-3">
+
+      <ul class="nav nav-tabs mb-3" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" data-bs-toggle="tab"
+                  data-bs-target="#bc-panel-expediente" type="button" role="tab"
+                  aria-selected="true">
+            <i class="fas fa-folder-open me-1"></i> Expediente
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" data-bs-toggle="tab"
+                  data-bs-target="#bc-panel-diagrama" type="button" role="tab"
+                  aria-selected="false">
+            <i class="fas fa-project-diagram me-1"></i> Diagrama
+          </button>
+        </li>
+      </ul>
+
+      <div class="tab-content">
+
+        <!-- Tab Expediente: contenido específico del nivel actual -->
+        <div class="tab-pane fade show active" id="bc-panel-expediente" role="tabpanel">
+          {% block bc_content %}{% endblock %}
+        </div>
+
+        <!-- Tab Diagrama: placeholder — issue #285 -->
+        <div class="tab-pane fade" id="bc-panel-diagrama" role="tabpanel"
+             data-expediente-id="{{ expediente.id }}">
+          <div class="card">
+            <div class="card-body text-center py-5 text-secondary">
+              <i class="fas fa-project-diagram fa-3x mb-3 opacity-50"></i>
+              <p class="mb-0 fst-italic">Diagrama interactivo — pendiente de implementar (#285)</p>
+            </div>
+          </div>
+        </div>
+
+      </div>{# /tab-content #}
+    </div>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block extra_js %}{{ super() }}
+<script src="{{ url_for('static', filename='js/entrada_fecha.js') }}"></script>
+{% block extra_js_bc %}{% endblock %}
+{% endblock %}

--- a/app/templates/macros/bc_cards.html
+++ b/app/templates/macros/bc_cards.html
@@ -1,0 +1,19 @@
+{#
+  bc_cards.html — Macros para los cards apilados compactos de la vista bc (#274)
+
+  Uso: {% from 'macros/bc_cards.html' import bc_card_compacto %}
+
+  bc_card_compacto(icon, icon_class, label, url)
+    icon       — clase FA del icono (ej: 'fas fa-file-alt')
+    icon_class — clase de color de nivel (ej: 'bc-icon-solicitud')
+    label      — texto del card compacto
+    url        — URL de navegación al clicar
+#}
+
+{% macro bc_card_compacto(icon, icon_class, label, url) %}
+<a href="{{ url }}" class="bc-card-compacto">
+  <i class="{{ icon }} fs-5 {{ icon_class }}"></i>
+  <span class="bc-compacto-label">{{ label }}</span>
+  <i class="fas fa-chevron-right text-secondary" style="font-size:0.75rem;"></i>
+</a>
+{% endmacro %}


### PR DESCRIPTION
## Cambios

- **`base_bc.html`** (nuevo): layout compartido para todas las vistas bc — centraliza header fijo (Expediente AT-XXXX + Titular/Responsable/Tipo), tabs permanentes "Expediente" | "Diagrama" y CSS/JS comunes
- Los 5 templates bc extienden `base_bc.html` y definen solo su `bc_content` específico
- Tab "Diagrama" siempre visible en todos los niveles SFTT (placeholder para #285), accesible desde cualquier profundidad de navegación
- Card header blanco en toda la vista bc; color identificativo por nivel exclusivamente en el icono (Solicitud azul, Fase ámbar, Trámite violeta, Tarea verde)
- Cards compactos apilados como breadcrumb visual: niveles superiores clicables encima del card activo expandido
- Badge de estado explícito en header de Fase y Trámite (deducido de fechas)
- Fechas en modo ver a tamaño normal con `fw-semibold`
- Macro `bc_card_compacto` en `macros/bc_cards.html`

Closes #274
