### PR TITLE
Motor reglas paso 3: tablas normas y catalogo_variables

### DIFF
--- a/app/models/motor_reglas.py
+++ b/app/models/motor_reglas.py
@@ -1,6 +1,63 @@
 from app import db
 
 
+class Norma(db.Model):
+    """
+    Norma legal de referencia para las reglas del motor.
+    """
+    __tablename__ = 'normas'
+    __table_args__ = (
+        db.Index('idx_normas_codigo', 'codigo', unique=True),
+        {'schema': 'public'}
+    )
+
+    id      = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    codigo  = db.Column(db.String(30),  unique=True, nullable=False,
+                        comment='Clave interna: DL26_2021 | LPACAP | RD337_2014')
+    titulo  = db.Column(db.String(300), nullable=False,
+                        comment='Texto completo: "Decreto-ley 26/2021, de 14 de diciembre"')
+    url_eli = db.Column(db.String(500), nullable=True,
+                        comment='URL texto consolidado BOE/BOJA')
+
+    def __repr__(self):
+        return f'<Norma {self.codigo}>'
+
+
+class CatalogoVariable(db.Model):
+    """
+    Registro de variables disponibles para el motor de reglas.
+
+    Fuente de verdad compartida entre el Variable Registry (código) y la UI
+    del Supervisor (dropdown). Solo las variables con activa=True aparecen
+    en el formulario de alta de reglas.
+
+    El ciclo de vida completo está descrito en
+    docs/DISEÑO_CONTEXT_ASSEMBLER.md §Ciclo de vida de una variable.
+    """
+    __tablename__ = 'catalogo_variables'
+    __table_args__ = (
+        db.Index('idx_catalogo_variables_nombre', 'nombre', unique=True),
+        {'schema': 'public'}
+    )
+
+    id        = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    nombre    = db.Column(db.String(80),  unique=True, nullable=False,
+                          comment='Clave del dict de variables: tension_nominal_kv')
+    etiqueta  = db.Column(db.String(150), nullable=False,
+                          comment='Texto legible para el Supervisor en el formulario')
+    tipo_dato = db.Column(db.String(20),  nullable=False,
+                          comment='boolean | numerico | texto | fecha | enum')
+    norma_id  = db.Column(db.Integer, db.ForeignKey('public.normas.id'), nullable=True,
+                          comment='Norma de origen principal de la variable')
+    activa    = db.Column(db.Boolean, nullable=False, default=False,
+                          comment='True solo cuando la función existe en el Variable Registry')
+
+    norma = db.relationship('Norma')
+
+    def __repr__(self):
+        return f'<CatalogoVariable {self.nombre} activa={self.activa}>'
+
+
 class ReglaMotor(db.Model):
     """
     Regla del motor de validación agnóstico.
@@ -17,12 +74,8 @@ class ReglaMotor(db.Model):
     EVALUACIÓN:
         El motor carga las reglas activas para (accion, sujeto, tipo_sujeto_id).
         Para cada regla evalúa sus condiciones (CondicionRegla) contra el dict de
-        variables compilado por el ContextAssembler. AND implícito entre condiciones.
+        variables compilado por el Variable Registry. AND implícito entre condiciones.
         Si todas se cumplen → aplica efecto. BLOQUEAR tiene prioridad sobre ADVERTIR.
-
-    NORMA:
-        norma_compilada es campo temporal hasta que se cree la tabla normas (paso 3).
-        En paso 3 se añade norma_id FK + articulo + apartado y se elimina este campo.
     """
     __tablename__ = 'reglas_motor'
     __table_args__ = (
@@ -51,9 +104,17 @@ class ReglaMotor(db.Model):
         db.String(10), nullable=False,
         comment='Efecto si se cumplen condiciones: BLOQUEAR | ADVERTIR'
     )
-    norma_compilada = db.Column(
-        db.String(300), nullable=True,
-        comment='Referencia normativa compilada (temporal hasta tabla normas en paso 3)'
+    norma_id = db.Column(
+        db.Integer, db.ForeignKey('public.normas.id'), nullable=True,
+        comment='FK a normas — norma legal de la regla'
+    )
+    articulo = db.Column(
+        db.String(20), nullable=True,
+        comment='Artículo exacto: "24.3" | "DA4" | "DF2"'
+    )
+    apartado = db.Column(
+        db.String(20), nullable=True,
+        comment='Sub-apartado si procede'
     )
     prioridad = db.Column(
         db.Integer, nullable=False, default=0,
@@ -64,6 +125,7 @@ class ReglaMotor(db.Model):
         comment='Desactivar en lugar de borrar — preserva trazabilidad'
     )
 
+    norma      = db.relationship('Norma')
     condiciones = db.relationship(
         'CondicionRegla',
         backref='regla',
@@ -97,7 +159,7 @@ class CondicionRegla(db.Model):
             name='ck_condiciones_regla_operador'
         ),
         db.Index('idx_condiciones_regla_regla',    'regla_id'),
-        db.Index('idx_condiciones_regla_variable', 'nombre_variable'),
+        db.Index('idx_condiciones_regla_variable', 'variable_id'),
         {'schema': 'public'}
     )
 
@@ -107,11 +169,13 @@ class CondicionRegla(db.Model):
         db.Integer,
         db.ForeignKey('public.reglas_motor.id', ondelete='CASCADE'),
         nullable=False,
-        comment='FK a REGLAS_MOTOR'
+        comment='FK a reglas_motor'
     )
-    nombre_variable = db.Column(
-        db.String(80), nullable=False,
-        comment='Clave en el dict de variables del ContextAssembler'
+    variable_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.catalogo_variables.id'),
+        nullable=False,
+        comment='FK a catalogo_variables — variable evaluada'
     )
     operador = db.Column(
         db.String(20), nullable=False,
@@ -126,8 +190,11 @@ class CondicionRegla(db.Model):
         comment='Orden informativo dentro de la regla'
     )
 
+    variable = db.relationship('CatalogoVariable')
+
     def __repr__(self):
-        return f'<CondicionRegla id={self.id} regla={self.regla_id} {self.nombre_variable} {self.operador} {self.valor!r}>'
+        nombre = self.variable.nombre if self.variable else f'var_id={self.variable_id}'
+        return f'<CondicionRegla id={self.id} regla={self.regla_id} {nombre} {self.operador} {self.valor!r}>'
 
 
 class TipoSolicitudCompatible(db.Model):

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -19,7 +19,6 @@ from flask import Blueprint, render_template, request, flash, redirect, url_for,
 from flask_login import login_required
 from app import db
 from app.models.expedientes import Expediente
-from app.routes.vista3 import _get_solicitudes_con_stats, _construir_arbol
 from app.models.proyectos import Proyecto
 from app.models.usuarios import Usuario
 from app.models.tipos_expedientes import TipoExpediente

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -17,9 +17,9 @@ Uso:
 
     bloqueo = check_invariante('FINALIZAR', 'FASE', fase.id)
     if bloqueo:
-        return jsonify({'ok': False, 'error': bloqueo.norma_compilada}), 422
+        return jsonify({'ok': False, 'error': bloqueo.mensaje}), 422
 
-    variables = {}  # TODO paso 5: context_assembler.build(expediente_id)
+    variables = {}  # TODO paso 5: variables = build(fase.expediente_id)
     resultado = evaluar('FINALIZAR', 'FASE', fase.tipo_fase_id, variables)
     if not resultado.permitido:
         return jsonify({'ok': False, 'error': resultado.norma_compilada,
@@ -30,6 +30,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from typing import Optional
+
+from sqlalchemy.orm import joinedload
 
 from app import db
 from app.models.motor_reglas import ReglaMotor, CondicionRegla
@@ -77,7 +79,7 @@ _OPERADORES = {
 
 
 def _evaluar_condicion(cond: CondicionRegla, variables: dict) -> bool:
-    nombre = cond.nombre_variable
+    nombre = cond.variable.nombre
     if nombre not in variables:
         log.warning('motor_reglas: variable ausente en dict: %s', nombre)
         return False
@@ -106,7 +108,7 @@ def _evaluar_regla(regla: ReglaMotor, variables: dict) -> tuple[bool, dict]:
     for cond in condiciones:
         if not _evaluar_condicion(cond, variables):
             return False, {}
-        trigger[cond.nombre_variable] = variables.get(cond.nombre_variable)
+        trigger[cond.variable.nombre] = variables.get(cond.variable.nombre)
     return True, trigger
 
 
@@ -133,7 +135,9 @@ def evaluar(
         EvaluacionResult. Lanza excepción ante error interno — nunca devuelve
         PERMITIDO silenciosamente ante un fallo.
     """
-    q = ReglaMotor.query.filter_by(accion=accion, sujeto=sujeto, activa=True)
+    q = ReglaMotor.query.options(
+        joinedload(ReglaMotor.condiciones).joinedload(CondicionRegla.variable)
+    ).filter_by(accion=accion, sujeto=sujeto, activa=True)
     if tipo_sujeto_id is not None:
         q = q.filter(
             db.or_(ReglaMotor.tipo_sujeto_id == tipo_sujeto_id,
@@ -149,21 +153,29 @@ def evaluar(
         disparada, trigger = _evaluar_regla(regla, variables)
         if not disparada:
             continue
+        norma_ref = ''
+        url_norma = ''
+        if regla.norma:
+            art = regla.articulo or ''
+            apt = f'.{regla.apartado}' if regla.apartado else ''
+            norma_ref = f'Art. {art}{apt} — {regla.norma.titulo}' if art else regla.norma.titulo
+            url_norma = regla.norma.url_eli or ''
+
         if regla.efecto == 'BLOQUEAR':
             return EvaluacionResult(
                 permitido=False,
                 nivel='BLOQUEAR',
                 variables_trigger=trigger,
-                norma_compilada=regla.norma_compilada or '',
-                url_norma='',
+                norma_compilada=norma_ref,
+                url_norma=url_norma,
             )
         if regla.efecto == 'ADVERTIR' and resultado_advertir is None:
             resultado_advertir = EvaluacionResult(
                 permitido=True,
                 nivel='ADVERTIR',
                 variables_trigger=trigger,
-                norma_compilada=regla.norma_compilada or '',
-                url_norma='',
+                norma_compilada=norma_ref,
+                url_norma=url_norma,
             )
 
     return resultado_advertir or PERMITIDO

--- a/docs/DISEÑO_CONTEXT_ASSEMBLER.md
+++ b/docs/DISEÑO_CONTEXT_ASSEMBLER.md
@@ -1,7 +1,7 @@
 # ContextAssembler — Diseño del contrato de variables
 
-> **Fecha:** 2026-04-05
-> **Estado:** En construcción — diccionario de variables activo; diseño de implementación pendiente.
+> **Fecha:** 2026-04-05 · **Actualizado:** 2026-04-21
+> **Estado:** En construcción — diccionario de variables activo; patrón Variable Registry y ciclo de vida definidos (sesión 2026-04-21).
 > **Referencia de arquitectura:** `DISEÑO_MOTOR_AGNOSTICO.md`
 
 Este documento define el contrato de entrada del ContextAssembler: qué variables
@@ -172,3 +172,78 @@ Las variables crecen en el paso `MAPEO_CONTEXTO` del protocolo de extracción
 | `es_ptd` | boolean | `dato` · Solicitud | RD 337/2014 arts. 16.1, 20.1 · **RD 223/2008 arts. 17.1, 20** — el titular/promotor es empresa de producción, transporte o distribución de energía eléctrica. Si `true`: procedimiento de autorización por legislación sectorial (RD 1955/2000 / LSE); si `false`: puesta en servicio directa (RAT) o autorización según tipo funcional (LAT) salvo `instalacion_cedida = true`. **Deduplicación:** este es el discriminador PTD/no-PTD; `tipo_promotor` no existe aún. | pendiente de implementar |
 | `instalacion_cedida` | boolean | `dato` · Solicitud | RD 337/2014 art. 20.3 / ITC-RAT 22 §5 · **RD 223/2008 ITC-LAT 04 §5** — la instalación va a ser cedida a una PTD antes de su puesta en servicio (pasa a formar parte de la red de transporte o distribución). Si `true`: se aplica el régimen de autorizaciones del RD 1955/2000 título VII aunque el promotor no sea PTD. **Deduplicación:** distinto de `tiene_linea_evacuacion_comun` (fraccionamiento entre promotores); este es sobre titularidad final. | pendiente de implementar |
 | `tipo_linea_funcional` | enum | `dato` · Solicitud | RD 223/2008 ITC-LAT 04 §4 — tipo funcional de la línea; determina si una línea no-PTD no cedida requiere autorización previa. Valores: `'generacion'` (conexión de central), `'consumidor_red'` (consumidor a red transporte/distribución), `'linea_directa'`, `'acometida'`, `'red_distribucion'` (varios consumidores) → todos requieren autorización; `'privada_exclusiva'` → exenta. Solo relevante cuando `es_ptd = false AND instalacion_cedida = false`. | pendiente de implementar |
+
+---
+
+## Ciclo de vida de una variable
+
+> Cómo implementa el programador una variable nueva y cómo la usa el Supervisor
+> para definir reglas, y el motor para evaluarlas.
+
+### Fase 1 — El programador implementa la variable
+
+Parte del diccionario de este documento. Hace dos cosas:
+
+**1. Escribe la función** en el submódulo correspondiente de `app/services/variables/`:
+
+```python
+# app/services/variables/calculado.py
+@variable('intermunicipal')
+def _(ctx: ExpedienteContext) -> bool:
+    return len(ctx.proyecto.municipios) > 1
+```
+
+Al arrancar Flask, el decorador `@variable` ejecuta `_REGISTRY['intermunicipal'] = esa_función`.
+El registro vive en memoria. No hay dispatcher, no hay ifs en `build()`.
+
+Los submódulos se organizan por naturaleza de la variable:
+- `dato.py` — leen directamente un campo del modelo
+- `calculado.py` — computan un valor a partir de otros datos
+- `derivado_fase.py` — consultan si existe una fase cerrada con resultado favorable
+- `derivado_documento.py` — consultan si existe un documento de tipo concreto
+
+**2. Activa la fila** en `catalogo_variables` (vía seed o UI del Supervisor):
+```sql
+UPDATE catalogo_variables SET activa = true WHERE nombre = 'intermunicipal';
+```
+`activa = false` mientras la función no exista en el registry. El Supervisor no puede
+referenciar variables no implementadas.
+
+### Fase 2 — El Supervisor define una regla
+
+Abre el formulario de alta de regla. El campo "variable" es un `<select>` poblado con:
+```sql
+SELECT id, etiqueta FROM catalogo_variables WHERE activa = true ORDER BY etiqueta;
+```
+El Supervisor elige variable, operador (en lenguaje natural: "igual a", "en el conjunto"...)
+y valor. Se guarda en `condiciones_regla` como:
+```
+variable_id = 7   ← FK al id de 'intermunicipal' en catalogo_variables
+operador    = 'EQ'
+valor       = true
+```
+Nunca escribe el nombre de la variable a mano. Si la variable que necesita no aparece
+en el dropdown, falta código — no puede forzarlo.
+
+### Fase 3 — El motor evalúa una acción
+
+La ruta Flask ejecuta siempre el mismo patrón de dos líneas:
+```python
+variables = build(expediente.id)   # dict completo de todas las variables
+resultado  = evaluar('INICIAR', 'FASE', fase.tipo_fase_id, variables)
+```
+
+`build()` recorre `_REGISTRY` y llama cada función con el contexto del expediente.
+Devuelve un dict plano: `{'intermunicipal': True, 'tension_nominal_kv': 220, ...}`.
+Las variables no aplicables llegan como `None`.
+
+`evaluar()` carga las reglas activas para `(accion, sujeto, tipo_sujeto_id)` de BD,
+resuelve cada condición buscando `variables[v.nombre]` en el dict y aplicando el operador
+contra `condiciones_regla.valor`. Si todas las condiciones de una regla se cumplen,
+esa regla se activa.
+
+### Regla de coherencia
+
+Toda variable referenciada en `condiciones_regla` debe existir en `catalogo_variables`
+(integridad referencial por FK) y tener su función en el registry (`activa = true`).
+Un comando `flask sync_variables` puede verificar que ambos lados están alineados.

--- a/docs/DISEÑO_MOTOR_AGNOSTICO.md
+++ b/docs/DISEÑO_MOTOR_AGNOSTICO.md
@@ -1,8 +1,9 @@
 # Motor de reglas agnóstico — Decisiones de rediseño
 
-> **Fecha:** 2026-04-05 · **Actualizado:** 2026-04-16
+> **Fecha:** 2026-04-05 · **Actualizado:** 2026-04-21
 > Sesión de reflexión arquitectural. Complementa `DISEÑO_MOTOR_REGLAS.md`.
 > Esquema de tablas cerrado en sesión 2026-04-16 — ver §Esquema de tablas.
+> Sesión 2026-04-21: esquema `catalogo_variables` cerrado; `condiciones_regla` pasa a FK entera; patrón Variable Registry adoptado — ver `DISEÑO_CONTEXT_ASSEMBLER.md §Ciclo de vida de una variable`.
 
 ---
 
@@ -184,13 +185,15 @@ implícito**. Para expresar OR se crean reglas separadas (Leyes de De Morgan).
 |---|---|---|
 | `id` | INTEGER PK | |
 | `regla_id` | FK → `reglas_motor` CASCADE | Regla a la que pertenece |
-| `nombre_variable` | VARCHAR | Clave en el dict de variables |
+| `variable_id` | FK → `catalogo_variables` | Variable evaluada (integridad referencial garantizada) |
 | `operador` | VARCHAR | Ver catálogo de operadores |
 | `valor` | JSON | Valor de referencia (string, número, lista para IN/BETWEEN) |
 | `orden` | INTEGER | Solo informativo — no cambia semántica |
 
 Sin `negacion` (redundante con los operadores contrarios), sin `operador_siguiente`
-(eliminado al adoptar AND-only), sin `tipo_criterio` (sustituido por `nombre_variable`).
+(eliminado al adoptar AND-only). El campo `nombre_variable VARCHAR` de la migración
+anterior se sustituye por `variable_id FK` — obliga a que toda condición referencie una
+variable registrada en `catalogo_variables`.
 
 **Catálogo de operadores:**
 
@@ -202,6 +205,26 @@ Sin `negacion` (redundante con los operadores contrarios), sin `operador_siguien
 | `GT` / `GTE` | mayor que / mayor o igual que |
 | `LT` / `LTE` | menor que / menor o igual que |
 | `BETWEEN` / `NOT_BETWEEN` | en el rango [a,b] / fuera del rango |
+
+### `catalogo_variables`
+
+Registro de todas las variables que el ContextAssembler sabe computar. Es la fuente de
+verdad compartida entre el código (Variable Registry) y la UI del Supervisor (dropdown).
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `id` | INTEGER PK | |
+| `nombre` | VARCHAR UNIQUE NOT NULL | Clave usada en el dict de variables (e.g. `tension_nominal_kv`) |
+| `etiqueta` | VARCHAR NOT NULL | Texto legible para el Supervisor en el formulario |
+| `tipo_dato` | VARCHAR NOT NULL | `boolean` \| `numerico` \| `texto` \| `fecha` \| `enum` — valida `condiciones_regla.valor` |
+| `norma_id` | FK → `normas` nullable | Norma de origen principal de la variable |
+| `activa` | BOOLEAN NOT NULL DEFAULT false | `true` solo cuando la función existe en el Variable Registry |
+
+`naturaleza` (`dato`/`calculado`/`derivado_fase`/`derivado_documento`) vive en el código
+Python del registro — no en BD. Es metadata de implementación, no dato operativo.
+
+El ciclo de vida completo de una variable está descrito en
+`DISEÑO_CONTEXT_ASSEMBLER.md §Ciclo de vida de una variable`.
 
 ### `normas`
 
@@ -383,10 +406,10 @@ extra de proyecto que aún no existen.
 Seis pasos, de más interior a más exterior. Actualizado sesión 2026-04-16 (no hay EventHandler, esquema tablas cerrado):
 
 1. ✅ **MRA — API + esquema tablas** — firma `evaluar(accion, sujeto, tipo_sujeto_id, variables)`, `EvaluacionResult` con `variables_trigger`/`norma_compilada`/`url_norma`, tablas `normas`/`reglas_motor`/`condiciones_regla`/`catalogo_variables` cerradas. Sin capa EventHandler — patrón dos líneas en ruta Flask.
-2. **MRA — implementación motor** — refactor `motor_reglas.py`: nueva firma, nuevo `EvaluacionResult`, eliminar imports BDDAT y criterios específicos (`EXISTE_FASE_CERRADA`, `EXISTE_TAREA_TIPO`, `_check_finalizar_tarea`)
-3. **Migración manual** — crear tablas `normas`, `reglas_motor`, `condiciones_regla`, `catalogo_variables` (esquema cerrado en §Esquema de tablas). Sin tabla `disparadores`.
-4. **Variables — recatalogación** — revisar `DISEÑO_CONTEXT_ASSEMBLER.md`, decidir primeras variables implementables para el primer sprint; seed de `catalogo_variables`; resolver modelo de BD de `Proyecto`/`Solicitud` para variables `dato` → issue #279
-5. **ContextAssembler — implementación** — `app/services/context_assembler.py` con las variables del paso 4; integrar `plazos.py`
+2. ✅ **MRA — implementación motor** — `motor_reglas.py` refactorizado: agnóstico de BDDAT, nueva firma, nuevo `EvaluacionResult`, criterios específicos eliminados.
+3. **Migración manual** — una sola migración con este orden interno: (1) crear `normas`, (2) crear `catalogo_variables`, (3) añadir `norma_id`/`articulo`/`apartado` a `reglas_motor` + eliminar `norma_compilada`, (4) renombrar `condiciones_regla.nombre_variable → variable_id FK → catalogo_variables`. Ver §Esquema de tablas.
+4. **Variables — recatalogación** — revisar `DISEÑO_CONTEXT_ASSEMBLER.md`, decidir primeras variables implementables; seed de `catalogo_variables`; resolver modelo de BD de `Proyecto`/`Solicitud` para variables `dato` → issue #279
+5. **Variable Registry + ContextAssembler** — `app/services/variables/` con patrón registry (`@variable` decorator); `build(expediente_id) → dict`; integrar `plazos.py`. Ver `DISEÑO_CONTEXT_ASSEMBLER.md §Ciclo de vida de una variable`.
 6. **Fuego real** — seed `normas` + 2-3 reglas + condiciones; wiring dos líneas en 2-3 rutas Flask; prueba con expediente real
 
 Issues afectados (no desbloquear hasta paso 5):

--- a/migrations/versions/a9cd38df8797_paso3_motor_normas_catalogo.py
+++ b/migrations/versions/a9cd38df8797_paso3_motor_normas_catalogo.py
@@ -1,0 +1,109 @@
+"""paso3_motor_normas_catalogo
+
+Revision ID: a9cd38df8797
+Revises: 95c2e862e8d6
+Create Date: 2026-04-21 20:07:34.474035
+
+Crea tablas normas y catalogo_variables.
+Ajusta reglas_motor: añade norma_id/articulo/apartado, elimina norma_compilada.
+Ajusta condiciones_regla: sustituye nombre_variable VARCHAR por variable_id FK.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a9cd38df8797'
+down_revision = '95c2e862e8d6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Crear normas
+    op.create_table(
+        'normas',
+        sa.Column('id',      sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('codigo',  sa.String(30),  nullable=False),
+        sa.Column('titulo',  sa.String(300), nullable=False),
+        sa.Column('url_eli', sa.String(500), nullable=True),
+        sa.UniqueConstraint('codigo', name='uq_normas_codigo'),
+        schema='public',
+    )
+    op.create_index('idx_normas_codigo', 'normas', ['codigo'], unique=True, schema='public')
+
+    # 2. Crear catalogo_variables (FK → normas)
+    op.create_table(
+        'catalogo_variables',
+        sa.Column('id',        sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('nombre',    sa.String(80),  nullable=False),
+        sa.Column('etiqueta',  sa.String(150), nullable=False),
+        sa.Column('tipo_dato', sa.String(20),  nullable=False),
+        sa.Column('norma_id',  sa.Integer,     nullable=True),
+        sa.Column('activa',    sa.Boolean,     nullable=False, server_default='false'),
+        sa.ForeignKeyConstraint(['norma_id'], ['public.normas.id'], name='fk_catalogo_variables_norma'),
+        sa.UniqueConstraint('nombre', name='uq_catalogo_variables_nombre'),
+        schema='public',
+    )
+    op.create_index('idx_catalogo_variables_nombre', 'catalogo_variables', ['nombre'], unique=True, schema='public')
+
+    # 3. Ajustar reglas_motor
+    op.add_column('reglas_motor',
+        sa.Column('norma_id',  sa.Integer,    nullable=True,
+                  comment='FK a normas — norma legal de la regla'),
+        schema='public')
+    op.add_column('reglas_motor',
+        sa.Column('articulo',  sa.String(20), nullable=True,
+                  comment='Artículo exacto: "24.3" | "DA4" | "DF2"'),
+        schema='public')
+    op.add_column('reglas_motor',
+        sa.Column('apartado',  sa.String(20), nullable=True,
+                  comment='Sub-apartado si procede'),
+        schema='public')
+    op.create_foreign_key(
+        'fk_reglas_motor_norma', 'reglas_motor', 'normas',
+        ['norma_id'], ['id'], source_schema='public', referent_schema='public'
+    )
+    op.drop_column('reglas_motor', 'norma_compilada', schema='public')
+
+    # 4. Ajustar condiciones_regla
+    op.drop_index('idx_condiciones_regla_variable', table_name='condiciones_regla', schema='public')
+    op.drop_column('condiciones_regla', 'nombre_variable', schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('variable_id', sa.Integer, nullable=False, server_default='0',
+                  comment='FK a catalogo_variables'),
+        schema='public')
+    op.create_foreign_key(
+        'fk_condiciones_regla_variable', 'condiciones_regla', 'catalogo_variables',
+        ['variable_id'], ['id'], source_schema='public', referent_schema='public'
+    )
+    op.alter_column('condiciones_regla', 'variable_id', server_default=None, schema='public')
+    op.create_index('idx_condiciones_regla_variable', 'condiciones_regla', ['variable_id'], schema='public')
+
+
+def downgrade():
+    # 4. Restaurar condiciones_regla
+    op.drop_index('idx_condiciones_regla_variable', table_name='condiciones_regla', schema='public')
+    op.drop_constraint('fk_condiciones_regla_variable', 'condiciones_regla', schema='public', type_='foreignkey')
+    op.drop_column('condiciones_regla', 'variable_id', schema='public')
+    op.add_column('condiciones_regla',
+        sa.Column('nombre_variable', sa.String(80), nullable=False, server_default=''),
+        schema='public')
+    op.alter_column('condiciones_regla', 'nombre_variable', server_default=None, schema='public')
+    op.create_index('idx_condiciones_regla_variable', 'condiciones_regla', ['nombre_variable'], schema='public')
+
+    # 3. Restaurar reglas_motor
+    op.drop_constraint('fk_reglas_motor_norma', 'reglas_motor', schema='public', type_='foreignkey')
+    op.drop_column('reglas_motor', 'norma_id',  schema='public')
+    op.drop_column('reglas_motor', 'articulo',  schema='public')
+    op.drop_column('reglas_motor', 'apartado',  schema='public')
+    op.add_column('reglas_motor',
+        sa.Column('norma_compilada', sa.String(300), nullable=True),
+        schema='public')
+
+    # 2. Drop catalogo_variables
+    op.drop_index('idx_catalogo_variables_nombre', table_name='catalogo_variables', schema='public')
+    op.drop_table('catalogo_variables', schema='public')
+
+    # 1. Drop normas
+    op.drop_index('idx_normas_codigo', table_name='normas', schema='public')
+    op.drop_table('normas', schema='public')


### PR DESCRIPTION
## Cambios

- **Migración `a9cd38df`**: crea tablas `normas` y `catalogo_variables`; ajusta `reglas_motor` (añade `norma_id` FK + `articulo` + `apartado`, elimina `norma_compilada`); sustituye `condiciones_regla.nombre_variable VARCHAR` por `variable_id INTEGER FK → catalogo_variables`
- **Modelos** (`motor_reglas.py`): nuevas clases `Norma` y `CatalogoVariable`; `ReglaMotor` y `CondicionRegla` actualizados al nuevo esquema
- **Motor** (`motor_reglas.py`): `cond.nombre_variable` → `cond.variable.nombre`; `joinedload` condiciones→variable para evitar N+1; `norma_compilada` del resultado se construye desde `norma.titulo` + `articulo`
- **Docs**: `DISEÑO_MOTOR_AGNOSTICO.md` y `DISEÑO_CONTEXT_ASSEMBLER.md` actualizados con esquema cerrado y patrón Variable Registry
- **Fix residual #309**: eliminado import huérfano de `app.routes.vista3` en `expedientes/routes.py`

Completa el paso 3 del plan `plan_motor_reglas.md`.
