### PR TITLE
Motor de reglas agnóstico y análisis arquitectónico de fechas ESFTT

### DIFF
--- a/app/models/motor_reglas.py
+++ b/app/models/motor_reglas.py
@@ -3,119 +3,67 @@ from app import db
 
 class ReglaMotor(db.Model):
     """
-    Regla del motor de validación de acciones sobre ESFTT.
+    Regla del motor de validación agnóstico.
 
-    PROPÓSITO:
-        Define qué está prohibido o requiere advertencia cuando el usuario
-        intenta una acción (CREAR, CERRAR, BORRAR) sobre una entidad ESFTT.
-        Principio rector: todo permitido excepto lo expresamente prohibido.
+    El motor evalúa si una acción sobre un sujeto ESFTT está permitida.
+    Principio rector: todo permitido excepto lo expresamente prohibido.
 
-    CAMPO EVENTO:
-        Acción que el usuario intenta realizar:
-        - CREAR: crear una nueva entidad
-        - CERRAR: cerrar/finalizar una entidad existente
-        - BORRAR: eliminar una entidad existente
-
-    CAMPO ENTIDAD:
-        Tipo de entidad sobre la que actúa:
-        - SOLICITUD: crear/cerrar/borrar una solicitud (cualquier tipo via solicitudes_tipos)
-        - FASE, TRAMITE, TAREA: sobre las entidades correspondientes
-        - EXPEDIENTE: borrar un expediente u otras acciones sobre él
-        NOTA: SOLICITUD_TIPO no es una entidad del motor. El handler de SOLICITUD
-        gestiona directamente la compatibilidad de tipos via TIPOS_SOLICITUDES_COMPATIBLES.
-        La N:M de solicitudes_tipos es un detalle de implementación, no una entidad de negocio.
-
-    CAMPO TIPO_ID:
-        ID en la tabla tipos_* correspondiente según entidad:
-        - entidad=FASE → tipos_fases.id
-        - entidad=TRAMITE → tipos_tramites.id
-        - entidad=TAREA → tipos_tareas.id
-        - entidad=SOLICITUD_TIPO → tipos_solicitudes.id
-        - entidad=EXPEDIENTE → tipos_expedientes.id
-        - NULL = la regla aplica a todos los tipos de esa entidad
-        Sin FK constraint (tabla referenciada varía según entidad).
-
-    CAMPO ACCION:
-        - BLOQUEAR: impide la acción. El usuario no puede continuar.
-        - ADVERTIR: informa pero permite. El usuario puede continuar.
-
-    CAMPO PARAMS_EXTRA:
-        Nombre del parámetro adicional requerido para evaluar esta regla.
-        Ej: 'organismo_id' para reglas de SEPARATAS.
-        NULL si no se necesitan parámetros extra.
+    CAMPOS CLAVE:
+        accion:         CREAR|INICIAR|FINALIZAR|BORRAR
+        sujeto:         SOLICITUD|FASE|TRAMITE|TAREA|EXPEDIENTE
+        tipo_sujeto_id: ID en tipos_* del sujeto. NULL = aplica a todos los tipos.
+        efecto:         BLOQUEAR|ADVERTIR
 
     EVALUACIÓN:
-        El motor evalúa todas las CONDICIONES_REGLA asociadas (ver CondicionRegla).
-        Si todas las condiciones activas se cumplen → aplica ACCION.
-        Si alguna no se cumple → acción PERMITIDA (todo permitido excepto prohibido).
+        El motor carga las reglas activas para (accion, sujeto, tipo_sujeto_id).
+        Para cada regla evalúa sus condiciones (CondicionRegla) contra el dict de
+        variables compilado por el ContextAssembler. AND implícito entre condiciones.
+        Si todas se cumplen → aplica efecto. BLOQUEAR tiene prioridad sobre ADVERTIR.
 
-    RELACIONES:
-        - condiciones ← CONDICIONES_REGLA.regla_id (condiciones de esta regla)
+    NORMA:
+        norma_compilada es campo temporal hasta que se cree la tabla normas (paso 3).
+        En paso 3 se añade norma_id FK + articulo + apartado y se elimina este campo.
     """
     __tablename__ = 'reglas_motor'
     __table_args__ = (
-        db.CheckConstraint("evento IN ('CREAR','INICIAR','FINALIZAR','BORRAR')", name='ck_reglas_motor_evento'),
-        db.CheckConstraint(
-            "entidad IN ('SOLICITUD','FASE','TRAMITE','TAREA','EXPEDIENTE')",
-            name='ck_reglas_motor_entidad'
-        ),
-        db.CheckConstraint("accion IN ('BLOQUEAR','ADVERTIR')", name='ck_reglas_motor_accion'),
-        db.Index('idx_reglas_motor_lookup', 'evento', 'entidad', 'tipo_id'),
+        db.CheckConstraint("accion IN ('CREAR','INICIAR','FINALIZAR','BORRAR')", name='ck_reglas_motor_accion'),
+        db.CheckConstraint("sujeto IN ('SOLICITUD','FASE','TRAMITE','TAREA','EXPEDIENTE')", name='ck_reglas_motor_sujeto'),
+        db.CheckConstraint("efecto IN ('BLOQUEAR','ADVERTIR')", name='ck_reglas_motor_efecto'),
+        db.Index('idx_reglas_motor_lookup', 'accion', 'sujeto', 'tipo_sujeto_id'),
         {'schema': 'public'}
     )
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
 
-    evento = db.Column(
-        db.String(10),
-        nullable=False,
-        comment='Acción evaluada: CREAR | CERRAR | BORRAR'
-    )
-
-    entidad = db.Column(
-        db.String(20),
-        nullable=False,
-        comment='Entidad sobre la que actúa: SOLICITUD | FASE | TRAMITE | TAREA | EXPEDIENTE'
-    )
-
-    tipo_id = db.Column(
-        db.Integer,
-        nullable=True,
-        comment='ID en la tabla tipos_* según entidad. NULL = aplica a todos los tipos'
-    )
-
     accion = db.Column(
-        db.String(10),
-        nullable=False,
-        comment='Acción si se cumplen condiciones: BLOQUEAR | ADVERTIR'
+        db.String(10), nullable=False,
+        comment='Acción evaluada: CREAR | INICIAR | FINALIZAR | BORRAR'
     )
-
-    mensaje = db.Column(
-        db.String(500),
-        nullable=False,
-        comment='Texto mostrado al usuario cuando se activa la regla'
+    sujeto = db.Column(
+        db.String(20), nullable=False,
+        comment='Sujeto sobre el que actúa: SOLICITUD | FASE | TRAMITE | TAREA | EXPEDIENTE'
     )
-
-    norma = db.Column(
-        db.String(200),
-        nullable=True,
-        comment='Referencia normativa (ej: "Decreto-ley 26/2021, DA 4ª")'
+    tipo_sujeto_id = db.Column(
+        db.Integer, nullable=True,
+        comment='ID en tipos_* del sujeto. NULL = aplica a todos los tipos'
     )
-
-    params_extra = db.Column(
-        db.String(100),
-        nullable=True,
-        comment='Nombre del param adicional requerido por alguna condición (ej: organismo_id)'
+    efecto = db.Column(
+        db.String(10), nullable=False,
+        comment='Efecto si se cumplen condiciones: BLOQUEAR | ADVERTIR'
     )
-
+    norma_compilada = db.Column(
+        db.String(300), nullable=True,
+        comment='Referencia normativa compilada (temporal hasta tabla normas en paso 3)'
+    )
+    prioridad = db.Column(
+        db.Integer, nullable=False, default=0,
+        comment='Orden entre reglas del mismo (accion, sujeto, tipo_sujeto_id)'
+    )
     activa = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=True,
-        comment='Permite desactivar la regla sin borrarla'
+        db.Boolean, nullable=False, default=True,
+        comment='Desactivar en lugar de borrar — preserva trazabilidad'
     )
 
-    # Relaciones
     condiciones = db.relationship(
         'CondicionRegla',
         backref='regla',
@@ -124,52 +72,32 @@ class ReglaMotor(db.Model):
     )
 
     def __repr__(self):
-        return f'<ReglaMotor id={self.id} {self.evento}/{self.entidad} tipo={self.tipo_id} → {self.accion}>'
+        return f'<ReglaMotor id={self.id} {self.accion}/{self.sujeto} tipo={self.tipo_sujeto_id} → {self.efecto}>'
 
 
 class CondicionRegla(db.Model):
     """
-    Condición individual que compone una ReglaMotor.
+    Condición individual de una ReglaMotor.
 
-    PROPÓSITO:
-        Cada regla tiene una o más condiciones. Si TODAS se cumplen (AND por defecto)
-        → la regla se activa y se aplica su acción.
-        Si alguna no se cumple → la regla no se activa → acción permitida.
+    Evalúa una variable del dict contra un valor de referencia con un operador.
+    Todas las condiciones de la misma regla se combinan con AND implícito.
+    Para expresar OR se crean reglas separadas.
 
-    CAMPO TIPO_CRITERIO:
-        Tipo de evaluación. Catálogo:
-        - EXISTE_DOCUMENTO_TIPO    params: {tipo_doc_codigo, ambito}
-        - EXISTE_DOC_ORGANISMO     params: {tipo_doc_codigo} + param organismo_id
-        - EXISTE_FASE_CERRADA      params: {tipo_fase_codigo}
-        - EXISTE_FASE_CON_RESULTADO  params: {tipo_fase_codigo, resultado_codigos:[]}
-        - VARIABLE_EXPEDIENTE      params: {campo, operador, valor}
-        - TIPO_FASE_PADRE_ES       params: {tipo_fase_codigo}
-        - EXISTE_TAREA_TIPO        params: {tipo_tarea_codigo, cerrada, requiere_doc_producido}
-        - EXISTE_TRAMITE_TIPO      params: {tipo_tramite_codigo, cerrado, requiere_doc_producido}
-        - ESTADO_SOLICITUD         params: {estado}
-        - EXISTE_TIPO_SOLICITUD    params: {tipo_solicitud_codigo}
-
-    CAMPO NEGACION:
-        Si TRUE, invierte el resultado de la condición.
-        Ej: EXISTE_FASE_CERRADA con negacion=TRUE evalúa
-        "NO existe fase cerrada" → TRUE si no hay fase cerrada.
-
-    CAMPO OPERADOR_SIGUIENTE:
-        Operador lógico con la siguiente condición de la misma regla.
-        La última condición lo ignora. Por defecto AND.
-
-    CAMPO PARAMETROS:
-        JSON con los parámetros específicos del tipo_criterio.
-        El evaluador los lee según el tipo_criterio declarado.
+    OPERADORES:
+        EQ / NEQ            igual / distinto
+        IN / NOT_IN         en el conjunto / fuera del conjunto
+        IS_NULL / NOT_NULL  ausente / presente
+        GT / GTE / LT / LTE comparaciones numéricas
+        BETWEEN / NOT_BETWEEN  rango [a, b] — valor es lista [min, max]
     """
     __tablename__ = 'condiciones_regla'
     __table_args__ = (
         db.CheckConstraint(
-            "operador_siguiente IN ('AND','OR')",
+            "operador IN ('EQ','NEQ','IN','NOT_IN','IS_NULL','NOT_NULL','GT','GTE','LT','LTE','BETWEEN','NOT_BETWEEN')",
             name='ck_condiciones_regla_operador'
         ),
-        db.Index('idx_condiciones_regla_regla', 'regla_id'),
-        db.Index('idx_condiciones_regla_criterio', 'tipo_criterio'),
+        db.Index('idx_condiciones_regla_regla',    'regla_id'),
+        db.Index('idx_condiciones_regla_variable', 'nombre_variable'),
         {'schema': 'public'}
     )
 
@@ -179,69 +107,39 @@ class CondicionRegla(db.Model):
         db.Integer,
         db.ForeignKey('public.reglas_motor.id', ondelete='CASCADE'),
         nullable=False,
-        comment='FK a REGLAS_MOTOR. Regla a la que pertenece esta condición'
+        comment='FK a REGLAS_MOTOR'
     )
-
-    tipo_criterio = db.Column(
-        db.String(40),
-        nullable=False,
-        comment='Tipo de evaluación (ver catálogo en docstring)'
+    nombre_variable = db.Column(
+        db.String(80), nullable=False,
+        comment='Clave en el dict de variables del ContextAssembler'
     )
-
-    parametros = db.Column(
-        db.JSON,
-        nullable=False,
-        comment='Parámetros JSON específicos del tipo_criterio'
+    operador = db.Column(
+        db.String(20), nullable=False,
+        comment='Operador de comparación (ver catálogo en docstring)'
     )
-
-    negacion = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=False,
-        comment='Si TRUE, invierte el resultado de esta condición (NOT)'
+    valor = db.Column(
+        db.JSON, nullable=True,
+        comment='Valor de referencia. Lista para IN/BETWEEN, None para IS_NULL/NOT_NULL'
     )
-
     orden = db.Column(
-        db.Integer,
-        nullable=False,
-        default=1,
-        comment='Orden de evaluación dentro de la regla (informativo)'
-    )
-
-    operador_siguiente = db.Column(
-        db.String(5),
-        nullable=False,
-        default='AND',
-        comment='Operador lógico con la siguiente condición: AND | OR'
+        db.Integer, nullable=False, default=1,
+        comment='Orden informativo dentro de la regla'
     )
 
     def __repr__(self):
-        neg = 'NOT ' if self.negacion else ''
-        return f'<CondicionRegla id={self.id} regla={self.regla_id} {neg}{self.tipo_criterio}>'
+        return f'<CondicionRegla id={self.id} regla={self.regla_id} {self.nombre_variable} {self.operador} {self.valor!r}>'
 
 
 class TipoSolicitudCompatible(db.Model):
     """
     Pares de tipos de solicitud que pueden coexistir en una misma solicitud.
 
-    PROPÓSITO:
-        Whitelist de combinaciones válidas. Una solicitud puede tener múltiples
-        tipos (N:M via SolicitudTipo) pero no todas las combinaciones son válidas.
-        Ej: AAP+AAC es compatible; AAP+AAE NO lo es.
-
-    DISEÑO:
-        Whitelist (pares permitidos), no blacklist (pares prohibidos).
-        Justificación: la mayoría de los 136 pares posibles (17 tipos) son inválidos.
-        Definir los ~16 válidos es más seguro y legible.
+    Whitelist de combinaciones válidas. Una solicitud puede tener múltiples
+    tipos (N:M via SolicitudTipo) pero no todas las combinaciones son válidas.
+    Ej: AAP+AAC es compatible; AAP+AAE NO lo es.
 
     CONSTRAINT tipo_a_id < tipo_b_id:
-        Evita duplicados simétricos: el par (AAP,AAC) y (AAC,AAP) son el mismo.
-        Al insertar, siempre poner el ID menor en tipo_a_id.
-
-    EVALUACIÓN:
-        Al añadir un tipo T a una solicitud que ya tiene tipos T1, T2...:
-        Verificar que existe registro compatible para cada par (T, Ti).
-        Si algún par no está en la tabla → acción bloqueada.
+        Evita duplicados simétricos — al insertar, siempre el ID menor en tipo_a_id.
     """
     __tablename__ = 'tipos_solicitudes_compatibles'
     __table_args__ = (
@@ -252,26 +150,20 @@ class TipoSolicitudCompatible(db.Model):
     )
 
     tipo_a_id = db.Column(
-        db.Integer,
-        db.ForeignKey('tipos_solicitudes.id'),
+        db.Integer, db.ForeignKey('tipos_solicitudes.id'),
         primary_key=True,
         comment='FK a TIPOS_SOLICITUDES. Siempre el ID menor del par'
     )
-
     tipo_b_id = db.Column(
-        db.Integer,
-        db.ForeignKey('tipos_solicitudes.id'),
+        db.Integer, db.ForeignKey('tipos_solicitudes.id'),
         primary_key=True,
         comment='FK a TIPOS_SOLICITUDES. Siempre el ID mayor del par'
     )
-
     nota = db.Column(
-        db.String(200),
-        nullable=True,
+        db.String(200), nullable=True,
         comment='Explicación de la compatibilidad / referencia normativa'
     )
 
-    # Relaciones
     tipo_a = db.relationship('TipoSolicitud', foreign_keys=[tipo_a_id])
     tipo_b = db.relationship('TipoSolicitud', foreign_keys=[tipo_b_id])
 

--- a/app/models/tareas.py
+++ b/app/models/tareas.py
@@ -51,9 +51,10 @@ class Tarea(db.Model):
     CAMPO NOTAS:
         - Campo libre para información adicional
         - Puede contener datos específicos según tipo:
-          * Plazos (ESPERARPLAZO)
           * Referencia publicación (PUBLICAR)
           * Remitente (INCORPORAR)
+        - ESPERARPLAZO: el plazo NO vive aquí — viene de `catalogo_plazos` por tipo de trámite.
+          La fecha de inicio del cómputo es `documento_usado.fecha_administrativa`.
     
     SEMÁNTICA SEGÚN TIPO:
         - INCORPORAR: usado=NULL, producido=obligatorio
@@ -62,7 +63,7 @@ class Tarea(db.Model):
         - FIRMAR: usado=obligatorio, producido=obligatorio
         - NOTIFICAR: usado=obligatorio, producido=obligatorio
         - PUBLICAR: usado=obligatorio, producido=obligatorio
-        - ESPERARPLAZO: usado=NULL, producido=NULL
+        - ESPERARPLAZO: usado=obligatorio (doc. de notificación — fuente de fecha inicio cómputo), producido=NULL
     
     RELACIONES:
         - tramite → TRAMITES.id (FK CASCADE, trámite contenedor)
@@ -139,7 +140,7 @@ class Tarea(db.Model):
     notas = db.Column(
         db.String(2000),
         nullable=True,
-        comment='Observaciones o información adicional (plazos, referencia, remitente, etc.)'
+        comment='Observaciones o información adicional (referencia publicación, remitente, etc.). NO usar para plazos — viven en catalogo_plazos.'
     )
     
     # Relaciones

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -520,7 +520,7 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
     )
 
 
-# Conjuntos de tipos de tarea que requieren documentos (espejo de motor_reglas.py)
+# Conjuntos de tipos de tarea que requieren documentos (espejo de invariantes_esftt.py)
 _TIPOS_REQUIEREN_DOC_USADO     = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
 _TIPOS_DOC_USADO_OPCIONAL      = {'REDACTAR'}   # visible en UI pero no obligatorio al finalizar
 _TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}

--- a/app/routes/vista3.py
+++ b/app/routes/vista3.py
@@ -26,6 +26,7 @@ from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_tareas import TipoTarea
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.motor_reglas import evaluar
+from app.services.invariantes_esftt import check_invariante
 
 bp = Blueprint('vista3', __name__, url_prefix='/api/vista3')
 
@@ -278,9 +279,12 @@ def editar_solicitud(sol_id):
         # Hook FINALIZAR (fecha_fin: None → valor)
         res_eval = None
         if sol.fecha_fin is None and nueva_fecha_fin is not None:
-            res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+            bloqueo = check_invariante('FINALIZAR', 'SOLICITUD', sol_id)
+            if bloqueo:
+                return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+            res_eval = evaluar('FINALIZAR', 'SOLICITUD', sol.tipo_solicitud_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         sol.fecha_solicitud = nueva_fecha_solicitud
         sol.fecha_fin = nueva_fecha_fin
@@ -292,7 +296,7 @@ def editar_solicitud(sol_id):
         result = _get_solicitudes_con_stats(sol.expediente_id)
         sol_data = next((s for s in result if s['obj'].id == sol_id), None)
         html = render_template('vistas/vista3/_acordeon_solicitud.html', sol_data=sol_data) if sol_data else ''
-        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
         return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
@@ -315,15 +319,18 @@ def editar_fase(fase_id):
         # Hook INICIAR (fecha_inicio: None → valor)
         res_eval = None
         if fase.fecha_inicio is None and nueva_fecha_inicio is not None:
-            res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+            res_eval = evaluar('INICIAR', 'FASE', fase.tipo_fase_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         # Hook FINALIZAR (fecha_fin: None → valor)
         if fase.fecha_fin is None and nueva_fecha_fin is not None:
-            res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+            bloqueo = check_invariante('FINALIZAR', 'FASE', fase_id)
+            if bloqueo:
+                return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+            res_eval = evaluar('FINALIZAR', 'FASE', fase.tipo_fase_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         fase.fecha_inicio = nueva_fecha_inicio
         fase.fecha_fin = nueva_fecha_fin
@@ -337,7 +344,7 @@ def editar_fase(fase_id):
         resultados_fase = TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
         html = render_template('vistas/vista3/_acordeon_fase.html', fase_data=fase_data,
                                resultados_fase=resultados_fase) if fase_data else ''
-        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
         return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
@@ -360,15 +367,18 @@ def editar_tramite(tram_id):
         # Hook INICIAR (fecha_inicio: None → valor)
         res_eval = None
         if tramite.fecha_inicio is None and nueva_fecha_inicio is not None:
-            res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+            res_eval = evaluar('INICIAR', 'TRAMITE', tramite.tipo_tramite_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         # Hook FINALIZAR (fecha_fin: None → valor)
         if tramite.fecha_fin is None and nueva_fecha_fin is not None:
-            res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+            bloqueo = check_invariante('FINALIZAR', 'TRAMITE', tram_id)
+            if bloqueo:
+                return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+            res_eval = evaluar('FINALIZAR', 'TRAMITE', tramite.tipo_tramite_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         tramite.fecha_inicio = nueva_fecha_inicio
         tramite.fecha_fin = nueva_fecha_fin
@@ -378,7 +388,7 @@ def editar_tramite(tram_id):
         result = _get_tramites_con_stats(tramite.fase_id)
         tramite_data = next((t for t in result if t['obj'].id == tram_id), None)
         html = render_template('vistas/vista3/_acordeon_tramite.html', tramite_data=tramite_data) if tramite_data else ''
-        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
         return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except Exception as e:
         db.session.rollback()
@@ -419,15 +429,18 @@ def editar_tarea(tarea_id):
         # Hook INICIAR (fecha_inicio: None → valor)
         res_eval = None
         if tarea.fecha_inicio is None and nueva_fecha_inicio is not None:
-            res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+            res_eval = evaluar('INICIAR', 'TAREA', tarea.tipo_tarea_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         # Hook FINALIZAR (fecha_fin: None → valor)
         if tarea.fecha_fin is None and nueva_fecha_fin is not None:
-            res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+            bloqueo = check_invariante('FINALIZAR', 'TAREA', tarea_id)
+            if bloqueo:
+                return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+            res_eval = evaluar('FINALIZAR', 'TAREA', tarea.tipo_tarea_id, {})
             if not res_eval.permitido:
-                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+                return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
         tarea.fecha_inicio = nueva_fecha_inicio
         tarea.fecha_fin = nueva_fecha_fin
@@ -439,7 +452,7 @@ def editar_tarea(tarea_id):
         documentos = _get_documentos_tarea(tarea_id)
         html = render_template('vistas/vista3/_acordeon_tarea.html', tarea_data=tarea_data,
                                documentos=documentos) if tarea_data else ''
-        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
         return jsonify({'ok': True, 'html': html, 'advertencia': advertencia})
     except IntegrityError:
         db.session.rollback()
@@ -497,9 +510,12 @@ def borrar_solicitud(sol_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar('BORRAR', 'SOLICITUD', entidad_id=sol_id)
+    bloqueo = check_invariante('BORRAR', 'SOLICITUD', sol_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('BORRAR', 'SOLICITUD', sol.tipo_solicitud_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol_id).all()]
     if fase_ids:
@@ -528,15 +544,15 @@ def crear_fase(sol_id):
     if not TipoFase.query.get(tipo_fase_id):
         return jsonify({'ok': False, 'error': 'Tipo de fase no encontrado'}), 404
 
-    res_eval = evaluar('CREAR', 'FASE', tipo_id=tipo_fase_id, padre_id=sol_id)
+    res_eval = evaluar('CREAR', 'FASE', tipo_fase_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
     db.session.add(fase)
     db.session.commit()
 
-    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval.nivel == 'ADVERTIR' else None
     return jsonify({'ok': True, 'id': fase.id, 'advertencia': advertencia})
 
 
@@ -555,15 +571,15 @@ def crear_tramite(fase_id):
     if not TipoTramite.query.get(tipo_tramite_id):
         return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
 
-    res_eval = evaluar('CREAR', 'TRAMITE', tipo_id=tipo_tramite_id, padre_id=fase_id)
+    res_eval = evaluar('CREAR', 'TRAMITE', tipo_tramite_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
     db.session.add(tramite)
     db.session.commit()
 
-    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval.nivel == 'ADVERTIR' else None
     return jsonify({'ok': True, 'id': tramite.id, 'advertencia': advertencia})
 
 
@@ -582,15 +598,15 @@ def crear_tarea(tram_id):
     if not TipoTarea.query.get(tipo_tarea_id):
         return jsonify({'ok': False, 'error': 'Tipo de tarea no encontrado'}), 404
 
-    res_eval = evaluar('CREAR', 'TAREA', tipo_id=tipo_tarea_id, padre_id=tram_id)
+    res_eval = evaluar('CREAR', 'TAREA', tipo_tarea_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tarea = Tarea(tramite_id=tram_id, tipo_tarea_id=tipo_tarea_id)
     db.session.add(tarea)
     db.session.commit()
 
-    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    advertencia = {'mensaje': res_eval.norma_compilada, 'norma': res_eval.url_norma} if res_eval.nivel == 'ADVERTIR' else None
     return jsonify({'ok': True, 'id': tarea.id, 'advertencia': advertencia})
 
 
@@ -607,9 +623,12 @@ def borrar_fase(fase_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar('BORRAR', 'FASE', entidad_id=fase_id)
+    bloqueo = check_invariante('BORRAR', 'FASE', fase_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('BORRAR', 'FASE', fase.tipo_fase_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase_id).all()]
     if tram_ids:
@@ -629,9 +648,12 @@ def borrar_tramite(tram_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar('BORRAR', 'TRAMITE', entidad_id=tram_id)
+    bloqueo = check_invariante('BORRAR', 'TRAMITE', tram_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('BORRAR', 'TRAMITE', tramite.tipo_tramite_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     Tarea.query.filter_by(tramite_id=tram_id).delete()
     db.session.delete(tramite)
@@ -648,9 +670,12 @@ def borrar_tarea(tarea_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar('BORRAR', 'TAREA', entidad_id=tarea_id)
+    bloqueo = check_invariante('BORRAR', 'TAREA', tarea_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('BORRAR', 'TAREA', tarea.tipo_tarea_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     db.session.delete(tarea)
     db.session.commit()
@@ -672,13 +697,13 @@ def iniciar_solicitud(sol_id):
     if sol.fecha_solicitud is not None:
         return jsonify({'ok': False, 'error': 'La solicitud ya tiene fecha de inicio'}), 422
 
-    res_eval = evaluar('INICIAR', 'SOLICITUD', entidad_id=sol_id)
+    res_eval = evaluar('INICIAR', 'SOLICITUD', sol.tipo_solicitud_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     sol.fecha_solicitud = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/solicitud/<int:sol_id>/finalizar', methods=['POST'])
@@ -692,13 +717,16 @@ def finalizar_solicitud(sol_id):
     if sol.fecha_fin is not None:
         return jsonify({'ok': False, 'error': 'La solicitud ya está finalizada'}), 422
 
-    res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+    bloqueo = check_invariante('FINALIZAR', 'SOLICITUD', sol_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('FINALIZAR', 'SOLICITUD', sol.tipo_solicitud_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     sol.fecha_fin = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/fase/<int:fase_id>/iniciar', methods=['POST'])
@@ -712,13 +740,13 @@ def iniciar_fase(fase_id):
     if fase.fecha_inicio is not None:
         return jsonify({'ok': False, 'error': 'La fase ya está iniciada'}), 422
 
-    res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+    res_eval = evaluar('INICIAR', 'FASE', fase.tipo_fase_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     fase.fecha_inicio = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/fase/<int:fase_id>/finalizar', methods=['POST'])
@@ -732,13 +760,16 @@ def finalizar_fase(fase_id):
     if fase.fecha_fin is not None:
         return jsonify({'ok': False, 'error': 'La fase ya está finalizada'}), 422
 
-    res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+    bloqueo = check_invariante('FINALIZAR', 'FASE', fase_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('FINALIZAR', 'FASE', fase.tipo_fase_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     fase.fecha_fin = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/tramite/<int:tram_id>/iniciar', methods=['POST'])
@@ -752,13 +783,13 @@ def iniciar_tramite(tram_id):
     if tramite.fecha_inicio is not None:
         return jsonify({'ok': False, 'error': 'El trámite ya está iniciado'}), 422
 
-    res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+    res_eval = evaluar('INICIAR', 'TRAMITE', tramite.tipo_tramite_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tramite.fecha_inicio = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/tramite/<int:tram_id>/finalizar', methods=['POST'])
@@ -772,13 +803,16 @@ def finalizar_tramite(tram_id):
     if tramite.fecha_fin is not None:
         return jsonify({'ok': False, 'error': 'El trámite ya está finalizado'}), 422
 
-    res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+    bloqueo = check_invariante('FINALIZAR', 'TRAMITE', tram_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('FINALIZAR', 'TRAMITE', tramite.tipo_tramite_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tramite.fecha_fin = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/tarea/<int:tarea_id>/iniciar', methods=['POST'])
@@ -792,13 +826,13 @@ def iniciar_tarea(tarea_id):
     if tarea.fecha_inicio is not None:
         return jsonify({'ok': False, 'error': 'La tarea ya está iniciada'}), 422
 
-    res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+    res_eval = evaluar('INICIAR', 'TAREA', tarea.tipo_tarea_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tarea.fecha_inicio = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})
 
 
 @bp.route('/tarea/<int:tarea_id>/finalizar', methods=['POST'])
@@ -812,10 +846,13 @@ def finalizar_tarea(tarea_id):
     if tarea.fecha_fin is not None:
         return jsonify({'ok': False, 'error': 'La tarea ya está finalizada'}), 422
 
-    res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+    bloqueo = check_invariante('FINALIZAR', 'TAREA', tarea_id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+    res_eval = evaluar('FINALIZAR', 'TAREA', tarea.tipo_tarea_id, {})
     if not res_eval.permitido:
-        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+        return jsonify({'ok': False, 'error': res_eval.norma_compilada, 'norma': res_eval.url_norma}), 422
 
     tarea.fecha_fin = date.today()
     db.session.commit()
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.norma_compilada})

--- a/app/services/invariantes_esftt.py
+++ b/app/services/invariantes_esftt.py
@@ -1,0 +1,128 @@
+"""
+Invariantes estructurales del árbol ESFTT.
+
+Checks de negocio hardcoded que el motor agnóstico no puede evaluar porque
+requieren consultas al dominio BDDAT. Se invocan desde las rutas Flask ANTES
+de llamar a motor_reglas.evaluar().
+
+En el futuro estas variables pasarán como variables del dict al ContextAssembler
+(tiene_hijos_abiertos, doc_producido_presente, etc.) y estos checks desaparecerán.
+Por ahora viven aquí para mantener el motor agnóstico sin romper el comportamiento.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app import db
+from app.models.fases import Fase
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+from app.models.solicitudes import Solicitud
+from app.services.motor_reglas import EvaluacionResult
+
+
+def _bloquear(mensaje: str) -> EvaluacionResult:
+    return EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR',
+        variables_trigger={}, norma_compilada=mensaje, url_norma=''
+    )
+
+
+def check_invariante(accion: str, sujeto: str, entidad_id: int) -> Optional[EvaluacionResult]:
+    """
+    Verifica los invariantes estructurales para (accion, sujeto, entidad_id).
+
+    Devuelve EvaluacionResult(BLOQUEAR) si se viola un invariante, None si todo OK.
+    Solo cubre los casos hardcoded — si no hay regla para la combinación devuelve None.
+    """
+    if accion == 'BORRAR':
+        return _check_borrar(sujeto, entidad_id)
+    if accion == 'FINALIZAR':
+        return _check_finalizar(sujeto, entidad_id)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Borrar
+# ---------------------------------------------------------------------------
+
+def _check_borrar(sujeto: str, entidad_id: int) -> Optional[EvaluacionResult]:
+    if sujeto in ('FASE', 'TRAMITE', 'TAREA'):
+        obj = _cargar(sujeto, entidad_id)
+        if obj and obj.fecha_inicio is not None:
+            return _bloquear('No se puede eliminar una entidad ya iniciada.')
+
+    elif sujeto == 'SOLICITUD':
+        tiene_fase_iniciada = db.session.query(Fase).filter(
+            Fase.solicitud_id == entidad_id,
+            Fase.fecha_inicio.isnot(None)
+        ).first()
+        if tiene_fase_iniciada:
+            return _bloquear('No se puede eliminar una solicitud con fases ya iniciadas.')
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Finalizar
+# ---------------------------------------------------------------------------
+
+def _check_finalizar(sujeto: str, entidad_id: int) -> Optional[EvaluacionResult]:
+    if sujeto == 'SOLICITUD':
+        fase_abierta = db.session.query(Fase).filter(
+            Fase.solicitud_id == entidad_id,
+            Fase.fecha_fin.is_(None)
+        ).first()
+        if fase_abierta:
+            return _bloquear('Hay fases sin cerrar. Finalice todas las fases antes de cerrar la solicitud.')
+
+    elif sujeto == 'FASE':
+        tramite_abierto = db.session.query(Tramite).filter(
+            Tramite.fase_id == entidad_id,
+            Tramite.fecha_fin.is_(None)
+        ).first()
+        if tramite_abierto:
+            return _bloquear('Hay trámites sin cerrar. Finalice todos los trámites antes de cerrar la fase.')
+
+    elif sujeto == 'TRAMITE':
+        tarea_abierta = db.session.query(Tarea).filter(
+            Tarea.tramite_id == entidad_id,
+            Tarea.fecha_fin.is_(None)
+        ).first()
+        if tarea_abierta:
+            return _bloquear('Hay tareas sin ejecutar. Finalice todas las tareas antes de cerrar el trámite.')
+
+    elif sujeto == 'TAREA':
+        return _check_finalizar_tarea(entidad_id)
+
+    return None
+
+
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+_TIPOS_REQUIEREN_DOC_USADO     = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+
+
+def _check_finalizar_tarea(tarea_id: int) -> Optional[EvaluacionResult]:
+    tarea = Tarea.query.get(tarea_id)
+    if not tarea or not tarea.tipo_tarea:
+        return None
+
+    codigo = tarea.tipo_tarea.codigo
+
+    if codigo in _TIPOS_REQUIEREN_DOC_PRODUCIDO and tarea.documento_producido_id is None:
+        return _bloquear('Falta el documento producido. Asócielo antes de finalizar la tarea.')
+
+    if codigo in _TIPOS_REQUIEREN_DOC_USADO and tarea.documento_usado_id is None:
+        return _bloquear('Falta el documento de entrada. Asócielo antes de finalizar la tarea.')
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cargar(sujeto: str, entidad_id: int):
+    modelos = {'FASE': Fase, 'TRAMITE': Tramite, 'TAREA': Tarea}
+    modelo = modelos.get(sujeto)
+    return modelo.query.get(entidad_id) if modelo else None

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -1,44 +1,40 @@
 """
-Motor de reglas — Evaluador de acciones sobre entidades ESFTT.
+Motor de reglas agnóstico.
 
-Principio rector: todo está PERMITIDO excepto lo expresamente prohibido.
-Flujo de evaluación:
-  1. Construir contexto jerárquico (sube hasta Expediente/Proyecto)
-  2. Ejecutar checks estructurales hardcoded (invariantes de negocio)
-  3. Consultar reglas en BD y evaluar condiciones configurables
-  4. BLOQUEAR tiene prioridad sobre ADVERTIR
+No conoce el dominio BDDAT. No importa modelos de negocio. No hace queries propias.
+Recibe un dict de variables compilado por el ContextAssembler y evalúa las reglas
+configuradas en BD (reglas_motor + condiciones_regla).
+
+Principio rector: todo PERMITIDO excepto lo expresamente prohibido.
+
+Los checks estructurales de negocio (entidad ya iniciada, hijos sin cerrar, etc.)
+viven en app/services/invariantes_esftt.py — son BDDAT-aware y se invocan antes
+de llamar a este motor.
 
 Uso:
     from app.services.motor_reglas import evaluar
+    from app.services.invariantes_esftt import check_invariante
 
-    # Crear una fase (tipo_fase_id=8) dentro de la solicitud 23
-    res = evaluar('CREAR', 'FASE', tipo_id=8, padre_id=23)
+    bloqueo = check_invariante('FINALIZAR', 'FASE', fase.id)
+    if bloqueo:
+        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
 
-    # Iniciar la fase 45
-    res = evaluar('INICIAR', 'FASE', entidad_id=45)
-
-    # Borrar la tarea 12
-    res = evaluar('BORRAR', 'TAREA', entidad_id=12)
-
-    if not res.permitido:
-        return jsonify({'ok': False, 'error': res.mensaje, 'norma': res.norma}), 422
+    variables = {}  # TODO paso 5: context_assembler.build(expediente_id)
+    resultado = evaluar('FINALIZAR', 'FASE', fase.tipo_fase_id, variables)
+    if not resultado.permitido:
+        return jsonify({'ok': False, 'error': resultado.norma_compilada,
+                        'norma': resultado.url_norma}), 422
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Optional
 
 from app import db
-from app.models.expedientes import Expediente
-from app.models.solicitudes import Solicitud
-from app.models.fases import Fase
-from app.models.tramites import Tramite
-from app.models.tareas import Tarea
-from app.models.tipos_fases import TipoFase
-from app.models.tipos_tramites import TipoTramite
-from app.models.tipos_tareas import TipoTarea
-from app.models.tipos_solicitudes import TipoSolicitud
 from app.models.motor_reglas import ReglaMotor, CondicionRegla
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -47,548 +43,127 @@ from app.models.motor_reglas import ReglaMotor, CondicionRegla
 
 @dataclass
 class EvaluacionResult:
-    permitido: bool
-    nivel: str     # 'BLOQUEAR' | 'ADVERTIR' | ''
-    mensaje: str
-    norma: str
+    permitido:         bool
+    nivel:             str   # 'BLOQUEAR' | 'ADVERTIR' | ''
+    variables_trigger: dict  # subconjunto del dict que disparó la regla
+    norma_compilada:   str   # referencia normativa compilada
+    url_norma:         str   # URL BOE/BOJA; '' si no existe
 
 
-# Resultado singleton para "todo ok"
-PERMITIDO = EvaluacionResult(permitido=True, nivel='', mensaje='', norma='')
-
-
-# ---------------------------------------------------------------------------
-# Contexto jerárquico (privado)
-# ---------------------------------------------------------------------------
-
-@dataclass
-class _Contexto:
-    """Snapshot del árbol ESFTT necesario para evaluar una regla."""
-    entidad: str
-    tarea:      Optional[Tarea]      = field(default=None)
-    tramite:    Optional[Tramite]    = field(default=None)
-    fase:       Optional[Fase]       = field(default=None)
-    solicitud:  Optional[Solicitud]  = field(default=None)
-    expediente: Optional[Expediente] = field(default=None)
-    proyecto:   Optional[object]     = field(default=None)  # Proyecto
-
-
-def _construir_contexto(evento: str, entidad: str,
-                        entidad_id: Optional[int],
-                        padre_id: Optional[int]) -> _Contexto:
-    """
-    Sube el árbol jerárquico desde el objeto indicado hasta Expediente/Proyecto.
-
-    Para CREAR, padre_id es el ID del contenedor (solicitud, fase o tramite).
-    Para INICIAR/FINALIZAR/BORRAR, entidad_id es el ID del objeto en cuestión.
-    """
-    ctx = _Contexto(entidad=entidad)
-
-    if evento == 'CREAR':
-        _ctx_crear(entidad, padre_id, ctx)
-    else:
-        _ctx_operar(entidad, entidad_id, ctx)
-
-    return ctx
-
-
-def _ctx_crear(entidad: str, padre_id: Optional[int], ctx: _Contexto) -> None:
-    """Construye contexto para evento CREAR (padre_id = contenedor)."""
-    if entidad == 'SOLICITUD':
-        # padre_id = expediente_id
-        if padre_id:
-            ctx.expediente = Expediente.query.get(padre_id)
-            if ctx.expediente:
-                ctx.proyecto = ctx.expediente.proyecto
-
-    elif entidad == 'FASE':
-        # padre_id = solicitud_id
-        if padre_id:
-            ctx.solicitud = Solicitud.query.get(padre_id)
-            if ctx.solicitud:
-                ctx.expediente = ctx.solicitud.expediente
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'TRAMITE':
-        # padre_id = fase_id
-        if padre_id:
-            ctx.fase = Fase.query.get(padre_id)
-            if ctx.fase:
-                ctx.solicitud = ctx.fase.solicitud
-                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'TAREA':
-        # padre_id = tramite_id
-        if padre_id:
-            ctx.tramite = Tramite.query.get(padre_id)
-            if ctx.tramite:
-                ctx.fase = ctx.tramite.fase
-                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
-                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-
-def _ctx_operar(entidad: str, entidad_id: Optional[int], ctx: _Contexto) -> None:
-    """Construye contexto para INICIAR/FINALIZAR/BORRAR."""
-    if entidad == 'TAREA':
-        if entidad_id:
-            ctx.tarea = Tarea.query.get(entidad_id)
-            if ctx.tarea:
-                ctx.tramite = ctx.tarea.tramite
-                ctx.fase = ctx.tramite.fase if ctx.tramite else None
-                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
-                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'TRAMITE':
-        if entidad_id:
-            ctx.tramite = Tramite.query.get(entidad_id)
-            if ctx.tramite:
-                ctx.fase = ctx.tramite.fase
-                ctx.solicitud = ctx.fase.solicitud if ctx.fase else None
-                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'FASE':
-        if entidad_id:
-            ctx.fase = Fase.query.get(entidad_id)
-            if ctx.fase:
-                ctx.solicitud = ctx.fase.solicitud
-                ctx.expediente = ctx.solicitud.expediente if ctx.solicitud else None
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'SOLICITUD':
-        if entidad_id:
-            ctx.solicitud = Solicitud.query.get(entidad_id)
-            if ctx.solicitud:
-                ctx.expediente = ctx.solicitud.expediente
-                ctx.proyecto = ctx.expediente.proyecto if ctx.expediente else None
-
-    elif entidad == 'EXPEDIENTE':
-        if entidad_id:
-            ctx.expediente = Expediente.query.get(entidad_id)
-            if ctx.expediente:
-                ctx.proyecto = ctx.expediente.proyecto
+PERMITIDO = EvaluacionResult(
+    permitido=True, nivel='',
+    variables_trigger={}, norma_compilada='', url_norma=''
+)
 
 
 # ---------------------------------------------------------------------------
-# Checks estructurales hardcoded
+# Evaluación de condiciones
 # ---------------------------------------------------------------------------
-
-def _checks_hardcoded(evento: str, entidad: str,
-                      ctx: _Contexto) -> Optional[EvaluacionResult]:
-    """
-    Invariantes de negocio no configurables en BD.
-    Retorna EvaluacionResult(BLOQUEAR) si se viola una regla, None si todo OK.
-    """
-    if evento == 'BORRAR':
-        return _check_borrar(entidad, ctx)
-    elif evento == 'FINALIZAR':
-        return _check_finalizar(entidad, ctx)
-    return None
-
-
-def _check_borrar(entidad: str, ctx: _Contexto) -> Optional[EvaluacionResult]:
-    if entidad in ('FASE', 'TRAMITE', 'TAREA'):
-        obj = {'FASE': ctx.fase, 'TRAMITE': ctx.tramite, 'TAREA': ctx.tarea}[entidad]
-        if obj and obj.fecha_inicio is not None:
-            return EvaluacionResult(
-                permitido=False,
-                nivel='BLOQUEAR',
-                mensaje='No se puede eliminar una entidad ya iniciada.',
-                norma=''
-            )
-
-    elif entidad == 'SOLICITUD':
-        if ctx.solicitud:
-            tiene_fase_iniciada = db.session.query(Fase).filter(
-                Fase.solicitud_id == ctx.solicitud.id,
-                Fase.fecha_inicio.isnot(None)
-            ).first()
-            if tiene_fase_iniciada:
-                return EvaluacionResult(
-                    permitido=False,
-                    nivel='BLOQUEAR',
-                    mensaje='No se puede eliminar una solicitud con fases ya iniciadas.',
-                    norma=''
-                )
-    return None
-
-
-def _check_finalizar(entidad: str, ctx: _Contexto) -> Optional[EvaluacionResult]:
-    if entidad == 'SOLICITUD':
-        if ctx.solicitud:
-            fase_abierta = db.session.query(Fase).filter(
-                Fase.solicitud_id == ctx.solicitud.id,
-                Fase.fecha_fin.is_(None)
-            ).first()
-            if fase_abierta:
-                return EvaluacionResult(
-                    permitido=False,
-                    nivel='BLOQUEAR',
-                    mensaje='Hay fases sin cerrar. Finalice todas las fases antes de cerrar la solicitud.',
-                    norma=''
-                )
-
-    elif entidad == 'FASE':
-        if ctx.fase:
-            tramite_abierto = db.session.query(Tramite).filter(
-                Tramite.fase_id == ctx.fase.id,
-                Tramite.fecha_fin.is_(None)
-            ).first()
-            if tramite_abierto:
-                return EvaluacionResult(
-                    permitido=False,
-                    nivel='BLOQUEAR',
-                    mensaje='Hay trámites sin cerrar. Finalice todos los trámites antes de cerrar la fase.',
-                    norma=''
-                )
-
-    elif entidad == 'TRAMITE':
-        if ctx.tramite:
-            tarea_abierta = db.session.query(Tarea).filter(
-                Tarea.tramite_id == ctx.tramite.id,
-                Tarea.fecha_fin.is_(None)
-            ).first()
-            if tarea_abierta:
-                return EvaluacionResult(
-                    permitido=False,
-                    nivel='BLOQUEAR',
-                    mensaje='Hay tareas sin ejecutar. Finalice todas las tareas antes de cerrar el trámite.',
-                    norma=''
-                )
-
-    elif entidad == 'TAREA':
-        return _check_finalizar_tarea(ctx)
-
-    return None
-
-
-# Tipos de tarea que requieren documento producido al finalizar
-_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
-
-# Tipos de tarea que requieren documento de entrada al finalizar
-_TIPOS_REQUIEREN_DOC_USADO = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
-
-# Tipos de tarea donde el documento de entrada es visible en UI pero no obligatorio
-_TIPOS_DOC_USADO_OPCIONAL = {'REDACTAR'}
-
-
-def _check_finalizar_tarea(ctx: _Contexto) -> Optional[EvaluacionResult]:
-    tarea = ctx.tarea
-    if not tarea or not tarea.tipo_tarea:
-        return None
-
-    codigo = tarea.tipo_tarea.codigo
-
-    if codigo in _TIPOS_REQUIEREN_DOC_PRODUCIDO and tarea.documento_producido_id is None:
-        return EvaluacionResult(
-            permitido=False,
-            nivel='BLOQUEAR',
-            mensaje='Falta el documento producido. Asócielo antes de finalizar la tarea.',
-            norma=''
-        )
-
-    if codigo in _TIPOS_REQUIEREN_DOC_USADO and tarea.documento_usado_id is None:
-        return EvaluacionResult(
-            permitido=False,
-            nivel='BLOQUEAR',
-            mensaje='Falta el documento de entrada. Asócielo antes de finalizar la tarea.',
-            norma=''
-        )
-
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Evaluadores de criterio
-# ---------------------------------------------------------------------------
-
-def _evaluar_criterio(tipo_criterio: str, parametros: dict,
-                      ctx: _Contexto, params: dict) -> bool:
-    """
-    Despacha al evaluador específico según el tipo_criterio.
-    Devuelve True si la condición se cumple.
-    """
-    evaluadores = {
-        'EXISTE_FASE_CERRADA':      _criterio_existe_fase_cerrada,
-        'EXISTE_FASE_CON_RESULTADO': _criterio_existe_fase_con_resultado,
-        'VARIABLE_EXPEDIENTE':      _criterio_variable_expediente,
-        'VARIABLE_PROYECTO':        _criterio_variable_proyecto,
-        'TIPO_FASE_PADRE_ES':       _criterio_tipo_fase_padre_es,
-        'EXISTE_TAREA_TIPO':        _criterio_existe_tarea_tipo,
-        'EXISTE_TRAMITE_TIPO':      _criterio_existe_tramite_tipo,
-        'ESTADO_SOLICITUD':         _criterio_estado_solicitud,
-        'EXISTE_TIPO_SOLICITUD':    _criterio_existe_tipo_solicitud,
-        # Stubs — requieren modelo Documento (pendiente)
-        'EXISTE_DOCUMENTO_TIPO':    lambda p, c, ps: False,
-        'EXISTE_DOC_ORGANISMO':     lambda p, c, ps: False,
-    }
-    fn = evaluadores.get(tipo_criterio)
-    if fn is None:
-        # Criterio desconocido: por seguridad, se considera no cumplido
-        return False
-    return fn(parametros, ctx, params)
-
-
-def _criterio_existe_fase_cerrada(p: dict, ctx: _Contexto, params: dict) -> bool:
-    """¿Existe una fase cerrada del tipo indicado en la solicitud?"""
-    if not ctx.solicitud:
-        return False
-    tipo_fase_codigo = p.get('tipo_fase_codigo')
-    q = db.session.query(Fase).join(TipoFase, Fase.tipo_fase_id == TipoFase.id).filter(
-        Fase.solicitud_id == ctx.solicitud.id,
-        Fase.fecha_fin.isnot(None)
-    )
-    if tipo_fase_codigo:
-        q = q.filter(TipoFase.codigo == tipo_fase_codigo)
-    return q.first() is not None
-
-
-def _criterio_existe_fase_con_resultado(p: dict, ctx: _Contexto, params: dict) -> bool:
-    """¿Existe una fase del tipo indicado con alguno de los resultados especificados?"""
-    if not ctx.solicitud:
-        return False
-    from app.models.tipos_resultados_fases import TipoResultadoFase
-    tipo_fase_codigo  = p.get('tipo_fase_codigo')
-    resultado_codigos = p.get('resultado_codigos', [])
-    q = (db.session.query(Fase)
-         .join(TipoFase, Fase.tipo_fase_id == TipoFase.id)
-         .join(TipoResultadoFase, Fase.resultado_fase_id == TipoResultadoFase.id)
-         .filter(Fase.solicitud_id == ctx.solicitud.id))
-    if tipo_fase_codigo:
-        q = q.filter(TipoFase.codigo == tipo_fase_codigo)
-    if resultado_codigos:
-        q = q.filter(TipoResultadoFase.codigo.in_(resultado_codigos))
-    return q.first() is not None
-
-
-def _navegar_dot(obj, ruta: str):
-    """Navega una ruta dot-notation ('campo.subcampo') sobre un objeto."""
-    for parte in ruta.split('.'):
-        if obj is None:
-            return None
-        obj = getattr(obj, parte, None)
-    return obj
-
 
 _OPERADORES = {
-    'EQ':      lambda v, ref: v == ref,
-    'NEQ':     lambda v, ref: v != ref,
-    'IN':      lambda v, ref: v in (ref if isinstance(ref, list) else [ref]),
-    'NOT_IN':  lambda v, ref: v not in (ref if isinstance(ref, list) else [ref]),
-    'IS_NULL': lambda v, _: v is None,
-    'NOT_NULL': lambda v, _: v is not None,
+    'EQ':          lambda v, ref: v == ref,
+    'NEQ':         lambda v, ref: v != ref,
+    'IN':          lambda v, ref: v in (ref if isinstance(ref, list) else [ref]),
+    'NOT_IN':      lambda v, ref: v not in (ref if isinstance(ref, list) else [ref]),
+    'IS_NULL':     lambda v, _: v is None,
+    'NOT_NULL':    lambda v, _: v is not None,
+    'GT':          lambda v, ref: v is not None and v > ref,
+    'GTE':         lambda v, ref: v is not None and v >= ref,
+    'LT':          lambda v, ref: v is not None and v < ref,
+    'LTE':         lambda v, ref: v is not None and v <= ref,
+    'BETWEEN':     lambda v, ref: v is not None and ref[0] <= v <= ref[1],
+    'NOT_BETWEEN': lambda v, ref: v is not None and not (ref[0] <= v <= ref[1]),
 }
 
 
-def _criterio_variable_expediente(p: dict, ctx: _Contexto, params: dict) -> bool:
-    if not ctx.expediente:
+def _evaluar_condicion(cond: CondicionRegla, variables: dict) -> bool:
+    nombre = cond.nombre_variable
+    if nombre not in variables:
+        log.warning('motor_reglas: variable ausente en dict: %s', nombre)
         return False
-    valor = _navegar_dot(ctx.expediente, p['campo'])
-    op_fn = _OPERADORES.get(p.get('operador', 'EQ'))
-    return op_fn(valor, p.get('valor')) if op_fn else False
-
-
-def _criterio_variable_proyecto(p: dict, ctx: _Contexto, params: dict) -> bool:
-    if not ctx.proyecto:
+    op_fn = _OPERADORES.get(cond.operador)
+    if op_fn is None:
+        log.warning('motor_reglas: operador desconocido: %s', cond.operador)
         return False
-    valor = _navegar_dot(ctx.proyecto, p['campo'])
-    op_fn = _OPERADORES.get(p.get('operador', 'EQ'))
-    return op_fn(valor, p.get('valor')) if op_fn else False
-
-
-def _criterio_tipo_fase_padre_es(p: dict, ctx: _Contexto, params: dict) -> bool:
-    if not ctx.fase or not ctx.fase.tipo_fase:
+    try:
+        return bool(op_fn(variables[nombre], cond.valor))
+    except Exception as exc:
+        log.warning('motor_reglas: error evaluando %s %s %r: %s', nombre, cond.operador, cond.valor, exc)
         return False
-    return ctx.fase.tipo_fase.codigo == p.get('tipo_fase_codigo')
 
 
-def _criterio_existe_tarea_tipo(p: dict, ctx: _Contexto, params: dict) -> bool:
-    """¿Existe una tarea del tipo indicado en el trámite actual?"""
-    if not ctx.tramite:
-        return False
-    codigo = p.get('tipo_tarea_codigo')
-    cerrada = p.get('cerrada', False)
-    requiere_doc_producido = p.get('requiere_doc_producido', False)
-
-    q = (db.session.query(Tarea)
-         .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
-         .filter(Tarea.tramite_id == ctx.tramite.id))
-    if codigo:
-        q = q.filter(TipoTarea.codigo == codigo)
-    if cerrada:
-        q = q.filter(Tarea.fecha_fin.isnot(None))
-    if requiere_doc_producido:
-        q = q.filter(Tarea.documento_producido_id.isnot(None))
-    return q.first() is not None
-
-
-def _criterio_existe_tramite_tipo(p: dict, ctx: _Contexto, params: dict) -> bool:
-    """¿Existe un trámite del tipo indicado en la fase actual?"""
-    if not ctx.fase:
-        return False
-    codigo = p.get('tipo_tramite_codigo')
-    cerrado = p.get('cerrado', False)
-    requiere_doc_producido = p.get('requiere_doc_producido', False)
-
-    q = (db.session.query(Tramite)
-         .join(TipoTramite, Tramite.tipo_tramite_id == TipoTramite.id)
-         .filter(Tramite.fase_id == ctx.fase.id))
-    if codigo:
-        q = q.filter(TipoTramite.codigo == codigo)
-    if cerrado:
-        q = q.filter(Tramite.fecha_fin.isnot(None))
-    if requiere_doc_producido:
-        # Existe al menos una tarea en ese trámite con documento producido
-        q = q.filter(
-            db.session.query(Tarea)
-            .filter(Tarea.tramite_id == Tramite.id,
-                    Tarea.documento_producido_id.isnot(None))
-            .exists()
-        )
-    return q.first() is not None
-
-
-def _criterio_estado_solicitud(p: dict, ctx: _Contexto, params: dict) -> bool:
-    if not ctx.solicitud:
-        return False
-    return ctx.solicitud.estado == p.get('estado')
-
-
-def _criterio_existe_tipo_solicitud(p: dict, ctx: _Contexto, params: dict) -> bool:
-    """Comparación exacta de siglas. La inteligencia está en la regla, no en el motor."""
-    if not ctx.solicitud or not ctx.solicitud.tipo_solicitud:
-        return False
-    siglas = p.get('tipo_solicitud_codigo')
-    return ctx.solicitud.tipo_solicitud.siglas == siglas
-
-
-# ---------------------------------------------------------------------------
-# Evaluación de condiciones de una regla
-# ---------------------------------------------------------------------------
-
-def _evaluar_regla(regla: ReglaMotor, ctx: _Contexto, params: dict) -> bool:
+def _evaluar_regla(regla: ReglaMotor, variables: dict) -> tuple[bool, dict]:
     """
-    Evalúa todas las condiciones de una regla.
-    Sin condiciones → regla siempre dispara (True).
-    Combina condiciones izq→dcha usando operador_siguiente[i].
+    Evalúa todas las condiciones con AND implícito.
+    Devuelve (disparada, variables_trigger).
+    Sin condiciones → regla siempre dispara.
     """
     condiciones = sorted(regla.condiciones, key=lambda c: c.orden)
     if not condiciones:
-        return True
+        return True, {}
 
-    resultados = []
+    trigger = {}
     for cond in condiciones:
-        val = _evaluar_criterio(cond.tipo_criterio, cond.parametros or {}, ctx, params)
-        if cond.negacion:
-            val = not val
-        resultados.append((val, cond.operador_siguiente))
-
-    # Combinar usando el operador_siguiente de cada condición con la siguiente
-    acumulado = resultados[0][0]
-    for i in range(1, len(resultados)):
-        operador = resultados[i - 1][1]  # operador entre i-1 e i
-        siguiente = resultados[i][0]
-        if operador == 'OR':
-            acumulado = acumulado or siguiente
-        else:  # AND (por defecto)
-            acumulado = acumulado and siguiente
-
-    return acumulado
+        if not _evaluar_condicion(cond, variables):
+            return False, {}
+        trigger[cond.nombre_variable] = variables.get(cond.nombre_variable)
+    return True, trigger
 
 
 # ---------------------------------------------------------------------------
-# Función pública principal
+# Función pública
 # ---------------------------------------------------------------------------
 
 def evaluar(
-    evento:     str,
-    entidad:    str,
-    tipo_id:    Optional[int] = None,
-    entidad_id: Optional[int] = None,
-    padre_id:   Optional[int] = None,
-    params:     Optional[dict] = None
+    accion:         str,
+    sujeto:         str,
+    tipo_sujeto_id: Optional[int],
+    variables:      dict,
 ) -> EvaluacionResult:
     """
-    Evalúa si un evento sobre una entidad está permitido.
+    Evalúa si una acción sobre un sujeto está permitida.
 
     Args:
-        evento:     'CREAR' | 'INICIAR' | 'FINALIZAR' | 'BORRAR'
-        entidad:    'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA' | 'EXPEDIENTE'
-        tipo_id:    ID en la tabla tipos_* correspondiente. Para CREAR, es obligatorio.
-                    Para INICIAR/FINALIZAR/BORRAR se deduce del objeto si no se pasa.
-        entidad_id: ID del objeto existente (INICIAR/FINALIZAR/BORRAR).
-        padre_id:   ID del contenedor (CREAR).
-        params:     Parámetros adicionales para evaluadores (ej: organismo_id).
+        accion:         'CREAR' | 'INICIAR' | 'FINALIZAR' | 'BORRAR'
+        sujeto:         'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA' | 'EXPEDIENTE'
+        tipo_sujeto_id: ID en tipos_* del sujeto. NULL = solo reglas genéricas.
+        variables:      dict plano compilado por ContextAssembler.
 
     Returns:
-        EvaluacionResult con permitido=True o False.
+        EvaluacionResult. Lanza excepción ante error interno — nunca devuelve
+        PERMITIDO silenciosamente ante un fallo.
     """
-    if params is None:
-        params = {}
-
-    # --- Construir contexto ---
-    ctx = _construir_contexto(evento, entidad, entidad_id, padre_id)
-
-    # --- Para INICIAR/FINALIZAR/BORRAR, deducir tipo_id si no se pasó ---
-    if tipo_id is None and evento != 'CREAR':
-        tipo_id = _deducir_tipo_id(entidad, ctx)
-
-    # --- Checks estructurales hardcoded ---
-    bloqueo = _checks_hardcoded(evento, entidad, ctx)
-    if bloqueo:
-        return bloqueo
-
-    # --- Consultar reglas en BD ---
-    q = ReglaMotor.query.filter_by(evento=evento, entidad=entidad, activa=True)
-    if tipo_id is not None:
-        # Reglas específicas del tipo O genéricas (tipo_id NULL)
+    q = ReglaMotor.query.filter_by(accion=accion, sujeto=sujeto, activa=True)
+    if tipo_sujeto_id is not None:
         q = q.filter(
-            db.or_(ReglaMotor.tipo_id == tipo_id, ReglaMotor.tipo_id.is_(None))
+            db.or_(ReglaMotor.tipo_sujeto_id == tipo_sujeto_id,
+                   ReglaMotor.tipo_sujeto_id.is_(None))
         )
     else:
-        # Sin tipo_id conocido: solo reglas genéricas
-        q = q.filter(ReglaMotor.tipo_id.is_(None))
+        q = q.filter(ReglaMotor.tipo_sujeto_id.is_(None))
 
-    reglas = q.all()
+    reglas = q.order_by(ReglaMotor.prioridad).all()
 
-    # --- Evaluar reglas: primero BLOQUEAR, luego ADVERTIR ---
     resultado_advertir = None
-
     for regla in reglas:
-        if _evaluar_regla(regla, ctx, params):
-            if regla.accion == 'BLOQUEAR':
-                return EvaluacionResult(
-                    permitido=False,
-                    nivel='BLOQUEAR',
-                    mensaje=regla.mensaje,
-                    norma=regla.norma or ''
-                )
-            elif regla.accion == 'ADVERTIR' and resultado_advertir is None:
-                # Guardamos la primera advertencia; seguimos buscando BLOQUEARs
-                resultado_advertir = EvaluacionResult(
-                    permitido=True,
-                    nivel='ADVERTIR',
-                    mensaje=regla.mensaje,
-                    norma=regla.norma or ''
-                )
+        disparada, trigger = _evaluar_regla(regla, variables)
+        if not disparada:
+            continue
+        if regla.efecto == 'BLOQUEAR':
+            return EvaluacionResult(
+                permitido=False,
+                nivel='BLOQUEAR',
+                variables_trigger=trigger,
+                norma_compilada=regla.norma_compilada or '',
+                url_norma='',
+            )
+        if regla.efecto == 'ADVERTIR' and resultado_advertir is None:
+            resultado_advertir = EvaluacionResult(
+                permitido=True,
+                nivel='ADVERTIR',
+                variables_trigger=trigger,
+                norma_compilada=regla.norma_compilada or '',
+                url_norma='',
+            )
 
-    if resultado_advertir:
-        return resultado_advertir
-
-    return PERMITIDO
-
-
-def _deducir_tipo_id(entidad: str, ctx: _Contexto) -> Optional[int]:
-    """Obtiene el tipo_id del objeto en contexto."""
-    if entidad == 'TAREA'    and ctx.tarea:
-        return ctx.tarea.tipo_tarea_id
-    if entidad == 'TRAMITE'  and ctx.tramite:
-        return ctx.tramite.tipo_tramite_id
-    if entidad == 'FASE'     and ctx.fase:
-        return ctx.fase.tipo_fase_id
-    if entidad == 'SOLICITUD' and ctx.solicitud:
-        return ctx.solicitud.tipo_solicitud_id
-    return None
+    return resultado_advertir or PERMITIDO

--- a/docs/ANALISIS_FECHAS_ESFTT.md
+++ b/docs/ANALISIS_FECHAS_ESFTT.md
@@ -45,10 +45,13 @@ crea callejones sin salida ante errores en el interior.
 
 ### Reglas de implementación
 
-1. **DESFINALIZAR está siempre permitido** para todos los elementos SFTT. No pasa por el
-   motor — es una operación de corrección estructural. Sí pasa por `invariantes_esftt.py`
-   para verificar que no rompe coherencia con el exterior (p.ej. no se puede DESFINALIZAR
-   una Fase si su Solicitud contenedora está cerrada — primero hay que DESFINALIZAR la Solicitud).
+1. **DESFINALIZAR — regla confirmada solo para Solicitud** (`fecha_fin` no administrativa):
+   siempre permitido, no pasa por el motor. Sí pasa por `invariantes_esftt.py` para
+   verificar coherencia con el exterior (no se puede DESFINALIZAR si el contenedor
+   externo está cerrado — primero hay que reabrir el nivel superior).
+   **Para Fase, Trámite y Tarea: pendiente de confirmar por tipo.** Si `fecha_fin`
+   resulta administrativa en algún tipo, DESFINALIZAR puede requerir condiciones
+   adicionales o estar bloqueado. Se resolverá en el análisis tipo a tipo de cada nivel.
 
 2. **DESFINALIZAR Solicitud** resetea también `estado` a `EN_TRAMITE`. Son dos campos que
    se escriben en la misma operación atómica.

--- a/docs/ANALISIS_FECHAS_ESFTT.md
+++ b/docs/ANALISIS_FECHAS_ESFTT.md
@@ -1,0 +1,69 @@
+# Análisis de fechas ESFTT — fuente para `metadatos_fechas`
+
+> **Fecha:** 2026-04-18
+> **Estado:** En construcción — sesión de análisis tipo a tipo.
+> **Destino:** seed y referencia de la tabla `metadatos_fechas` (diseño en `DISEÑO_FECHAS_PLAZOS.md §3.1`).
+>
+> **Columnas:**
+> - **es_administrativa** — tiene valor legal para cómputo de plazos (art. 21 LPACAP y norma sectorial)
+> - **DESINICIAR/DESFINALIZAR** — si puede borrarse el valor una vez puesto
+> - **Coherencia** — validaciones de rango/contexto que el sistema debería aplicar
+> - **Estado modelo** — situación actual en el modelo Python y la BD
+> - **Estado UI** — situación actual en el interfaz
+> - **Decisiones/pendientes** — lo que queda por resolver o implementar
+
+---
+
+## SOLICITUD
+
+### `fecha_solicitud`
+
+| Atributo | Valor | Notas |
+|---|---|---|
+| **es_administrativa** | Sí — todos los tipos | Fecha de entrada en Registro (art. 16 LPACAP). Inicio del cómputo del plazo de resolución (art. 21). |
+| **DESINICIAR (→ NULL)** | No permitido | Borrarla equivale a borrar la solicitud. No tiene semántica de DESINICIAR. |
+| **Coherencia** | ⬜ No comprobada | No se valida que sea ≤ hoy, ni coherencia con fechas de hijos. |
+| **Estado modelo** | ✅ Correcto | `NOT NULL`, tipo `Date`. |
+| **Estado UI — creación** | ✅ Correcto | El wizard no permite crear solicitud sin esta fecha. |
+| **Estado UI — edición** | ⚠️ Parcial | Se puede editar (cambiar por otra fecha). Error al intentar poner NULL: se captura pero con mensaje no humano. No se valida coherencia de la nueva fecha. |
+| **Decisiones/pendientes** | Mejorar mensaje de error al intentar NULL. Añadir validación de coherencia (¿fecha ≤ hoy? ¿fecha ≥ fecha_inicio de hijos?). |
+
+#### Clasificación por tipo
+
+| Tipos | `es_administrativa` | Decisión |
+|---|---|---|
+| AAP, AAC, DUP, AAE_PROVISIONAL, AAE_DEFINITIVA, AAT, RAIPEE_PREVIA, RAIPEE_DEFINITIVA, RADNE, CIERRE, DESISTIMIENTO, RENUNCIA, AMPLIACION_PLAZO, RECURSO, AAP_AAC | **Sí** | A instancia de parte, con entrada en Registro. Sin duda. |
+| CORRECCION_ERRORES | **Sí** | Puede ser de oficio (art. 109 LPACAP) o a instancia. **Decisión de simplificación:** siempre administrativa. El tramitador introduce la fecha del documento de registro o la fecha de hoy si es de oficio. |
+| INTERESADO | **Sí** | A instancia de parte tiene entrada en Registro. Cuando la Administración emplaza de oficio (art. 8 LPACAP) se introduce la fecha del oficio. **Decisión de simplificación:** siempre administrativa, igual que el resto. El cierre de la solicitud se gestiona mediante un nuevo tipo de **fase finalizadora** (`RECONOCIMIENTO_INTERESADO`) que porta el resultado y el documento (oficio de reconocimiento o resolución denegatoria). No se añade ningún campo nuevo a Solicitud. La regla del motor para FINALIZAR esta solicitud sería: `EXISTS fase RECONOCIMIENTO_INTERESADO con fecha_fin IS NOT NULL`. |
+| OTRO | **Sí** | Mismo criterio de simplificación. La fase finalizadora es de tipo genérico; el tramitador elige el documento de cierre libremente. |
+
+---
+
+### `fecha_fin`
+
+| Atributo | Valor | Notas |
+|---|---|---|
+| **es_administrativa** | — | **Pendiente de respuesta.** ¿Es la fecha de firma de la resolución o de notificación al interesado? |
+| **DESFINALIZAR (→ NULL)** | — | Pendiente — depende de si es administrativa. |
+| **Coherencia** | — | Pendiente. |
+| **Estado modelo** | — | Pendiente de revisar. |
+| **Estado UI** | — | Pendiente de revisar. |
+| **Decisiones/pendientes** | Confirmar semántica: ¿firma o notificación? Si notificación → `es_administrativa = true` y el sistema puede computar correctamente el plazo art. 21. Si firma → estudiar si se necesita campo `fecha_notificacion` separado o se asume simplificación consciente. |
+
+---
+
+## FASE
+
+> Pendiente — sesión siguiente.
+
+---
+
+## TRÁMITE
+
+> Pendiente — sesión siguiente.
+
+---
+
+## TAREA
+
+> Pendiente — sesión siguiente.

--- a/docs/ANALISIS_FECHAS_ESFTT.md
+++ b/docs/ANALISIS_FECHAS_ESFTT.md
@@ -1,126 +1,150 @@
-# Análisis de fechas ESFTT — fuente para `metadatos_fechas`
+# Análisis de fechas ESFTT — conclusión arquitectónica
 
-> **Fecha:** 2026-04-18
-> **Estado:** En construcción — sesión de análisis tipo a tipo.
-> **Destino:** seed y referencia de la tabla `metadatos_fechas` (diseño en `DISEÑO_FECHAS_PLAZOS.md §3.1`).
->
-> **Columnas:**
-> - **es_administrativa** — tiene valor legal para cómputo de plazos (art. 21 LPACAP y norma sectorial)
-> - **DESINICIAR/DESFINALIZAR** — si puede borrarse el valor una vez puesto
-> - **Coherencia** — validaciones de rango/contexto que el sistema debería aplicar
-> - **Estado modelo** — situación actual en el modelo Python y la BD
-> - **Estado UI** — situación actual en el interfaz
-> - **Decisiones/pendientes** — lo que queda por resolver o implementar
+> **Fecha inicio:** 2026-04-18 | **Fecha cierre:** 2026-04-19
+> **Estado:** CERRADO — conclusión arquitectónica alcanzada.
+> **Contexto:** sesión de análisis que comenzó tipo a tipo (fases) y llegó a una conclusión general sobre el modelo de fechas en todos los niveles ESFTT.
 
 ---
 
-## Principio transversal — Coherencia de fechas
+## CONCLUSIÓN ARQUITECTÓNICA
 
-**Las validaciones de coherencia de fechas son invariantes estructurales del sistema, no reglas del motor.**
-Se implementan en `invariantes_esftt.py` y se aplican uniformemente a todos los elementos SFTT,
-independientemente del tipo. No son imposiciones legales — son la integridad mínima del modelo.
+### Ningún elemento ESFTT almacena fechas
 
-| Invariante | Aplica a |
+Esta conclusión aplica a los cinco niveles: **Expediente, Solicitud, Fase, Trámite y Tarea**.
+
+**Fechas no administrativas** (`fecha_inicio`, `fecha_fin` de fases, trámites, tareas):
+Son marcas temporales de acciones del usuario en el sistema ("cuándo hice clic"). No tienen cliente real: no computan plazos legales, no tienen valor jurídico, no aportan nada que no esté ya en el cuaderno de bitácora. La mera existencia del registro con su `id` prueba que el usuario interactuó.
+
+**Fechas administrativas** (`fecha_solicitud`, fechas de notificación, firma, publicación…):
+Su único hogar válido es `Documento.fecha_administrativa` del documento que las porta. Leer una fecha administrativa es leer del Documento (fuente de verdad). Almacenar un duplicado en el modelo ESFTT crea un dato que puede divergir del documento real con consecuencias legales, y cuya consistencia no puede garantizarse.
+
+**El estado tampoco se almacena.** Es deducible en tiempo de consulta a partir de las reglas del motor (tablas de reglas) y de los documentos existentes. No es un campo.
+
+### Trazabilidad por FK, no por duplicación
+
+Los documentos son agnósticos: no saben quién los usa. La trazabilidad (quién los produce, a qué elemento pertenecen) vive en FKs en las tablas relacionadas. El FK no almacena el dato — señala dónde está la fuente de verdad.
+
+**Implicación para `Solicitud`:** debe existir un FK `documento_solicitud_id` que apunta al documento de solicitud en el pool. Este FK permite al motor y al usuario localizar la fuente de verdad de los dos datos capitales de la solicitud:
+- **cuándo** → `Documento.fecha_administrativa` del documento referenciado.
+- **qué** → tipo deducible por análisis del PDF (ver issue #304).
+
+`documento_solicitud_id` **no existe actualmente en el modelo** — debe añadirse.
+
+### Cuaderno de bitácora
+
+Todo episodio de interacción usuario → sistema se compila en el cuaderno de bitácora: evento del clic, contexto ensamblado, respuesta del motor, resultado. Es el único registro inmutable de "qué pasó y cuándo". Admin y supervisor pueden auditar y rebobinar desde ahí. La regla de escape ante cualquier incidencia (regla del motor incorrecta, validación hardcodeada que falló) siempre está en la bitácora.
+
+El motor **no** se apoya en la bitácora. El motor es agnóstico y consulta exclusivamente las tablas de reglas.
+
+### Cómo se capturan las fechas administrativas
+
+Las fechas administrativas no se introducen manualmente en campos de modelos ESFTT. El flujo:
+
+1. El documento se sube al pool (requisito previo al acto que lo origina).
+2. BDDAT analiza el documento: metadata del PDF, firma digital (issues existentes), OCR si hace falta.
+3. El sistema **propone** la fecha extraída para validación del usuario — nunca asignación automática sin confirmación.
+4. El usuario valida. La fecha queda en `Documento.fecha_administrativa`.
+5. Solo en caso extremo el usuario introduce la fecha manualmente en el Documento. La bitácora lo registra.
+
+Este flujo aplica también al **wizard de creación de expediente**: el documento de solicitud debe estar en el pool antes de crear el expediente. La fecha de solicitud se extrae del documento, no de un campo `Solicitud.fecha_solicitud`. El documento de proyecto puede estar ausente (el administrado lo omitió) — eso no bloquea la apertura del expediente sino que genera un trámite de reclamación; el tipo de solicitud se deduce igualmente del documento de solicitud.
+
+---
+
+## MAPA DE FECHAS ADMINISTRATIVAS POR FASE
+
+El análisis tipo a tipo de la sesión reveló qué documento porta la fecha administrativa relevante en cada fase. Este mapa es referencia para el seed de reglas del motor y para la UI (dónde apuntar al usuario para ver la fecha clave de cada fase).
+
+| Fase | Fecha administrativa | Documento que la porta | Tarea productora |
+|---|---|---|---|
+| ANALISIS_SOLICITUD | — | No aplica (contenedor puro) | — |
+| CONSULTA_MINISTERIO | Notificación al Ministerio | Doc. de notificación | NOTIFICAR en `SOLICITUD_INFORME` |
+| COMPATIBILIDAD_AMBIENTAL | Notificación a Medio Ambiente | Doc. de notificación | NOTIFICAR en `SOLICITUD_COMPATIBILIDAD` |
+| CONSULTAS | Notificación a cada organismo (30/15 días) | Doc. de separata/traslado | NOTIFICAR en `CONSULTA_SEPARATA` y traslados |
+| INFORMACION_PUBLICA | Fecha de publicación en cada medio | Doc. publicado/incorporado | PUBLICAR o INCORPORAR por trámite |
+| FIGURA_AMBIENTAL_EXTERNA | Notificación al titular | Doc. de notificación al titular | NOTIFICAR en `SOLICITUD_FIGURA` |
+| AAU_AAUS_INTEGRADA | Notificación al órgano ambiental | Doc. de notificación | NOTIFICAR en `REMISION_MEDIO_AMBIENTE` |
+| RESOLUCION | Firma, notificación y publicación | Doc. de resolución / notif. / publicación | FIRMAR, NOTIFICAR, PUBLICAR (un doc. por trámite) |
+
+**Nota RESOLUCION:** los tres trámites interiores (`ELABORACION`, `NOTIFICACION`, `PUBLICACION`) portan fechas con efectos jurídicos distintos (inicio de plazo de recurso, publicidad registral, etc.). Se analizarán en detalle cuando se aborde el nivel Trámite.
+
+---
+
+## REFACTORIZACIÓN PENDIENTE
+
+### Campos a eliminar de los modelos
+
+| Modelo | Campo | Motivo |
+|---|---|---|
+| `Solicitud` | `fecha_solicitud` | Vive en `Documento.fecha_administrativa` del doc. de solicitud |
+| `Solicitud` | `fecha_fin` | Marcador operacional sin valor; se registra en bitácora |
+| `Solicitud` | `estado` | Deducible por motor; no almacenable |
+| `Fase` | `fecha_inicio` | Marcador operacional; bitácora |
+| `Fase` | `fecha_fin` | Marcador operacional; bitácora |
+| `Tramite` | `fecha_inicio` | Ídem |
+| `Tramite` | `fecha_fin` | Ídem |
+| `Tarea` | `fecha_inicio` | Ídem |
+| `Tarea` | `fecha_fin` | Ídem |
+
+### Campos a añadir
+
+| Modelo | Campo | Tipo | Motivo |
+|---|---|---|---|
+| `Solicitud` | `documento_solicitud_id` | FK → `documentos.id` nullable | Ancla de trazabilidad al documento fundacional |
+
+### Lógica a adaptar
+
+- **Wizard de creación de expediente**: requiere que el documento de solicitud esté en el pool antes de crear el expediente. Integrar helper de extracción de fecha y propuesta de tipo (issues #304, #305).
+- **Motor de reglas**: cualquier lectura de `solicitud.fecha_solicitud` pasa a leer `Documento.fecha_administrativa` del documento referenciado por `documento_solicitud_id`.
+- **Cómputo de plazos** (art. 21 LPACAP): ídem.
+- **UI**: eliminar campos de fecha y estado de las vistas de Solicitud, Fase, Trámite y Tarea. Mostrar únicamente fechas leídas desde los documentos correspondientes.
+- **`invariantes_esftt.py`**: las invariantes de coherencia de fechas quedan obsoletas al no existir los campos. Revisar qué lógica permanece válida.
+
+### Issues abiertos en esta sesión
+
+| Issue | Título | Estado |
+|---|---|---|
+| #303 | Acción RE_INICIAR | **CERRADO** — innecesario al no existir los campos |
+| #304 | Script detección tipo de solicitud por PDF | Abierto |
+| #305 | Script detección tipo de expediente por proyecto | Abierto |
+| #306 | Helper cálculo de tasa + extracción presupuesto | Abierto |
+
+---
+
+## HISTÓRICO DE ANÁLISIS
+
+> El análisis detallado tipo a tipo que sigue fue el camino que llevó a la conclusión arquitectónica anterior. Se mantiene como contexto histórico de la sesión. Las tablas de atributos por campo (es_administrativa, DESINICIAR, coherencia, estado modelo, estado UI) corresponden a campos que, según la conclusión alcanzada, **no deben existir en el modelo**.
+
+---
+
+### Principio transversal original — Coherencia de fechas
+
+*(Supersedido por la conclusión arquitectónica. Los invariantes de coherencia de fechas quedan sin efecto al eliminarse los campos.)*
+
+### Principio transversal original — Interior de solo lectura y DESFINALIZAR
+
+*(Supersedido. La lógica de "contenedor cerrado bloquea su interior" pasa a ser responsabilidad del motor evaluando el estado deducido, sin leer campos fecha_fin.)*
+
+---
+
+### SOLICITUD — análisis histórico
+
+#### `fecha_solicitud`
+Conclusión del análisis: fecha administrativa (art. 16 LPACAP). Inicio del cómputo del plazo de resolución (art. 21). Clasificada como `es_administrativa = Sí` para todos los tipos. **Conclusión arquitectónica posterior:** no debe existir como campo en `Solicitud` — vive en `Documento.fecha_administrativa` del documento de solicitud vinculado por `documento_solicitud_id`.
+
+Clasificación por tipo (referencia para seed de reglas):
+
+| Tipos | Nota |
 |---|---|
-| `fecha_fin ≥ fecha_inicio` (o `fecha_solicitud`) | Todos los elementos SFTT |
-| `fecha_inicio` del hijo ≥ `fecha_inicio` del padre | Fase/Trámite/Tarea respecto a su contenedor |
-| `fecha_fin` del hijo ≤ `fecha_fin` del padre | Solo cuando el padre esté cerrado |
+| AAP, AAC, DUP, AAE_PROVISIONAL, AAE_DEFINITIVA, AAT, RAIPEE_PREVIA, RAIPEE_DEFINITIVA, RADNE, CIERRE, DESISTIMIENTO, RENUNCIA, AMPLIACION_PLAZO, RECURSO, AAP_AAC | A instancia de parte, entrada en Registro. |
+| CORRECCION_ERRORES | Puede ser de oficio o a instancia. Decisión de simplificación: siempre administrativa. |
+| INTERESADO | Cierre mediante fase finalizadora `RECONOCIMIENTO_INTERESADO`. No requiere campo nuevo en Solicitud. |
+| OTRO | Fase finalizadora genérica; el tramitador elige el documento de cierre. |
 
-La columna **Coherencia** de las tablas siguientes recoge solo las particularidades por tipo,
-asumiendo que los invariantes anteriores se comprueban siempre.
-
----
-
-## Principio transversal — Interior de solo lectura y DESFINALIZAR
-
-**Un contenedor cerrado (`fecha_fin IS NOT NULL`) convierte su interior en solo lectura.**
-DESFINALIZAR (borrar `fecha_fin`) es el mecanismo de corrección — sin él el sistema
-crea callejones sin salida ante errores en el interior.
-
-| Contenedor cerrado | Interior bloqueado (solo lectura) |
-|---|---|
-| Solicitud (`fecha_fin IS NOT NULL`) | Fases, Trámites, Tareas |
-| Fase (`fecha_fin IS NOT NULL`) | Trámites, Tareas |
-| Trámite (`fecha_fin IS NOT NULL`) | Tareas |
-
-### Reglas de implementación
-
-1. **DESFINALIZAR — regla confirmada solo para Solicitud** (`fecha_fin` no administrativa):
-   siempre permitido, no pasa por el motor. Sí pasa por `invariantes_esftt.py` para
-   verificar coherencia con el exterior (no se puede DESFINALIZAR si el contenedor
-   externo está cerrado — primero hay que reabrir el nivel superior).
-   **Para Fase, Trámite y Tarea: pendiente de confirmar por tipo.** Si `fecha_fin`
-   resulta administrativa en algún tipo, DESFINALIZAR puede requerir condiciones
-   adicionales o estar bloqueado. Se resolverá en el análisis tipo a tipo de cada nivel.
-
-2. **DESFINALIZAR Solicitud** resetea también `estado` a `EN_TRAMITE`. Son dos campos que
-   se escriben en la misma operación atómica.
-
-3. **Invariante en `invariantes_esftt.py`**: antes de cualquier operación sobre un hijo
-   (CREAR, INICIAR, FINALIZAR, BORRAR, editar), comprobar que el contenedor está abierto.
-   Si está cerrado → bloquear con mensaje que identifica el contenedor a reabrir.
-
-4. **UX — oferta de reapertura**: la vista puede ofrecer el atajo "¿Reabrir [contenedor]
-   primero?" cuando el invariante bloquea. El motor solo bloquea; la vista decide si ofrece
-   el atajo. No es responsabilidad del motor ni de `invariantes_esftt.py`.
-
-5. **DESFINALIZAR en cascada**: si el elemento a reabrir está dentro de un contenedor
-   cerrado, se bloquea hasta que el usuario reabra primero el contenedor externo.
-   El sistema no reabre en cascada automáticamente — el usuario confirma cada nivel.
-   La oferta de reapertura puede mostrar la cadena completa para orientar al usuario.
+#### `fecha_fin`
+Conclusión del análisis: no administrativa (marcador operacional). La fecha administrativa real vive en el documento de la fase finalizadora. **Conclusión arquitectónica posterior:** no debe existir como campo.
 
 ---
 
-## SOLICITUD
+### FASE — análisis histórico
 
-### `fecha_solicitud`
-
-| Atributo | Valor | Notas |
-|---|---|---|
-| **es_administrativa** | Sí — todos los tipos | Fecha de entrada en Registro (art. 16 LPACAP). Inicio del cómputo del plazo de resolución (art. 21). |
-| **DESINICIAR (→ NULL)** | No permitido | Borrarla equivale a borrar la solicitud. No tiene semántica de DESINICIAR. |
-| **Coherencia** | ⬜ No comprobada | No se valida que sea ≤ hoy, ni coherencia con fechas de hijos. |
-| **Estado modelo** | ✅ Correcto | `NOT NULL`, tipo `Date`. |
-| **Estado UI — creación** | ✅ Correcto | El wizard no permite crear solicitud sin esta fecha. |
-| **Estado UI — edición** | ⚠️ Parcial | Se puede editar (cambiar por otra fecha). Error al intentar poner NULL: se captura pero con mensaje no humano. No se valida coherencia de la nueva fecha. |
-| **Decisiones/pendientes** | Mejorar mensaje de error al intentar NULL. Añadir validación de coherencia (¿fecha ≤ hoy? ¿fecha ≥ fecha_inicio de hijos?). |
-
-#### Clasificación por tipo
-
-| Tipos | `es_administrativa` | Decisión |
-|---|---|---|
-| AAP, AAC, DUP, AAE_PROVISIONAL, AAE_DEFINITIVA, AAT, RAIPEE_PREVIA, RAIPEE_DEFINITIVA, RADNE, CIERRE, DESISTIMIENTO, RENUNCIA, AMPLIACION_PLAZO, RECURSO, AAP_AAC | **Sí** | A instancia de parte, con entrada en Registro. Sin duda. |
-| CORRECCION_ERRORES | **Sí** | Puede ser de oficio (art. 109 LPACAP) o a instancia. **Decisión de simplificación:** siempre administrativa. El tramitador introduce la fecha del documento de registro o la fecha de hoy si es de oficio. |
-| INTERESADO | **Sí** | A instancia de parte tiene entrada en Registro. Cuando la Administración emplaza de oficio (art. 8 LPACAP) se introduce la fecha del oficio. **Decisión de simplificación:** siempre administrativa, igual que el resto. El cierre de la solicitud se gestiona mediante un nuevo tipo de **fase finalizadora** (`RECONOCIMIENTO_INTERESADO`) que porta el resultado y el documento (oficio de reconocimiento o resolución denegatoria). No se añade ningún campo nuevo a Solicitud. La regla del motor para FINALIZAR esta solicitud sería: `EXISTS fase RECONOCIMIENTO_INTERESADO con fecha_fin IS NOT NULL`. |
-| OTRO | **Sí** | Mismo criterio de simplificación. La fase finalizadora es de tipo genérico; el tramitador elige el documento de cierre libremente. |
-
----
-
-### `fecha_fin`
-
-| Atributo | Valor | Notas |
-|---|---|---|
-| **es_administrativa** | **No** | Marcador operacional — "cierre voluntario de la tramitación por el usuario". Sin valor jurídico propio. La fecha administrativa real vive en el Documento de la fase finalizadora (RESOLUCION, RECONOCIMIENTO_INTERESADO…). Fuente: `DISEÑO_FECHAS_PLAZOS.md §3.0`. |
-| **DESFINALIZAR (→ NULL)** | **Permitido** | Mecanismo de corrección necesario. También resetea `estado` → `EN_TRAMITE` en la misma operación atómica. Ver principio transversal de solo lectura. |
-| **Coherencia** | Invariante estructural | `fecha_fin ≥ fecha_solicitud`. Comprobado en `invariantes_esftt.py`. |
-| **Estado modelo** | ✅ Correcto | `Date nullable`. Regla en docstring: "debería tener fecha_fin si estado ≠ EN_TRAMITE" (débil — correcta). |
-| **Estado UI** | ⬜ Pendiente de revisar | Verificar: ¿se puede poner fecha_fin sin que exista fase finalizadora cerrada? ¿Se bloquea la edición del interior cuando fecha_fin IS NOT NULL? |
-| **Decisiones/pendientes** | Ver issue #302 (fase finalizadora). Implementar bloqueo de interior cuando solicitud cerrada. Implementar oferta de reapertura en UI. |
-
----
-
-## FASE
-
-> Pendiente — sesión siguiente.
-
----
-
-## TRÁMITE
-
-> Pendiente — sesión siguiente.
-
----
-
-## TAREA
-
-> Pendiente — sesión siguiente.
+*(Todas las fases analizadas. Conclusión uniforme: fecha_inicio y fecha_fin son marcadores operacionales sin valor de dominio. No deben existir como campos. Ver mapa de fechas administrativas por fase en la sección anterior.)*

--- a/docs/ANALISIS_FECHAS_ESFTT.md
+++ b/docs/ANALISIS_FECHAS_ESFTT.md
@@ -14,6 +14,60 @@
 
 ---
 
+## Principio transversal — Coherencia de fechas
+
+**Las validaciones de coherencia de fechas son invariantes estructurales del sistema, no reglas del motor.**
+Se implementan en `invariantes_esftt.py` y se aplican uniformemente a todos los elementos SFTT,
+independientemente del tipo. No son imposiciones legales — son la integridad mínima del modelo.
+
+| Invariante | Aplica a |
+|---|---|
+| `fecha_fin ≥ fecha_inicio` (o `fecha_solicitud`) | Todos los elementos SFTT |
+| `fecha_inicio` del hijo ≥ `fecha_inicio` del padre | Fase/Trámite/Tarea respecto a su contenedor |
+| `fecha_fin` del hijo ≤ `fecha_fin` del padre | Solo cuando el padre esté cerrado |
+
+La columna **Coherencia** de las tablas siguientes recoge solo las particularidades por tipo,
+asumiendo que los invariantes anteriores se comprueban siempre.
+
+---
+
+## Principio transversal — Interior de solo lectura y DESFINALIZAR
+
+**Un contenedor cerrado (`fecha_fin IS NOT NULL`) convierte su interior en solo lectura.**
+DESFINALIZAR (borrar `fecha_fin`) es el mecanismo de corrección — sin él el sistema
+crea callejones sin salida ante errores en el interior.
+
+| Contenedor cerrado | Interior bloqueado (solo lectura) |
+|---|---|
+| Solicitud (`fecha_fin IS NOT NULL`) | Fases, Trámites, Tareas |
+| Fase (`fecha_fin IS NOT NULL`) | Trámites, Tareas |
+| Trámite (`fecha_fin IS NOT NULL`) | Tareas |
+
+### Reglas de implementación
+
+1. **DESFINALIZAR está siempre permitido** para todos los elementos SFTT. No pasa por el
+   motor — es una operación de corrección estructural. Sí pasa por `invariantes_esftt.py`
+   para verificar que no rompe coherencia con el exterior (p.ej. no se puede DESFINALIZAR
+   una Fase si su Solicitud contenedora está cerrada — primero hay que DESFINALIZAR la Solicitud).
+
+2. **DESFINALIZAR Solicitud** resetea también `estado` a `EN_TRAMITE`. Son dos campos que
+   se escriben en la misma operación atómica.
+
+3. **Invariante en `invariantes_esftt.py`**: antes de cualquier operación sobre un hijo
+   (CREAR, INICIAR, FINALIZAR, BORRAR, editar), comprobar que el contenedor está abierto.
+   Si está cerrado → bloquear con mensaje que identifica el contenedor a reabrir.
+
+4. **UX — oferta de reapertura**: la vista puede ofrecer el atajo "¿Reabrir [contenedor]
+   primero?" cuando el invariante bloquea. El motor solo bloquea; la vista decide si ofrece
+   el atajo. No es responsabilidad del motor ni de `invariantes_esftt.py`.
+
+5. **DESFINALIZAR en cascada**: si el elemento a reabrir está dentro de un contenedor
+   cerrado, se bloquea hasta que el usuario reabra primero el contenedor externo.
+   El sistema no reabre en cascada automáticamente — el usuario confirma cada nivel.
+   La oferta de reapertura puede mostrar la cadena completa para orientar al usuario.
+
+---
+
 ## SOLICITUD
 
 ### `fecha_solicitud`
@@ -43,12 +97,12 @@
 
 | Atributo | Valor | Notas |
 |---|---|---|
-| **es_administrativa** | — | **Pendiente de respuesta.** ¿Es la fecha de firma de la resolución o de notificación al interesado? |
-| **DESFINALIZAR (→ NULL)** | — | Pendiente — depende de si es administrativa. |
-| **Coherencia** | — | Pendiente. |
-| **Estado modelo** | — | Pendiente de revisar. |
-| **Estado UI** | — | Pendiente de revisar. |
-| **Decisiones/pendientes** | Confirmar semántica: ¿firma o notificación? Si notificación → `es_administrativa = true` y el sistema puede computar correctamente el plazo art. 21. Si firma → estudiar si se necesita campo `fecha_notificacion` separado o se asume simplificación consciente. |
+| **es_administrativa** | **No** | Marcador operacional — "cierre voluntario de la tramitación por el usuario". Sin valor jurídico propio. La fecha administrativa real vive en el Documento de la fase finalizadora (RESOLUCION, RECONOCIMIENTO_INTERESADO…). Fuente: `DISEÑO_FECHAS_PLAZOS.md §3.0`. |
+| **DESFINALIZAR (→ NULL)** | **Permitido** | Mecanismo de corrección necesario. También resetea `estado` → `EN_TRAMITE` en la misma operación atómica. Ver principio transversal de solo lectura. |
+| **Coherencia** | Invariante estructural | `fecha_fin ≥ fecha_solicitud`. Comprobado en `invariantes_esftt.py`. |
+| **Estado modelo** | ✅ Correcto | `Date nullable`. Regla en docstring: "debería tener fecha_fin si estado ≠ EN_TRAMITE" (débil — correcta). |
+| **Estado UI** | ⬜ Pendiente de revisar | Verificar: ¿se puede poner fecha_fin sin que exista fase finalizadora cerrada? ¿Se bloquea la edición del interior cuando fecha_fin IS NOT NULL? |
+| **Decisiones/pendientes** | Ver issue #302 (fase finalizadora). Implementar bloqueo de interior cuando solicitud cerrada. Implementar oferta de reapertura en UI. |
 
 ---
 

--- a/migrations/versions/d715b074b58c_motor_reglas_agnostico_renombrar_.py
+++ b/migrations/versions/d715b074b58c_motor_reglas_agnostico_renombrar_.py
@@ -1,0 +1,169 @@
+"""motor_reglas_agnostico_renombrar_columnas
+
+Revision ID: d715b074b58c
+Revises: f77b09ef7c1e
+Create Date: 2026-04-17
+
+Refactoriza las tablas reglas_motor y condiciones_regla para el motor agnóstico.
+Las tablas estaban vacías en el momento de la migración.
+
+reglas_motor:
+  evento      → accion        (CREAR|INICIAR|FINALIZAR|BORRAR)
+  entidad     → sujeto        (SOLICITUD|FASE|TRAMITE|TAREA|EXPEDIENTE)
+  tipo_id     → tipo_sujeto_id
+  accion      → efecto        (BLOQUEAR|ADVERTIR)
+  mensaje     → eliminado (el texto se compila en la vista)
+  params_extra → eliminado
+  norma_compilada ADD (temporal hasta paso 3 cuando se cree tabla normas)
+  prioridad   ADD (orden entre reglas del mismo trío accion/sujeto/tipo_sujeto_id)
+
+condiciones_regla:
+  tipo_criterio, parametros, negacion, operador_siguiente → eliminados
+  nombre_variable ADD  (clave en el dict de variables del ContextAssembler)
+  operador ADD         (EQ|NEQ|IN|NOT_IN|IS_NULL|NOT_NULL|GT|GTE|LT|LTE|BETWEEN|NOT_BETWEEN)
+  valor ADD            (JSON — valor de referencia)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'd715b074b58c'
+down_revision = 'f77b09ef7c1e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # -----------------------------------------------------------------------
+    # reglas_motor
+    # -----------------------------------------------------------------------
+    op.drop_constraint('ck_reglas_motor_evento',  'reglas_motor', schema='public')
+    op.drop_constraint('ck_reglas_motor_entidad', 'reglas_motor', schema='public')
+    op.drop_constraint('ck_reglas_motor_accion',  'reglas_motor', schema='public')
+    op.drop_index('idx_reglas_motor_lookup', table_name='reglas_motor', schema='public')
+
+    # Renombrar en orden: primero accion→efecto (libera el nombre), luego evento→accion
+    op.alter_column('reglas_motor', 'accion',  new_column_name='efecto',         schema='public')
+    op.alter_column('reglas_motor', 'evento',  new_column_name='accion',         schema='public')
+    op.alter_column('reglas_motor', 'entidad', new_column_name='sujeto',         schema='public')
+    op.alter_column('reglas_motor', 'tipo_id', new_column_name='tipo_sujeto_id', schema='public')
+
+    op.drop_column('reglas_motor', 'mensaje',      schema='public')
+    op.drop_column('reglas_motor', 'params_extra', schema='public')
+
+    op.add_column('reglas_motor',
+        sa.Column('norma_compilada', sa.String(300), nullable=True,
+                  comment='Referencia normativa (temporal hasta tabla normas en paso 3)'),
+        schema='public'
+    )
+    op.add_column('reglas_motor',
+        sa.Column('prioridad', sa.Integer, nullable=False, server_default='0',
+                  comment='Orden entre reglas del mismo (accion, sujeto, tipo_sujeto_id)'),
+        schema='public'
+    )
+
+    op.create_check_constraint(
+        'ck_reglas_motor_accion', 'reglas_motor',
+        "accion IN ('CREAR','INICIAR','FINALIZAR','BORRAR')", schema='public'
+    )
+    op.create_check_constraint(
+        'ck_reglas_motor_sujeto', 'reglas_motor',
+        "sujeto IN ('SOLICITUD','FASE','TRAMITE','TAREA','EXPEDIENTE')", schema='public'
+    )
+    op.create_check_constraint(
+        'ck_reglas_motor_efecto', 'reglas_motor',
+        "efecto IN ('BLOQUEAR','ADVERTIR')", schema='public'
+    )
+    op.create_index(
+        'idx_reglas_motor_lookup', 'reglas_motor',
+        ['accion', 'sujeto', 'tipo_sujeto_id'], schema='public'
+    )
+
+    # -----------------------------------------------------------------------
+    # condiciones_regla
+    # -----------------------------------------------------------------------
+    op.drop_constraint('ck_condiciones_regla_operador', 'condiciones_regla', schema='public')
+    op.drop_index('idx_condiciones_regla_criterio', table_name='condiciones_regla', schema='public')
+
+    op.drop_column('condiciones_regla', 'tipo_criterio',      schema='public')
+    op.drop_column('condiciones_regla', 'parametros',         schema='public')
+    op.drop_column('condiciones_regla', 'negacion',           schema='public')
+    op.drop_column('condiciones_regla', 'operador_siguiente', schema='public')
+
+    op.add_column('condiciones_regla',
+        sa.Column('nombre_variable', sa.String(80), nullable=False, server_default='',
+                  comment='Clave en el dict de variables del ContextAssembler'),
+        schema='public'
+    )
+    op.add_column('condiciones_regla',
+        sa.Column('operador', sa.String(20), nullable=False, server_default='EQ',
+                  comment='EQ|NEQ|IN|NOT_IN|IS_NULL|NOT_NULL|GT|GTE|LT|LTE|BETWEEN|NOT_BETWEEN'),
+        schema='public'
+    )
+    op.add_column('condiciones_regla',
+        sa.Column('valor', sa.JSON, nullable=True,
+                  comment='Valor de referencia. Lista para IN/BETWEEN, None para IS_NULL/NOT_NULL'),
+        schema='public'
+    )
+
+    op.create_check_constraint(
+        'ck_condiciones_regla_operador', 'condiciones_regla',
+        "operador IN ('EQ','NEQ','IN','NOT_IN','IS_NULL','NOT_NULL','GT','GTE','LT','LTE','BETWEEN','NOT_BETWEEN')",
+        schema='public'
+    )
+    op.create_index(
+        'idx_condiciones_regla_variable', 'condiciones_regla',
+        ['nombre_variable'], schema='public'
+    )
+
+
+def downgrade():
+    # condiciones_regla
+    op.drop_constraint('ck_condiciones_regla_operador', 'condiciones_regla', schema='public')
+    op.drop_index('idx_condiciones_regla_variable', table_name='condiciones_regla', schema='public')
+    op.drop_column('condiciones_regla', 'nombre_variable', schema='public')
+    op.drop_column('condiciones_regla', 'operador',        schema='public')
+    op.drop_column('condiciones_regla', 'valor',           schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('tipo_criterio', sa.String(40), nullable=False, server_default=''), schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('parametros', sa.JSON, nullable=False, server_default='{}'), schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('negacion', sa.Boolean, nullable=False, server_default='false'), schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('operador_siguiente', sa.String(5), nullable=False, server_default='AND'),
+        schema='public')
+    op.create_check_constraint(
+        'ck_condiciones_regla_operador', 'condiciones_regla',
+        "operador_siguiente IN ('AND','OR')", schema='public'
+    )
+    op.create_index('idx_condiciones_regla_criterio', 'condiciones_regla', ['tipo_criterio'], schema='public')
+
+    # reglas_motor
+    op.drop_constraint('ck_reglas_motor_accion', 'reglas_motor', schema='public')
+    op.drop_constraint('ck_reglas_motor_sujeto', 'reglas_motor', schema='public')
+    op.drop_constraint('ck_reglas_motor_efecto', 'reglas_motor', schema='public')
+    op.drop_index('idx_reglas_motor_lookup', table_name='reglas_motor', schema='public')
+    op.drop_column('reglas_motor', 'norma_compilada', schema='public')
+    op.drop_column('reglas_motor', 'prioridad',       schema='public')
+    op.alter_column('reglas_motor', 'efecto',         new_column_name='accion',   schema='public')
+    op.alter_column('reglas_motor', 'tipo_sujeto_id', new_column_name='tipo_id',  schema='public')
+    op.alter_column('reglas_motor', 'sujeto',         new_column_name='entidad',  schema='public')
+    op.alter_column('reglas_motor', 'accion',         new_column_name='evento',   schema='public')
+    op.add_column('reglas_motor',
+        sa.Column('mensaje', sa.String(500), nullable=False, server_default=''), schema='public')
+    op.add_column('reglas_motor',
+        sa.Column('params_extra', sa.String(100), nullable=True), schema='public')
+    op.create_check_constraint(
+        'ck_reglas_motor_evento', 'reglas_motor',
+        "evento IN ('CREAR','INICIAR','FINALIZAR','BORRAR')", schema='public'
+    )
+    op.create_check_constraint(
+        'ck_reglas_motor_entidad', 'reglas_motor',
+        "entidad IN ('SOLICITUD','FASE','TRAMITE','TAREA','EXPEDIENTE')", schema='public'
+    )
+    op.create_check_constraint(
+        'ck_reglas_motor_accion', 'reglas_motor',
+        "accion IN ('BLOQUEAR','ADVERTIR')", schema='public'
+    )
+    op.create_index('idx_reglas_motor_lookup', 'reglas_motor', ['evento', 'entidad', 'tipo_id'], schema='public')


### PR DESCRIPTION
## Cambios

- **Motor de reglas agnóstico**: refactor completo — el motor recibe un dict plano de variables y evalúa reglas sin conocer el dominio BDDAT. Eliminados criterios BDDAT-específicos. La lógica de dominio pasa a `invariantes_esftt.py` y al futuro ContextAssembler.
- **Migración**: renombrado de columnas en `motor_reglas` para alinear con el nuevo diseño agnóstico.
- **`invariantes_esftt.py`**: nuevo servicio que centraliza los invariantes estructurales hardcoded que el motor agnóstico no puede evaluar por sí solo.
- **Call sites actualizados**: `expedientes/routes.py` y `vista3.py` actualizados para invocar `invariantes_esftt` antes de llamar al motor.
- **`ANALISIS_FECHAS_ESFTT.md`**: sesión de análisis completa — conclusión arquitectónica: ningún campo de fecha debe existir en modelos ESFTT. Las fechas viven exclusivamente en `Documento.fecha_administrativa`. Plan de refactorización en `~/.claude/plans/refactor_eliminacion_fechas_esftt.md`.
- **`tareas.py`**: corregido docstring que inducía a error sobre el origen del plazo en ESPERARPLAZO (vive en `catalogo_plazos`, no en `notas`).