### PR TITLE
Añadir campo descripcion a reglas_motor para mensajes de bloqueo legibles

### DIFF
--- a/app/models/motor_reglas.py
+++ b/app/models/motor_reglas.py
@@ -121,6 +121,10 @@ class ReglaMotor(db.Model):
         db.Boolean, nullable=False, default=True,
         comment='Desactivar en lugar de borrar — preserva trazabilidad'
     )
+    descripcion = db.Column(
+        db.String(500), nullable=True,
+        comment='Explicación en lenguaje natural para el usuario al bloquear'
+    )
 
     norma       = db.relationship('Norma')
     condiciones = db.relationship(

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -256,16 +256,16 @@ def tramitacion_bc(exp_id):
         tipos_str = s.tipo_solicitud.siglas if s.tipo_solicitud else f'Solicitud #{s.id}'
         fecha_sol = s.documento_solicitud.fecha_administrativa if s.documento_solicitud else None
         hijos.append({
-            'nombre':        tipos_str,
-            'fecha_inicio':  _fmt_fecha(fecha_sol),
-            'estado':        _estado_indicador_solicitud(s),
-            'url_detalle':   url_for('expedientes.tramitacion_bc_solicitud',
-                                    exp_id=exp_id, sol_id=s.id),
+            'nombre':          tipos_str,
+            'fecha_solicitud': _fmt_fecha(fecha_sol),
+            'estado':          _estado_indicador_solicitud(s),
+            'url_detalle':     url_for('expedientes.tramitacion_bc_solicitud',
+                                      exp_id=exp_id, sol_id=s.id),
         })
 
     columnas = [
-        {'key': 'nombre',       'label': 'Tipos de solicitud'},
-        {'key': 'fecha_inicio', 'label': 'F. Solicitud'},
+        {'key': 'nombre',          'label': 'Tipos de solicitud'},
+        {'key': 'fecha_solicitud', 'label': 'F. Solicitud'},
     ]
 
     tipos_solicitud = TipoSolicitud.query.order_by(TipoSolicitud.siglas).all()

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -7,7 +7,6 @@ bc-edicion.js actualiza el DOM directamente desde los valores del formulario.
 
 Creado para resolver el bug #314.
 """
-from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
 from sqlalchemy.exc import IntegrityError
@@ -60,21 +59,12 @@ def crear_solicitud(exp_id):
 
     # El template envía tipo_solicitud_id[] (multi-select)
     tipo_ids = request.form.getlist('tipo_solicitud_id[]') or request.form.getlist('tipo_solicitud_id')
-    fecha_str = request.form.get('fecha_solicitud')
     entidad_id = request.form.get('entidad_id', type=int) or expediente.titular_id
 
     if not tipo_ids:
         return jsonify({'ok': False, 'error': 'Selecciona al menos un tipo de solicitud'}), 400
     if not entidad_id:
         return jsonify({'ok': False, 'error': 'El expediente no tiene titular asignado. Asígnelo antes de crear solicitudes.'}), 422
-
-    if fecha_str:
-        try:
-            fecha = date.fromisoformat(fecha_str)
-        except ValueError:
-            return jsonify({'ok': False, 'error': 'Fecha inválida'}), 400
-    else:
-        fecha = None
 
     creadas = []
     try:
@@ -87,8 +77,7 @@ def crear_solicitud(exp_id):
             if not tipo:
                 return jsonify({'ok': False, 'error': f'Tipo de solicitud {tid_int} no encontrado'}), 404
             sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
-                            tipo_solicitud_id=tid_int,
-                            fecha_solicitud=fecha, estado='EN_TRAMITE')
+                            tipo_solicitud_id=tid_int)
             db.session.add(sol)
             creadas.append(sol)
         db.session.commit()
@@ -208,9 +197,22 @@ def editar_fase(fase_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
+    doc_resultado_raw = request.form.get('documento_resultado_id')
+    nuevo_doc_resultado_id = int(doc_resultado_raw) if doc_resultado_raw else None
+
+    # Motor FINALIZAR cuando documento_resultado_id transiciona None → valor
+    if nuevo_doc_resultado_id and fase.documento_resultado_id is None:
+        doc = Documento.query.get(nuevo_doc_resultado_id)
+        if not doc or doc.expediente_id != fase.solicitud.expediente_id:
+            return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
+        res_eval = evaluar_multi('FINALIZAR', fase.solicitud.expediente, objeto=fase)
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+
     try:
         resultado_id = request.form.get('resultado_fase_id')
         fase.resultado_fase_id = int(resultado_id) if resultado_id else None
+        fase.documento_resultado_id = nuevo_doc_resultado_id
         fase.observaciones = request.form.get('observaciones') or None
         db.session.commit()
         return jsonify({'ok': True})
@@ -366,6 +368,8 @@ def iniciar_solicitud(sol_id):
     resultado = verificar_acceso_expediente(sol.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.fases:
+        return jsonify({'ok': False, 'error': 'La solicitud ya tiene fases en trámite'}), 422
     res_eval = evaluar_multi('INICIAR', sol.expediente, objeto=sol)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
@@ -379,6 +383,8 @@ def finalizar_solicitud(sol_id):
     resultado = verificar_acceso_expediente(sol.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if sol.estado == 'RESUELTA':
+        return jsonify({'ok': False, 'error': 'La solicitud ya está resuelta'}), 422
     res_eval = evaluar_multi('FINALIZAR', sol.expediente, objeto=sol)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
@@ -392,6 +398,8 @@ def iniciar_fase(fase_id):
     resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if not fase.planificada:
+        return jsonify({'ok': False, 'error': 'La fase ya está en curso'}), 422
     res_eval = evaluar_multi('INICIAR', fase.solicitud.expediente, objeto=fase)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
@@ -412,7 +420,6 @@ def finalizar_fase(fase_id):
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
-    db.session.commit()
     return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
@@ -423,6 +430,8 @@ def iniciar_tramite(tram_id):
     resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if not tramite.planificado:
+        return jsonify({'ok': False, 'error': 'El trámite ya está en curso'}), 422
     res_eval = evaluar_multi('INICIAR', tramite.fase.solicitud.expediente, objeto=tramite)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
@@ -436,6 +445,8 @@ def finalizar_tramite(tram_id):
     resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if tramite.finalizado:
+        return jsonify({'ok': False, 'error': 'El trámite ya está finalizado'}), 422
     res_eval = evaluar_multi('FINALIZAR', tramite.fase.solicitud.expediente, objeto=tramite)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
@@ -449,6 +460,8 @@ def iniciar_tarea(tarea_id):
     resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+    if not tarea.planificada:
+        return jsonify({'ok': False, 'error': 'La tarea ya está en curso o ejecutada'}), 422
     res_eval = evaluar_multi('INICIAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
     if not res_eval.permitido:
         return _bloqueo(res_eval)

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -32,6 +32,7 @@ def _bloqueo(res_eval):
     """Respuesta de error cuando el motor bloquea la acción."""
     return jsonify({
         'ok': False,
+        'motivo': res_eval.motivo,
         'error': res_eval.norma_compilada or 'Acción no permitida',
         'url_norma': res_eval.url_norma,
     }), 422
@@ -40,7 +41,7 @@ def _bloqueo(res_eval):
 def _advertencia(res_eval):
     """Dict de advertencia para incluir en la respuesta ok (o None si no hay)."""
     if res_eval and res_eval.nivel == 'ADVERTIR':
-        return {'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma}
+        return {'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma}
     return None
 
 
@@ -373,7 +374,7 @@ def iniciar_solicitud(sol_id):
     res_eval = evaluar_multi('INICIAR', sol.expediente, objeto=sol)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/solicitud/<int:sol_id>/finalizar', methods=['POST'])
@@ -388,7 +389,7 @@ def finalizar_solicitud(sol_id):
     res_eval = evaluar_multi('FINALIZAR', sol.expediente, objeto=sol)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/fase/<int:fase_id>/iniciar', methods=['POST'])
@@ -403,7 +404,7 @@ def iniciar_fase(fase_id):
     res_eval = evaluar_multi('INICIAR', fase.solicitud.expediente, objeto=fase)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/fase/<int:fase_id>/finalizar', methods=['POST'])
@@ -420,7 +421,7 @@ def finalizar_fase(fase_id):
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/tramite/<int:tram_id>/iniciar', methods=['POST'])
@@ -435,7 +436,7 @@ def iniciar_tramite(tram_id):
     res_eval = evaluar_multi('INICIAR', tramite.fase.solicitud.expediente, objeto=tramite)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/tramite/<int:tram_id>/finalizar', methods=['POST'])
@@ -450,7 +451,7 @@ def finalizar_tramite(tram_id):
     res_eval = evaluar_multi('FINALIZAR', tramite.fase.solicitud.expediente, objeto=tramite)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/tarea/<int:tarea_id>/iniciar', methods=['POST'])
@@ -465,7 +466,7 @@ def iniciar_tarea(tarea_id):
     res_eval = evaluar_multi('INICIAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
 
 
 @bp.route('/tarea/<int:tarea_id>/finalizar', methods=['POST'])
@@ -481,4 +482,4 @@ def finalizar_tarea(tarea_id):
     res_eval = evaluar_multi('FINALIZAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
-    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+    return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})

--- a/app/routes/wizard_expediente.py
+++ b/app/routes/wizard_expediente.py
@@ -335,7 +335,6 @@ def paso3():
                 entidad_id=solicitante.id,
                 tipo_solicitud_id=tipo_solicitud_id,
                 documento_solicitud_id=None,
-                estado='EN_TRAMITE',
                 observaciones=observaciones,
             )
             db.session.add(solicitud)

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -60,11 +60,12 @@ class EvaluacionResult:
     variables_trigger: dict  # subconjunto del dict que disparó la regla
     norma_compilada:   str   # referencia normativa compilada
     url_norma:         str   # URL BOE/BOJA; '' si no existe
+    motivo:            str = ''  # descripción editorial de la regla; '' si no configurada
 
 
 PERMITIDO = EvaluacionResult(
     permitido=True, nivel='',
-    variables_trigger={}, norma_compilada='', url_norma=''
+    variables_trigger={}, norma_compilada='', url_norma='', motivo=''
 )
 
 
@@ -207,6 +208,7 @@ def evaluar(
                     variables_trigger=trigger,
                     norma_compilada=norma_ref,
                     url_norma=url_norma,
+                    motivo=regla.descripcion or '',
                 )
 
         elif regla.efecto == 'ADVERTIR' and resultado_advertir is None:
@@ -217,6 +219,7 @@ def evaluar(
                 variables_trigger=trigger,
                 norma_compilada=norma_ref,
                 url_norma=url_norma,
+                motivo=regla.descripcion or '',
             )
 
     return resultado_advertir or PERMITIDO

--- a/app/static/js/v3-breadcrumbs-acciones.js
+++ b/app/static/js/v3-breadcrumbs-acciones.js
@@ -66,7 +66,7 @@ document.addEventListener('click', async function (e) {
         if (!json.ok) {
             // Motor bloqueó la acción o error de servidor
             _toast_accion(
-                json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''),
+                (json.motivo ? json.motivo + ' ' : '') + json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''),
                 'danger'
             );
         } else {
@@ -80,7 +80,7 @@ document.addEventListener('click', async function (e) {
             if (json.nivel === 'ADVERTIR') {
                 // El motor permite con advertencia: mostrar warning y ejecutar
                 _toast_accion(
-                    (json.norma_compilada || 'Acción permitida con advertencia') + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''),
+                    (json.motivo ? json.motivo + ' ' : '') + (json.norma_compilada || 'Acción permitida con advertencia') + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''),
                     'warning'
                 );
                 setTimeout(() => _navegar_tras_accion(accion, redirect), 1500);

--- a/app/static/js/v3-breadcrumbs-crear.js
+++ b/app/static/js/v3-breadcrumbs-crear.js
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (!json.ok) {
                     // Mostrar error dentro del modal (sin cerrarlo)
                     if (alert_el) {
-                        alert_el.innerHTML = json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : '');
+                        alert_el.innerHTML = (json.motivo ? json.motivo + ' ' : '') + json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : '');
                         alert_el.classList.remove('d-none');
                     }
                     if (submit_btn) {

--- a/app/static/js/v3-breadcrumbs-edicion.js
+++ b/app/static/js/v3-breadcrumbs-edicion.js
@@ -59,13 +59,13 @@ document.addEventListener('DOMContentLoaded', function () {
       const json = await resp.json();
 
       if (!json.ok) {
-        _mostrar_alert('danger', json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''));
+        _mostrar_alert('danger', (json.motivo ? json.motivo + ' ' : '') + json.error + (json.url_norma ? ` (<a href="${json.url_norma}" target="_blank">ver norma</a>)` : ''));
       } else {
         _actualizar_display(datos);
         activar_modo_ver();
         form.dispatchEvent(new CustomEvent('bc:guardado', { bubbles: false }));
         if (json.advertencia) {
-          _mostrar_alert('warning', json.advertencia.norma_compilada || '');
+          _mostrar_alert('warning', (json.advertencia.motivo ? json.advertencia.motivo + ' ' : '') + (json.advertencia.norma_compilada || ''));
         }
       }
     } catch (_e) {

--- a/migrations/versions/319_descripcion_regla_motor_reglas_motor_añadir_descripcion_para_.py
+++ b/migrations/versions/319_descripcion_regla_motor_reglas_motor_añadir_descripcion_para_.py
@@ -1,0 +1,39 @@
+"""reglas_motor: añadir descripcion para mensajes de bloqueo legibles
+
+Revision ID: 319_descripcion_regla_motor
+Revises: e40ce8475305
+Create Date: 2026-04-24 16:56:00.916958
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '319_descripcion_regla_motor'
+down_revision = 'e40ce8475305'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reglas_motor',
+        sa.Column('descripcion', sa.String(500), nullable=True,
+                  comment='Explicación en lenguaje natural para el usuario al bloquear'),
+        schema='public'
+    )
+    # Descripciones iniciales para las 2 reglas existentes
+    op.execute("""
+        UPDATE public.reglas_motor
+        SET descripcion = 'Para crear la fase Resolución es necesario que exista una fase de Información Pública finalizada.'
+        WHERE accion = 'CREAR' AND sujeto = 'ANY/AAP/RESOLUCION'
+    """)
+    op.execute("""
+        UPDATE public.reglas_motor
+        SET descripcion = 'Para finalizar la fase Resolución es necesario que exista el trámite de Publicación.'
+        WHERE accion = 'FINALIZAR' AND sujeto = 'ANY/AAP/RESOLUCION'
+    """)
+
+
+def downgrade():
+    op.drop_column('reglas_motor', 'descripcion', schema='public')

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -135,7 +135,7 @@ def crear_doc(exp, url, tipo_doc_id, asunto, fecha_adm=None):
     return d
 
 
-def crear_fase(sol, tipo_fase_id, fecha_ini=None, fin=None, resultado_id=None):
+def crear_fase(sol, tipo_fase_id, resultado_id=None):
     f = Fase(
         solicitud_id=sol.id,
         tipo_fase_id=tipo_fase_id,
@@ -146,7 +146,7 @@ def crear_fase(sol, tipo_fase_id, fecha_ini=None, fin=None, resultado_id=None):
     return f
 
 
-def crear_tramite(fase, tipo_tramite_id, fecha_ini=None):
+def crear_tramite(fase, tipo_tramite_id):
     t = Tramite(
         fase_id=fase.id,
         tipo_tramite_id=tipo_tramite_id,
@@ -156,7 +156,7 @@ def crear_tramite(fase, tipo_tramite_id, fecha_ini=None):
     return t
 
 
-def crear_tarea(tramite, tipo_tarea_id, fecha_ini=None,
+def crear_tarea(tramite, tipo_tarea_id,
                 doc_usado=None, doc_producido=None, notas=None):
     t = Tarea(
         tramite_id=tramite.id,
@@ -170,7 +170,7 @@ def crear_tarea(tramite, tipo_tarea_id, fecha_ini=None,
     return t
 
 
-def fase_fin(sol, tipo_fase_id, fecha_ini=None, fecha_fin=None, resultado_id=None):
+def fase_fin(sol, tipo_fase_id, resultado_id=None):
     return crear_fase(sol, tipo_fase_id, resultado_id=resultado_id)
 
 
@@ -383,11 +383,11 @@ with app.app_context():
             'expedientes/AT-2001/entrada/2024-09-15_Planos_general_y_parcelas.pdf',
             TDOC_OTROS, 'Planos — situación general y parcelas afectadas', date(2024, 9, 15))
         sol01 = crear_sol(exp01, TS_AAP_AAC, gestora, sol01_entrada)
-        f01 = crear_fase(sol01, TF_SOL, date(2024, 9, 18))
-        t01 = crear_tramite(f01, TT_ANAL, date(2024, 9, 18))
-        crear_tarea(t01, TAREA_ANAL, date(2024, 9, 18), doc_usado=sol01_entrada)
-        t01b = crear_tramite(f01, TT_REQ, date(2024, 10, 14))
-        crear_tarea(t01b, TAREA_RED, date(2024, 10, 14), doc_usado=sol01_mem)
+        f01 = crear_fase(sol01, TF_SOL)
+        t01 = crear_tramite(f01, TT_ANAL)
+        crear_tarea(t01, TAREA_ANAL, doc_usado=sol01_entrada)
+        t01b = crear_tramite(f01, TT_REQ)
+        crear_tarea(t01b, TAREA_RED, doc_usado=sol01_mem)
         print('AT-2001 OK — Renovable, AAP+AAC, fase SOL pendiente redactar req.')
     else:
         print('AT-2001 ya existe — omitido')
@@ -418,10 +418,10 @@ with app.app_context():
             'expedientes/AT-2002/salida/2024-07-08_Separata_consultas.pdf',
             TDOC_OTROS, 'Separata para organismos consultados', date(2024, 7, 8))
         sol02 = crear_sol(exp02, TS_AAP_AAC, gestora, sol02_entrada)
-        fase_fin(sol02, TF_SOL, date(2024, 3, 12), date(2024, 6, 20), TRES_FAV)
-        f02_cons = crear_fase(sol02, TF_CONS, date(2024, 7, 8))
-        t02_sep = crear_tramite(f02_cons, TT_SEP, date(2024, 7, 8))
-        crear_tarea(t02_sep, TAREA_NOT, date(2024, 7, 8), doc_usado=sol02_sep)
+        fase_fin(sol02, TF_SOL, TRES_FAV)
+        f02_cons = crear_fase(sol02, TF_CONS)
+        t02_sep = crear_tramite(f02_cons, TT_SEP)
+        crear_tarea(t02_sep, TAREA_NOT, doc_usado=sol02_sep)
         print('AT-2002 OK — Renovable, AAP+AAC, SOL=FIN, CONSULTAS pendiente notificar')
     else:
         print('AT-2002 ya existe — omitido')
@@ -449,12 +449,12 @@ with app.app_context():
             'expedientes/AT-2003/salida/2024-08-15_Anuncio_informacion_publica_BOP.pdf',
             TDOC_OTROS, 'Anuncio para publicación en BOP — Información Pública', date(2024, 8, 15))
         sol03 = crear_sol(exp03, TS_AAP_AAC_DUP, gestora, sol03_entrada)
-        fase_fin(sol03, TF_SOL,  date(2023, 6, 5),  date(2023, 9, 10), TRES_FAV)
-        fase_fin(sol03, TF_CONS, date(2023, 9, 12), date(2024, 1, 20), TRES_FAV)
-        fase_fin(sol03, TF_MA,   date(2024, 1, 22), date(2024, 7, 30), TRES_FAV)
-        f03_ip = crear_fase(sol03, TF_IP, date(2024, 8, 15))
-        t03_bop = crear_tramite(f03_ip, TT_BOP, date(2024, 8, 15))
-        crear_tarea(t03_bop, TAREA_PUB, date(2024, 8, 15), doc_usado=sol03_anuncio)
+        fase_fin(sol03, TF_SOL, TRES_FAV)
+        fase_fin(sol03, TF_CONS, TRES_FAV)
+        fase_fin(sol03, TF_MA, TRES_FAV)
+        f03_ip = crear_fase(sol03, TF_IP)
+        t03_bop = crear_tramite(f03_ip, TT_BOP)
+        crear_tarea(t03_bop, TAREA_PUB, doc_usado=sol03_anuncio)
         print('AT-2003 OK — Eólico, AAP+AAC+DUP+AAE, IP pendiente publicar BOP')
     else:
         print('AT-2003 ya existe — omitido')
@@ -479,13 +479,13 @@ with app.app_context():
             'expedientes/AT-2004/salida/2024-09-20_Resolucion_AAP_firmada.pdf',
             TDOC_OTROS, 'Resolución AAP — firmada y sellada', date(2024, 9, 20))
         sol04 = crear_sol(exp04, TS_AAP_AAC_DUP, gestora, sol04_entrada)
-        fase_fin(sol04, TF_SOL,  date(2022, 11, 9),  date(2023, 2, 28), TRES_FAV)
-        fase_fin(sol04, TF_CONS, date(2023, 3, 1),   date(2023, 7, 15), TRES_FAV)
-        fase_fin(sol04, TF_MA,   date(2023, 7, 17),  date(2024, 2, 10), TRES_FAV)
-        fase_fin(sol04, TF_IP,   date(2024, 2, 12),  date(2024, 8, 30), TRES_FAV)
-        f04_res = crear_fase(sol04, TF_RES, date(2024, 9, 2))
-        t04_not = crear_tramite(f04_res, TT_NOTIF, date(2024, 9, 20))
-        crear_tarea(t04_not, TAREA_NOT, date(2024, 9, 20), doc_usado=sol04_res)
+        fase_fin(sol04, TF_SOL, TRES_FAV)
+        fase_fin(sol04, TF_CONS, TRES_FAV)
+        fase_fin(sol04, TF_MA, TRES_FAV)
+        fase_fin(sol04, TF_IP, TRES_FAV)
+        f04_res = crear_fase(sol04, TF_RES)
+        t04_not = crear_tramite(f04_res, TT_NOTIF)
+        crear_tarea(t04_not, TAREA_NOT, doc_usado=sol04_res)
         print('AT-2004 OK — Eólico, AAP+AAC+DUP+AAE, RES pendiente notificar resolución')
     else:
         print('AT-2004 ya existe — omitido')
@@ -510,12 +510,11 @@ with app.app_context():
             'expedientes/AT-2005/salida/2024-07-12_Solicitud_compatibilidad_ambiental.pdf',
             TDOC_OTROS, 'Solicitud de Compatibilidad Ambiental al órgano ambiental', date(2024, 7, 12))
         sol05 = crear_sol(exp05, TS_AAP_AAC, endesa, sol05_entrada)
-        fase_fin(sol05, TF_SOL,  date(2024, 2, 6),  date(2024, 5, 20), TRES_FAV)
-        fase_fin(sol05, TF_CONS, date(2024, 5, 21), date(2024, 7, 10), TRES_FAV)
-        f05_ma = crear_fase(sol05, TF_MA, date(2024, 7, 12))
-        t05_comp = crear_tramite(f05_ma, TT_COMP, date(2024, 7, 12))
-        crear_tarea(t05_comp, TAREA_ESP, date(2024, 7, 12),
-                    doc_usado=sol05_comp, notas='PLAZO_DIAS=30')
+        fase_fin(sol05, TF_SOL, TRES_FAV)
+        fase_fin(sol05, TF_CONS, TRES_FAV)
+        f05_ma = crear_fase(sol05, TF_MA)
+        t05_comp = crear_tramite(f05_ma, TT_COMP)
+        crear_tarea(t05_comp, TAREA_ESP, doc_usado=sol05_comp, notas='PLAZO_DIAS=30')
         print('AT-2005 OK — Distribución Endesa, AAP+AAC, MA pendiente plazo')
     else:
         print('AT-2005 ya existe — omitido')
@@ -540,9 +539,9 @@ with app.app_context():
             'expedientes/AT-2006/entrada/2024-10-03_Acta_inspeccion_previa.pdf',
             TDOC_OTROS, 'Acta de inspección previa favorable', date(2024, 10, 3))
         sol06 = crear_sol(exp06, TS_AAE_DEF, endesa, sol06_acta)
-        f06 = crear_fase(sol06, TF_SOL, date(2024, 10, 7))
-        t06 = crear_tramite(f06, TT_ANAL, date(2024, 10, 7))
-        crear_tarea(t06, TAREA_ANAL, date(2024, 10, 7), doc_usado=sol06_acta)
+        f06 = crear_fase(sol06, TF_SOL)
+        t06 = crear_tramite(f06, TT_ANAL)
+        crear_tarea(t06, TAREA_ANAL, doc_usado=sol06_acta)
         print('AT-2006 OK — Distribución Endesa, AAE Definitiva, fase SOL pendiente estudio')
     else:
         print('AT-2006 ya existe — omitido')
@@ -567,11 +566,11 @@ with app.app_context():
             'expedientes/AT-2007/salida/2024-09-30_Requerimiento_documentacion_tecnica.pdf',
             TDOC_OTROS, 'Requerimiento de documentación técnica complementaria', date(2024, 9, 30))
         sol07 = crear_sol(exp07, TS_AAP_AAC, sevillana, sol07_sol)
-        f07 = crear_fase(sol07, TF_SOL, date(2024, 8, 21))
-        t07a = crear_tramite(f07, TT_ANAL, date(2024, 8, 21))
-        crear_tarea(t07a, TAREA_ANAL, date(2024, 8, 21), doc_usado=sol07_sol)
-        t07b = crear_tramite(f07, TT_REQ, date(2024, 9, 30))
-        crear_tarea(t07b, TAREA_FIR, date(2024, 9, 30), doc_usado=sol07_req)
+        f07 = crear_fase(sol07, TF_SOL)
+        t07a = crear_tramite(f07, TT_ANAL)
+        crear_tarea(t07a, TAREA_ANAL, doc_usado=sol07_sol)
+        t07b = crear_tramite(f07, TT_REQ)
+        crear_tarea(t07b, TAREA_FIR, doc_usado=sol07_req)
         print('AT-2007 OK — Distribución cedida Sevillana, AAC, SOL pendiente firma req.')
     else:
         print('AT-2007 ya existe — omitido')
@@ -623,18 +622,17 @@ with app.app_context():
             'expedientes/AT-2009/entrada/2024-02-15_Respuestas_organismos_consulta.pdf',
             TDOC_OTROS, 'Respuestas recibidas de organismos consultados', date(2024, 2, 15))
         sol09a = crear_sol(exp09, TS_AAP_AAC, gestora, sol09a_entrada)
-        fase_fin(sol09a, TF_SOL, date(2023, 3, 16), date(2023, 8, 20), TRES_FAV)
-        f09a_cons = crear_fase(sol09a, TF_CONS, date(2023, 9, 10))
-        t09a_sep = crear_tramite(f09a_cons, TT_SEP, date(2023, 9, 10))
-        crear_tarea(t09a_sep, TAREA_ESP, date(2023, 9, 10),
-                    doc_usado=sol09a_sep, notas='PLAZO_DIAS=0')
+        fase_fin(sol09a, TF_SOL, TRES_FAV)
+        f09a_cons = crear_fase(sol09a, TF_CONS)
+        t09a_sep = crear_tramite(f09a_cons, TT_SEP)
+        crear_tarea(t09a_sep, TAREA_ESP, doc_usado=sol09a_sep, notas='PLAZO_DIAS=0')
         sol09b_sol = crear_doc(exp09,
             'expedientes/AT-2009/entrada/2024-10-28_Solicitud_AAE_definitiva.pdf',
             TDOC_OTROS, 'Solicitud de AAE Definitiva', date(2024, 10, 28))
         sol09b = crear_sol(exp09, TS_AAE_DEF, gestora, sol09b_sol)
-        f09b = crear_fase(sol09b, TF_SOL, date(2024, 10, 30))
-        t09b = crear_tramite(f09b, TT_ANAL, date(2024, 10, 30))
-        crear_tarea(t09b, TAREA_ANAL, date(2024, 10, 30), doc_usado=sol09b_sol)
+        f09b = crear_fase(sol09b, TF_SOL)
+        t09b = crear_tramite(f09b, TT_ANAL)
+        crear_tarea(t09b, TAREA_ANAL, doc_usado=sol09b_sol)
         print('AT-2009 OK — Renovable Almería (GEA), dos solicitudes activas')
     else:
         print('AT-2009 ya existe — omitido')
@@ -659,8 +657,8 @@ with app.app_context():
             'expedientes/AT-2010/salida/2023-04-18_Resolucion_AAT_firmada.pdf',
             TDOC_OTROS, 'Resolución AAT — favorable y notificada', date(2023, 4, 18))
         sol10 = crear_sol(exp10, TS_AAT, endesa, sol10_sol)
-        fase_fin(sol10, TF_SOL, date(2023, 1, 12), date(2023, 4, 18), TRES_FAV)
-        fase_fin(sol10, TF_RES, date(2023, 4, 18), date(2023, 4, 25), TRES_FAV)
+        fase_fin(sol10, TF_SOL, TRES_FAV)
+        fase_fin(sol10, TF_RES, TRES_FAV)
         print('AT-2010 OK — Distribución Endesa, AAT, expediente completamente resuelto')
     else:
         print('AT-2010 ya existe — omitido')

--- a/scripts/seed_listado.py
+++ b/scripts/seed_listado.py
@@ -123,7 +123,7 @@ def crear_doc(exp, url, tipo_doc_id, fecha_adm=None):
     return d
 
 
-def crear_fase(sol, tipo_fase_id, fin=None, resultado_id=None):
+def crear_fase(sol, tipo_fase_id, resultado_id=None):
     f = Fase(
         solicitud_id=sol.id,
         tipo_fase_id=tipo_fase_id,

--- a/scripts/verificar_seed.py
+++ b/scripts/verificar_seed.py
@@ -63,9 +63,10 @@ def q1(sql, **params):
 
 
 def fases_de_sol(sol_id):
-    """Devuelve lista de (tipo_fase_codigo, fecha_fin, resultado_fase_codigo)."""
+    """Devuelve lista de (tipo_fase_codigo, documento_resultado_id, resultado_fase_codigo).
+    f[1] IS NULL → fase no finalizada; f[1] IS NOT NULL → fase finalizada (doc de resultado asignado)."""
     return q("""
-        SELECT tf.codigo, f.fecha_fin, trf.codigo
+        SELECT tf.codigo, f.documento_resultado_id, trf.codigo
         FROM fases f
         JOIN tipos_fases tf ON tf.id = f.tipo_fase_id
         LEFT JOIN tipos_resultados_fases trf ON trf.id = f.resultado_fase_id
@@ -137,7 +138,7 @@ def verificar_T01():
     fases = fases_de_sol(sid)
     check('T01: exactamente 1 fase', len(fases) == 1, f'hay {len(fases)}')
     check('T01: fase es ANALISIS_SOLICITUD', any(f[0] == 'ANALISIS_SOLICITUD' for f in fases))
-    check('T01: fase abierta (sin fecha_fin)', all(f[1] is None for f in fases))
+    check('T01: fase no finalizada (sin doc_resultado)', all(f[1] is None for f in fases))
 
     trams = tramites_de_fase('ANALISIS_SOLICITUD', sid)
     check('T01: 1 trámite ANALISIS_DOCUMENTAL', len(trams) == 1 and trams[0][0] == 'ANALISIS_DOCUMENTAL',
@@ -366,11 +367,17 @@ def verificar_T10():
     check('T10: 5 fases presentes', pistas_esperadas == codigos,
           f'hay: {codigos}')
     check('T10: todas las fases finalizadas', all(f[1] is not None for f in fases),
-          f'abiertas: {[f[0] for f in fases if f[1] is None]}')
+          f'sin doc_resultado: {[f[0] for f in fases if f[1] is None]}')
     check('T10: todas con resultado', all(f[2] is not None for f in fases),
           f'sin resultado: {[f[0] for f in fases if f[2] is None]}')
-    check('T10: sin trámites ni tareas abiertas',
-          q1("SELECT COUNT(*) FROM tramites tr JOIN fases f ON f.id=tr.fase_id WHERE f.solicitud_id=:s AND tr.fecha_fin IS NULL", s=sid) == 0)
+    check('T10: sin tareas documentales pendientes',
+          q1("""SELECT COUNT(*) FROM tareas ta
+                JOIN tramites tr ON tr.id = ta.tramite_id
+                JOIN fases f ON f.id = tr.fase_id
+                JOIN tipos_tareas tt ON tt.id = ta.tipo_tarea_id
+                WHERE f.solicitud_id = :s
+                AND tt.codigo IN ('INCORPORAR','ANALISIS','REDACTAR','FIRMAR','NOTIFICAR','PUBLICAR')
+                AND ta.documento_producido_id IS NULL""", s=sid) == 0)
 
 
 def verificar_T11():


### PR DESCRIPTION
## Cambios

- Migración `319_descripcion_regla_motor`: añade `descripcion VARCHAR(500) NULLABLE` a `reglas_motor` con UPDATE de seed para las 2 reglas existentes
- `ReglaMotor`: nuevo campo `descripcion`
- `EvaluacionResult`: nuevo campo `motivo: str`
- `evaluar()`: propaga `regla.descripcion` como `motivo` en resultados BLOQUEAR y ADVERTIR
- `_bloqueo()` y respuestas `ok=True` en `api_bc.py`: incluyen `motivo` en el JSON
- `v3-breadcrumbs-acciones.js`, `v3-breadcrumbs-crear.js`, `v3-breadcrumbs-edicion.js`: muestran `motivo` antes de la referencia normativa si existe

Closes #319
