### PR TITLE
[FEATURE] #290: INCORPORAR multi-doc (tabla documentos_tarea, v5.5)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -59,6 +59,7 @@ from app.models.municipios_proyecto import MunicipioProyecto  # Depende de Munic
 # Modelos operacionales con dependencias complejas (al final)
 from app.models.tramites import Tramite  # Depende de Fase, TipoTramite
 from app.models.tareas import Tarea  # Depende de Tramite, TipoTarea, Documento
+from app.models.documentos_tarea import DocumentoTarea  # Depende de Tarea, Documento
 
 # Motor de reglas (depende de TipoSolicitud; tipo_id sin FK por diseño polimórfico)
 from app.models.motor_reglas import ReglaMotor, CondicionRegla
@@ -102,6 +103,7 @@ __all__ = [
     'MunicipioProyecto',
     'Tramite',
     'Tarea',
+    'DocumentoTarea',
     # Motor de reglas
     'ReglaMotor',
     'CondicionRegla',

--- a/app/models/documentos_tarea.py
+++ b/app/models/documentos_tarea.py
@@ -1,0 +1,44 @@
+from app import db
+
+
+class DocumentoTarea(db.Model):
+    """
+    Tabla puente N:N entre tareas INCORPORAR y sus documentos vinculados.
+
+    Desde v5.5, la tarea INCORPORAR no usa documento_producido_id.
+    En su lugar, este modelo registra los N documentos incorporados en un acto
+    de recepción. Completitud: ≥1 registro con el tarea_id de la tarea INCORPORAR.
+
+    REGLAS:
+        - tarea_id → TAREAS (CASCADE delete)
+        - documento_id → DOCUMENTOS (CASCADE delete)
+        - (tarea_id, documento_id) UNIQUE: un documento solo se vincula una vez por acto
+    """
+    __tablename__ = 'documentos_tarea'
+    __table_args__ = (
+        db.UniqueConstraint('tarea_id', 'documento_id', name='uq_documentos_tarea'),
+        db.Index('idx_documentos_tarea_tarea', 'tarea_id'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    tarea_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tareas.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a TAREAS. Acto de incorporación al que pertenece el vínculo'
+    )
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a DOCUMENTOS. Documento incorporado en este acto'
+    )
+
+    tarea = db.relationship('Tarea', backref='documentos_tarea')
+    documento = db.relationship('Documento', backref='documentos_tarea')
+
+    def __repr__(self):
+        return f'<DocumentoTarea tarea={self.tarea_id} doc={self.documento_id}>'

--- a/app/models/tareas.py
+++ b/app/models/tareas.py
@@ -137,14 +137,20 @@ class Tarea(db.Model):
 
     @property
     def ejecutada(self):
-        """True si la tarea ha producido su documento de salida.
-        ESPERAR_PLAZO no produce documento — su completitud se evalúa via plazos.py
-        en el ContextAssembler (ver §4.1 DISEÑO_FECHAS_PLAZOS.md)."""
+        """True si la tarea está completa.
+        INCORPORAR: completitud = ≥1 registro en documentos_tarea (v5.5).
+        Resto: completitud = documento_producido_id not None.
+        ESPERAR_PLAZO: completitud vía plazos.py (ContextAssembler)."""
+        if self.tipo_tarea and self.tipo_tarea.codigo == 'INCORPORAR':
+            return bool(self.documentos_tarea)
         return self.documento_producido_id is not None
 
     @property
     def planificada(self):
-        """True si la tarea no tiene ningún documento asignado aún."""
+        """True si la tarea no tiene ningún documento asignado aún.
+        INCORPORAR: planificada = sin documentos_tarea vinculados."""
+        if self.tipo_tarea and self.tipo_tarea.codigo == 'INCORPORAR':
+            return not bool(self.documentos_tarea)
         return self.documento_producido_id is None and self.documento_usado_id is None
 
     @property

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -35,6 +35,7 @@ from app.models.tramites import Tramite
 from app.models.tareas import Tarea
 from app.models.documentos import Documento
 from app.models.tipos_documentos import TipoDocumento
+from app.models.documentos_tarea import DocumentoTarea
 from app.decorators import role_required
 from app.utils.permisos import (
     puede_cambiar_responsable,
@@ -454,6 +455,20 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
     doc_usado_opcional     = codigo_tipo in _TIPOS_DOC_USADO_OPCIONAL
     requiere_doc_producido = codigo_tipo in _TIPOS_REQUIEREN_DOC_PRODUCIDO
     es_tarea_redactar      = (codigo_tipo == 'REDACTAR')
+    es_tarea_incorporar    = (codigo_tipo == 'INCORPORAR')
+
+    documentos_incorporar = []
+    if es_tarea_incorporar:
+        vinculos = DocumentoTarea.query.filter_by(tarea_id=tarea_id).all()
+        for v in vinculos:
+            doc = v.documento
+            filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else ''
+            filename_limpio = filename.split('?')[0].split('#')[0]
+            documentos_incorporar.append({
+                'vinculo_id': v.id,
+                'doc': doc,
+                'nombre_display': filename_limpio or f'Documento {doc.id}',
+            })
 
     return render_template(
         'expedientes/tramitacion_bc_tarea.html',
@@ -466,13 +481,16 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         doc_usado_opcional=doc_usado_opcional,
         requiere_doc_producido=requiere_doc_producido,
         es_tarea_redactar=es_tarea_redactar,
+        es_tarea_incorporar=es_tarea_incorporar,
+        documentos_incorporar=documentos_incorporar,
     )
 
 
 # Conjuntos de tipos de tarea que requieren documentos (espejo de invariantes_esftt.py)
 _TIPOS_REQUIEREN_DOC_USADO     = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
 _TIPOS_DOC_USADO_OPCIONAL      = {'REDACTAR'}   # visible en UI pero no obligatorio al finalizar
-_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+# INCORPORAR usa documentos_tarea (N docs) — no documento_producido_id
 
 
 # ===========================================================================
@@ -499,6 +517,8 @@ def _documento_es_referenciado(doc):
     if doc.tareas_que_usan:
         return True
     if doc.tarea_productora:
+        return True
+    if doc.documentos_tarea:
         return True
     return False
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -72,7 +72,7 @@
               </a>
             </li>
             {% endif %}
-            {% if tarea.en_curso %}
+            {% if tarea.en_curso or (es_tarea_incorporar and tarea.ejecutada) %}
             <li>
               <a class="dropdown-item" href="#"
                  data-accion="finalizar"
@@ -143,7 +143,48 @@
   </div>
   <div class="card-body card-body-tinted py-3">
 
-    {% if not requiere_doc_usado and not doc_usado_opcional and not requiere_doc_producido %}
+    {% if es_tarea_incorporar %}
+
+    {# ── INCORPORAR: listado multi-doc + añadir desde pool ─────────────────── #}
+    <div id="incorporar-lista" class="mb-3">
+      {% if documentos_incorporar %}
+        {% for item in documentos_incorporar %}
+        <div class="d-flex align-items-center gap-2 flex-wrap mb-2 incorporar-fila"
+             data-vinculo-id="{{ item.vinculo_id }}">
+          <i class="fas fa-file-import text-secondary"></i>
+          <span class="fw-semibold">{{ item.nombre_display }}</span>
+          <small class="text-secondary">
+            — {{ item.doc.tipo_doc.nombre if item.doc.tipo_doc else '' }}
+            {% if item.doc.fecha_administrativa %}
+              — {{ item.doc.fecha_administrativa.strftime('%d/%m/%Y') }}
+            {% endif %}
+          </small>
+          <a href="{{ url_for('expedientes.pool_descargar_documento', id=expediente.id, doc_id=item.doc.id) }}"
+             class="btn btn-sm btn-outline-secondary ms-auto"
+             target="_blank" rel="noopener">
+            <i class="fas fa-download me-1"></i>Descargar
+          </a>
+          <button type="button" class="btn btn-sm btn-outline-danger btn-desvincular-incorporar"
+                  data-vinculo-id="{{ item.vinculo_id }}"
+                  data-url="{{ url_for('api_bc.tarea_incorporar_desvincular', tarea_id=tarea.id, vinculo_id=item.vinculo_id) }}">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
+        {% endfor %}
+      {% else %}
+        <p id="incorporar-vacio" class="fst-italic text-secondary small mb-2">Sin documentos vinculados.</p>
+      {% endif %}
+    </div>
+
+    <div class="d-flex gap-2 align-items-start">
+      <div id="sb-incorporar" style="flex:1"></div>
+      <button type="button" id="btn-vincular-incorporar" class="btn btn-sm btn-outline-primary" disabled>
+        <i class="fas fa-plus me-1"></i>Añadir
+      </button>
+    </div>
+    <div id="alert-incorporar" class="alert d-none mt-2 py-2 mb-0" role="alert"></div>
+
+    {% elif not requiere_doc_usado and not doc_usado_opcional and not requiere_doc_producido %}
     <p class="text-secondary mb-0 fst-italic small">Este tipo de tarea no requiere documentos.</p>
 
     {% else %}
@@ -288,6 +329,16 @@
 <script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-edicion.js') }}"></script>
 <script src="{{ url_for('static', filename='js/v3-breadcrumbs-acciones.js') }}"></script>
+{% if es_tarea_incorporar %}
+<script>
+window.INCORPORAR_CONFIG = {
+  urlVincular:    "{{ url_for('api_bc.tarea_incorporar_vincular', tarea_id=tarea.id) }}",
+  urlDesvincularBase: "/api/bc/tarea/{{ tarea.id }}/incorporar/",
+  urlApiDocs:     "{{ url_for('expedientes.pool_documentos_json', id=expediente.id) }}"
+};
+</script>
+<script src="{{ url_for('static', filename='js/incorporar_documentos.js') }}"></script>
+{% else %}
 <script>
 window.TAREA_DOCS_CONFIG = {
   requiereDocUsado:     {{ requiere_doc_usado | tojson }},
@@ -299,6 +350,7 @@ window.TAREA_DOCS_CONFIG = {
 };
 </script>
 <script src="{{ url_for('static', filename='js/tarea_documentos.js') }}"></script>
+{% endif %}
 {% if es_tarea_redactar %}
 <script>window.GE_CONFIG = { tareaId: {{ tarea.id }} };</script>
 <script src="{{ url_for('static', filename='js/generar_escrito.js') }}"></script>

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -25,6 +25,7 @@ from app.models.tipos_tareas import TipoTarea
 from app.models.documentos_tarea import DocumentoTarea
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
+from app.services.invariantes_esftt import check_invariante
 
 bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
 
@@ -479,6 +480,10 @@ def finalizar_tarea(tarea_id):
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     if tarea.ejecutada:
         return jsonify({'ok': False, 'error': 'La tarea ya está finalizada'}), 422
+
+    res_inv = check_invariante('FINALIZAR', 'TAREA', tarea_id)
+    if res_inv:
+        return _bloqueo(res_inv)
 
     res_eval = evaluar_multi('FINALIZAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
     if not res_eval.permitido:

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -22,6 +22,7 @@ from app.models.tipos_resultados_fases import TipoResultadoFase
 from app.models.tipos_fases import TipoFase
 from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_tareas import TipoTarea
+from app.models.documentos_tarea import DocumentoTarea
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
 
@@ -476,10 +477,83 @@ def finalizar_tarea(tarea_id):
     resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
-    if tarea.documento_producido_id is not None:
+    if tarea.ejecutada:
         return jsonify({'ok': False, 'error': 'La tarea ya está finalizada'}), 422
 
     res_eval = evaluar_multi('FINALIZAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
     if not res_eval.permitido:
         return _bloqueo(res_eval)
     return jsonify({'ok': True, 'nivel': res_eval.nivel, 'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma})
+
+
+# ============================================
+# ENDPOINTS INCORPORAR — documentos_tarea
+# ============================================
+
+@bp.route('/tarea/<int:tarea_id>/incorporar/vincular', methods=['POST'])
+@login_required
+def tarea_incorporar_vincular(tarea_id):
+    """Vincula un documento del pool a una tarea INCORPORAR."""
+    tarea = Tarea.query.get_or_404(tarea_id)
+    expediente = tarea.tramite.fase.solicitud.expediente
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    if not tarea.tipo_tarea or tarea.tipo_tarea.codigo != 'INCORPORAR':
+        return jsonify({'ok': False, 'error': 'Solo aplicable a tareas INCORPORAR'}), 422
+
+    doc_id = request.form.get('documento_id', type=int)
+    if not doc_id:
+        return jsonify({'ok': False, 'error': 'documento_id es obligatorio'}), 400
+
+    doc = Documento.query.get(doc_id)
+    if not doc or doc.expediente_id != expediente.id:
+        return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
+
+    existente = DocumentoTarea.query.filter_by(tarea_id=tarea_id, documento_id=doc_id).first()
+    if existente:
+        return jsonify({'ok': False, 'error': 'Este documento ya está vinculado a la tarea'}), 422
+
+    try:
+        vinculo = DocumentoTarea(tarea_id=tarea_id, documento_id=doc_id)
+        db.session.add(vinculo)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    filename = doc.url.replace('\\', '/').rsplit('/', 1)[-1] if doc.url else ''
+    filename_limpio = filename.split('?')[0].split('#')[0]
+    return jsonify({
+        'ok': True,
+        'vinculo_id': vinculo.id,
+        'doc_id': doc.id,
+        'nombre_display': filename_limpio or f'Documento {doc.id}',
+        'tipo_nombre': doc.tipo_doc.nombre if doc.tipo_doc else '',
+        'fecha': doc.fecha_administrativa.strftime('%d/%m/%Y') if doc.fecha_administrativa else '',
+        'url_descargar': f'/expedientes/{expediente.id}/documentos/{doc.id}/fichero',
+    })
+
+
+@bp.route('/tarea/<int:tarea_id>/incorporar/<int:vinculo_id>/desvincular', methods=['POST'])
+@login_required
+def tarea_incorporar_desvincular(tarea_id, vinculo_id):
+    """Elimina el vínculo entre un documento y una tarea INCORPORAR."""
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    vinculo = DocumentoTarea.query.get_or_404(vinculo_id)
+    if vinculo.tarea_id != tarea_id:
+        return jsonify({'ok': False, 'error': 'Vínculo no pertenece a esta tarea'}), 422
+
+    try:
+        db.session.delete(vinculo)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    return jsonify({'ok': True})

--- a/app/services/invariantes_esftt.py
+++ b/app/services/invariantes_esftt.py
@@ -20,7 +20,7 @@ from app.models.tareas import Tarea
 from app.models.solicitudes import Solicitud
 from app.services.motor_reglas import EvaluacionResult
 
-_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'INCORPORAR', 'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'ANALISIS', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
 _TIPOS_REQUIEREN_DOC_USADO     = {'ANALISIS', 'FIRMAR', 'NOTIFICAR', 'PUBLICAR'}
 
 
@@ -107,6 +107,7 @@ def _check_finalizar(sujeto: str, entidad_id: int) -> Optional[EvaluacionResult]
 
 def _check_finalizar_fase(fase_id: int) -> Optional[EvaluacionResult]:
     from app.models.tipos_tareas import TipoTarea
+    from app.models.documentos_tarea import DocumentoTarea
     tarea_incompleta = (
         db.session.query(Tarea)
         .join(Tramite, Tarea.tramite_id == Tramite.id)
@@ -120,11 +121,27 @@ def _check_finalizar_fase(fase_id: int) -> Optional[EvaluacionResult]:
     )
     if tarea_incompleta:
         return _bloquear('Hay tareas sin documento producido en esta fase. Finalice todas las tareas antes de cerrar la fase.')
+
+    incorporar_incompleta = (
+        db.session.query(Tarea)
+        .join(Tramite, Tarea.tramite_id == Tramite.id)
+        .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
+        .outerjoin(DocumentoTarea, DocumentoTarea.tarea_id == Tarea.id)
+        .filter(
+            Tramite.fase_id == fase_id,
+            TipoTarea.codigo == 'INCORPORAR',
+            DocumentoTarea.id.is_(None)
+        )
+        .first()
+    )
+    if incorporar_incompleta:
+        return _bloquear('Hay tareas INCORPORAR sin documentos vinculados. Añada al menos un documento antes de cerrar la fase.')
     return None
 
 
 def _check_finalizar_tramite(tramite_id: int) -> Optional[EvaluacionResult]:
     from app.models.tipos_tareas import TipoTarea
+    from app.models.documentos_tarea import DocumentoTarea
     tarea_incompleta = (
         db.session.query(Tarea)
         .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
@@ -137,6 +154,20 @@ def _check_finalizar_tramite(tramite_id: int) -> Optional[EvaluacionResult]:
     )
     if tarea_incompleta:
         return _bloquear('Hay tareas sin ejecutar. Finalice todas las tareas antes de cerrar el trámite.')
+
+    incorporar_incompleta = (
+        db.session.query(Tarea)
+        .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
+        .outerjoin(DocumentoTarea, DocumentoTarea.tarea_id == Tarea.id)
+        .filter(
+            Tarea.tramite_id == tramite_id,
+            TipoTarea.codigo == 'INCORPORAR',
+            DocumentoTarea.id.is_(None)
+        )
+        .first()
+    )
+    if incorporar_incompleta:
+        return _bloquear('Hay tareas INCORPORAR sin documentos vinculados. Añada al menos un documento antes de cerrar el trámite.')
     return None
 
 
@@ -146,6 +177,11 @@ def _check_finalizar_tarea(tarea_id: int) -> Optional[EvaluacionResult]:
         return None
 
     codigo = tarea.tipo_tarea.codigo
+
+    if codigo == 'INCORPORAR':
+        if not tarea.documentos_tarea:
+            return _bloquear('Falta vincular al menos un documento. Añádalo antes de finalizar la tarea.')
+        return None
 
     if codigo in _TIPOS_REQUIEREN_DOC_PRODUCIDO and tarea.documento_producido_id is None:
         return _bloquear('Falta el documento producido. Asócielo antes de finalizar la tarea.')

--- a/app/static/js/incorporar_documentos.js
+++ b/app/static/js/incorporar_documentos.js
@@ -1,0 +1,143 @@
+// incorporar_documentos.js — issue #290
+// Gestiona el listado multi-doc y el selector de vincular en tareas INCORPORAR.
+//
+// Depende de: selector_busqueda.js
+// Datos de entrada: window.INCORPORAR_CONFIG (inyectado por el template)
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  const cfg = window.INCORPORAR_CONFIG;
+  if (!cfg) return;
+
+  const lista     = document.getElementById('incorporar-lista');
+  const alertEl   = document.getElementById('alert-incorporar');
+  const sbContenedor = document.getElementById('sb-incorporar');
+  const btnVincular  = document.getElementById('btn-vincular-incorporar');
+  if (!lista || !sbContenedor || !btnVincular) return;
+
+  // ── SelectorBusqueda para elegir documento del pool ───────────────────────
+  const sel = new SelectorBusqueda('#sb-incorporar', [], {
+    placeholder: '— Seleccione documento del pool —',
+    onChange: function (v) {
+      btnVincular.disabled = !v;
+    }
+  });
+
+  // Cargar opciones del pool al iniciar
+  fetch(cfg.urlApiDocs)
+    .then(r => r.json())
+    .then(json => { if (json.ok) sel.setOpciones(json.docs); })
+    .catch(() => {});
+
+  // ── Vincular ──────────────────────────────────────────────────────────────
+  btnVincular.addEventListener('click', async function () {
+    const docId = sel.getValue();
+    if (!docId) return;
+
+    btnVincular.disabled = true;
+    _alerta('', '');
+
+    try {
+      const fd = new FormData();
+      fd.append('documento_id', docId);
+      const resp = await fetch(cfg.urlVincular, { method: 'POST', body: fd });
+      const json = await resp.json();
+
+      if (!json.ok) {
+        _alerta('danger', json.error || 'Error al vincular el documento.');
+        return;
+      }
+
+      _añadir_fila(json);
+      sel.clear();
+      _ocultar_vacio();
+    } catch (_e) {
+      _alerta('danger', 'Error de red. Inténtelo de nuevo.');
+    } finally {
+      btnVincular.disabled = !sel.getValue();
+    }
+  });
+
+  // ── Desvincular (delegación de eventos) ──────────────────────────────────
+  lista.addEventListener('click', async function (e) {
+    const btn = e.target.closest('.btn-desvincular-incorporar');
+    if (!btn) return;
+
+    const vinculoId = btn.dataset.vinculoId;
+    const url = cfg.urlDesvincularBase + vinculoId + '/desvincular';
+
+    btn.disabled = true;
+    _alerta('', '');
+
+    try {
+      const resp = await fetch(url, { method: 'POST' });
+      const json = await resp.json();
+
+      if (!json.ok) {
+        _alerta('danger', json.error || 'Error al desvincular.');
+        btn.disabled = false;
+        return;
+      }
+
+      const fila = lista.querySelector('.incorporar-fila[data-vinculo-id="' + vinculoId + '"]');
+      if (fila) fila.remove();
+      _mostrar_vacio_si_vacia();
+    } catch (_e) {
+      _alerta('danger', 'Error de red. Inténtelo de nuevo.');
+      btn.disabled = false;
+    }
+  });
+
+  // ── Helpers DOM ───────────────────────────────────────────────────────────
+
+  function _añadir_fila(data) {
+    const fila = document.createElement('div');
+    fila.className = 'd-flex align-items-center gap-2 flex-wrap mb-2 incorporar-fila';
+    fila.dataset.vinculoId = data.vinculo_id;
+
+    const meta = [data.tipo_nombre, data.fecha].filter(Boolean).join(' — ');
+    fila.innerHTML =
+      '<i class="fas fa-file-import text-secondary"></i>' +
+      '<span class="fw-semibold">' + _esc(data.nombre_display) + '</span>' +
+      (meta ? '<small class="text-secondary">— ' + _esc(meta) + '</small>' : '') +
+      '<a href="' + _esc(data.url_descargar) + '" class="btn btn-sm btn-outline-secondary ms-auto"' +
+        ' target="_blank" rel="noopener"><i class="fas fa-download me-1"></i>Descargar</a>' +
+      '<button type="button" class="btn btn-sm btn-outline-danger btn-desvincular-incorporar"' +
+        ' data-vinculo-id="' + data.vinculo_id + '"' +
+        ' data-url="' + _esc(cfg.urlDesvincularBase + data.vinculo_id + '/desvincular') + '">' +
+        '<i class="fas fa-times"></i></button>';
+
+    lista.appendChild(fila);
+  }
+
+  function _ocultar_vacio() {
+    const vacio = document.getElementById('incorporar-vacio');
+    if (vacio) vacio.remove();
+  }
+
+  function _mostrar_vacio_si_vacia() {
+    const filas = lista.querySelectorAll('.incorporar-fila');
+    if (filas.length === 0 && !document.getElementById('incorporar-vacio')) {
+      const p = document.createElement('p');
+      p.id = 'incorporar-vacio';
+      p.className = 'fst-italic text-secondary small mb-2';
+      p.textContent = 'Sin documentos vinculados.';
+      lista.appendChild(p);
+    }
+  }
+
+  function _alerta(tipo, msg) {
+    if (!tipo) { alertEl.classList.add('d-none'); return; }
+    alertEl.className = 'alert alert-' + tipo + ' mt-2 py-2 mb-0';
+    alertEl.textContent = msg;
+  }
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+});

--- a/migrations/versions/a3f1c8e290bd_documentos_tarea.py
+++ b/migrations/versions/a3f1c8e290bd_documentos_tarea.py
@@ -1,0 +1,38 @@
+"""Crear tabla documentos_tarea (issue #290 — INCORPORAR multi-doc v5.5)
+
+Revision ID: a3f1c8e290bd
+Revises: fd2bc02d2474
+Create Date: 2026-04-25 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a3f1c8e290bd'
+down_revision = '319_descripcion_regla_motor'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'documentos_tarea',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('tarea_id', sa.Integer(), nullable=False,
+                  comment='FK a TAREAS. Acto de incorporación'),
+        sa.Column('documento_id', sa.Integer(), nullable=False,
+                  comment='FK a DOCUMENTOS. Documento incorporado'),
+        sa.ForeignKeyConstraint(['tarea_id'], ['public.tareas.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('tarea_id', 'documento_id', name='uq_documentos_tarea'),
+        schema='public'
+    )
+    op.create_index('idx_documentos_tarea_tarea', 'documentos_tarea', ['tarea_id'], schema='public')
+
+
+def downgrade():
+    op.drop_index('idx_documentos_tarea_tarea', table_name='documentos_tarea', schema='public')
+    op.drop_table('documentos_tarea', schema='public')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from app import create_app, db as _db
+
+
+@pytest.fixture(scope='session')
+def app():
+    application = create_app()
+    application.config['TESTING'] = True
+    return application
+
+
+@pytest.fixture(scope='function')
+def app_ctx(app):
+    """Contexto de aplicación con rollback automático al terminar."""
+    with app.app_context():
+        connection = _db.engine.connect()
+        transaction = connection.begin_nested()
+        _db.session.bind = connection
+        yield app
+        _db.session.rollback()
+        connection.close()
+
+
+@pytest.fixture(scope='function')
+def client(app):
+    """Flask test client — sin contexto de BD gestionado."""
+    with app.test_client() as c:
+        yield c

--- a/tests/test_290_documentos_tarea.py
+++ b/tests/test_290_documentos_tarea.py
@@ -1,0 +1,361 @@
+"""
+Tests issue #290 — tabla documentos_tarea (INCORPORAR multi-doc v5.5).
+
+Tres bloques:
+  A) Propiedades Tarea.ejecutada / planificada — sin BD, sin app context.
+  B) Invariantes _check_finalizar_tarea — con patching de Tarea.query.
+  C) API endpoints /api/bc/tarea/<id>/incorporar/* — Flask test client + BD real.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# A) Propiedades Tarea.ejecutada / planificada
+#    Se invoca directamente el fget de la property sobre un objeto stub,
+#    evitando SQLAlchemy por completo.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class _StubTarea:
+    """Stub mínimo que implementa los atributos que leen las properties."""
+    def __init__(self, codigo, documentos_tarea=None,
+                 doc_producido_id=None, doc_usado_id=None):
+        self.tipo_tarea = MagicMock(codigo=codigo)
+        self.documentos_tarea = documentos_tarea or []
+        self.documento_producido_id = doc_producido_id
+        self.documento_usado_id = doc_usado_id
+
+
+def _ejecutada(stub):
+    from app.models.tareas import Tarea
+    return Tarea.ejecutada.fget(stub)
+
+
+def _planificada(stub):
+    from app.models.tareas import Tarea
+    return Tarea.planificada.fget(stub)
+
+
+def _en_curso(stub):
+    # en_curso depende de planificada y ejecutada; se resuelven explícitamente
+    return not _planificada(stub) and not _ejecutada(stub)
+
+
+class TestTareaEjecutadaIncorporar:
+
+    def test_incorporar_sin_docs_no_ejecutada(self):
+        t = _StubTarea('INCORPORAR', documentos_tarea=[])
+        assert _ejecutada(t) is False
+
+    def test_incorporar_con_un_doc_ejecutada(self):
+        t = _StubTarea('INCORPORAR', documentos_tarea=[MagicMock()])
+        assert _ejecutada(t) is True
+
+    def test_incorporar_con_varios_docs_ejecutada(self):
+        t = _StubTarea('INCORPORAR', documentos_tarea=[MagicMock(), MagicMock()])
+        assert _ejecutada(t) is True
+
+    def test_incorporar_sin_docs_planificada(self):
+        t = _StubTarea('INCORPORAR', documentos_tarea=[])
+        assert _planificada(t) is True
+
+    def test_incorporar_con_doc_no_planificada(self):
+        t = _StubTarea('INCORPORAR', documentos_tarea=[MagicMock()])
+        assert _planificada(t) is False
+
+    def test_incorporar_en_curso_siempre_false(self):
+        # INCORPORAR no tiene estado intermedio: o planificada o ejecutada
+        sin_docs = _StubTarea('INCORPORAR', documentos_tarea=[])
+        assert _en_curso(sin_docs) is False
+        con_docs = _StubTarea('INCORPORAR', documentos_tarea=[MagicMock()])
+        assert _en_curso(con_docs) is False
+
+    def test_analisis_sin_doc_producido_no_ejecutada(self):
+        t = _StubTarea('ANALISIS', doc_producido_id=None)
+        assert _ejecutada(t) is False
+
+    def test_analisis_con_doc_producido_ejecutada(self):
+        t = _StubTarea('ANALISIS', doc_producido_id=42)
+        assert _ejecutada(t) is True
+
+    def test_analisis_con_doc_usado_en_curso(self):
+        t = _StubTarea('ANALISIS', doc_producido_id=None, doc_usado_id=7)
+        assert _planificada(t) is False
+        assert _ejecutada(t) is False
+        assert _en_curso(t) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# B) Invariante _check_finalizar_tarea
+#    Se parchea Tarea.query.get para devolver un stub — sin tocar la BD.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _check_finalizar_tarea(tarea_id):
+    from app.services.invariantes_esftt import _check_finalizar_tarea as fn
+    return fn(tarea_id)
+
+
+class TestCheckFinalizarTareaIncorporar:
+
+    def _mock_tarea(self, codigo, documentos_tarea=None,
+                    doc_producido_id=None, doc_usado_id=None):
+        t = MagicMock()
+        t.tipo_tarea = MagicMock(codigo=codigo)
+        t.documentos_tarea = documentos_tarea if documentos_tarea is not None else []
+        t.documento_producido_id = doc_producido_id
+        t.documento_usado_id = doc_usado_id
+        return t
+
+    def test_incorporar_sin_docs_bloquea(self, app):
+        with app.app_context():
+            tarea = self._mock_tarea('INCORPORAR', documentos_tarea=[])
+            with patch('app.services.invariantes_esftt.Tarea') as MockTarea:
+                MockTarea.query.get.return_value = tarea
+                resultado = _check_finalizar_tarea(99)
+            assert resultado is not None
+            assert resultado.permitido is False
+            assert 'INCORPORAR' in resultado.norma_compilada or 'documento' in resultado.norma_compilada.lower()
+
+    def test_incorporar_con_docs_no_bloquea(self, app):
+        with app.app_context():
+            tarea = self._mock_tarea('INCORPORAR', documentos_tarea=[MagicMock()])
+            with patch('app.services.invariantes_esftt.Tarea') as MockTarea:
+                MockTarea.query.get.return_value = tarea
+                resultado = _check_finalizar_tarea(99)
+            assert resultado is None
+
+    def test_analisis_sin_doc_producido_bloquea(self, app):
+        with app.app_context():
+            tarea = self._mock_tarea('ANALISIS', doc_producido_id=None)
+            with patch('app.services.invariantes_esftt.Tarea') as MockTarea:
+                MockTarea.query.get.return_value = tarea
+                resultado = _check_finalizar_tarea(99)
+            assert resultado is not None
+            assert resultado.permitido is False
+
+    def test_analisis_con_ambos_docs_no_bloquea(self, app):
+        with app.app_context():
+            tarea = self._mock_tarea('ANALISIS', doc_producido_id=5, doc_usado_id=3)
+            with patch('app.services.invariantes_esftt.Tarea') as MockTarea:
+                MockTarea.query.get.return_value = tarea
+                resultado = _check_finalizar_tarea(99)
+            assert resultado is None
+
+    def test_tarea_inexistente_no_bloquea(self, app):
+        with app.app_context():
+            with patch('app.services.invariantes_esftt.Tarea') as MockTarea:
+                MockTarea.query.get.return_value = None
+                resultado = _check_finalizar_tarea(9999)
+            assert resultado is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# C) Endpoints API — Flask test client con BD real + limpieza
+#    Se crea data mínima, se prueba, se elimina.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _setup_incorporar():
+    """Crea fixture mínimo en la BD. Llamar dentro de with app.app_context()."""
+    from app.models.expedientes import Expediente
+    from app.models.solicitudes import Solicitud
+    from app.models.fases import Fase
+    from app.models.tramites import Tramite
+    from app.models.tareas import Tarea
+    from app.models.documentos import Documento
+    from app.models.tipos_tareas import TipoTarea
+    from app import db
+
+    tipo_incorporar = TipoTarea.query.filter_by(codigo='INCORPORAR').first()
+    if not tipo_incorporar:
+        return None  # El llamador hace pytest.skip si es None
+
+    exp = Expediente.query.first()
+    if not exp:
+        return None
+
+    sol = Solicitud(expediente_id=exp.id,
+                    entidad_id=exp.titular_id or 1,
+                    tipo_solicitud_id=1)
+    db.session.add(sol)
+    db.session.flush()
+
+    fase = Fase(solicitud_id=sol.id, tipo_fase_id=1)
+    db.session.add(fase)
+    db.session.flush()
+
+    tramite = Tramite(fase_id=fase.id, tipo_tramite_id=1)
+    db.session.add(tramite)
+    db.session.flush()
+
+    tarea = Tarea(tramite_id=tramite.id, tipo_tarea_id=tipo_incorporar.id)
+    db.session.add(tarea)
+    db.session.flush()
+
+    doc = Documento(expediente_id=exp.id, url='/tmp/test_incorporar.pdf',
+                    tipo_doc_id=1)
+    db.session.add(doc)
+    db.session.flush()
+
+    db.session.commit()
+    return {
+        'exp_id': exp.id, 'sol_id': sol.id, 'fase_id': fase.id,
+        'tramite_id': tramite.id, 'tarea_id': tarea.id, 'doc_id': doc.id,
+    }
+
+
+def _teardown_incorporar(ids):
+    """Elimina el fixture. Llamar dentro de with app.app_context()."""
+    from app.models.documentos_tarea import DocumentoTarea
+    from app.models.tareas import Tarea
+    from app.models.tramites import Tramite
+    from app.models.fases import Fase
+    from app.models.solicitudes import Solicitud
+    from app.models.documentos import Documento
+    from app import db
+
+    DocumentoTarea.query.filter_by(tarea_id=ids['tarea_id']).delete()
+    Tarea.query.filter_by(id=ids['tarea_id']).delete()
+    Tramite.query.filter_by(id=ids['tramite_id']).delete()
+    Fase.query.filter_by(id=ids['fase_id']).delete()
+    Solicitud.query.filter_by(id=ids['sol_id']).delete()
+    Documento.query.filter_by(id=ids['doc_id']).delete()
+    db.session.commit()
+
+
+def _get_test_user_id(app):
+    """Devuelve el ID del primer usuario activo para injectar en sesión."""
+    from app.models.usuarios import Usuario
+    with app.app_context():
+        user = Usuario.query.filter_by(activo=True).first()
+        return user.id if user else None
+
+
+def _inject_session(client, user_id):
+    """Inyecta sesión de Flask-Login sin pasar por el formulario de login."""
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+
+class TestApiIncorporarVincular:
+    """
+    Tests de integración — usa BD real.
+    Patrón: setup en app_context → requests con test_client → teardown en app_context.
+    Los tres bloques son SECUENCIALES, nunca anidados.
+    """
+
+    def test_vincular_documento_ok(self, app):
+        user_id = _get_test_user_id(app)
+        if not user_id:
+            pytest.skip('No hay usuarios activos en BD de test')
+
+        with app.app_context():
+            ids = _setup_incorporar()
+        if not ids:
+            pytest.skip('Datos maestros insuficientes en BD de test')
+
+        try:
+            with app.test_client() as c:
+                _inject_session(c, user_id)
+                resp = c.post(
+                    f'/api/bc/tarea/{ids["tarea_id"]}/incorporar/vincular',
+                    data={'documento_id': ids['doc_id']}
+                )
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data['ok'] is True
+            assert 'vinculo_id' in data
+        finally:
+            with app.app_context():
+                _teardown_incorporar(ids)
+
+    def test_vincular_doc_duplicado_error(self, app):
+        user_id = _get_test_user_id(app)
+        if not user_id:
+            pytest.skip('No hay usuarios activos en BD de test')
+
+        with app.app_context():
+            ids = _setup_incorporar()
+        if not ids:
+            pytest.skip('Datos maestros insuficientes en BD de test')
+
+        try:
+            with app.test_client() as c:
+                _inject_session(c, user_id)
+                url = f'/api/bc/tarea/{ids["tarea_id"]}/incorporar/vincular'
+                c.post(url, data={'documento_id': ids['doc_id']})
+                resp = c.post(url, data={'documento_id': ids['doc_id']})
+            assert resp.status_code == 422
+            assert resp.get_json()['ok'] is False
+        finally:
+            with app.app_context():
+                _teardown_incorporar(ids)
+
+    def test_vincular_sin_documento_id_error(self, app):
+        user_id = _get_test_user_id(app)
+        if not user_id:
+            pytest.skip('No hay usuarios activos en BD de test')
+
+        with app.app_context():
+            ids = _setup_incorporar()
+        if not ids:
+            pytest.skip('Datos maestros insuficientes en BD de test')
+
+        try:
+            with app.test_client() as c:
+                _inject_session(c, user_id)
+                resp = c.post(
+                    f'/api/bc/tarea/{ids["tarea_id"]}/incorporar/vincular',
+                    data={}
+                )
+            assert resp.status_code == 400
+        finally:
+            with app.app_context():
+                _teardown_incorporar(ids)
+
+    def test_desvincular_ok(self, app):
+        user_id = _get_test_user_id(app)
+        if not user_id:
+            pytest.skip('No hay usuarios activos en BD de test')
+
+        with app.app_context():
+            ids = _setup_incorporar()
+        if not ids:
+            pytest.skip('Datos maestros insuficientes en BD de test')
+
+        try:
+            with app.test_client() as c:
+                _inject_session(c, user_id)
+                resp_v = c.post(
+                    f'/api/bc/tarea/{ids["tarea_id"]}/incorporar/vincular',
+                    data={'documento_id': ids['doc_id']}
+                )
+                vinculo_id = resp_v.get_json()['vinculo_id']
+                resp_d = c.post(
+                    f'/api/bc/tarea/{ids["tarea_id"]}/incorporar/{vinculo_id}/desvincular'
+                )
+            assert resp_d.status_code == 200
+            assert resp_d.get_json()['ok'] is True
+        finally:
+            with app.app_context():
+                _teardown_incorporar(ids)
+
+    def test_finalizar_incorporar_sin_docs_bloquea(self, app):
+        user_id = _get_test_user_id(app)
+        if not user_id:
+            pytest.skip('No hay usuarios activos en BD de test')
+
+        with app.app_context():
+            ids = _setup_incorporar()
+        if not ids:
+            pytest.skip('Datos maestros insuficientes en BD de test')
+
+        try:
+            with app.test_client() as c:
+                _inject_session(c, user_id)
+                resp = c.post(f'/api/bc/tarea/{ids["tarea_id"]}/finalizar')
+            assert resp.status_code == 422
+            assert resp.get_json()['ok'] is False
+        finally:
+            with app.app_context():
+                _teardown_incorporar(ids)


### PR DESCRIPTION
## Resumen

- Tabla `documentos_tarea` (FK `tareas.id` + `documentos.id`, UNIQUE por par) para vincular N documentos a un acto INCORPORAR (v5.5 FTT).
- `Tarea.ejecutada` / `planificada` actualizados: INCORPORAR es "ejecutada" cuando tiene ≥1 `documentos_tarea`.
- Selector `documento_producido` ocultado para tipo INCORPORAR en BC; reemplazado por listado multi-doc con selector inline.
- Nuevos endpoints `POST /api/bc/tarea/<id>/incorporar/vincular` y `.../incorporar/<vinculo_id>/desvincular`.
- Invariantes de finalizar (tarea/trámite/fase) comprueban que INCORPORAR tiene ≥1 `documentos_tarea`.
- `_documento_es_referenciado` en pool_documentos incluye `documentos_tarea`.

## Plan de prueba

- [ ] Crear tarea INCORPORAR en un trámite
- [ ] Verificar que la sección "Documentos" no muestra el selector "Documento producido"
- [ ] Vincular documentos del pool → aparecen en la lista con botón "Desvincular"
- [ ] Desvincular un documento → desaparece de la lista
- [ ] Intentar "Finalizar" sin documentos → error del motor
- [ ] Intentar "Finalizar" con ≥1 documento → ok
- [ ] Intentar finalizar un Trámite/Fase con INCORPORAR sin documentos → bloqueado
- [ ] Verificar que un documento vinculado a INCORPORAR no puede borrarse del pool

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
