### PR TITLE
Fase finalizadora: es_finalizadora en tipos_fases (#302)

### DIFF
--- a/app/models/tipos_fases.py
+++ b/app/models/tipos_fases.py
@@ -79,6 +79,13 @@ class TipoFase(db.Model):
         comment='Nombre legible usado en nombres de documentos generados'
     )
 
+    es_finalizadora = db.Column(
+        db.Boolean,
+        nullable=False,
+        server_default='false',
+        comment='True si esta fase cierra la solicitud al finalizarse'
+    )
+
     @property
     def label_bc(self):
         """Etiqueta corta para breadcrumb: abreviatura si existe, nombre completo si no."""

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -45,6 +45,11 @@
     <span class="fw-semibold d-flex align-items-center gap-2">
       <i class="fas fa-layer-group fs-5 bc-icon-fase"></i>
       <span>Fase: {{ fase.tipo_fase.nombre if fase.tipo_fase else '#' ~ fase.id }}</span>
+      {% if fase.tipo_fase and fase.tipo_fase.es_finalizadora %}
+      <span class="badge bg-warning text-dark ms-1" title="Esta fase cierra la solicitud">
+        <i class="fas fa-flag-checkered me-1"></i>Cierra solicitud
+      </span>
+      {% endif %}
       <span class="badge {{ fase_badge_class }} ms-1">{{ fase_badge_label }}</span>
     </span>
     <div class="bc-acciones-bar">

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -42,3 +42,15 @@ def _(ctx) -> bool:
                 if tramite.tipo_tramite and tramite.tipo_tramite.codigo == 'PUBLICACION':
                     return True
     return False
+
+
+@variable('existe_fase_finalizadora_cerrada')
+def _(ctx) -> bool:
+    """True si la solicitud en contexto tiene al menos una fase finalizadora cerrada."""
+    solicitud = ctx.solicitud
+    if solicitud is None:
+        return False
+    for fase in solicitud.fases:
+        if fase.tipo_fase and fase.tipo_fase.es_finalizadora and fase.finalizada:
+            return True
+    return False

--- a/migrations/versions/8deef1de808e_302_fase_finalizadora.py
+++ b/migrations/versions/8deef1de808e_302_fase_finalizadora.py
@@ -1,0 +1,111 @@
+"""302_fase_finalizadora
+
+Revision ID: 8deef1de808e
+Revises: a3f1c8e290bd
+Create Date: 2026-04-27 19:02:19.513121
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8deef1de808e'
+down_revision = 'a3f1c8e290bd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # A. Campo es_finalizadora en tipos_fases
+    op.add_column('tipos_fases',
+        sa.Column('es_finalizadora', sa.Boolean, nullable=False,
+                  server_default='false',
+                  comment='True si esta fase cierra la solicitud al finalizarse')
+    )
+    op.execute("UPDATE tipos_fases SET es_finalizadora = TRUE WHERE codigo = 'RESOLUCION'")
+
+    # B. Nuevo tipo_fase RECONOCIMIENTO_INTERESADO
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        "INSERT INTO tipos_fases (codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) "
+        "VALUES ('RECONOCIMIENTO_INTERESADO', 'Reconocimiento de Interesado', "
+        "'Rec. Interesado', 'Reconocimiento de Interesado', TRUE) RETURNING id"
+    ))
+    nuevo_id = result.scalar()
+
+    # C. fases_tramites: ELABORACION(22) y NOTIFICACION(23)
+    conn.execute(sa.text(
+        f"INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES "
+        f"({nuevo_id}, 22), ({nuevo_id}, 23)"
+    ))
+
+    # D. solicitudes_fases — 4 entradas de whitelist
+    conn.execute(sa.text(
+        f"INSERT INTO solicitudes_fases (tipo_solicitud_id, tipo_fase_id) VALUES "
+        f"(14, {nuevo_id}), "   # INTERESADO → RECONOCIMIENTO_INTERESADO
+        f"(11, 8), "            # DESISTIMIENTO → RESOLUCION
+        f"(12, 8), "            # RENUNCIA → RESOLUCION
+        f"(17, 8)"              # OTRO → RESOLUCION
+    ))
+
+    # E. catalogo_variables — nueva variable del motor
+    result2 = conn.execute(sa.text(
+        "INSERT INTO catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa) "
+        "VALUES ('existe_fase_finalizadora_cerrada', "
+        "'Existe fase finalizadora cerrada en la solicitud', "
+        "'boolean', NULL, TRUE) RETURNING id"
+    ))
+    var_id = result2.scalar()
+
+    # F. regla FINALIZAR SOLICITUD + condición
+    result3 = conn.execute(sa.text(
+        "INSERT INTO reglas_motor (accion, sujeto, efecto, prioridad, activa, descripcion) "
+        "VALUES ('FINALIZAR', 'ANY/ANY', 'BLOQUEAR', 0, TRUE, "
+        "'No se puede finalizar la solicitud: no existe ninguna fase finalizadora cerrada') "
+        "RETURNING id"
+    ))
+    regla_id = result3.scalar()
+
+    conn.execute(sa.text(
+        f"INSERT INTO condiciones_regla (regla_id, variable_id, operador, valor, orden) "
+        f"VALUES ({regla_id}, {var_id}, 'EQ', 'false'::json, 1)"
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # Eliminar condición y regla FINALIZAR SOLICITUD
+    conn.execute(sa.text(
+        "DELETE FROM condiciones_regla WHERE regla_id = "
+        "(SELECT id FROM reglas_motor WHERE accion='FINALIZAR' AND sujeto='ANY/ANY')"
+    ))
+    conn.execute(sa.text(
+        "DELETE FROM reglas_motor WHERE accion='FINALIZAR' AND sujeto='ANY/ANY'"
+    ))
+
+    # Eliminar variable del catálogo
+    conn.execute(sa.text(
+        "DELETE FROM catalogo_variables WHERE nombre='existe_fase_finalizadora_cerrada'"
+    ))
+
+    # Eliminar entradas de solicitudes_fases
+    conn.execute(sa.text(
+        "DELETE FROM solicitudes_fases WHERE tipo_fase_id IN "
+        "(SELECT id FROM tipos_fases WHERE codigo='RECONOCIMIENTO_INTERESADO') "
+        "OR (tipo_solicitud_id IN (11,12,17) AND tipo_fase_id=8)"
+    ))
+
+    # Eliminar fases_tramites y tipo_fase RECONOCIMIENTO_INTERESADO
+    conn.execute(sa.text(
+        "DELETE FROM fases_tramites WHERE tipo_fase_id = "
+        "(SELECT id FROM tipos_fases WHERE codigo='RECONOCIMIENTO_INTERESADO')"
+    ))
+    conn.execute(sa.text(
+        "DELETE FROM tipos_fases WHERE codigo='RECONOCIMIENTO_INTERESADO'"
+    ))
+
+    # Revertir es_finalizadora en RESOLUCION y eliminar columna
+    op.execute("UPDATE tipos_fases SET es_finalizadora = FALSE WHERE codigo = 'RESOLUCION'")
+    op.drop_column('tipos_fases', 'es_finalizadora')

--- a/scripts/data/datos_estructurales.sql
+++ b/scripts/data/datos_estructurales.sql
@@ -32,14 +32,15 @@ INSERT INTO tipos_expedientes (id, tipo, descripcion, nombre_en_plantilla) VALUE
 -- -----------------------------------------------------------------------------
 -- tipos_fases
 -- -----------------------------------------------------------------------------
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (1, 'ANALISIS_SOLICITUD', 'Análisis de Solicitud', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (2, 'CONSULTA_MINISTERIO', 'Consulta al Ministerio', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (3, 'COMPATIBILIDAD_AMBIENTAL', 'Compatibilidad Ambiental', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (4, 'CONSULTAS', 'Consultas a Organismos', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (5, 'INFORMACION_PUBLICA', 'Información Pública', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (6, 'FIGURA_AMBIENTAL_EXTERNA', 'Instrumento Ambiental Externo', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (7, 'AAU_AAUS_INTEGRADA', 'AAU/AAUS Integrada', NULL, NULL);
-INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla) VALUES (8, 'RESOLUCION', 'Resolución', NULL, NULL);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (1, 'ANALISIS_SOLICITUD', 'Análisis de Solicitud', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (2, 'CONSULTA_MINISTERIO', 'Consulta al Ministerio', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (3, 'COMPATIBILIDAD_AMBIENTAL', 'Compatibilidad Ambiental', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (4, 'CONSULTAS', 'Consultas a Organismos', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (5, 'INFORMACION_PUBLICA', 'Información Pública', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (6, 'FIGURA_AMBIENTAL_EXTERNA', 'Instrumento Ambiental Externo', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (7, 'AAU_AAUS_INTEGRADA', 'AAU/AAUS Integrada', NULL, NULL, FALSE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (8, 'RESOLUCION', 'Resolución', NULL, NULL, TRUE);
+INSERT INTO tipos_fases (id, codigo, nombre, abrev, nombre_en_plantilla, es_finalizadora) VALUES (9, 'RECONOCIMIENTO_INTERESADO', 'Reconocimiento de Interesado', 'Rec. Interesado', 'Reconocimiento de Interesado', TRUE);
 
 -- -----------------------------------------------------------------------------
 -- tipos_tramites
@@ -97,6 +98,8 @@ INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (7, 21);
 INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (8, 22);
 INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (8, 23);
 INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (8, 24);
+INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (9, 22);
+INSERT INTO fases_tramites (tipo_fase_id, tipo_tramite_id) VALUES (9, 23);
 
 -- -----------------------------------------------------------------------------
 -- tipos_tareas
@@ -160,6 +163,13 @@ INSERT INTO tipos_ia (id, siglas, descripcion) VALUES (4, 'CA', 'Calificación A
 INSERT INTO tipos_ia (id, siglas, descripcion) VALUES (5, 'EXENTO', 'Exento de instrumento ambiental');
 
 -- -----------------------------------------------------------------------------
+-- solicitudes_fases (whitelist tipo_solicitud × tipo_fase)
+-- -----------------------------------------------------------------------------
+INSERT INTO solicitudes_fases (tipo_solicitud_id, tipo_fase_id) VALUES (14, 9);  -- INTERESADO → RECONOCIMIENTO_INTERESADO
+INSERT INTO solicitudes_fases (tipo_solicitud_id, tipo_fase_id) VALUES (11, 8);  -- DESISTIMIENTO → RESOLUCION
+INSERT INTO solicitudes_fases (tipo_solicitud_id, tipo_fase_id) VALUES (12, 8);  -- RENUNCIA → RESOLUCION
+INSERT INTO solicitudes_fases (tipo_solicitud_id, tipo_fase_id) VALUES (17, 8);  -- OTRO → RESOLUCION
+
 -- normas
 -- -----------------------------------------------------------------------------
 INSERT INTO normas (id, codigo, titulo, url_eli) VALUES (3, 'RD1955_2000', 'Real Decreto 1955/2000, de 1 de diciembre', NULL);
@@ -173,5 +183,6 @@ INSERT INTO catalogo_variables (id, nombre, etiqueta, tipo_dato, norma_id, activ
 INSERT INTO catalogo_variables (id, nombre, etiqueta, tipo_dato, norma_id, activa) VALUES (3, 'sin_linea_aerea', 'Sin línea aérea (instalación íntegramente subterránea)', 'boolean', NULL, true);
 INSERT INTO catalogo_variables (id, nombre, etiqueta, tipo_dato, norma_id, activa) VALUES (4, 'max_tension_nominal_kv', 'Tensión nominal máxima (kV)', 'numerico', NULL, true);
 INSERT INTO catalogo_variables (id, nombre, etiqueta, tipo_dato, norma_id, activa) VALUES (5, 'solo_suelo_urbano_urbanizable', 'Recorrido íntegro en suelo urbano o urbanizable', 'boolean', NULL, true);
+INSERT INTO catalogo_variables (id, nombre, etiqueta, tipo_dato, norma_id, activa) VALUES (6, 'existe_fase_finalizadora_cerrada', 'Existe fase finalizadora cerrada en la solicitud', 'boolean', NULL, true);
 
 -- municipios: cargar aparte con scripts/data/municipios.sql


### PR DESCRIPTION
## Cambios

- `TipoFase`: nuevo campo `es_finalizadora` (Boolean, NOT NULL, default False) — identifica las fases que cierran una solicitud al finalizarse
- `RESOLUCION` marcada como `es_finalizadora=True`; nuevo tipo `RECONOCIMIENTO_INTERESADO` (`es_finalizadora=True`) con trámites ELABORACION + NOTIFICACION
- Whitelist `solicitudes_fases` poblada: INTERESADO→RECONOCIMIENTO_INTERESADO, DESISTIMIENTO/RENUNCIA/OTRO→RESOLUCION
- Variable `existe_fase_finalizadora_cerrada` añadida al catálogo del motor (reemplaza el hardcoding de `codigo='RESOLUCION'`)
- Regla FINALIZAR / ANY/ANY / BLOQUEAR insertada en `reglas_motor` con su condición
- Badge visual "Cierra solicitud" en `tramitacion_bc_fase.html` para fases con `es_finalizadora=True`
- Migración `8deef1de808e` + seed `datos_estructurales.sql` actualizados

Closes #302
