### PR TITLE
POC React+Vite: diagrama interactivo ESFTT con ReactFlow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ app/static/uploads/*
 # Documentos de prueba locales (no versionar binarios ni datos reales)
 docs_prueba/
 contexto_completo_gemini.txt
+
+# React+Vite POC #291 — artefactos de build
+react-diagramas/node_modules/
+app/static/js/react/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,11 +55,12 @@ def create_app(config_name='development'):
         return Usuario.query.get(int(user_id))
 
     # Registrar blueprints - Rutas principales
-    from app.routes import auth, dashboard, perfil
+    from app.routes import auth, dashboard, perfil, demo
 
     app.register_blueprint(auth.bp)
     app.register_blueprint(dashboard.bp)
     app.register_blueprint(perfil.bp)
+    app.register_blueprint(demo.bp)  # POC React #291
 
     # Registrar blueprints - Wizards
     from app.routes import wizard_expediente

--- a/app/routes/demo.py
+++ b/app/routes/demo.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+bp = Blueprint('demo', __name__, url_prefix='/demo')
+
+
+@bp.route('/diagrama')
+def diagrama():
+    """POC React+Vite — diagrama interactivo árbol ESFTT. Spike #291."""
+    return render_template('demo/diagrama.html')

--- a/app/templates/demo/diagrama.html
+++ b/app/templates/demo/diagrama.html
@@ -1,0 +1,52 @@
+{% extends "layout/base_fullwidth.html" %}
+
+{% block title %}Diagrama ESFTT POC{% endblock %}
+
+{% block breadcrumb %}
+<a href="{{ url_for('dashboard.index') }}">Inicio</a>
+<span>›</span>
+<span>Demo React — Diagrama ESFTT</span>
+{% endblock %}
+
+{% block content %}
+<div class="lista-cabecera">
+  <div class="page-header content-constrained">
+    <div>
+      <h1>
+        <i class="bi bi-diagram-3-fill"></i>
+        Diagrama ESFTT — POC React+Vite
+      </h1>
+      <p class="text-secondary">
+        Árbol interactivo Solicitud → Fase → Trámite.
+        Arrastra nodos, zoom con rueda, pan con click+arrastrar.
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="content-constrained mt-3">
+  <div class="card">
+    <div class="card-header d-flex align-items-center gap-2">
+      <strong>Expediente AT-2024-042</strong>
+      <span class="badge bg-secondary">POC #291</span>
+    </div>
+    <div class="card-body p-0">
+      {# Contenedor donde React monta el diagrama #}
+      <div id="diagrama-esftt-root" class="diagrama-esftt-wrapper"></div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{# Bundle IIFE — incluye React, ReactFlow y sus estilos (inyectados por JS) #}
+<script src="{{ url_for('static', filename='js/react/diagrama-esftt.iife.js') }}"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var el = document.getElementById('diagrama-esftt-root');
+    if (el && window.DiagramaEsftt) {
+      window.DiagramaEsftt.mount(el);
+    }
+  });
+</script>
+{% endblock %}

--- a/app/templates/demo/diagrama.html
+++ b/app/templates/demo/diagrama.html
@@ -38,8 +38,13 @@
 </div>
 {% endblock %}
 
+{% block extra_css %}
+{# CSS de ReactFlow extraído por Vite build — debe cargarse antes del bundle #}
+<link rel="stylesheet" href="{{ url_for('static', filename='js/react/diagrama-esftt.css') }}">
+{% endblock %}
+
 {% block extra_js %}
-{# Bundle IIFE — incluye React, ReactFlow y sus estilos (inyectados por JS) #}
+{# Bundle IIFE — incluye React y ReactFlow #}
 <script src="{{ url_for('static', filename='js/react/diagrama-esftt.iife.js') }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {

--- a/react-diagramas/index.html
+++ b/react-diagramas/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diagrama ESFTT — desarrollo standalone</title>
+  <style>
+    body { margin: 0; }
+    #root { width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/react-diagramas/package.json
+++ b/react-diagramas/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bddat-react-diagramas",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@xyflow/react": "^12.3.6"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.1.0"
+  }
+}

--- a/react-diagramas/src/DiagramaEsftt.jsx
+++ b/react-diagramas/src/DiagramaEsftt.jsx
@@ -1,7 +1,7 @@
 import '@xyflow/react/dist/style.css'
 import './styles/diagrama.css'
 import React, { useMemo } from 'react'
-import { ReactFlow, Background, Controls } from '@xyflow/react'
+import { ReactFlow, Background, Controls, useNodesState, useEdgesState } from '@xyflow/react'
 import { COLORES, MOCK } from './mockData.js'
 
 // Posición X fija por nivel (columnas)
@@ -82,13 +82,18 @@ function buildGraph(data) {
 }
 
 export default function DiagramaEsftt() {
-  const { nodes, edges } = useMemo(() => buildGraph(MOCK), [])
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(() => buildGraph(MOCK), [])
+  // useNodesState/useEdgesState habilitan el drag: onNodesChange actualiza posiciones en el store
+  const [nodes, , onNodesChange] = useNodesState(initialNodes)
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges)
 
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
         fitView
         fitViewOptions={{ padding: 0.3 }}
         minZoom={0.2}

--- a/react-diagramas/src/DiagramaEsftt.jsx
+++ b/react-diagramas/src/DiagramaEsftt.jsx
@@ -1,0 +1,86 @@
+import '@xyflow/react/dist/style.css'
+import './styles/diagrama.css'
+import React, { useMemo } from 'react'
+import { ReactFlow, Background, Controls, MiniMap } from '@xyflow/react'
+import { COLORES, MOCK } from './mockData.js'
+
+// Posición X fija por nivel (columnas)
+const X = { solicitud: 0, fase: 320, tramite: 640 }
+// Separación vertical entre nodos del mismo nivel
+const DY = 110
+
+function nodeStyle(nivel) {
+  return {
+    background:   COLORES[nivel],
+    color:        '#fff',
+    border:       'none',
+    borderRadius: 8,
+    padding:      '8px 14px',
+    width:        260,
+    fontSize:     13,
+    fontWeight:   600,
+    whiteSpace:   'normal',
+    textAlign:    'center',
+  }
+}
+
+// Convierte el árbol MOCK en arrays nodes/edges de ReactFlow.
+// Usa contadores globales yFase/yTram para evitar solapamientos entre ramas.
+function buildGraph(data) {
+  const nodes = []
+  const edges = []
+  let yFase = 0
+  let yTram = 0
+
+  data.solicitudes.forEach((sol, i) => {
+    nodes.push({
+      id:       sol.id,
+      data:     { label: sol.nombre },
+      position: { x: X.solicitud, y: i * DY * 4 },
+      style:    nodeStyle('solicitud'),
+    })
+
+    sol.fases.forEach(fase => {
+      nodes.push({
+        id:       fase.id,
+        data:     { label: fase.nombre },
+        position: { x: X.fase, y: yFase++ * DY },
+        style:    nodeStyle('fase'),
+      })
+      edges.push({ id: `e-${sol.id}-${fase.id}`, source: sol.id, target: fase.id })
+
+      fase.tramites.forEach(tram => {
+        nodes.push({
+          id:       tram.id,
+          data:     { label: tram.nombre },
+          position: { x: X.tramite, y: yTram++ * DY },
+          style:    nodeStyle('tramite'),
+        })
+        edges.push({ id: `e-${fase.id}-${tram.id}`, source: fase.id, target: tram.id })
+      })
+    })
+  })
+
+  return { nodes, edges }
+}
+
+export default function DiagramaEsftt() {
+  const { nodes, edges } = useMemo(() => buildGraph(MOCK), [])
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        fitView
+        fitViewOptions={{ padding: 0.3 }}
+        minZoom={0.2}
+        maxZoom={2}
+      >
+        <Background />
+        <Controls />
+        <MiniMap nodeStrokeWidth={3} />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/react-diagramas/src/DiagramaEsftt.jsx
+++ b/react-diagramas/src/DiagramaEsftt.jsx
@@ -1,7 +1,7 @@
 import '@xyflow/react/dist/style.css'
 import './styles/diagrama.css'
 import React, { useMemo } from 'react'
-import { ReactFlow, Background, Controls, useNodesState, useEdgesState } from '@xyflow/react'
+import { ReactFlow, Background, Controls, MiniMap, useNodesState, useEdgesState } from '@xyflow/react'
 import { COLORES, MOCK } from './mockData.js'
 
 // Posición X fija por nivel (columnas)
@@ -101,6 +101,7 @@ export default function DiagramaEsftt() {
       >
         <Background />
         <Controls />
+        <MiniMap nodeColor={(n) => n.style?.background ?? '#ccc'} nodeStrokeWidth={3} />
       </ReactFlow>
     </div>
   )

--- a/react-diagramas/src/DiagramaEsftt.jsx
+++ b/react-diagramas/src/DiagramaEsftt.jsx
@@ -1,13 +1,16 @@
 import '@xyflow/react/dist/style.css'
 import './styles/diagrama.css'
 import React, { useMemo } from 'react'
-import { ReactFlow, Background, Controls, MiniMap } from '@xyflow/react'
+import { ReactFlow, Background, Controls } from '@xyflow/react'
 import { COLORES, MOCK } from './mockData.js'
 
 // Posición X fija por nivel (columnas)
 const X = { solicitud: 0, fase: 320, tramite: 640 }
 // Separación vertical entre nodos del mismo nivel
 const DY = 110
+
+// width/height en style controla el render visual; en el nodo raíz lo necesita el MiniMap
+const NODE_WIDTH = 260
 
 function nodeStyle(nivel) {
   return {
@@ -16,7 +19,7 @@ function nodeStyle(nivel) {
     border:       'none',
     borderRadius: 8,
     padding:      '8px 14px',
-    width:        260,
+    width:        NODE_WIDTH,
     fontSize:     13,
     fontWeight:   600,
     whiteSpace:   'normal',
@@ -25,29 +28,19 @@ function nodeStyle(nivel) {
 }
 
 // Convierte el árbol MOCK en arrays nodes/edges de ReactFlow.
-// Usa contadores globales yFase/yTram para evitar solapamientos entre ramas.
+// Las Y de cada nivel se calculan en orden de aparición para evitar solapamientos.
+// La Y de cada solicitud se centra respecto a su bloque de fases.
 function buildGraph(data) {
   const nodes = []
   const edges = []
   let yFase = 0
   let yTram = 0
 
-  data.solicitudes.forEach((sol, i) => {
-    nodes.push({
-      id:       sol.id,
-      data:     { label: sol.nombre },
-      position: { x: X.solicitud, y: i * DY * 4 },
-      style:    nodeStyle('solicitud'),
-    })
+  data.solicitudes.forEach((sol) => {
+    const yFaseInicio = yFase
 
     sol.fases.forEach(fase => {
-      nodes.push({
-        id:       fase.id,
-        data:     { label: fase.nombre },
-        position: { x: X.fase, y: yFase++ * DY },
-        style:    nodeStyle('fase'),
-      })
-      edges.push({ id: `e-${sol.id}-${fase.id}`, source: sol.id, target: fase.id })
+      const yTramInicio = yTram
 
       fase.tramites.forEach(tram => {
         nodes.push({
@@ -55,9 +48,33 @@ function buildGraph(data) {
           data:     { label: tram.nombre },
           position: { x: X.tramite, y: yTram++ * DY },
           style:    nodeStyle('tramite'),
+          width:    NODE_WIDTH,
         })
         edges.push({ id: `e-${fase.id}-${tram.id}`, source: fase.id, target: tram.id })
       })
+
+      // Centrar la fase respecto a sus trámites
+      const yFaseCentrada = (yTramInicio + yTram - 1) / 2 * DY
+      nodes.push({
+        id:       fase.id,
+        data:     { label: fase.nombre },
+        position: { x: X.fase, y: yFaseCentrada },
+        style:    nodeStyle('fase'),
+        width:    NODE_WIDTH,
+      })
+      edges.push({ id: `e-${sol.id}-${fase.id}`, source: sol.id, target: fase.id })
+      yFase++
+    })
+
+    // Centrar la solicitud respecto a sus fases
+    const yFaseFin = yTram - 1
+    const ySolCentrada = (yFaseInicio * DY + yFaseFin * DY) / 2
+    nodes.push({
+      id:       sol.id,
+      data:     { label: sol.nombre },
+      position: { x: X.solicitud, y: ySolCentrada },
+      style:    nodeStyle('solicitud'),
+      width:    NODE_WIDTH,
     })
   })
 
@@ -79,7 +96,6 @@ export default function DiagramaEsftt() {
       >
         <Background />
         <Controls />
-        <MiniMap nodeStrokeWidth={3} />
       </ReactFlow>
     </div>
   )

--- a/react-diagramas/src/main.jsx
+++ b/react-diagramas/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import DiagramaEsftt from './DiagramaEsftt.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <DiagramaEsftt />
+  </React.StrictMode>
+)

--- a/react-diagramas/src/main.lib.jsx
+++ b/react-diagramas/src/main.lib.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import DiagramaEsftt from './DiagramaEsftt.jsx'
+
+// El bundle IIFE expone window.DiagramaEsftt = { mount }
+// El template Flask llama: window.DiagramaEsftt.mount(element)
+export function mount(element) {
+  ReactDOM.createRoot(element).render(
+    <React.StrictMode>
+      <DiagramaEsftt />
+    </React.StrictMode>
+  )
+}

--- a/react-diagramas/src/mockData.js
+++ b/react-diagramas/src/mockData.js
@@ -1,0 +1,54 @@
+// Colores por nivel ESFTT — definidos en ANALISIS_GENERACION_DIAGRAMA_EXPEDIENTE.md §9
+export const COLORES = {
+  solicitud: '#3b7dd8',  // azul
+  fase:      '#d97706',  // ámbar
+  tramite:   '#7c3aed',  // violeta
+}
+
+// Datos mock para la POC — refleja estructura real de ESTRUCTURA_FTT.json
+export const MOCK = {
+  solicitudes: [
+    {
+      id: 'sol-001',
+      nombre: 'Autorización Administrativa Previa',
+      fases: [
+        {
+          id: 'f-001',
+          nombre: 'Análisis de Admisibilidad',
+          tramites: [
+            { id: 't-001', nombre: 'Análisis técnico' },
+            { id: 't-002', nombre: 'Análisis ambiental' },
+          ],
+        },
+        {
+          id: 'f-002',
+          nombre: 'Consultas Previas',
+          tramites: [
+            { id: 't-003', nombre: 'Consulta a organismos' },
+          ],
+        },
+        {
+          id: 'f-003',
+          nombre: 'Información Pública',
+          tramites: [
+            { id: 't-004', nombre: 'Publicación BOE' },
+            { id: 't-005', nombre: 'Publicación BOJA' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'sol-002',
+      nombre: 'Autorización Ambiental Unificada',
+      fases: [
+        {
+          id: 'f-004',
+          nombre: 'Evaluación Ambiental',
+          tramites: [
+            { id: 't-006', nombre: 'Estudio de impacto' },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/react-diagramas/src/styles/diagrama.css
+++ b/react-diagramas/src/styles/diagrama.css
@@ -1,0 +1,8 @@
+/* ReactFlow necesita que el contenedor padre tenga dimensiones explícitas */
+.diagrama-esftt-wrapper {
+  width: 100%;
+  height: 620px;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/react-diagramas/vite.config.js
+++ b/react-diagramas/vite.config.js
@@ -12,6 +12,10 @@ export default defineConfig(({ command }) => {
   // El bundle expone window.DiagramaEsftt = { mount }
   return {
     plugins: [react()],
+    // React usa process.env.NODE_ENV — no existe en browser; hay que reemplazarlo
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    },
     build: {
       lib: {
         entry:    resolve(__dirname, 'src/main.lib.jsx'),

--- a/react-diagramas/vite.config.js
+++ b/react-diagramas/vite.config.js
@@ -21,6 +21,12 @@ export default defineConfig(({ command }) => {
       },
       outDir:      resolve(__dirname, '../app/static/js/react'),
       emptyOutDir: true,
+      rollupOptions: {
+        output: {
+          // Nombre fijo para el CSS — Flask lo referencia con url_for
+          assetFileNames: 'diagrama-esftt[extname]',
+        },
+      },
     },
   }
 })

--- a/react-diagramas/vite.config.js
+++ b/react-diagramas/vite.config.js
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+
+export default defineConfig(({ command }) => {
+  if (command === 'serve') {
+    // Modo desarrollo: SPA normal con HMR
+    return { plugins: [react()] }
+  }
+
+  // Modo build: library IIFE para Flask
+  // El bundle expone window.DiagramaEsftt = { mount }
+  return {
+    plugins: [react()],
+    build: {
+      lib: {
+        entry:    resolve(__dirname, 'src/main.lib.jsx'),
+        name:     'DiagramaEsftt',
+        formats:  ['iife'],
+        fileName: () => 'diagrama-esftt.iife.js',
+      },
+      outDir:      resolve(__dirname, '../app/static/js/react'),
+      emptyOutDir: true,
+    },
+  }
+})


### PR DESCRIPTION
## Cambios

- Scaffolding `react-diagramas/` con Vite+React en modo dual: SPA (`npm run dev`) para desarrollo y IIFE (`npm run build`) para integración con Flask
- Componente `DiagramaEsftt` con ReactFlow (@xyflow/react v12): nodos con nombre y color por nivel (azul=Solicitud, ámbar=Fase, violeta=Trámite), drag, zoom, pan y MiniMap
- Datos mock estáticos del árbol ESFTT (2 solicitudes, 4 fases, 6 trámites)
- Blueprint Flask `demo` con ruta `GET /demo/diagrama` y template que embebe el bundle IIFE en el layout de la Junta
- Fix `process.env.NODE_ENV` en vite.config para modo IIFE (React lo necesita en browser)
- `.gitignore` actualizado: `react-diagramas/node_modules/` y `app/static/js/react/` (bundles compilados no se versionan)

Closes #291
