### PR TITLE
Formalizar contrato plazos.py + variables motor estado_plazo/efecto_plazo (#190)

### DIFF
--- a/app/services/plazos.py
+++ b/app/services/plazos.py
@@ -1,0 +1,62 @@
+"""
+Servicio de plazos administrativos — BDDAT.
+
+Calcula el estado del plazo legal asociado a un elemento ESFTT
+(Solicitud, Fase, Trámite, Tarea) y devuelve un EstadoPlazo.
+
+Arquitectura (DISEÑO_FECHAS_PLAZOS.md §4):
+    ContextAssembler llama a obtener_estado_plazo() para poblar las variables
+    'estado_plazo' y 'efecto_plazo' que el motor agnóstico evalúa con operadores
+    estándar (EQ/IN/etc.). El motor no conoce este servicio.
+
+Stub Fase 2 (#190):
+    Devuelve SIN_PLAZO/NINGUNO siempre. Ninguna regla del motor dispara por plazo.
+    La lógica real (catalogo_plazos, dias_inhabiles, suspensiones) se implementa en #172.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class EstadoPlazo:
+    estado: str                    # 'SIN_PLAZO' | 'EN_PLAZO' | 'PROXIMO_VENCER' | 'VENCIDO'
+    efecto: str                    # 'NINGUNO' | 'SILENCIO_ESTIMATORIO' | 'RESPONSABILIDAD_DISCIPLINARIA'
+                                   # | 'SILENCIO_DESESTIMATORIO' | 'CADUCIDAD_PROCEDIMIENTO'
+                                   # | 'PERDIDA_TRAMITE' | 'APERTURA_RECURSO'
+                                   # | 'PRESCRIPCION_CONDICIONADO' | 'CONFORMIDAD_PRESUNTA'
+                                   # | 'SIN_EFECTO_AUTOMATICO'
+    fecha_limite: Optional[date]   # None si SIN_PLAZO
+    dias_restantes: Optional[int]  # None si SIN_PLAZO; negativo si VENCIDO
+
+
+def obtener_estado_plazo(elemento, tipo_elemento: str) -> EstadoPlazo:
+    """
+    Devuelve el estado del plazo legal asociado a un elemento ESFTT.
+
+    Args:
+        elemento:      Instancia ORM del elemento evaluado
+                       (Solicitud, Fase, Tramite o Tarea).
+        tipo_elemento: Literal del tipo: 'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA'.
+
+    Returns:
+        EstadoPlazo con estado, efecto, fecha_limite y dias_restantes.
+
+    Stub (#190 Fase 2):
+        Siempre devuelve SIN_PLAZO/NINGUNO. Seguro: no bloquea ningún flujo.
+
+    M3 (#172):
+        1. Buscar en catalogo_plazos el plazo aplicable a (tipo_elemento, tipo_elemento_id).
+        2. Resolver campo_fecha JSONB → Documento.fecha_administrativa.
+        3. calcular_fecha_fin(fecha_administrativa, plazo, dias_inhabiles, suspensiones).
+        4. Derivar estado según (fecha_limite, hoy(), umbral_alerta=5 días hábiles).
+        5. Leer efecto_vencimiento del catalogo_plazos.
+    """
+    return EstadoPlazo(
+        estado='SIN_PLAZO',
+        efecto='NINGUNO',
+        fecha_limite=None,
+        dias_restantes=None,
+    )

--- a/app/services/variables/__init__.py
+++ b/app/services/variables/__init__.py
@@ -37,3 +37,4 @@ def get_registry() -> dict[str, Callable]:
 # Importar submódulos para que sus @variable se registren al arrancar Flask
 from app.services.variables import dato        # noqa: E402, F401
 from app.services.variables import calculado   # noqa: E402, F401
+from app.services.variables import plazo       # noqa: E402, F401

--- a/app/services/variables/plazo.py
+++ b/app/services/variables/plazo.py
@@ -1,0 +1,60 @@
+"""
+Variables de tipo 'plazo' — delegan en plazos.py para obtener el estado
+del plazo legal asociado al elemento en contexto.
+
+Stub Fase 2 (#190): siempre devuelven SIN_PLAZO / NINGUNO.
+M3 (#172): plazos.obtener_estado_plazo() calculará el estado real.
+"""
+from __future__ import annotations
+
+from app.services.variables import variable
+
+
+def _resolver_elemento(ctx):
+    """
+    Devuelve (elemento, tipo_elemento) del objeto en contexto usando duck-typing.
+
+    Misma lógica que ExpedienteContext en assembler.py:
+      Solicitud → tiene 'fases', NO tiene 'solicitud'
+      Fase      → tiene 'solicitud' y 'tramites'
+      Tramite   → tiene 'fase', NO tiene 'tramites'
+      Tarea     → tiene 'tramite'
+    """
+    obj = ctx._objeto
+    if obj is None or isinstance(obj, dict):
+        return None, None
+    if hasattr(obj, 'fases') and not hasattr(obj, 'solicitud'):
+        return obj, 'SOLICITUD'
+    if hasattr(obj, 'solicitud') and hasattr(obj, 'tramites'):
+        return obj, 'FASE'
+    if hasattr(obj, 'fase') and not hasattr(obj, 'tramites'):
+        return obj, 'TRAMITE'
+    if hasattr(obj, 'tramite'):
+        return obj, 'TAREA'
+    return None, None
+
+
+@variable('estado_plazo')
+def _(ctx) -> str:
+    """
+    Estado del plazo legal del elemento en tramitación.
+    Valores: 'SIN_PLAZO' | 'EN_PLAZO' | 'PROXIMO_VENCER' | 'VENCIDO'
+    """
+    elemento, tipo = _resolver_elemento(ctx)
+    if elemento is None:
+        return 'SIN_PLAZO'
+    from app.services import plazos
+    return plazos.obtener_estado_plazo(elemento, tipo).estado
+
+
+@variable('efecto_plazo')
+def _(ctx) -> str:
+    """
+    Efecto legal del vencimiento del plazo del elemento en tramitación.
+    Valores: 'NINGUNO' | 'SILENCIO_ESTIMATORIO' | 'RESPONSABILIDAD_DISCIPLINARIA' | ...
+    """
+    elemento, tipo = _resolver_elemento(ctx)
+    if elemento is None:
+        return 'NINGUNO'
+    from app.services import plazos
+    return plazos.obtener_estado_plazo(elemento, tipo).efecto

--- a/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
+++ b/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
@@ -508,15 +508,15 @@ Pendiente de diseño:
 
 ## 4. Cadena de evaluación
 
-> **Estado:** Parcialmente cerrado — §4.1 cerrado sesión 2026-04-23. Contrato de interfaz `plazos.py` pendiente.
+> **Estado:** Cerrado — §4.1 cerrado 2026-04-23; contrato de interfaz formalizado en #190 (2026-04-28).
 
 Arquitectura acordada en conversación (2026-04-01):
 
 ```
 Motor agnóstico (evalúa variables, no conoce plazos)
-    ↑  variables: plazo_vencido, dias_transcurridos, fecha_limite, silencio_producido...
+    ↑  variables: estado_plazo, efecto_plazo  (operadores estándar EQ/IN/etc.)
 ContextAssembler
-    ↑  llama a plazos.py para obtener variables de plazo
+    ↑  llama a variables/plazo.py (@variable 'estado_plazo', 'efecto_plazo')
     ↑  llama a plazos.py para derivar estado de tareas ESPERAR_PLAZO (§4.1)
 plazos.py
     ├── Norma sectorial → plazo específico por tipo de Fase/Trámite
@@ -527,7 +527,38 @@ plazos.py
     └── Calendario inhábiles Junta de Andalucía
 ```
 
-Pendiente de formalizar: contrato de interfaz de `plazos.py` (qué recibe, qué devuelve).
+### Contrato de interfaz — `app/services/plazos.py`
+
+```python
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+@dataclass
+class EstadoPlazo:
+    estado: str                    # 'SIN_PLAZO' | 'EN_PLAZO' | 'PROXIMO_VENCER' | 'VENCIDO'
+    efecto: str                    # 'NINGUNO' | 'SILENCIO_ESTIMATORIO' | ... (ver §2.4)
+    fecha_limite: Optional[date]   # None si SIN_PLAZO
+    dias_restantes: Optional[int]  # None si SIN_PLAZO; negativo si VENCIDO
+
+def obtener_estado_plazo(elemento, tipo_elemento: str) -> EstadoPlazo:
+    """
+    elemento:      objeto ORM (Solicitud, Fase, Tramite, Tarea)
+    tipo_elemento: 'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA'
+    """
+```
+
+**Variables expuestas al motor** (registradas en `catalogo_variables`, ambas `activa=TRUE`):
+
+| Variable | tipo_dato | Valores posibles |
+|---|---|---|
+| `estado_plazo` | texto | `SIN_PLAZO` · `EN_PLAZO` · `PROXIMO_VENCER` · `VENCIDO` |
+| `efecto_plazo` | texto | `NINGUNO` · `SILENCIO_ESTIMATORIO` · `RESPONSABILIDAD_DISCIPLINARIA` · `SILENCIO_DESESTIMATORIO` · `CADUCIDAD_PROCEDIMIENTO` · `PERDIDA_TRAMITE` · `APERTURA_RECURSO` · `PRESCRIPCION_CONDICIONADO` · `CONFORMIDAD_PRESUNTA` · `SIN_EFECTO_AUTOMATICO` |
+
+**Stub Fase 2 (#190):** `obtener_estado_plazo` devuelve `SIN_PLAZO`/`NINGUNO` siempre.
+Ninguna regla del motor disparará por plazo hasta que #172 implemente la lógica real.
+
+**M3 (#172):** la función leerá `catalogo_plazos`, resolverá `campo_fecha` JSONB → `Documento.fecha_administrativa`, calculará `fecha_limite` con `dias_inhabiles` y `suspensiones_plazo`, y devolverá el estado calculado según las condiciones de §2.4.
 
 ---
 
@@ -704,6 +735,6 @@ Issues preexistentes relacionados (pendientes de revisar contra este diseño):
 - [ ] **§3.6 Condicionados de resolución** — diseñar nombre y tipos de fase, régimen de plazos (sujeto = administrado), mecanismo de generación desde la resolución, reglas de colisión y distinción visual en UI
 - [ ] **§4 Cadena de evaluación** — formalizar contrato de interfaz `plazos.py`
 - [x] **Leyes sectoriales (parcial)** — ~~RD 1955/2000~~: ✅ añadido en §5.2 (sesión 2026-04-04). ~~Decreto 9/2011~~: sin plazos propios (suprime trámite). ~~DL 26/2021~~: sin plazos propios (suprime trámite). Pendiente: Ley 21/2013 (EIA) — en revisión previa, ver `normas_catalog.csv`.
-- [ ] **Revisar #190** — determinar si el criterio `PLAZO_ESTADO` queda obsoleto o se reorienta
+- [x] **Revisar #190** — reorientado (2026-04-28): criterio `PLAZO_ESTADO` queda obsoleto; reemplazado por variables motor-agnósticas `estado_plazo`/`efecto_plazo` expuestas via `plazos.py` stub (Fase 2). Lógica real en #172.
 - [ ] **Revisar #172 y #173** — actualizar alcance según arquitectura agnóstica
 - [ ] **Reutilización de trámites entre expedientes** — art. 95.3: procedimiento caducado cuyo derecho no ha prescrito permite nuevo procedimiento incorporando actos del anterior. Implica modelo de enlace entre expedientes y reutilización del pool documental. Diseñar cuando se estudie normativa sectorial.

--- a/migrations/versions/bc4a9f1d8e02_190_variables_plazo.py
+++ b/migrations/versions/bc4a9f1d8e02_190_variables_plazo.py
@@ -1,0 +1,37 @@
+"""190_variables_plazo
+
+Revision ID: bc4a9f1d8e02
+Revises: 39fccabb9426
+Create Date: 2026-04-28
+
+Registra las variables de plazo en catalogo_variables (#190):
+  - estado_plazo  — 'SIN_PLAZO' | 'EN_PLAZO' | 'PROXIMO_VENCER' | 'VENCIDO'
+  - efecto_plazo  — 'NINGUNO' | 'SILENCIO_ESTIMATORIO' | ...
+
+Ambas activa=TRUE (stub Fase 2: siempre devuelven SIN_PLAZO/NINGUNO).
+La lógica real se implementa en #172 (plazos en días hábiles).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'bc4a9f1d8e02'
+down_revision = '39fccabb9426'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa) VALUES "
+        "('estado_plazo', 'Estado del plazo del elemento en tramitación', 'texto', NULL, TRUE), "
+        "('efecto_plazo', 'Efecto legal del vencimiento del plazo', 'texto', NULL, TRUE)"
+    ))
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "DELETE FROM public.catalogo_variables WHERE nombre IN ('estado_plazo', 'efecto_plazo')"
+    ))

--- a/tests/test_190_plazos_contrato.py
+++ b/tests/test_190_plazos_contrato.py
@@ -1,0 +1,182 @@
+"""
+Tests issue #190 — contrato interfaz plazos.py + variables motor estado_plazo/efecto_plazo.
+
+Bloques:
+  A) Stub plazos.py          — sin BD ni app context.
+  B) Variables registry      — sin BD ni app context.
+  C) Motor: condición EQ     — sin BD ni app context.
+"""
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Stubs de contexto y objetos ORM mínimos
+# ---------------------------------------------------------------------------
+
+class _StubCtx:
+    """Contexto mínimo para las funciones de variable de plazo."""
+    def __init__(self, objeto=None):
+        self._objeto = objeto
+        self.expediente = MagicMock()
+
+
+class _StubFase:
+    """Duck-type de Fase: tiene solicitud y tramites, NO fases ni fase ni tramite."""
+    def __init__(self):
+        self.solicitud = MagicMock()
+        self.tramites = []
+
+
+class _StubTramite:
+    """Duck-type de Tramite: tiene fase, NO tramites."""
+    def __init__(self):
+        self.fase = MagicMock()
+
+
+class _StubTarea:
+    """Duck-type de Tarea: tiene tramite."""
+    def __init__(self):
+        self.tramite = MagicMock()
+
+
+class _StubSolicitud:
+    """Duck-type de Solicitud: tiene fases, NO solicitud."""
+    def __init__(self):
+        self.fases = []
+
+
+# ---------------------------------------------------------------------------
+# A) Stub plazos.py
+# ---------------------------------------------------------------------------
+
+def test_stub_devuelve_sin_plazo_para_todos_los_tipos():
+    from app.services.plazos import obtener_estado_plazo, EstadoPlazo
+    for tipo in ('SOLICITUD', 'FASE', 'TRAMITE', 'TAREA'):
+        r = obtener_estado_plazo(object(), tipo)
+        assert isinstance(r, EstadoPlazo)
+        assert r.estado == 'SIN_PLAZO'
+        assert r.efecto == 'NINGUNO'
+        assert r.fecha_limite is None
+        assert r.dias_restantes is None
+
+
+def test_stub_acepta_none_como_elemento():
+    from app.services.plazos import obtener_estado_plazo
+    r = obtener_estado_plazo(None, 'FASE')
+    assert r.estado == 'SIN_PLAZO'
+    assert r.efecto == 'NINGUNO'
+
+
+# ---------------------------------------------------------------------------
+# B) Variables registry
+# ---------------------------------------------------------------------------
+
+def test_variables_registradas_en_registry():
+    import app.services.variables.plazo  # noqa: F401 — registra los @variable
+    from app.services.variables import _REGISTRY
+    assert 'estado_plazo' in _REGISTRY
+    assert 'efecto_plazo' in _REGISTRY
+
+
+def test_estado_plazo_objeto_none():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto=None)) == 'SIN_PLAZO'
+
+
+def test_efecto_plazo_objeto_none():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['efecto_plazo']
+    assert fn(_StubCtx(objeto=None)) == 'NINGUNO'
+
+
+def test_estado_plazo_objeto_dict_crear():
+    """Para CREAR (objeto=dict) el stub devuelve SIN_PLAZO."""
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto={'tipo_fase': MagicMock()})) == 'SIN_PLAZO'
+
+
+def test_estado_plazo_con_fase():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto=_StubFase())) == 'SIN_PLAZO'
+
+
+def test_efecto_plazo_con_fase():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['efecto_plazo']
+    assert fn(_StubCtx(objeto=_StubFase())) == 'NINGUNO'
+
+
+def test_estado_plazo_con_tramite():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto=_StubTramite())) == 'SIN_PLAZO'
+
+
+def test_estado_plazo_con_solicitud():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto=_StubSolicitud())) == 'SIN_PLAZO'
+
+
+def test_estado_plazo_con_tarea():
+    import app.services.variables.plazo  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY['estado_plazo']
+    assert fn(_StubCtx(objeto=_StubTarea())) == 'SIN_PLAZO'
+
+
+# ---------------------------------------------------------------------------
+# C) Motor agnóstico — condición EQ con variables de plazo
+# ---------------------------------------------------------------------------
+
+def test_motor_no_dispara_sin_plazo_contra_vencido():
+    """
+    Regla hipotética: estado_plazo == 'VENCIDO' → BLOQUEAR.
+    Con estado='SIN_PLAZO' la condición no se cumple → no dispara.
+    """
+    from app.services.motor_reglas import _evaluar_condiciones
+    cond = MagicMock()
+    cond.variable = MagicMock(nombre='estado_plazo')
+    cond.operador = 'EQ'
+    cond.valor = 'VENCIDO'
+    cond.orden = 1
+    disparada, _ = _evaluar_condiciones([cond], {'estado_plazo': 'SIN_PLAZO'})
+    assert not disparada
+
+
+def test_motor_dispara_vencido_cuando_vencido():
+    """La condición SÍ dispara si el estado es VENCIDO (validación del operador EQ)."""
+    from app.services.motor_reglas import _evaluar_condiciones
+    cond = MagicMock()
+    cond.variable = MagicMock(nombre='estado_plazo')
+    cond.operador = 'EQ'
+    cond.valor = 'VENCIDO'
+    cond.orden = 1
+    disparada, _ = _evaluar_condiciones([cond], {'estado_plazo': 'VENCIDO'})
+    assert disparada
+
+
+def test_motor_dispara_in_proximo_o_vencido():
+    """Operador IN: alerta si estado en ['PROXIMO_VENCER', 'VENCIDO']."""
+    from app.services.motor_reglas import _evaluar_condiciones
+    cond = MagicMock()
+    cond.variable = MagicMock(nombre='estado_plazo')
+    cond.operador = 'IN'
+    cond.valor = ['PROXIMO_VENCER', 'VENCIDO']
+    cond.orden = 1
+    for estado in ('PROXIMO_VENCER', 'VENCIDO'):
+        disparada, _ = _evaluar_condiciones([cond], {'estado_plazo': estado})
+        assert disparada, f'Esperaba disparo para {estado}'
+    for estado in ('SIN_PLAZO', 'EN_PLAZO'):
+        disparada, _ = _evaluar_condiciones([cond], {'estado_plazo': estado})
+        assert not disparada, f'No esperaba disparo para {estado}'


### PR DESCRIPTION
## Cambios

- **`app/services/plazos.py`** (nuevo) — stub con contrato de interfaz formalizado: dataclass `EstadoPlazo` + función `obtener_estado_plazo(elemento, tipo_elemento)` que devuelve `SIN_PLAZO`/`NINGUNO` siempre (Fase 2 segura)
- **`app/services/variables/plazo.py`** (nuevo) — variables motor `estado_plazo` y `efecto_plazo` registradas via `@variable`; delegan en `plazos.py` usando duck-typing para identificar el tipo de elemento en contexto
- **`app/services/variables/__init__.py`** — añadido import de `plazo` para que las variables se registren al arrancar Flask
- **`migrations/versions/bc4a9f1d8e02`** — INSERT en `catalogo_variables` para `estado_plazo` y `efecto_plazo` (`activa=TRUE`, `tipo_dato='texto'`)
- **`docs/referencia/DISEÑO_FECHAS_PLAZOS.md`** — §4 cerrado con contrato formalizado (firma, tabla de variables, descripción stub vs M3); ítem §7 "Revisar #190" marcado como resuelto
- **`tests/test_190_plazos_contrato.py`** (nuevo) — 14 tests sin BD: stub `plazos.py`, variables registry con stubs de Solicitud/Fase/Trámite/Tarea/dict-CREAR, y operadores EQ/IN del motor sobre `estado_plazo`

El criterio `PLAZO_ESTADO` como `tipo_criterio` especial queda **obsoleto** (ver §1 y §7 del doc de diseño). El motor permanece 100% agnóstico: evalúa `estado_plazo` con los operadores estándar existentes.

Closes #190
