### PR TITLE
Defensividad del backend ante catálogo ausente o BD no disponible

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,11 +7,15 @@ Responsabilidades:
 - Configuración de Jinja2
 - Manejo de errores HTTP
 """
-from flask import Flask, render_template, request
+import logging
+
+from flask import Flask, jsonify, render_template, request
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_login import LoginManager, current_user
 from app.config import config
+
+log = logging.getLogger(__name__)
 
 # Instancias de extensiones (sin vincular a app aún)
 db = SQLAlchemy()
@@ -41,6 +45,11 @@ def create_app(config_name='development'):
     db.init_app(app)
     migrate.init_app(app, db)
     login_manager.init_app(app)
+
+    # Validar catálogo estructural al arranque (#347)
+    with app.app_context():
+        from app.checks.catalogo_requerido import validar_catalogo
+        validar_catalogo()
 
     # Configuración de Flask-Login
     login_manager.login_view = 'auth.login'
@@ -170,5 +179,24 @@ def create_app(config_name='development'):
     def internal_error(error):
         db.session.rollback()
         return render_template('errors/500.html'), 500
+
+    # Manejadores de errores de infraestructura (#347)
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
+    @app.errorhandler(OperationalError)
+    def handle_db_operational(exc):
+        db.session.rollback()
+        log.error('BD no disponible: %s', exc)
+        if request.path.startswith('/api/'):
+            return jsonify({'error': 'Servicio de base de datos no disponible', 'code': 'DB_ERROR'}), 503
+        return render_template('errors/500.html'), 503
+
+    @app.errorhandler(ProgrammingError)
+    def handle_db_programming(exc):
+        db.session.rollback()
+        log.error('Error de esquema de BD: %s', exc)
+        if request.path.startswith('/api/'):
+            return jsonify({'error': 'Servicio de base de datos no disponible', 'code': 'DB_ERROR'}), 503
+        return render_template('errors/500.html'), 503
 
     return app

--- a/app/checks/catalogo_requerido.py
+++ b/app/checks/catalogo_requerido.py
@@ -1,0 +1,107 @@
+"""Manifiesto de registros estructurales requeridos en tablas de catálogo (#347).
+
+validar_catalogo() es la única fuente de verdad de qué códigos deben existir
+para que el sistema funcione. Llamar desde create_app() tras db.init_app().
+"""
+from __future__ import annotations
+
+import logging
+from typing import List
+
+log = logging.getLogger(__name__)
+
+# Mapa modelo → lista de códigos que el código fuente espera encontrar.
+# Añadir aquí cuando se use un código nuevo en cualquier servicio o ruta.
+REGISTROS_REQUERIDOS: dict = {
+    'TipoTramite': [
+        'AAC', 'AAP',
+        'PUBLICACION', 'NOTIFICACION',
+        'SUBSANACION', 'AUDIENCIA',
+        'ADMISIBILIDAD_TECNICA',
+        'INFORME_AAPP', 'INFORME_SERVICIOS',
+    ],
+    'TipoTarea': [
+        'ANALIZAR', 'REDACTAR', 'FIRMAR',
+        'NOTIFICAR', 'PUBLICAR',
+        'ESPERAR_PLAZO', 'INCORPORAR',
+    ],
+    'TipoFase': [
+        'ANALISIS_SOLICITUD',
+        'CONSULTAS', 'CONSULTA_MINISTERIO',
+        'COMPATIBILIDAD_AMBIENTAL',
+        'FIGURA_AMBIENTAL_EXTERNA',
+        'AAU_AAUS_INTEGRADA',
+        'INFORMACION_PUBLICA',
+        'RESOLUCION',
+    ],
+    # TipoSolicitud usa 'siglas' como identificador estable (no 'codigo')
+    'TipoSolicitud': ['AAC', 'AAP'],
+}
+
+# Atributo del modelo que contiene el identificador estable.
+# TipoSolicitud usa 'siglas'; el resto usa 'codigo'.
+_CODIGO_ATTR: dict[str, str] = {
+    'TipoTramite':   'codigo',
+    'TipoTarea':     'codigo',
+    'TipoFase':      'codigo',
+    'TipoSolicitud': 'siglas',
+}
+
+
+def validar_catalogo() -> List[str]:
+    """
+    Comprueba que todos los códigos de REGISTROS_REQUERIDOS existen en BD.
+
+    Returns:
+        Lista de strings describiendo cada registro ausente.
+        Lista vacía → catálogo completo.
+        No lanza excepción; si la BD no está disponible loguea y devuelve lista vacía.
+    """
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
+    _MODELOS = {
+        'TipoTramite':   _importar('app.models.tipos_tramites',  'TipoTramite'),
+        'TipoTarea':     _importar('app.models.tipos_tareas',    'TipoTarea'),
+        'TipoFase':      _importar('app.models.tipos_fases',     'TipoFase'),
+        'TipoSolicitud': _importar('app.models.tipos_solicitudes', 'TipoSolicitud'),
+    }
+
+    faltantes: List[str] = []
+
+    for nombre_modelo, codigos in REGISTROS_REQUERIDOS.items():
+        modelo = _MODELOS.get(nombre_modelo)
+        if modelo is None:
+            log.error('catalogo: no se pudo importar modelo %s', nombre_modelo)
+            continue
+
+        attr = _CODIGO_ATTR.get(nombre_modelo, 'codigo')
+        try:
+            attr_col = getattr(modelo, attr)
+            existentes = {
+                getattr(row, attr)
+                for row in modelo.query.with_entities(attr_col).all()
+            }
+        except (OperationalError, ProgrammingError) as exc:
+            log.warning('catalogo: tabla de %s no disponible — %s', nombre_modelo, exc)
+            continue
+
+        for codigo in codigos:
+            if codigo not in existentes:
+                faltantes.append(f"{nombre_modelo}.codigo='{codigo}' → no encontrado")
+
+    if faltantes:
+        log.error(
+            'catalogo: faltan registros estructurales requeridos:\n%s',
+            '\n'.join(f'  - {f}' for f in faltantes),
+        )
+
+    return faltantes
+
+
+def _importar(modulo: str, clase: str):
+    try:
+        import importlib
+        mod = importlib.import_module(modulo)
+        return getattr(mod, clase, None)
+    except Exception:
+        return None

--- a/app/models/catalogo_plazos.py
+++ b/app/models/catalogo_plazos.py
@@ -30,8 +30,10 @@ class CatalogoPlazo(db.Model):
     """
     __tablename__ = 'catalogo_plazos'
     __table_args__ = (
-        db.Index('idx_catalogo_plazos_tipo_elem',  'tipo_elemento', 'tipo_elemento_id'),
-        db.Index('idx_catalogo_plazos_tipo_orden', 'tipo_elemento', 'tipo_elemento_id', 'orden'),
+        db.Index('idx_catalogo_plazos_tipo_elem',        'tipo_elemento', 'tipo_elemento_id'),
+        db.Index('idx_catalogo_plazos_tipo_orden',       'tipo_elemento', 'tipo_elemento_id', 'orden'),
+        db.Index('idx_catalogo_plazos_tipo_codigo',      'tipo_elemento', 'tipo_elemento_codigo'),
+        db.Index('idx_catalogo_plazos_tipo_codigo_orden','tipo_elemento', 'tipo_elemento_codigo', 'orden'),
         {'schema': 'public'},
     )
 
@@ -42,7 +44,11 @@ class CatalogoPlazo(db.Model):
     )
     tipo_elemento_id = db.Column(
         db.Integer, nullable=False,
-        comment='ID en tipos_solicitudes / tipos_fases / tipos_tramites / tipos_tareas (sin FK BD — polimórfico)',
+        comment='DEPRECATED — usar tipo_elemento_codigo. Se eliminará en issue posterior.',
+    )
+    tipo_elemento_codigo = db.Column(
+        db.String(60), nullable=False,
+        comment='Código estable del tipo (reemplaza tipo_elemento_id — polimorfismo seguro)',
     )
     campo_fecha = db.Column(
         JSONB, nullable=True,

--- a/app/services/plazos.py
+++ b/app/services/plazos.py
@@ -37,6 +37,23 @@ _TIPO_ID_CAMPO = {
     'TAREA':     'tipo_tarea_id',
 }
 
+# Relación ORM que expone el identificador estable del tipo (sin FK BD)
+_TIPO_REL_CAMPO = {
+    'SOLICITUD': 'tipo_solicitud',
+    'FASE':      'tipo_fase',
+    'TRAMITE':   'tipo_tramite',
+    'TAREA':     'tipo_tarea',
+}
+
+# Atributo del modelo tipo que contiene el identificador estable.
+# TipoSolicitud usa 'siglas'; el resto usa 'codigo'.
+_TIPO_CODIGO_ATTR = {
+    'SOLICITUD': 'siglas',
+    'FASE':      'codigo',
+    'TRAMITE':   'codigo',
+    'TAREA':     'codigo',
+}
+
 
 @dataclass
 class EstadoPlazo:
@@ -83,8 +100,8 @@ def obtener_estado_plazo(
     if elemento is None or isinstance(elemento, dict):
         return _SIN_PLAZO
 
-    tipo_elemento_id = _get_tipo_elemento_id(elemento, tipo_elemento)
-    if tipo_elemento_id is None:
+    tipo_codigo = _get_tipo_elemento_codigo(elemento, tipo_elemento)
+    if tipo_codigo is None:
         return _SIN_PLAZO
 
     if variables is not None:
@@ -97,7 +114,7 @@ def obtener_estado_plazo(
     else:
         variables_dict = {}
 
-    catalogo = _seleccionar_catalogo(tipo_elemento, tipo_elemento_id, variables_dict)
+    catalogo = _seleccionar_catalogo(tipo_elemento, tipo_codigo, variables_dict)
 
     if catalogo is None:
         return _SIN_PLAZO
@@ -246,9 +263,12 @@ def _evaluar_condiciones_plazo(condiciones, variables: dict) -> bool:
     return True
 
 
-def _seleccionar_catalogo(tipo_elemento: str, tipo_id: int, variables_dict: dict):
+def _seleccionar_catalogo(tipo_elemento: str, tipo_codigo: str, variables_dict: dict):
     """
     Devuelve la primera entrada activa de catalogo_plazos que supera sus condiciones.
+
+    Filtra por tipo_elemento_codigo (código estable) en lugar del ID autoincremental
+    frágil ante borrado+reinserción (#347).
 
     Algoritmo (IMPLEMENTACION_341.md §Sesión 4):
       1. Carga entradas activas con joinedload de condiciones+variable.
@@ -259,16 +279,21 @@ def _seleccionar_catalogo(tipo_elemento: str, tipo_id: int, variables_dict: dict
     """
     from app.models.catalogo_plazos import CatalogoPlazo
     from app.models.condiciones_plazo import CondicionPlazo
+    from sqlalchemy.exc import OperationalError, ProgrammingError
 
-    entradas = (
-        CatalogoPlazo.query
-        .options(
-            joinedload(CatalogoPlazo.condiciones).joinedload(CondicionPlazo.variable)
+    try:
+        entradas = (
+            CatalogoPlazo.query
+            .options(
+                joinedload(CatalogoPlazo.condiciones).joinedload(CondicionPlazo.variable)
+            )
+            .filter_by(tipo_elemento=tipo_elemento, tipo_elemento_codigo=tipo_codigo, activo=True)
+            .order_by(CatalogoPlazo.orden.asc(), CatalogoPlazo.id.asc())
+            .all()
         )
-        .filter_by(tipo_elemento=tipo_elemento, tipo_elemento_id=tipo_id, activo=True)
-        .order_by(CatalogoPlazo.orden.asc(), CatalogoPlazo.id.asc())
-        .all()
-    )
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('plazos: tabla catalogo_plazos no disponible (%s) — devolviendo SIN_PLAZO', exc)
+        return None
 
     for entrada in entradas:
         if not entrada.condiciones:
@@ -280,7 +305,7 @@ def _seleccionar_catalogo(tipo_elemento: str, tipo_id: int, variables_dict: dict
         log.warning(
             'plazos: ninguna entrada de catalogo_plazos satisface condiciones '
             'para %s/%s — se devuelve SIN_PLAZO',
-            tipo_elemento, tipo_id,
+            tipo_elemento, tipo_codigo,
         )
     return None
 
@@ -288,6 +313,15 @@ def _seleccionar_catalogo(tipo_elemento: str, tipo_id: int, variables_dict: dict
 def _get_tipo_elemento_id(elemento, tipo_elemento: str) -> Optional[int]:
     campo = _TIPO_ID_CAMPO.get(tipo_elemento)
     return getattr(elemento, campo, None) if campo else None
+
+
+def _get_tipo_elemento_codigo(elemento, tipo_elemento: str) -> Optional[str]:
+    rel_nombre = _TIPO_REL_CAMPO.get(tipo_elemento)
+    attr_nombre = _TIPO_CODIGO_ATTR.get(tipo_elemento, 'codigo')
+    if not rel_nombre:
+        return None
+    tipo_rel = getattr(elemento, rel_nombre, None)
+    return getattr(tipo_rel, attr_nombre, None) if tipo_rel else None
 
 
 def _resolver_campo_fecha(elemento, tipo_elemento: str, campo_fecha: dict) -> Optional[date]:

--- a/app/services/seguimiento.py
+++ b/app/services/seguimiento.py
@@ -25,7 +25,13 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Optional
 
+import logging
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
 from app.models.solicitudes import Solicitud
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -101,15 +107,29 @@ def estado_solicitud(solicitud_id: int) -> dict[str, Optional[EstadoPista]]:
         Dict con claves SOL, CONSULTAS, MA, IP, RES.
         None  → pista N/A (sin fases de ese tipo).
         EstadoPista → estado más urgente, con contador acumulado desde los niveles inferiores.
+        PENDIENTE_TRAMITAR en todas las pistas obligatorias si la BD no está disponible.
     """
-    sol = Solicitud.query.get(solicitud_id)
+    try:
+        sol = Solicitud.query.get(solicitud_id)
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('seguimiento: BD no disponible para solicitud %s — %s', solicitud_id, exc)
+        return {p: EstadoPista('PENDIENTE_TRAMITAR', 'rojo') for p in PISTAS_OBLIGATORIAS}
+
     if sol is None:
         raise ValueError(f'Solicitud {solicitud_id} no encontrada')
 
     result: dict[str, Optional[EstadoPista]] = {}
 
     for pista, tipos_fases in PISTAS.items():
-        fases = [f for f in sol.fases if f.tipo_fase.codigo in tipos_fases]
+        try:
+            fases = [f for f in sol.fases if f.tipo_fase.codigo in tipos_fases]
+        except (AttributeError, OperationalError, ProgrammingError) as exc:
+            log.warning('seguimiento: error accediendo a fases de pista %s — %s', pista, exc)
+            if pista in PISTAS_OBLIGATORIAS:
+                result[pista] = EstadoPista('PENDIENTE_TRAMITAR', 'rojo')
+            else:
+                result[pista] = None
+            continue
 
         if not fases:
             if pista in PISTAS_OBLIGATORIAS:
@@ -183,7 +203,11 @@ def _estado_tarea(tarea, pista: str) -> tuple[str, int]:
     if tarea.planificada:  # sin documentos asignados aún
         return ('PENDIENTE_TRAMITAR', 1)
 
-    tipo = tarea.tipo_tarea.codigo
+    tipo_rel = getattr(tarea, 'tipo_tarea', None)
+    if tipo_rel is None:
+        log.warning('seguimiento: tarea %s sin tipo_tarea — tratando como PENDIENTE_TRAMITAR', getattr(tarea, 'id', '?'))
+        return ('PENDIENTE_TRAMITAR', 1)
+    tipo = tipo_rel.codigo
 
     if tipo == 'ANALIZAR':
         if tarea.documento_usado_id is None:

--- a/docs/guias/REGLAS_DESARROLLO.md
+++ b/docs/guias/REGLAS_DESARROLLO.md
@@ -104,6 +104,31 @@ Orden de imports en `app/models/__init__.py`: primero modelos sin FKs operaciona
 
 FK format: `db.ForeignKey('public.tabla.campo')` — siempre con prefijo de schema.
 
+### Servicios con dependencias de catálogo (#347)
+
+Todo servicio que acceda a una tabla de catálogo (`TipoTramite`, `TipoTarea`, `TipoFase`, `TipoSolicitud`, `CatalogoPlazo`, etc.) debe:
+
+1. Capturar `OperationalError` / `ProgrammingError` (tabla inexistente o BD caída).
+2. Tratar resultado `None` de `.first()` / `.get()` como registro ausente.
+3. Devolver un valor degradado y loguear con `log.warning`, **sin propagar la excepción**.
+
+```python
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+def mi_servicio(elemento):
+    try:
+        resultado = MiModelo.query.filter_by(codigo='ESPERADO').first()
+        if resultado is None:
+            log.warning("Registro de catálogo 'ESPERADO' no encontrado")
+            return VALOR_DEGRADADO
+        return resultado
+    except (OperationalError, ProgrammingError):
+        log.warning("Tabla de catálogo no disponible — devolviendo valor degradado")
+        return VALOR_DEGRADADO
+```
+
+Cuando se use un código nuevo en cualquier servicio, añadirlo en `app/checks/catalogo_requerido.py` (`REGISTROS_REQUERIDOS`).
+
 ### Notificaciones
 
 `flash()` con toasts Bootstrap, categorías `success/danger/warning/info`. Nunca modales para notificaciones.

--- a/migrations/versions/347_tipo_elemento_codigo_catalogo_plazos.py
+++ b/migrations/versions/347_tipo_elemento_codigo_catalogo_plazos.py
@@ -1,0 +1,107 @@
+"""347_tipo_elemento_codigo_catalogo_plazos
+
+Revision ID: 347a0b1c2d3e
+Revises: 90655e484fb2
+Create Date: 2026-05-03
+
+Issue #347 — Fix polimorfismo en catalogo_plazos:
+  - Añade tipo_elemento_codigo (VARCHAR, NOT NULL) con backfill desde la tabla
+    de tipos referenciada. El servicio plazos.py pasa a filtrar por
+    (tipo_elemento, tipo_elemento_codigo) en lugar del ID frágil autoincremental.
+  - tipo_elemento_id se marca DEPRECATED (columna conservada hasta issue posterior).
+  - Índices actualizados para la nueva columna.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '347a0b1c2d3e'
+down_revision = '90655e484fb2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Añadir columna nullable para poder hacer backfill
+    op.add_column(
+        'catalogo_plazos',
+        sa.Column(
+            'tipo_elemento_codigo',
+            sa.String(60),
+            nullable=True,
+            comment='Código estable del tipo (reemplaza tipo_elemento_id — DEPRECATED)',
+        ),
+        schema='public',
+    )
+
+    # 2. Backfill desde las tablas de tipos según tipo_elemento
+    conn = op.get_bind()
+
+    # TipoSolicitud usa 'siglas' como identificador estable (no tiene columna 'codigo')
+    conn.execute(sa.text("""
+        UPDATE public.catalogo_plazos cp
+        SET tipo_elemento_codigo = ts.siglas
+        FROM public.tipos_solicitudes ts
+        WHERE cp.tipo_elemento = 'SOLICITUD'
+          AND cp.tipo_elemento_id = ts.id
+    """))
+
+    conn.execute(sa.text("""
+        UPDATE public.catalogo_plazos cp
+        SET tipo_elemento_codigo = tf.codigo
+        FROM public.tipos_fases tf
+        WHERE cp.tipo_elemento = 'FASE'
+          AND cp.tipo_elemento_id = tf.id
+    """))
+
+    conn.execute(sa.text("""
+        UPDATE public.catalogo_plazos cp
+        SET tipo_elemento_codigo = tt.codigo
+        FROM public.tipos_tramites tt
+        WHERE cp.tipo_elemento = 'TRAMITE'
+          AND cp.tipo_elemento_id = tt.id
+    """))
+
+    conn.execute(sa.text("""
+        UPDATE public.catalogo_plazos cp
+        SET tipo_elemento_codigo = tta.codigo
+        FROM public.tipos_tareas tta
+        WHERE cp.tipo_elemento = 'TAREA'
+          AND cp.tipo_elemento_id = tta.id
+    """))
+
+    # 3. Marcar NOT NULL tras el backfill
+    op.alter_column(
+        'catalogo_plazos',
+        'tipo_elemento_codigo',
+        nullable=False,
+        schema='public',
+    )
+
+    # 4. Añadir comentario DEPRECATED a tipo_elemento_id
+    op.alter_column(
+        'catalogo_plazos',
+        'tipo_elemento_id',
+        comment='DEPRECATED — usar tipo_elemento_codigo. Se eliminará en issue posterior.',
+        schema='public',
+    )
+
+    # 5. Índice sobre la nueva columna
+    op.create_index(
+        'idx_catalogo_plazos_tipo_codigo',
+        'catalogo_plazos',
+        ['tipo_elemento', 'tipo_elemento_codigo'],
+        schema='public',
+    )
+    op.create_index(
+        'idx_catalogo_plazos_tipo_codigo_orden',
+        'catalogo_plazos',
+        ['tipo_elemento', 'tipo_elemento_codigo', 'orden'],
+        schema='public',
+    )
+
+
+def downgrade():
+    op.drop_index('idx_catalogo_plazos_tipo_codigo_orden', table_name='catalogo_plazos', schema='public')
+    op.drop_index('idx_catalogo_plazos_tipo_codigo', table_name='catalogo_plazos', schema='public')
+    op.drop_column('catalogo_plazos', 'tipo_elemento_codigo', schema='public')

--- a/tests/test_341_evaluador_plazo.py
+++ b/tests/test_341_evaluador_plazo.py
@@ -41,10 +41,11 @@ def _mock_entrada(orden=100, entrada_id=1, condiciones=None,
     return e
 
 
-def _mock_fase(tipo_fase_id, fecha_administrativa):
+def _mock_fase(tipo_fase_id, fecha_administrativa, tipo_fase_codigo='CONSULTAS'):
     """Fase mínima para obtener_estado_plazo."""
     fase = MagicMock()
     fase.tipo_fase_id = tipo_fase_id
+    fase.tipo_fase = MagicMock(codigo=tipo_fase_codigo)
     doc = MagicMock()
     doc.fecha_administrativa = fecha_administrativa
     fase.documento_resultado = doc
@@ -286,7 +287,7 @@ def test_ctx_llama_compilar_variables_con_excluir():
         obtener_estado_plazo(fase, 'FASE', ctx=ctx)
 
     mock_cv.assert_called_once_with(ctx, excluir={'estado_plazo', 'efecto_plazo'})
-    mock_sel.assert_called_once_with('FASE', 1, {})
+    mock_sel.assert_called_once_with('FASE', 'CONSULTAS', {})
 
 
 def test_variables_directo_no_llama_compilar_variables():
@@ -339,6 +340,7 @@ def _mock_fase_aac(fecha_admin):
     """Fase INFORME_AAPP_AAC con documento_solicitud."""
     fase = MagicMock()
     fase.tipo_fase_id = 42
+    fase.tipo_fase = MagicMock(codigo='CONSULTAS')
     fase.tareas = []
     doc_sol = MagicMock()
     doc_sol.fecha_administrativa = fecha_admin

--- a/tests/test_341_modelo_condicion_plazo.py
+++ b/tests/test_341_modelo_condicion_plazo.py
@@ -45,6 +45,7 @@ def plazo_base(app_ctx):
     plazo = CatalogoPlazo(
         tipo_elemento='FASE',
         tipo_elemento_id=9999,
+        tipo_elemento_codigo='TEST_FIXTURE',
         plazo_valor=30,
         plazo_unidad='DIAS_NATURALES',
         efecto_vencimiento_id=efecto.id,
@@ -132,6 +133,7 @@ def test_catalogo_plazo_orden_default(app_ctx):
     plazo = CatalogoPlazo(
         tipo_elemento='FASE',
         tipo_elemento_id=9998,
+        tipo_elemento_codigo='TEST_ORDEN',
         plazo_valor=10,
         plazo_unidad='DIAS_HABILES',
         efecto_vencimiento_id=efecto.id,

--- a/tests/test_347_defensividad_backend.py
+++ b/tests/test_347_defensividad_backend.py
@@ -1,0 +1,173 @@
+"""Tests issue #347 — Defensividad del backend ante catálogo ausente o BD no disponible.
+
+Bloques:
+  A) validar_catalogo() — registro ausente y catálogo completo.
+  B) plazos.py — _seleccionar_catalogo devuelve SIN_PLAZO ante OperationalError.
+  C) Manejador global — OperationalError en ruta API → HTTP 503 JSON.
+  D) seguimiento.py — estado_solicitud degrada ante BD no disponible.
+"""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+
+# ---------------------------------------------------------------------------
+# A) validar_catalogo()
+# ---------------------------------------------------------------------------
+
+def _mock_modelo_con_codigos(nombre_modelo, codigos):
+    """Mock de modelo SQLAlchemy con query.with_entities().all() devolviendo el atributo correcto."""
+    from app.checks.catalogo_requerido import _CODIGO_ATTR
+    attr = _CODIGO_ATTR.get(nombre_modelo, 'codigo')
+    rows = [MagicMock(**{attr: c}) for c in codigos]
+    mock_modelo = MagicMock()
+    mock_modelo.query.with_entities.return_value.all.return_value = rows
+    setattr(mock_modelo, attr, MagicMock())
+    return mock_modelo
+
+
+def test_validar_catalogo_registro_ausente(caplog):
+    """Si falta un código requerido, validar_catalogo lo informa sin lanzar excepción."""
+    from app.checks.catalogo_requerido import REGISTROS_REQUERIDOS, validar_catalogo
+
+    mocks = {}
+    for nombre_modelo, codigos in REGISTROS_REQUERIDOS.items():
+        presentes = [c for c in codigos if not (nombre_modelo == 'TipoTarea' and c == 'FIRMAR')]
+        mocks[nombre_modelo] = _mock_modelo_con_codigos(nombre_modelo, presentes)
+
+    def fake_importar(modulo, clase):
+        return mocks.get(clase)
+
+    with patch('app.checks.catalogo_requerido._importar', side_effect=fake_importar):
+        with caplog.at_level(logging.ERROR, logger='app.checks.catalogo_requerido'):
+            faltantes = validar_catalogo()
+
+    assert any("TipoTarea.codigo='FIRMAR'" in f for f in faltantes)
+    assert "TipoTarea.codigo='FIRMAR' → no encontrado" in faltantes
+
+
+def test_validar_catalogo_bd_completa():
+    """Con todos los registros presentes, validar_catalogo retorna lista vacía."""
+    from app.checks.catalogo_requerido import REGISTROS_REQUERIDOS, validar_catalogo
+
+    mocks = {}
+    for nombre_modelo, codigos in REGISTROS_REQUERIDOS.items():
+        mocks[nombre_modelo] = _mock_modelo_con_codigos(nombre_modelo, list(codigos))
+
+    def fake_importar(modulo, clase):
+        return mocks.get(clase)
+
+    with patch('app.checks.catalogo_requerido._importar', side_effect=fake_importar):
+        faltantes = validar_catalogo()
+
+    assert faltantes == []
+
+
+def test_validar_catalogo_bd_no_disponible_no_lanza():
+    """Si la BD lanza OperationalError, validar_catalogo loguea y continúa sin excepción."""
+    from app.checks.catalogo_requerido import validar_catalogo
+
+    mock_modelo = MagicMock()
+    mock_modelo.query.with_entities.return_value.all.side_effect = OperationalError(
+        'connection refused', None, None
+    )
+
+    with patch('app.checks.catalogo_requerido._importar', return_value=mock_modelo):
+        faltantes = validar_catalogo()  # no debe lanzar
+
+    assert isinstance(faltantes, list)
+
+
+# ---------------------------------------------------------------------------
+# B) plazos.py — defensividad en _seleccionar_catalogo
+# ---------------------------------------------------------------------------
+
+def test_seleccionar_catalogo_operational_error_retorna_none(caplog):
+    """OperationalError en query → devuelve None sin propagar excepción."""
+    from app.services.plazos import _seleccionar_catalogo
+
+    with patch('app.models.catalogo_plazos.CatalogoPlazo') as MockCP, \
+         patch('app.models.condiciones_plazo.CondicionPlazo'), \
+         patch('app.services.plazos.joinedload', return_value=MagicMock()):
+        MockCP.query.options.return_value.filter_by.return_value \
+              .order_by.return_value.all.side_effect = OperationalError(
+                  'connection refused', None, None
+              )
+        with caplog.at_level(logging.WARNING, logger='app.services.plazos'):
+            result = _seleccionar_catalogo('FASE', 'CONSULTAS', {})
+
+    assert result is None
+    assert any('catalogo_plazos no disponible' in m for m in caplog.messages)
+
+
+def test_seleccionar_catalogo_programming_error_retorna_none():
+    """ProgrammingError (tabla inexistente) → devuelve None sin propagar excepción."""
+    from app.services.plazos import _seleccionar_catalogo
+
+    with patch('app.models.catalogo_plazos.CatalogoPlazo') as MockCP, \
+         patch('app.models.condiciones_plazo.CondicionPlazo'), \
+         patch('app.services.plazos.joinedload', return_value=MagicMock()):
+        MockCP.query.options.return_value.filter_by.return_value \
+              .order_by.return_value.all.side_effect = ProgrammingError(
+                  'relation does not exist', None, None
+              )
+        result = _seleccionar_catalogo('FASE', 'CONSULTAS', {})
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# C) Manejador global — OperationalError en ruta API → HTTP 503 JSON
+# ---------------------------------------------------------------------------
+
+def test_manejador_operational_error_devuelve_503_json(app):
+    """OperationalError lanzada en contexto /api/ → HTTP 503 con JSON {"code": "DB_ERROR"}."""
+    # Buscamos el manejador registrado para OperationalError
+    handlers = app.error_handler_spec.get(None, {}).get(None, {})
+    handler_fn = next(
+        (fn for cls, fn in handlers.items() if cls is OperationalError),
+        None,
+    )
+    assert handler_fn is not None, 'No hay manejador registrado para OperationalError'
+
+    exc = OperationalError('connection refused', None, None)
+
+    # Invocamos el manejador dentro de un request context /api/ para que
+    # request.path.startswith('/api/') devuelva True
+    with app.test_request_context('/api/expedientes/test'):
+        with patch('app.db.session'):
+            result = handler_fn(exc)
+
+    # Flask acepta tanto Response como (Response, code)
+    if isinstance(result, tuple):
+        resp, code = result
+        assert code == 503
+    else:
+        resp = result
+        assert resp.status_code == 503
+
+    data = resp.get_json()
+    assert data is not None
+    assert data.get('code') == 'DB_ERROR'
+
+
+# ---------------------------------------------------------------------------
+# D) seguimiento.py — degradación ante BD no disponible
+# ---------------------------------------------------------------------------
+
+def test_estado_solicitud_bd_no_disponible_degrada():
+    """Si la query de Solicitud lanza OperationalError → PENDIENTE_TRAMITAR para pistas obligatorias."""
+    from app.services.seguimiento import PISTAS_OBLIGATORIAS, estado_solicitud
+
+    exc = OperationalError('connection refused', None, None)
+    mock_solicitud = MagicMock()
+    mock_solicitud.query.get.side_effect = exc
+
+    # Parcheamos el símbolo Solicitud dentro del módulo seguimiento
+    with patch('app.services.seguimiento.Solicitud', mock_solicitud):
+        estados = estado_solicitud(1)
+
+    for pista in PISTAS_OBLIGATORIAS:
+        assert estados[pista].codigo == 'PENDIENTE_TRAMITAR'


### PR DESCRIPTION
## Cambios

- **Migración `347_tipo_elemento_codigo_catalogo_plazos`**: añade columna `tipo_elemento_codigo` (VARCHAR, NOT NULL) a `catalogo_plazos` con backfill automático desde las tablas de tipos; `tipo_elemento_id` marcado DEPRECATED.
- **`app/checks/catalogo_requerido.py`** (nuevo): manifiesto `REGISTROS_REQUERIDOS` + `validar_catalogo()` — comprueba códigos obligatorios en tablas de catálogo al arranque sin lanzar excepción.
- **`app/__init__.py`**: llama a `validar_catalogo()` tras `db.init_app()`; añade manejadores globales para `OperationalError`/`ProgrammingError` → HTTP 503 JSON `{"code":"DB_ERROR"}` en rutas `/api/`.
- **`app/services/plazos.py`**: `_seleccionar_catalogo` filtra por `tipo_elemento_codigo` (código estable) en lugar del ID frágil; captura `OperationalError`/`ProgrammingError` → `SIN_PLAZO` con warning.
- **`app/services/seguimiento.py`**: `estado_solicitud` captura `OperationalError`/`ProgrammingError` y `AttributeError` → `PENDIENTE_TRAMITAR` con warning; `_estado_tarea` protege acceso a `tipo_tarea` nulo.
- **`docs/guias/REGLAS_DESARROLLO.md`**: sección nueva con el patrón obligatorio para servicios que acceden a tablas de catálogo.
- **Tests**: 10 tests nuevos (`test_347_defensividad_backend.py`); `test_341_evaluador_plazo.py` y `test_341_modelo_condicion_plazo.py` actualizados para la nueva firma de `_seleccionar_catalogo` y el campo `tipo_elemento_codigo`.

Closes #347
