### PR TITLE
Crear blueprint api_bc con endpoints ESFTT para vista BC

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -68,7 +68,7 @@ def create_app(config_name='development'):
     app.register_blueprint(wizard_expediente.bp)  # Issue #67
 
     # Registrar blueprints - APIs
-    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento
+    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento, api_bc
 
     app.register_blueprint(api_expedientes.api_bp)                  # usa 'api_bp'
     app.register_blueprint(api_municipios.bp)                       # usa 'bp'
@@ -76,6 +76,7 @@ def create_app(config_name='development'):
     app.register_blueprint(api_proyectos.api_proyectos_bp)          # usa 'api_proyectos_bp' — Issue #123
     app.register_blueprint(api_escritos.api_escritos_bp)            # usa 'api_escritos_bp' — Issue #167
     app.register_blueprint(api_seguimiento.api_seguimiento_bp)      # usa 'api_seguimiento_bp' — Issue #262
+    app.register_blueprint(api_bc.bp)                               # usa 'bp' — fix #314
 
     # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc.html
@@ -39,7 +39,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <form class="form-nueva-bc"
-            data-url="{{ url_for('vista3.crear_solicitud', exp_id=expediente.id) }}">
+            data-url="{{ url_for('api_bc.crear_solicitud', exp_id=expediente.id) }}">
         <div class="modal-body">
           <div class="mb-3">
             <label class="form-label fw-semibold">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -62,7 +62,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="iniciar"
-                 data-url="{{ url_for('vista3.iniciar_fase', fase_id=fase.id) }}">
+                 data-url="{{ url_for('api_bc.iniciar_fase', fase_id=fase.id) }}">
                 <i class="fas fa-play me-2 text-success"></i> Iniciar
               </a>
             </li>
@@ -71,7 +71,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="finalizar"
-                 data-url="{{ url_for('vista3.finalizar_fase', fase_id=fase.id) }}">
+                 data-url="{{ url_for('api_bc.finalizar_fase', fase_id=fase.id) }}">
                 <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
               </a>
             </li>
@@ -80,7 +80,7 @@
             <li>
               <a class="dropdown-item text-danger" href="#"
                  data-accion="borrar"
-                 data-url="{{ url_for('vista3.borrar_fase', fase_id=fase.id) }}"
+                 data-url="{{ url_for('api_bc.borrar_fase', fase_id=fase.id) }}"
                  data-redirect="{{ url_for('expedientes.tramitacion_bc_solicitud', exp_id=expediente.id, sol_id=solicitud.id) }}">
                 <i class="fas fa-trash me-2"></i> Borrar
               </a>
@@ -111,7 +111,7 @@
     </div>
 
     <form data-modo-editar class="d-none row g-2 pt-1"
-          data-url="{{ url_for('vista3.editar_fase', fase_id=fase.id) }}">
+          data-url="{{ url_for('api_bc.editar_fase', fase_id=fase.id) }}">
       <div class="col-md-3">
         <label class="form-label fw-semibold mb-1">Tipo</label>
         <input type="text" class="form-control form-control-sm" readonly
@@ -169,7 +169,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <form class="form-nueva-bc"
-            data-url="{{ url_for('vista3.crear_tramite', fase_id=fase.id) }}">
+            data-url="{{ url_for('api_bc.crear_tramite', fase_id=fase.id) }}">
         <div class="modal-body">
           <div class="mb-3">
             <label class="form-label fw-semibold">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_solicitud.html
@@ -47,7 +47,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="iniciar"
-                 data-url="{{ url_for('vista3.iniciar_solicitud', sol_id=solicitud.id) }}">
+                 data-url="{{ url_for('api_bc.iniciar_solicitud', sol_id=solicitud.id) }}">
                 <i class="fas fa-play me-2 text-success"></i> Iniciar
               </a>
             </li>
@@ -56,7 +56,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="finalizar"
-                 data-url="{{ url_for('vista3.finalizar_solicitud', sol_id=solicitud.id) }}">
+                 data-url="{{ url_for('api_bc.finalizar_solicitud', sol_id=solicitud.id) }}">
                 <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
               </a>
             </li>
@@ -65,7 +65,7 @@
             <li>
               <a class="dropdown-item text-danger" href="#"
                  data-accion="borrar"
-                 data-url="{{ url_for('vista3.borrar_solicitud', sol_id=solicitud.id) }}"
+                 data-url="{{ url_for('api_bc.borrar_solicitud', sol_id=solicitud.id) }}"
                  data-redirect="{{ url_for('expedientes.tramitacion_bc', exp_id=expediente.id) }}">
                 <i class="fas fa-trash me-2"></i> Borrar
               </a>
@@ -106,7 +106,7 @@
     </div>
 
     <form data-modo-editar class="d-none row g-2 pt-1"
-          data-url="{{ url_for('vista3.editar_solicitud', sol_id=solicitud.id) }}">
+          data-url="{{ url_for('api_bc.editar_solicitud', sol_id=solicitud.id) }}">
       <div class="col-12">
         <label class="form-label fw-semibold mb-1">Observaciones</label>
         <textarea class="form-control form-control-sm" name="observaciones"
@@ -146,7 +146,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <form class="form-nueva-bc"
-            data-url="{{ url_for('vista3.crear_fase', sol_id=solicitud.id) }}">
+            data-url="{{ url_for('api_bc.crear_fase', sol_id=solicitud.id) }}">
         <div class="modal-body">
           <div class="mb-3">
             <label class="form-label fw-semibold">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -67,7 +67,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="iniciar"
-                 data-url="{{ url_for('vista3.iniciar_tarea', tarea_id=tarea.id) }}">
+                 data-url="{{ url_for('api_bc.iniciar_tarea', tarea_id=tarea.id) }}">
                 <i class="fas fa-play me-2 text-success"></i> Iniciar
               </a>
             </li>
@@ -76,7 +76,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="finalizar"
-                 data-url="{{ url_for('vista3.finalizar_tarea', tarea_id=tarea.id) }}">
+                 data-url="{{ url_for('api_bc.finalizar_tarea', tarea_id=tarea.id) }}">
                 <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
               </a>
             </li>
@@ -93,7 +93,7 @@
             <li>
               <a class="dropdown-item text-danger" href="#"
                  data-accion="borrar"
-                 data-url="{{ url_for('vista3.borrar_tarea', tarea_id=tarea.id) }}"
+                 data-url="{{ url_for('api_bc.borrar_tarea', tarea_id=tarea.id) }}"
                  data-redirect="{{ url_for('expedientes.tramitacion_bc_tramite', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id, tram_id=tramite.id) }}">
                 <i class="fas fa-trash me-2"></i> Borrar
               </a>
@@ -117,7 +117,7 @@
     <div data-modo-ver></div>
 
     <form data-modo-editar class="d-none row g-2 pt-1"
-          data-url="{{ url_for('vista3.editar_tarea', tarea_id=tarea.id) }}">
+          data-url="{{ url_for('api_bc.editar_tarea', tarea_id=tarea.id) }}">
       <div class="col-md-4">
         <label class="form-label fw-semibold mb-1">Tipo</label>
         <input type="text" class="form-control form-control-sm" readonly

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tramite.html
@@ -69,7 +69,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="iniciar"
-                 data-url="{{ url_for('vista3.iniciar_tramite', tram_id=tramite.id) }}">
+                 data-url="{{ url_for('api_bc.iniciar_tramite', tram_id=tramite.id) }}">
                 <i class="fas fa-play me-2 text-success"></i> Iniciar
               </a>
             </li>
@@ -78,7 +78,7 @@
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="finalizar"
-                 data-url="{{ url_for('vista3.finalizar_tramite', tram_id=tramite.id) }}">
+                 data-url="{{ url_for('api_bc.finalizar_tramite', tram_id=tramite.id) }}">
                 <i class="fas fa-flag-checkered me-2 text-primary"></i> Finalizar
               </a>
             </li>
@@ -87,7 +87,7 @@
             <li>
               <a class="dropdown-item text-danger" href="#"
                  data-accion="borrar"
-                 data-url="{{ url_for('vista3.borrar_tramite', tram_id=tramite.id) }}"
+                 data-url="{{ url_for('api_bc.borrar_tramite', tram_id=tramite.id) }}"
                  data-redirect="{{ url_for('expedientes.tramitacion_bc_fase', exp_id=expediente.id, sol_id=solicitud.id, fase_id=fase.id) }}">
                 <i class="fas fa-trash me-2"></i> Borrar
               </a>
@@ -111,7 +111,7 @@
     <div data-modo-ver></div>
 
     <form data-modo-editar class="d-none row g-2 pt-1"
-          data-url="{{ url_for('vista3.editar_tramite', tram_id=tramite.id) }}">
+          data-url="{{ url_for('api_bc.editar_tramite', tram_id=tramite.id) }}">
       <div class="col-md-4">
         <label class="form-label fw-semibold mb-1">Tipo</label>
         <input type="text" class="form-control form-control-sm" readonly
@@ -157,7 +157,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <form class="form-nueva-bc"
-            data-url="{{ url_for('vista3.crear_tarea', tram_id=tramite.id) }}">
+            data-url="{{ url_for('api_bc.crear_tarea', tram_id=tramite.id) }}">
         <div class="modal-body">
           <div class="mb-3">
             <label class="form-label fw-semibold">

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -1,0 +1,562 @@
+"""
+API para Vista BC (breadcrumbs) — tramitación ESFTT.
+
+Endpoints equivalentes a los que tenía el blueprint vista3 (eliminado en #309),
+adaptados para el sistema BC: los editar_* no re-renderizan HTML porque el JS
+bc-edicion.js actualiza el DOM directamente desde los valores del formulario.
+
+Creado para resolver el bug #314.
+"""
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_login import login_required
+from sqlalchemy.exc import IntegrityError
+from app import db
+from app.models.expedientes import Expediente
+from app.models.solicitudes import Solicitud
+from app.models.fases import Fase
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.tipos_resultados_fases import TipoResultadoFase
+from app.models.tipos_fases import TipoFase
+from app.models.tipos_tramites import TipoTramite
+from app.models.tipos_tareas import TipoTarea
+from app.utils.permisos import verificar_acceso_expediente
+from app.services.motor_reglas import evaluar
+
+bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
+
+
+# ============================================
+# ENDPOINTS POST — CREAR entidades
+# ============================================
+
+@bp.route('/expediente/<int:exp_id>/solicitudes/nueva', methods=['POST'])
+@login_required
+def crear_solicitud(exp_id):
+    """Crea una o varias solicitudes en el expediente (multi-select de tipos)."""
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    # El template envía tipo_solicitud_id[] (multi-select)
+    tipo_ids = request.form.getlist('tipo_solicitud_id[]') or request.form.getlist('tipo_solicitud_id')
+    fecha_str = request.form.get('fecha_solicitud')
+    entidad_id = request.form.get('entidad_id', type=int) or expediente.titular_id
+
+    if not tipo_ids:
+        return jsonify({'ok': False, 'error': 'Selecciona al menos un tipo de solicitud'}), 400
+    if not entidad_id:
+        return jsonify({'ok': False, 'error': 'El expediente no tiene titular asignado. Asígnelo antes de crear solicitudes.'}), 422
+
+    if fecha_str:
+        try:
+            fecha = date.fromisoformat(fecha_str)
+        except ValueError:
+            return jsonify({'ok': False, 'error': 'Fecha inválida'}), 400
+    else:
+        fecha = None
+
+    creadas = []
+    try:
+        for tid in tipo_ids:
+            try:
+                tid_int = int(tid)
+            except (ValueError, TypeError):
+                return jsonify({'ok': False, 'error': f'Tipo de solicitud inválido: {tid}'}), 400
+            tipo = TipoSolicitud.query.get(tid_int)
+            if not tipo:
+                return jsonify({'ok': False, 'error': f'Tipo de solicitud {tid_int} no encontrado'}), 404
+            sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
+                            tipo_solicitud_id=tid_int,
+                            fecha_solicitud=fecha, estado='EN_TRAMITE')
+            db.session.add(sol)
+            creadas.append(sol)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    ids = [s.id for s in creadas]
+    return jsonify({'ok': True, 'ids': ids})
+
+
+@bp.route('/solicitud/<int:sol_id>/fases/nueva', methods=['POST'])
+@login_required
+def crear_fase(sol_id):
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_fase_id = request.form.get('tipo_fase_id', type=int)
+    if not tipo_fase_id:
+        return jsonify({'ok': False, 'error': 'tipo_fase_id es obligatorio'}), 400
+    if not TipoFase.query.get(tipo_fase_id):
+        return jsonify({'ok': False, 'error': 'Tipo de fase no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'FASE', tipo_id=tipo_fase_id, padre_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
+    db.session.add(fase)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': fase.id, 'advertencia': advertencia})
+
+
+@bp.route('/fase/<int:fase_id>/tramites/nuevo', methods=['POST'])
+@login_required
+def crear_tramite(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_tramite_id = request.form.get('tipo_tramite_id', type=int)
+    if not tipo_tramite_id:
+        return jsonify({'ok': False, 'error': 'tipo_tramite_id es obligatorio'}), 400
+    if not TipoTramite.query.get(tipo_tramite_id):
+        return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'TRAMITE', tipo_id=tipo_tramite_id, padre_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
+    db.session.add(tramite)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': tramite.id, 'advertencia': advertencia})
+
+
+@bp.route('/tramite/<int:tram_id>/tareas/nueva', methods=['POST'])
+@login_required
+def crear_tarea(tram_id):
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    tipo_tarea_id = request.form.get('tipo_tarea_id', type=int)
+    if not tipo_tarea_id:
+        return jsonify({'ok': False, 'error': 'tipo_tarea_id es obligatorio'}), 400
+    if not TipoTarea.query.get(tipo_tarea_id):
+        return jsonify({'ok': False, 'error': 'Tipo de tarea no encontrado'}), 404
+
+    res_eval = evaluar('CREAR', 'TAREA', tipo_id=tipo_tarea_id, padre_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea = Tarea(tramite_id=tram_id, tipo_tarea_id=tipo_tarea_id)
+    db.session.add(tarea)
+    db.session.commit()
+
+    advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval.nivel == 'ADVERTIR' else None
+    return jsonify({'ok': True, 'id': tarea.id, 'advertencia': advertencia})
+
+
+# ============================================
+# ENDPOINTS POST — EDITAR entidades
+# (el JS bc-edicion.js actualiza el DOM directamente — no se re-renderiza HTML)
+# ============================================
+
+@bp.route('/solicitud/<int:sol_id>/editar', methods=['POST'])
+@login_required
+def editar_solicitud(sol_id):
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    try:
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        res_eval = None
+        if sol.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        sol.fecha_fin = nueva_fecha_fin
+        if request.form.get('estado'):
+            sol.estado = request.form['estado']
+        sol.observaciones = request.form.get('observaciones') or None
+        db.session.commit()
+
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'advertencia': advertencia})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@bp.route('/fase/<int:fase_id>/editar', methods=['POST'])
+@login_required
+def editar_fase(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    try:
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        res_eval = None
+        if fase.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        if fase.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        fase.fecha_inicio = nueva_fecha_inicio
+        fase.fecha_fin = nueva_fecha_fin
+        resultado_id = request.form.get('resultado_fase_id')
+        fase.resultado_fase_id = int(resultado_id) if resultado_id else None
+        fase.observaciones = request.form.get('observaciones') or None
+        db.session.commit()
+
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'advertencia': advertencia})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@bp.route('/tramite/<int:tram_id>/editar', methods=['POST'])
+@login_required
+def editar_tramite(tram_id):
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    try:
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        res_eval = None
+        if tramite.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        if tramite.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        tramite.fecha_inicio = nueva_fecha_inicio
+        tramite.fecha_fin = nueva_fecha_fin
+        tramite.observaciones = request.form.get('observaciones') or None
+        db.session.commit()
+
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'advertencia': advertencia})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@bp.route('/tarea/<int:tarea_id>/editar', methods=['POST'])
+@login_required
+def editar_tarea(tarea_id):
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    expediente_id = tarea.tramite.fase.solicitud.expediente_id
+
+    try:
+        nueva_fecha_inicio = date.fromisoformat(request.form['fecha_inicio']) if request.form.get('fecha_inicio') else None
+        nueva_fecha_fin = date.fromisoformat(request.form['fecha_fin']) if request.form.get('fecha_fin') else None
+
+        doc_usado_raw     = request.form.get('documento_usado_id') or None
+        doc_producido_raw = request.form.get('documento_producido_id') or None
+        nuevo_doc_usado_id     = int(doc_usado_raw)     if doc_usado_raw     else None
+        nuevo_doc_producido_id = int(doc_producido_raw) if doc_producido_raw else None
+
+        for doc_id in filter(None, [nuevo_doc_usado_id, nuevo_doc_producido_id]):
+            doc = Documento.query.get(doc_id)
+            if not doc or doc.expediente_id != expediente_id:
+                return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
+
+        tarea.documento_usado_id     = nuevo_doc_usado_id
+        tarea.documento_producido_id = nuevo_doc_producido_id
+
+        res_eval = None
+        if tarea.fecha_inicio is None and nueva_fecha_inicio is not None:
+            res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        if tarea.fecha_fin is None and nueva_fecha_fin is not None:
+            res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+            if not res_eval.permitido:
+                return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+        tarea.fecha_inicio = nueva_fecha_inicio
+        tarea.fecha_fin = nueva_fecha_fin
+        tarea.notas = request.form.get('notas') or None
+        db.session.commit()
+
+        advertencia = {'mensaje': res_eval.mensaje, 'norma': res_eval.norma} if res_eval and res_eval.nivel == 'ADVERTIR' else None
+        return jsonify({'ok': True, 'advertencia': advertencia})
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': 'Este documento ya está asignado como producido a otra tarea'}), 422
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+# ============================================
+# ENDPOINTS POST — BORRAR entidades
+# ============================================
+
+@bp.route('/solicitud/<int:sol_id>/borrar', methods=['POST'])
+@login_required
+def borrar_solicitud(sol_id):
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol_id).all()]
+    if fase_ids:
+        tram_ids = [t.id for t in Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).all()]
+        if tram_ids:
+            Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+        Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).delete()
+    Fase.query.filter_by(solicitud_id=sol_id).delete()
+    db.session.delete(sol)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/fase/<int:fase_id>/borrar', methods=['POST'])
+@login_required
+def borrar_fase(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase_id).all()]
+    if tram_ids:
+        Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+    Tramite.query.filter_by(fase_id=fase_id).delete()
+    db.session.delete(fase)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/tramite/<int:tram_id>/borrar', methods=['POST'])
+@login_required
+def borrar_tramite(tram_id):
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    Tarea.query.filter_by(tramite_id=tram_id).delete()
+    db.session.delete(tramite)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+@bp.route('/tarea/<int:tarea_id>/borrar', methods=['POST'])
+@login_required
+def borrar_tarea(tarea_id):
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    res_eval = evaluar('BORRAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    db.session.delete(tarea)
+    db.session.commit()
+    return jsonify({'ok': True})
+
+
+# ============================================
+# ENDPOINTS POST — ACCIONES contextuales (INICIAR / FINALIZAR)
+# ============================================
+
+@bp.route('/solicitud/<int:sol_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_solicitud(sol_id):
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.fecha_solicitud is not None:
+        return jsonify({'ok': False, 'error': 'La solicitud ya tiene fecha de inicio'}), 422
+
+    res_eval = evaluar('INICIAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    sol.fecha_solicitud = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/solicitud/<int:sol_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_solicitud(sol_id):
+    sol = Solicitud.query.get_or_404(sol_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La solicitud ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'SOLICITUD', entidad_id=sol_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    sol.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/fase/<int:fase_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_fase(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if fase.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'La fase ya está iniciada'}), 422
+
+    res_eval = evaluar('INICIAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/fase/<int:fase_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_fase(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if fase.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La fase ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'FASE', entidad_id=fase_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    fase.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tramite/<int:tram_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_tramite(tram_id):
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tramite.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'El trámite ya está iniciado'}), 422
+
+    res_eval = evaluar('INICIAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tramite/<int:tram_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_tramite(tram_id):
+    tramite = Tramite.query.get_or_404(tram_id)
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tramite.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'El trámite ya está finalizado'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'TRAMITE', entidad_id=tram_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tramite.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tarea/<int:tarea_id>/iniciar', methods=['POST'])
+@login_required
+def iniciar_tarea(tarea_id):
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tarea.fecha_inicio is not None:
+        return jsonify({'ok': False, 'error': 'La tarea ya está iniciada'}), 422
+
+    res_eval = evaluar('INICIAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea.fecha_inicio = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})
+
+
+@bp.route('/tarea/<int:tarea_id>/finalizar', methods=['POST'])
+@login_required
+def finalizar_tarea(tarea_id):
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tarea.fecha_fin is not None:
+        return jsonify({'ok': False, 'error': 'La tarea ya está finalizada'}), 422
+
+    res_eval = evaluar('FINALIZAR', 'TAREA', entidad_id=tarea_id)
+    if not res_eval.permitido:
+        return jsonify({'ok': False, 'error': res_eval.mensaje, 'norma': res_eval.norma}), 422
+
+    tarea.fecha_fin = date.today()
+    db.session.commit()
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'mensaje': res_eval.mensaje})


### PR DESCRIPTION
## Cambios

- Crea `app/routes/api_bc.py` — nuevo blueprint `api_bc` (prefix `/api/bc`) con los 20 endpoints ESFTT (crear/editar/borrar/iniciar/finalizar sobre solicitudes, fases, trámites y tareas)
- Los `editar_*` devuelven `{'ok': True}` sin re-renderizar HTML, ya que el JS `bc-edicion.js` actualiza el DOM directamente desde los valores del formulario
- `crear_solicitud` maneja correctamente el multi-select `tipo_solicitud_id[]` del template
- Registra el blueprint en `app/__init__.py`
- Migra los 20 `url_for('vista3.*')` a `url_for('api_bc.*')` en los 5 templates BC afectados

Closes #314
