### PR TITLE
Implementar plazos legales: cómputo días hábiles y tablas catálogo

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,6 +11,8 @@ ORDEN IMPORTANTE:
 """
 
 # Modelos maestros primero (no tienen FKs entre ellos)
+from app.models.efectos_plazo import EfectoPlazo
+from app.models.ambitos_inhabilidad import AmbitoInhabilidad
 from app.models.usuarios import Usuario, Rol
 from app.models.municipios import Municipio
 from app.models.tipos_expedientes import TipoExpediente
@@ -64,11 +66,17 @@ from app.models.tareas import Tarea  # Depende de Tramite, TipoTarea, Documento
 from app.models.documentos_tarea import DocumentoTarea  # Depende de Tarea, Documento
 from app.models.resultados_documentos import ResultadoDocumento  # Depende de Documento, TipoResultadoDocumento
 
+# Plazos — maestros sin dependencias operacionales (efectos_plazo, ambitos ya importados arriba)
+from app.models.dias_inhabiles import DiaInhabil        # depende de AmbitoInhabilidad
+from app.models.catalogo_plazos import CatalogoPlazo    # depende de EfectoPlazo
+
 # Motor de reglas (depende de TipoSolicitud; tipo_id sin FK por diseño polimórfico)
 from app.models.motor_reglas import ReglaMotor, CondicionRegla
 
 __all__ = [
     # Maestros
+    'EfectoPlazo',
+    'AmbitoInhabilidad',
     'Usuario',
     'Rol',
     'Municipio',
@@ -110,6 +118,9 @@ __all__ = [
     'Tarea',
     'DocumentoTarea',
     'ResultadoDocumento',
+    # Plazos
+    'DiaInhabil',
+    'CatalogoPlazo',
     # Motor de reglas
     'ReglaMotor',
     'CondicionRegla',

--- a/app/models/ambitos_inhabilidad.py
+++ b/app/models/ambitos_inhabilidad.py
@@ -1,0 +1,35 @@
+"""Modelo AmbitoInhabilidad — catálogo de ámbitos del calendario de inhábiles.
+
+Referencia: DISEÑO_FECHAS_PLAZOS.md §3.4
+"""
+from app import db
+
+
+class AmbitoInhabilidad(db.Model):
+    """Ámbito territorial de aplicación de una fecha inhábil.
+
+    PROPÓSITO: distinguir festivos nacionales, autonómicos andaluces y
+    provinciales para filtrar el calendario aplicable al órgano tramitador.
+
+    CAMPO codigo: 'NACIONAL' | 'AUTONOMICO_AND' | 'PROVINCIAL_CAD' | ...
+    """
+    __tablename__ = 'ambitos_inhabilidad'
+    __table_args__ = (
+        db.UniqueConstraint('codigo', name='uq_ambitos_inhabilidad_codigo'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    codigo = db.Column(
+        db.String(40), nullable=False,
+        comment='Código: NACIONAL | AUTONOMICO_AND | PROVINCIAL_CAD | ...',
+    )
+    nombre = db.Column(
+        db.String(200), nullable=False,
+        comment='Nombre legible del ámbito territorial',
+    )
+
+    dias_inhabiles = db.relationship('DiaInhabil', back_populates='ambito')
+
+    def __repr__(self):
+        return f'<AmbitoInhabilidad {self.codigo}>'

--- a/app/models/catalogo_plazos.py
+++ b/app/models/catalogo_plazos.py
@@ -1,0 +1,88 @@
+"""Modelo CatalogoPlazo — catálogo de plazos legales por tipo de elemento ESFTT.
+
+Referencia: DISEÑO_FECHAS_PLAZOS.md §3.2
+"""
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app import db
+
+
+class CatalogoPlazo(db.Model):
+    """Plazo legal asociado a un tipo de elemento ESFTT.
+
+    PROPÓSITO: tabla maestra administrable por el Supervisor que vincula un
+    tipo de Solicitud/Fase/Trámite/Tarea con su plazo legal y el efecto del
+    vencimiento. Permite histórico de cambios normativos sin alterar el
+    catálogo de tipos ESFTT.
+
+    CAMPO tipo_elemento: nivel ESFTT ('SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA').
+    CAMPO tipo_elemento_id: ID en la tabla tipos_* correspondiente.
+        FK polimórfica sin constraint BD (como motor_reglas).
+    CAMPO campo_fecha: JSONB que indica qué Documento.fecha_administrativa
+        es el inicio del cómputo. Formato:
+            {'fk': 'documento_solicitud_id'}           -- caso directo
+            {'via_tarea_tipo': 'ESPERAR_PLAZO',
+             'fk': 'documento_usado_id'}               -- vía tarea hija
+    CAMPO plazo_unidad: 'DIAS_HABILES' | 'DIAS_NATURALES' | 'MESES' | 'ANOS'
+    CAMPO efecto_vencimiento_id: FK a efectos_plazo.
+    CAMPO vigencia_desde / vigencia_hasta: rango de vigencia. NULL = sin límite.
+    CAMPO activo: TRUE para la entrada vigente; permite desactivar sin borrar.
+    """
+    __tablename__ = 'catalogo_plazos'
+    __table_args__ = (
+        db.Index('idx_catalogo_plazos_tipo_elem', 'tipo_elemento', 'tipo_elemento_id'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    tipo_elemento = db.Column(
+        db.String(20), nullable=False,
+        comment='Nivel ESFTT: SOLICITUD | FASE | TRAMITE | TAREA',
+    )
+    tipo_elemento_id = db.Column(
+        db.Integer, nullable=False,
+        comment='ID en tipos_solicitudes / tipos_fases / tipos_tramites / tipos_tareas (sin FK BD — polimórfico)',
+    )
+    campo_fecha = db.Column(
+        JSONB, nullable=True,
+        comment='Referencia al Documento.fecha_administrativa de inicio: {"fk":"..."} o {"via_tarea_tipo":"...","fk":"..."}',
+    )
+    plazo_valor = db.Column(
+        db.Integer, nullable=False,
+        comment='Valor numérico del plazo (días, meses o años)',
+    )
+    plazo_unidad = db.Column(
+        db.String(20), nullable=False,
+        comment='Unidad: DIAS_HABILES | DIAS_NATURALES | MESES | ANOS',
+    )
+    efecto_vencimiento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.efectos_plazo.id', ondelete='RESTRICT'),
+        nullable=False,
+        comment='FK a efectos_plazo — efecto del vencimiento',
+    )
+    norma_origen = db.Column(
+        db.Text, nullable=True,
+        comment='Cita de la norma que fija el plazo (art. 21.3 LPACAP, art. 128 RD 1955/2000, etc.)',
+    )
+    vigencia_desde = db.Column(
+        db.Date, nullable=True,
+        comment='Inicio de vigencia de este plazo. NULL = desde siempre',
+    )
+    vigencia_hasta = db.Column(
+        db.Date, nullable=True,
+        comment='Fin de vigencia de este plazo. NULL = indefinido',
+    )
+    activo = db.Column(
+        db.Boolean, nullable=False, default=True, server_default='TRUE',
+        comment='FALSE para entradas desactivadas sin borrar',
+    )
+
+    efecto_plazo = db.relationship(
+        'EfectoPlazo',
+        foreign_keys=[efecto_vencimiento_id],
+        back_populates='plazos',
+    )
+
+    def __repr__(self):
+        return f'<CatalogoPlazo {self.tipo_elemento}:{self.tipo_elemento_id} {self.plazo_valor}{self.plazo_unidad}>'

--- a/app/models/dias_inhabiles.py
+++ b/app/models/dias_inhabiles.py
@@ -1,0 +1,44 @@
+"""Modelo DiaInhabil — calendario de días inhábiles por ámbito.
+
+Referencia: DISEÑO_FECHAS_PLAZOS.md §3.4
+"""
+from app import db
+
+
+class DiaInhabil(db.Model):
+    """Registro de un día inhábil en el calendario administrativo.
+
+    PROPÓSITO: fuente de verdad del calendario de festivos para el cómputo
+    de plazos en días hábiles (art. 30 LPACAP). La misma fecha puede
+    aparecer en múltiples ámbitos (nacional, autonómico, provincial).
+
+    CAMPO fecha: la fecha inhábil.
+    CAMPO ambito_id: FK al ámbito territorial que declara la inhabilidad.
+    La PK es (fecha, ambito_id) para permitir la misma fecha en distintos ámbitos.
+    """
+    __tablename__ = 'dias_inhabiles'
+    __table_args__ = (
+        db.PrimaryKeyConstraint('fecha', 'ambito_id', name='pk_dias_inhabiles'),
+        db.Index('idx_dias_inhabiles_fecha', 'fecha'),
+        {'schema': 'public'},
+    )
+
+    fecha = db.Column(
+        db.Date, nullable=False,
+        comment='Fecha inhábil',
+    )
+    descripcion = db.Column(
+        db.String(200), nullable=True,
+        comment='Denominación del festivo (Día de Andalucía, Viernes Santo, etc.)',
+    )
+    ambito_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.ambitos_inhabilidad.id', ondelete='RESTRICT'),
+        nullable=False,
+        comment='FK al ámbito territorial que declara la inhabilidad',
+    )
+
+    ambito = db.relationship('AmbitoInhabilidad', back_populates='dias_inhabiles')
+
+    def __repr__(self):
+        return f'<DiaInhabil {self.fecha} [{self.ambito_id}]>'

--- a/app/models/efectos_plazo.py
+++ b/app/models/efectos_plazo.py
@@ -1,0 +1,36 @@
+"""Modelo EfectoPlazo — catálogo de efectos del vencimiento de plazos.
+
+Referencia: DISEÑO_FECHAS_PLAZOS.md §2.4
+"""
+from app import db
+
+
+class EfectoPlazo(db.Model):
+    """Catálogo de efectos que produce el vencimiento de un plazo administrativo.
+
+    PROPÓSITO: tabla maestra que evita hardcodear efectos como ENUM en Python.
+    Los valores se administran por el Supervisor sin tocar código.
+
+    CAMPO codigo: identificador único de negocio ('SILENCIO_ESTIMATORIO', etc.)
+    CAMPO nombre: descripción legible en castellano.
+    """
+    __tablename__ = 'efectos_plazo'
+    __table_args__ = (
+        db.UniqueConstraint('codigo', name='uq_efectos_plazo_codigo'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    codigo = db.Column(
+        db.String(60), nullable=False,
+        comment='Código único de negocio: NINGUNO | SILENCIO_ESTIMATORIO | ...',
+    )
+    nombre = db.Column(
+        db.String(200), nullable=False,
+        comment='Descripción legible del efecto',
+    )
+
+    plazos = db.relationship('CatalogoPlazo', back_populates='efecto_plazo')
+
+    def __repr__(self):
+        return f'<EfectoPlazo {self.codigo}>'

--- a/app/services/plazos.py
+++ b/app/services/plazos.py
@@ -9,15 +9,28 @@ Arquitectura (DISEÑO_FECHAS_PLAZOS.md §4):
     'estado_plazo' y 'efecto_plazo' que el motor agnóstico evalúa con operadores
     estándar (EQ/IN/etc.). El motor no conoce este servicio.
 
-Stub Fase 2 (#190):
-    Devuelve SIN_PLAZO/NINGUNO siempre. Ninguna regla del motor dispara por plazo.
-    La lógica real (catalogo_plazos, dias_inhabiles, suspensiones) se implementa en #172.
+Lógica real (#172):
+    1. Busca en catalogo_plazos el plazo aplicable al tipo de elemento.
+    2. Resuelve campo_fecha JSONB → Documento.fecha_administrativa.
+    3. Calcula fecha_limite con calcular_fecha_fin() (art. 30 LPACAP).
+    4. Deriva estado según condiciones de §2.4 (umbral 5 días hábiles).
+    Suspensiones: hook _obtener_suspensiones() → [] hasta que #173 lo implemente.
 """
 from __future__ import annotations
 
+import calendar
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from typing import Optional
+
+UMBRAL_ALERTA = 5  # días hábiles (DISEÑO_FECHAS_PLAZOS.md §2.4)
+
+_TIPO_ID_CAMPO = {
+    'SOLICITUD': 'tipo_solicitud_id',
+    'FASE':      'tipo_fase_id',
+    'TRAMITE':   'tipo_tramite_id',
+    'TAREA':     'tipo_tarea_id',
+}
 
 
 @dataclass
@@ -32,6 +45,18 @@ class EstadoPlazo:
     dias_restantes: Optional[int]  # None si SIN_PLAZO; negativo si VENCIDO
 
 
+_SIN_PLAZO = EstadoPlazo(
+    estado='SIN_PLAZO',
+    efecto='NINGUNO',
+    fecha_limite=None,
+    dias_restantes=None,
+)
+
+
+# ---------------------------------------------------------------------------
+# API pública
+# ---------------------------------------------------------------------------
+
 def obtener_estado_plazo(elemento, tipo_elemento: str) -> EstadoPlazo:
     """
     Devuelve el estado del plazo legal asociado a un elemento ESFTT.
@@ -39,24 +64,216 @@ def obtener_estado_plazo(elemento, tipo_elemento: str) -> EstadoPlazo:
     Args:
         elemento:      Instancia ORM del elemento evaluado
                        (Solicitud, Fase, Tramite o Tarea).
+                       None o dict → SIN_PLAZO sin consultar BD.
         tipo_elemento: Literal del tipo: 'SOLICITUD' | 'FASE' | 'TRAMITE' | 'TAREA'.
 
     Returns:
         EstadoPlazo con estado, efecto, fecha_limite y dias_restantes.
-
-    Stub (#190 Fase 2):
-        Siempre devuelve SIN_PLAZO/NINGUNO. Seguro: no bloquea ningún flujo.
-
-    M3 (#172):
-        1. Buscar en catalogo_plazos el plazo aplicable a (tipo_elemento, tipo_elemento_id).
-        2. Resolver campo_fecha JSONB → Documento.fecha_administrativa.
-        3. calcular_fecha_fin(fecha_administrativa, plazo, dias_inhabiles, suspensiones).
-        4. Derivar estado según (fecha_limite, hoy(), umbral_alerta=5 días hábiles).
-        5. Leer efecto_vencimiento del catalogo_plazos.
     """
-    return EstadoPlazo(
-        estado='SIN_PLAZO',
-        efecto='NINGUNO',
-        fecha_limite=None,
-        dias_restantes=None,
+    if elemento is None or isinstance(elemento, dict):
+        return _SIN_PLAZO
+
+    tipo_elemento_id = _get_tipo_elemento_id(elemento, tipo_elemento)
+    if tipo_elemento_id is None:
+        return _SIN_PLAZO
+
+    from app.models.catalogo_plazos import CatalogoPlazo
+    catalogo = CatalogoPlazo.query.filter_by(
+        tipo_elemento=tipo_elemento,
+        tipo_elemento_id=tipo_elemento_id,
+        activo=True,
+    ).first()
+
+    if catalogo is None:
+        return _SIN_PLAZO
+
+    fecha_acto = _resolver_campo_fecha(elemento, tipo_elemento, catalogo.campo_fecha or {})
+    if fecha_acto is None:
+        return _SIN_PLAZO
+
+    hoy = _hoy()
+    margen_dias = max(catalogo.plazo_valor * 60, 400)
+    inhabiles = _obtener_inhabiles_bd(fecha_acto, hoy + timedelta(days=margen_dias))
+
+    suspensiones = _obtener_suspensiones(elemento)
+    fecha_limite = _aplicar_suspensiones(
+        calcular_fecha_fin(fecha_acto, catalogo.plazo_valor, catalogo.plazo_unidad, inhabiles),
+        suspensiones,
+        inhabiles,
     )
+
+    efecto = catalogo.efecto_plazo.codigo if catalogo.efecto_plazo else 'SIN_EFECTO_AUTOMATICO'
+
+    if hoy > fecha_limite:
+        dias = -_dias_habiles_entre(fecha_limite + timedelta(days=1), hoy, inhabiles)
+        return EstadoPlazo(estado='VENCIDO', efecto=efecto,
+                           fecha_limite=fecha_limite, dias_restantes=dias)
+
+    dias = _dias_habiles_entre(hoy, fecha_limite, inhabiles)
+    if dias <= UMBRAL_ALERTA:
+        return EstadoPlazo(estado='PROXIMO_VENCER', efecto=efecto,
+                           fecha_limite=fecha_limite, dias_restantes=dias)
+
+    return EstadoPlazo(estado='EN_PLAZO', efecto=efecto,
+                       fecha_limite=fecha_limite, dias_restantes=dias)
+
+
+# ---------------------------------------------------------------------------
+# Cómputo de plazos — funciones puras (testables sin BD)
+# ---------------------------------------------------------------------------
+
+def calcular_fecha_fin(
+    fecha_acto: date,
+    plazo_valor: int,
+    plazo_unidad: str,
+    inhabiles: frozenset,
+) -> date:
+    """
+    Calcula la fecha límite (último día hábil inclusive) dado el acto y el plazo.
+
+    Art. 30 LPACAP:
+    - El cómputo empieza el día siguiente al acto (art. 30.1).
+    - DIAS_HABILES: suma plazo_valor días saltando fines de semana e inhábiles.
+      El último día es siempre hábil por construcción (art. 30.2).
+    - DIAS_NATURALES: suma plazo_valor días naturales; si cae en inhábil,
+      prorroga al primer hábil siguiente (art. 30.5).
+    - MESES: mismo día ordinal en el mes de vencimiento (art. 30.4).
+      Si ese día no existe → último día del mes. Prorroga si inhábil (art. 30.5).
+    - ANOS: mismo día y mes en el año de vencimiento. Prorroga si inhábil (art. 30.5).
+
+    Args:
+        fecha_acto:  Fecha del acto administrativo que inicia el cómputo.
+        plazo_valor: Valor numérico del plazo.
+        plazo_unidad: 'DIAS_HABILES' | 'DIAS_NATURALES' | 'MESES' | 'ANOS'.
+        inhabiles:   Conjunto de fechas inhábiles (festivos de calendario).
+    """
+    if plazo_unidad == 'DIAS_HABILES':
+        cursor = fecha_acto
+        dias = 0
+        while dias < plazo_valor:
+            cursor += timedelta(days=1)
+            if _es_habil(cursor, inhabiles):
+                dias += 1
+        return cursor
+
+    if plazo_unidad == 'DIAS_NATURALES':
+        return _primer_habil_desde(fecha_acto + timedelta(days=plazo_valor), inhabiles)
+
+    if plazo_unidad == 'MESES':
+        total_meses = fecha_acto.month - 1 + plazo_valor
+        año_dest = fecha_acto.year + total_meses // 12
+        mes_dest = total_meses % 12 + 1
+        dia_dest = min(fecha_acto.day, calendar.monthrange(año_dest, mes_dest)[1])
+        return _primer_habil_desde(date(año_dest, mes_dest, dia_dest), inhabiles)
+
+    if plazo_unidad == 'ANOS':
+        año_dest = fecha_acto.year + plazo_valor
+        dia_dest = min(fecha_acto.day, calendar.monthrange(año_dest, fecha_acto.month)[1])
+        return _primer_habil_desde(date(año_dest, fecha_acto.month, dia_dest), inhabiles)
+
+    raise ValueError(f'plazo_unidad desconocida: {plazo_unidad!r}')
+
+
+# ---------------------------------------------------------------------------
+# Utilidades internas
+# ---------------------------------------------------------------------------
+
+def _es_habil(fecha: date, inhabiles: frozenset) -> bool:
+    return fecha.weekday() < 5 and fecha not in inhabiles
+
+
+def _primer_habil_desde(fecha: date, inhabiles: frozenset) -> date:
+    """Art. 30.5: si el último día cae en inhábil, prorroga al primer hábil siguiente."""
+    while not _es_habil(fecha, inhabiles):
+        fecha += timedelta(days=1)
+    return fecha
+
+
+def _dias_habiles_entre(fecha_ini: date, fecha_fin: date, inhabiles: frozenset) -> int:
+    """Cuenta días hábiles en [fecha_ini, fecha_fin] ambos inclusive."""
+    if fecha_fin < fecha_ini:
+        return 0
+    cursor = fecha_ini
+    cuenta = 0
+    while cursor <= fecha_fin:
+        if _es_habil(cursor, inhabiles):
+            cuenta += 1
+        cursor += timedelta(days=1)
+    return cuenta
+
+
+def _get_tipo_elemento_id(elemento, tipo_elemento: str) -> Optional[int]:
+    campo = _TIPO_ID_CAMPO.get(tipo_elemento)
+    return getattr(elemento, campo, None) if campo else None
+
+
+def _resolver_campo_fecha(elemento, tipo_elemento: str, campo_fecha: dict) -> Optional[date]:
+    """Resuelve campo_fecha JSONB → Documento.fecha_administrativa.
+
+    Navega el ORM según el JSON configurado en catalogo_plazos:
+      {'fk': 'documento_resultado_id'}             → elemento.documento_resultado
+      {'via_tarea_tipo': 'T', 'fk': 'doc_id'}     → tarea hija tipo T → rel
+    Para FASE con 'documento_solicitud_id': navega vía fase.solicitud.
+    """
+    fk_col = campo_fecha.get('fk', '')
+    via_tarea_tipo = campo_fecha.get('via_tarea_tipo')
+
+    obj = elemento
+
+    if via_tarea_tipo:
+        tareas = getattr(obj, 'tareas', None) or []
+        obj = next(
+            (t for t in tareas
+             if getattr(getattr(t, 'tipo_tarea', None), 'codigo', None) == via_tarea_tipo),
+            None,
+        )
+        if obj is None:
+            return None
+
+    rel_name = fk_col[:-3] if fk_col.endswith('_id') else fk_col
+
+    doc = getattr(obj, rel_name, None)
+
+    if doc is None and tipo_elemento == 'FASE' and not via_tarea_tipo:
+        solicitud = getattr(obj, 'solicitud', None)
+        doc = getattr(solicitud, rel_name, None) if solicitud else None
+
+    if doc is None:
+        return None
+    return getattr(doc, 'fecha_administrativa', None)
+
+
+def _hoy() -> date:
+    return date.today()
+
+
+def _obtener_inhabiles_bd(fecha_ini: date, fecha_fin: date) -> frozenset:
+    """Carga fechas inhábiles del calendario BD en el rango dado."""
+    from app.models.dias_inhabiles import DiaInhabil
+    registros = DiaInhabil.query.filter(
+        DiaInhabil.fecha >= fecha_ini,
+        DiaInhabil.fecha <= fecha_fin,
+    ).all()
+    return frozenset(r.fecha for r in registros)
+
+
+def _obtener_suspensiones(elemento) -> list:
+    """Hook de suspensiones — stub hasta #173."""
+    return []
+
+
+def _aplicar_suspensiones(fecha_limite: date, suspensiones: list, inhabiles: frozenset) -> date:
+    """Suma los días de suspensión al plazo (art. 22 LPACAP). Stub hasta #173."""
+    if not suspensiones:
+        return fecha_limite
+    dias_suspension = sum(
+        _dias_habiles_entre(s['fecha_inicio'], s['fecha_fin'], inhabiles)
+        for s in suspensiones
+    )
+    cursor = fecha_limite
+    dias = 0
+    while dias < dias_suspension:
+        cursor += timedelta(days=1)
+        if _es_habil(cursor, inhabiles):
+            dias += 1
+    return cursor

--- a/migrations/versions/c9379e09ae01_172_plazos_tablas_catalogo.py
+++ b/migrations/versions/c9379e09ae01_172_plazos_tablas_catalogo.py
@@ -1,0 +1,192 @@
+"""172_plazos_tablas_catalogo
+
+Revision ID: c9379e09ae01
+Revises: bc4a9f1d8e02
+Create Date: 2026-04-28
+
+Cuatro tablas nuevas para el cómputo de plazos administrativos (#172):
+  - efectos_plazo       — catálogo de efectos del vencimiento
+  - ambitos_inhabilidad — ámbito territorial del calendario de inhábiles
+  - dias_inhabiles      — calendario de festivos (PK compuesta fecha+ambito)
+  - catalogo_plazos     — plazo legal por tipo de elemento ESFTT
+
+Seeds incluidos:
+  - efectos_plazo completo (10 efectos, DISEÑO_FECHAS_PLAZOS.md §2.4)
+  - ambitos_inhabilidad (NACIONAL, AUTONOMICO_AND)
+  - dias_inhabiles: festivos nacionales + andaluces 2025-2026 (días laborables)
+  - catalogo_plazos: fases RESOLUCION_* sin [PENDIENTE] (§5.2 RD 1955/2000)
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = 'c9379e09ae01'
+down_revision = 'bc4a9f1d8e02'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ------------------------------------------------------------------
+    # A. efectos_plazo — catálogo maestro (sin dependencias)
+    # ------------------------------------------------------------------
+    op.create_table(
+        'efectos_plazo',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('codigo', sa.String(60), nullable=False,
+                  comment='Código único: NINGUNO | SILENCIO_ESTIMATORIO | ...'),
+        sa.Column('nombre', sa.String(200), nullable=False,
+                  comment='Descripción legible del efecto'),
+        sa.UniqueConstraint('codigo', name='uq_efectos_plazo_codigo'),
+        schema='public',
+    )
+
+    op.execute(
+        "INSERT INTO public.efectos_plazo (codigo, nombre) VALUES "
+        "('NINGUNO', 'Sin efecto de plazo'), "
+        "('SILENCIO_ESTIMATORIO', 'Silencio administrativo estimatorio'), "
+        "('RESPONSABILIDAD_DISCIPLINARIA', 'Responsabilidad disciplinaria del funcionario'), "
+        "('SILENCIO_DESESTIMATORIO', 'Silencio administrativo desestimatorio'), "
+        "('CADUCIDAD_PROCEDIMIENTO', 'Caducidad del procedimiento por inactividad del interesado'), "
+        "('PERDIDA_TRAMITE', 'Pérdida de trámite no indispensable'), "
+        "('APERTURA_RECURSO', 'Apertura de la vía impugnatoria'), "
+        "('PRESCRIPCION_CONDICIONADO', 'Prescripción del derecho condicionado por resolución propia'), "
+        "('CONFORMIDAD_PRESUNTA', 'Conformidad presunta del organismo consultado'), "
+        "('SIN_EFECTO_AUTOMATICO', 'Plazo de trámite interno sin consecuencia legal directa')"
+    )
+
+    # ------------------------------------------------------------------
+    # B. ambitos_inhabilidad — catálogo de ámbitos territoriales
+    # ------------------------------------------------------------------
+    op.create_table(
+        'ambitos_inhabilidad',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('codigo', sa.String(40), nullable=False,
+                  comment='Código: NACIONAL | AUTONOMICO_AND | PROVINCIAL_CAD | ...'),
+        sa.Column('nombre', sa.String(200), nullable=False,
+                  comment='Nombre legible del ámbito territorial'),
+        sa.UniqueConstraint('codigo', name='uq_ambitos_inhabilidad_codigo'),
+        schema='public',
+    )
+
+    op.execute(
+        "INSERT INTO public.ambitos_inhabilidad (codigo, nombre) VALUES "
+        "('NACIONAL', 'Festivos nacionales (BOE)'), "
+        "('AUTONOMICO_AND', 'Festivos autonómicos de Andalucía (BOJA)')"
+    )
+
+    # ------------------------------------------------------------------
+    # C. dias_inhabiles — calendario de festivos
+    # ------------------------------------------------------------------
+    op.create_table(
+        'dias_inhabiles',
+        sa.Column('fecha', sa.Date, nullable=False,
+                  comment='Fecha inhábil'),
+        sa.Column('descripcion', sa.String(200), nullable=True,
+                  comment='Denominación del festivo'),
+        sa.Column('ambito_id', sa.Integer, nullable=False,
+                  comment='FK al ámbito territorial'),
+        sa.ForeignKeyConstraint(
+            ['ambito_id'], ['public.ambitos_inhabilidad.id'],
+            name='fk_dias_inhabiles_ambito', ondelete='RESTRICT',
+        ),
+        sa.PrimaryKeyConstraint('fecha', 'ambito_id', name='pk_dias_inhabiles'),
+        sa.Index('idx_dias_inhabiles_fecha', 'fecha'),
+        schema='public',
+    )
+
+    op.execute("""
+        INSERT INTO public.dias_inhabiles (fecha, descripcion, ambito_id)
+        SELECT d.fecha, d.descripcion, a.id
+        FROM (VALUES
+            ('2025-01-01'::date, 'Año Nuevo',                   'NACIONAL'),
+            ('2025-01-06'::date, 'Epifanía del Señor',          'NACIONAL'),
+            ('2025-04-17'::date, 'Jueves Santo',                'NACIONAL'),
+            ('2025-04-18'::date, 'Viernes Santo',               'NACIONAL'),
+            ('2025-05-01'::date, 'Fiesta del Trabajo',          'NACIONAL'),
+            ('2025-08-15'::date, 'Asunción de la Virgen',       'NACIONAL'),
+            ('2025-12-08'::date, 'Inmaculada Concepción',       'NACIONAL'),
+            ('2025-12-25'::date, 'Natividad del Señor',         'NACIONAL'),
+            ('2026-01-01'::date, 'Año Nuevo',                   'NACIONAL'),
+            ('2026-01-06'::date, 'Epifanía del Señor',          'NACIONAL'),
+            ('2026-04-02'::date, 'Jueves Santo',                'NACIONAL'),
+            ('2026-04-03'::date, 'Viernes Santo',               'NACIONAL'),
+            ('2026-05-01'::date, 'Fiesta del Trabajo',          'NACIONAL'),
+            ('2026-10-12'::date, 'Día de la Hispanidad',        'NACIONAL'),
+            ('2026-12-08'::date, 'Inmaculada Concepción',       'NACIONAL'),
+            ('2026-12-25'::date, 'Natividad del Señor',         'NACIONAL'),
+            ('2025-02-28'::date, 'Día de Andalucía',            'AUTONOMICO_AND'),
+            ('2025-04-21'::date, 'Lunes de Pascua',             'AUTONOMICO_AND'),
+            ('2026-04-06'::date, 'Lunes de Pascua',             'AUTONOMICO_AND')
+        ) AS d(fecha, descripcion, ambito_codigo)
+        JOIN public.ambitos_inhabilidad a ON a.codigo = d.ambito_codigo
+    """)
+
+    # ------------------------------------------------------------------
+    # D. catalogo_plazos — plazos legales por tipo ESFTT
+    # ------------------------------------------------------------------
+    op.create_table(
+        'catalogo_plazos',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('tipo_elemento', sa.String(20), nullable=False,
+                  comment='SOLICITUD | FASE | TRAMITE | TAREA'),
+        sa.Column('tipo_elemento_id', sa.Integer, nullable=False,
+                  comment='ID en tipos_* correspondiente (FK polimórfica sin constraint BD)'),
+        sa.Column('campo_fecha', JSONB, nullable=True,
+                  comment='Referencia al Documento.fecha_administrativa de inicio'),
+        sa.Column('plazo_valor', sa.Integer, nullable=False,
+                  comment='Valor numérico del plazo'),
+        sa.Column('plazo_unidad', sa.String(20), nullable=False,
+                  comment='DIAS_HABILES | DIAS_NATURALES | MESES | ANOS'),
+        sa.Column('efecto_vencimiento_id', sa.Integer, nullable=False,
+                  comment='FK a efectos_plazo'),
+        sa.Column('norma_origen', sa.Text, nullable=True,
+                  comment='Cita de la norma que fija el plazo'),
+        sa.Column('vigencia_desde', sa.Date, nullable=True,
+                  comment='Inicio de vigencia. NULL = desde siempre'),
+        sa.Column('vigencia_hasta', sa.Date, nullable=True,
+                  comment='Fin de vigencia. NULL = indefinido'),
+        sa.Column('activo', sa.Boolean, nullable=False,
+                  server_default='TRUE',
+                  comment='FALSE para entradas desactivadas sin borrar'),
+        sa.ForeignKeyConstraint(
+            ['efecto_vencimiento_id'], ['public.efectos_plazo.id'],
+            name='fk_catalogo_plazos_efecto', ondelete='RESTRICT',
+        ),
+        sa.Index('idx_catalogo_plazos_tipo_elem', 'tipo_elemento', 'tipo_elemento_id'),
+        schema='public',
+    )
+
+    op.execute("""
+        INSERT INTO public.catalogo_plazos
+            (tipo_elemento, tipo_elemento_id, campo_fecha, plazo_valor,
+             plazo_unidad, efecto_vencimiento_id, norma_origen, activo)
+        SELECT
+            'FASE',
+            tf.id,
+            '{"fk": "documento_solicitud_id"}'::jsonb,
+            plazos.valor,
+            'MESES',
+            ep.id,
+            plazos.norma,
+            TRUE
+        FROM (VALUES
+            ('RESOLUCION_AAP',          3, 'Art. 128 RD 1955/2000'),
+            ('RESOLUCION_AAC',          3, 'Art. 131.7 RD 1955/2000'),
+            ('RESOLUCION_AE',           1, 'Art. 132 RD 1955/2000 + DA 3a LSE'),
+            ('RESOLUCION_AE_PROVISIONAL', 1, 'Art. 132 bis RD 1955/2000 + DA 3a LSE'),
+            ('RESOLUCION_AE_DEFINITIVA',  1, 'Art. 132 ter RD 1955/2000 + DA 3a LSE'),
+            ('RESOLUCION_TRANSMISION',  3, 'Art. 133 RD 1955/2000'),
+            ('RESOLUCION_CIERRE',       3, 'Art. 137 RD 1955/2000')
+        ) AS plazos(codigo, valor, norma)
+        JOIN public.tipos_fases tf ON tf.codigo = plazos.codigo
+        CROSS JOIN public.efectos_plazo ep
+        WHERE ep.codigo = 'SILENCIO_DESESTIMATORIO'
+    """)
+
+
+def downgrade():
+    op.drop_table('catalogo_plazos', schema='public')
+    op.drop_table('dias_inhabiles', schema='public')
+    op.drop_table('ambitos_inhabilidad', schema='public')
+    op.drop_table('efectos_plazo', schema='public')

--- a/tests/test_172_plazos_computo.py
+++ b/tests/test_172_plazos_computo.py
@@ -1,0 +1,288 @@
+"""
+Tests issue #172 — algoritmo de cómputo de plazos y obtener_estado_plazo.
+
+Bloques:
+  A) calcular_fecha_fin    — función pura, sin BD ni app context.
+  B) obtener_estado_plazo  — cuatro estados; BD y fecha.today() mockeados.
+"""
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixture: festivos nacionales + andaluces 2025-2026 (sólo días laborables)
+# ---------------------------------------------------------------------------
+
+INHABILES = frozenset({
+    date(2025, 1, 1),   date(2025, 1, 6),
+    date(2025, 2, 28),  date(2025, 4, 17), date(2025, 4, 18), date(2025, 4, 21),
+    date(2025, 5, 1),   date(2025, 8, 15),
+    date(2025, 12, 8),  date(2025, 12, 25),
+    date(2026, 1, 1),   date(2026, 1, 6),
+    date(2026, 4, 2),   date(2026, 4, 3),  date(2026, 4, 6),
+    date(2026, 5, 1),   date(2026, 10, 12),
+    date(2026, 12, 8),  date(2026, 12, 25),
+})
+
+
+# ---------------------------------------------------------------------------
+# A) Tests unitarios de calcular_fecha_fin — sin BD
+# ---------------------------------------------------------------------------
+
+class TestCalcularFechaFinDiasHabiles:
+
+    def test_basico_sin_inhabiles(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 6, 2),   # lunes
+            5, 'DIAS_HABILES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 6, 9)  # lunes siguiente (5 hábiles: mar-vie + lunes)
+
+    def test_salta_fin_de_semana(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 6, 6),   # viernes
+            3, 'DIAS_HABILES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 6, 11)  # mié (7=sáb, 8=dom, 9=lun, 10=mar, 11=mié)
+
+    def test_salta_festivo_en_mitad(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 4, 16),   # miércoles (día anterior a Jueves Santo 2025)
+            5, 'DIAS_HABILES', INHABILES,
+        )
+        # Inhabiles: jue 17 + vie 18 + sáb 19 + dom 20 + lun 21 (Lunes Pascua AND)
+        # Cómputo arranca jue 17 (inhábil) → vie 18 (inhábil) → lun 21 (inhábil AND)
+        # Día 1=mar 22, 2=mié 23, 3=jue 24, 4=vie 25, 5=lun 28
+        assert fecha_limite == date(2025, 4, 28)
+
+    def test_resultado_siempre_habil(self):
+        from app.services.plazos import calcular_fecha_fin, _es_habil
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 6, 2), 10, 'DIAS_HABILES', INHABILES,
+        )
+        assert _es_habil(fecha_limite, INHABILES)
+
+
+class TestCalcularFechaFinDiasNaturales:
+
+    def test_basico_sin_inhabiles(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 6, 1),   # domingo
+            30, 'DIAS_NATURALES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 7, 1)  # 1 jul = martes → hábil ✓
+
+    def test_prorroga_art30_5_si_cae_sabado(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 6, 3),   # martes: +4 días = sábado 7
+            4, 'DIAS_NATURALES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 6, 9)  # sáb 7 inhábil → dom 8 inhábil → lun 9
+
+    def test_prorroga_sobre_festivo(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 4, 30),   # miércoles: +1 día = 1 mayo (festivo)
+            1, 'DIAS_NATURALES', INHABILES,
+        )
+        assert fecha_limite == date(2025, 5, 2)  # 1 mayo inhábil → 2 mayo (viernes)
+
+
+class TestCalcularFechaFinMeses:
+
+    def test_basico(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 1, 10),   # viernes; 3 meses = 10 abr 2025 (jueves, hábil)
+            3, 'MESES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 4, 10)
+
+    def test_ultimo_dia_mes_cuando_no_existe(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 1, 31),
+            1, 'MESES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 2, 28)  # feb no tiene día 31
+
+    def test_cruza_anyo(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 11, 6),
+            3, 'MESES', frozenset(),
+        )
+        assert fecha_limite == date(2026, 2, 6)
+
+    def test_prorroga_art30_5(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 5, 4),   # domingo; 3 meses = 4 ago (lunes) ← sin inhabiles → hábil
+            3, 'MESES', frozenset(),
+        )
+        assert fecha_limite == date(2025, 8, 4)
+
+    def test_prorroga_sobre_festivo_agosto(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 5, 15),   # 3 meses = 15 ago 2025 (festivo nacional)
+            3, 'MESES', INHABILES,
+        )
+        assert fecha_limite == date(2025, 8, 18)  # 15=festivo, 16=sáb, 17=dom, 18=lun
+
+
+class TestCalcularFechaFinAnos:
+
+    def test_basico(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 3, 17),   # lunes; +1 año = 17 mar 2026 (martes, hábil)
+            1, 'ANOS', frozenset(),
+        )
+        assert fecha_limite == date(2026, 3, 17)
+
+    def test_bisiesto_29_feb(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2024, 2, 29),   # año bisiesto; +1 año → 2025 no tiene 29 feb
+            1, 'ANOS', frozenset(),
+        )
+        assert fecha_limite == date(2025, 2, 28)
+
+    def test_prorroga_art30_5(self):
+        from app.services.plazos import calcular_fecha_fin
+        fecha_limite = calcular_fecha_fin(
+            date(2025, 1, 25),   # +1 año = 25 ene 2026 (domingo)
+            1, 'ANOS', frozenset(),
+        )
+        assert fecha_limite == date(2026, 1, 26)   # lunes siguiente
+
+
+# ---------------------------------------------------------------------------
+# Helpers para tests de obtener_estado_plazo
+# ---------------------------------------------------------------------------
+
+HOY = date(2025, 6, 2)   # lunes fijo para todos los tests de estado
+
+
+def _mock_catalogo(plazo_valor, plazo_unidad, campo_fecha, efecto_codigo):
+    m = MagicMock()
+    m.plazo_valor = plazo_valor
+    m.plazo_unidad = plazo_unidad
+    m.campo_fecha = campo_fecha
+    m.efecto_plazo.codigo = efecto_codigo
+    return m
+
+
+def _mock_fase(tipo_fase_id, fecha_administrativa):
+    """Fase mínima con tipo_fase_id y documento_resultado.fecha_administrativa."""
+    fase = MagicMock()
+    fase.tipo_fase_id = tipo_fase_id
+    doc = MagicMock()
+    doc.fecha_administrativa = fecha_administrativa
+    fase.documento_resultado = doc
+    return fase
+
+
+# ---------------------------------------------------------------------------
+# B) Tests de obtener_estado_plazo — BD y today() mockeados
+# ---------------------------------------------------------------------------
+
+class TestObtenerEstadoPlazoSinPlazo:
+
+    def test_elemento_none(self):
+        from app.services.plazos import obtener_estado_plazo
+        r = obtener_estado_plazo(None, 'FASE')
+        assert r.estado == 'SIN_PLAZO'
+        assert r.efecto == 'NINGUNO'
+        assert r.fecha_limite is None
+        assert r.dias_restantes is None
+
+    def test_elemento_dict(self):
+        from app.services.plazos import obtener_estado_plazo
+        r = obtener_estado_plazo({'tipo_fase': MagicMock()}, 'FASE')
+        assert r.estado == 'SIN_PLAZO'
+
+    def test_sin_tipo_elemento_id(self):
+        from app.services.plazos import obtener_estado_plazo
+        r = obtener_estado_plazo(object(), 'FASE')
+        assert r.estado == 'SIN_PLAZO'
+
+    def test_sin_entrada_catalogo(self):
+        from app.services.plazos import obtener_estado_plazo
+        fase = _mock_fase(tipo_fase_id=999, fecha_administrativa=date(2025, 1, 1))
+        with patch('app.models.catalogo_plazos.CatalogoPlazo') as mock_cp:
+            mock_cp.query.filter_by.return_value.first.return_value = None
+            r = obtener_estado_plazo(fase, 'FASE')
+        assert r.estado == 'SIN_PLAZO'
+
+    def test_sin_fecha_acto(self):
+        from app.services.plazos import obtener_estado_plazo
+        fase = MagicMock()
+        fase.tipo_fase_id = 1
+        fase.documento_resultado = None
+        fase.solicitud = None   # evitar que el fallback FASE genere un MagicMock auto
+        catalogo = _mock_catalogo(20, 'DIAS_HABILES', {'fk': 'documento_resultado_id'}, 'SILENCIO_DESESTIMATORIO')
+        with patch('app.models.catalogo_plazos.CatalogoPlazo') as mock_cp:
+            mock_cp.query.filter_by.return_value.first.return_value = catalogo
+            r = obtener_estado_plazo(fase, 'FASE')
+        assert r.estado == 'SIN_PLAZO'
+
+
+class TestObtenerEstadoPlazoEnPlazo:
+
+    def test_en_plazo(self):
+        """fecha_acto=12 may → 20 hábiles → 9 jun; hoy=2 jun; dias=6 > 5 → EN_PLAZO"""
+        from app.services.plazos import obtener_estado_plazo
+        fase = _mock_fase(tipo_fase_id=1, fecha_administrativa=date(2025, 5, 12))
+        catalogo = _mock_catalogo(20, 'DIAS_HABILES', {'fk': 'documento_resultado_id'}, 'SILENCIO_DESESTIMATORIO')
+        with (patch('app.services.plazos._hoy', return_value=HOY),
+              patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()),
+              patch('app.models.catalogo_plazos.CatalogoPlazo') as mock_cp):
+            mock_cp.query.filter_by.return_value.first.return_value = catalogo
+            r = obtener_estado_plazo(fase, 'FASE')
+        assert r.estado == 'EN_PLAZO'
+        assert r.efecto == 'SILENCIO_DESESTIMATORIO'
+        assert r.fecha_limite == date(2025, 6, 9)
+        assert r.dias_restantes == 6
+
+
+class TestObtenerEstadoPlazoProximoVencer:
+
+    def test_proximo_vencer(self):
+        """fecha_acto=9 may → 20 hábiles → 6 jun; hoy=2 jun; dias=5 ≤ 5 → PROXIMO_VENCER"""
+        from app.services.plazos import obtener_estado_plazo
+        fase = _mock_fase(tipo_fase_id=2, fecha_administrativa=date(2025, 5, 9))
+        catalogo = _mock_catalogo(20, 'DIAS_HABILES', {'fk': 'documento_resultado_id'}, 'RESPONSABILIDAD_DISCIPLINARIA')
+        with (patch('app.services.plazos._hoy', return_value=HOY),
+              patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()),
+              patch('app.models.catalogo_plazos.CatalogoPlazo') as mock_cp):
+            mock_cp.query.filter_by.return_value.first.return_value = catalogo
+            r = obtener_estado_plazo(fase, 'FASE')
+        assert r.estado == 'PROXIMO_VENCER'
+        assert r.efecto == 'RESPONSABILIDAD_DISCIPLINARIA'
+        assert r.fecha_limite == date(2025, 6, 6)
+        assert r.dias_restantes == 5
+
+
+class TestObtenerEstadoPlazoVencido:
+
+    def test_vencido(self):
+        """fecha_acto=16 may → 10 hábiles → 30 may; hoy=2 jun > 30 may → VENCIDO"""
+        from app.services.plazos import obtener_estado_plazo
+        fase = _mock_fase(tipo_fase_id=3, fecha_administrativa=date(2025, 5, 16))
+        catalogo = _mock_catalogo(10, 'DIAS_HABILES', {'fk': 'documento_resultado_id'}, 'SILENCIO_ESTIMATORIO')
+        with (patch('app.services.plazos._hoy', return_value=HOY),
+              patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()),
+              patch('app.models.catalogo_plazos.CatalogoPlazo') as mock_cp):
+            mock_cp.query.filter_by.return_value.first.return_value = catalogo
+            r = obtener_estado_plazo(fase, 'FASE')
+        assert r.estado == 'VENCIDO'
+        assert r.efecto == 'SILENCIO_ESTIMATORIO'
+        assert r.fecha_limite == date(2025, 5, 30)
+        assert r.dias_restantes == -1   # 1 día hábil de retraso (lun 2 jun)


### PR DESCRIPTION
## Cambios

- **Migración `c9379e09ae01`** — 4 tablas nuevas: `efectos_plazo` (10 efectos vencimiento), `ambitos_inhabilidad` (NACIONAL + AUTONOMICO_AND), `dias_inhabiles` (19 festivos 2025-2026), `catalogo_plazos` (plazos por tipo ESFTT con `campo_fecha` JSONB)
- **4 modelos ORM**: `EfectoPlazo`, `AmbitoInhabilidad`, `DiaInhabil`, `CatalogoPlazo`
- **`app/services/plazos.py`** — lógica real (sustituye stub de #190):
  - `calcular_fecha_fin`: art. 30 LPACAP para DIAS_HABILES, DIAS_NATURALES, MESES, ANOS con prórroga art. 30.5
  - `_resolver_campo_fecha`: resuelve JSONB → `Documento.fecha_administrativa` (incl. `via_tarea_tipo` para ESPERAR_PLAZO)
  - `_obtener_inhabiles_bd`: carga calendario desde BD
  - `_obtener_suspensiones`: stub hasta #173; `_aplicar_suspensiones` preparada
- **23 tests unitarios**: `calcular_fecha_fin` (15 casos — básico, fin de semana, festivo, último día mes, bisiesto) + `obtener_estado_plazo` (8 casos — SIN_PLAZO ×5, EN_PLAZO, PROXIMO_VENCER, VENCIDO); sin BD ni app context

Closes #172
