### PR TITLE
Corregir catalogo_requerido: RECONOCIMIENTO_INTERESADO y mensaje attr

### DIFF
--- a/app/checks/catalogo_requerido.py
+++ b/app/checks/catalogo_requerido.py
@@ -30,6 +30,7 @@ REGISTROS_REQUERIDOS: dict = {
         'AAU_AAUS_INTEGRADA',
         'INFORMACION_PUBLICA',
         'RESOLUCION',
+        'RECONOCIMIENTO_INTERESADO',
     ],
     # TipoSolicitud usa 'siglas' como identificador estable (no 'codigo')
     'TipoSolicitud': ['AAC', 'AAP'],
@@ -91,7 +92,7 @@ def validar_catalogo() -> List[str]:
 
         for codigo in codigos:
             if codigo not in existentes:
-                faltantes.append(f"{nombre_modelo}.codigo='{codigo}' → no encontrado")
+                faltantes.append(f"{nombre_modelo}.{attr}='{codigo}' → no encontrado")
 
     if faltantes:
         log.error(


### PR DESCRIPTION
## Cambios

- Añade `RECONOCIMIENTO_INTERESADO` a la lista `TipoFase` en `REGISTROS_REQUERIDOS` — la migración `8deef1de808e` lo inserta pero el validador de arranque no lo comprobaba
- Corrige el mensaje de error en `validar_catalogo()`: sustituye `.codigo=` hardcodeado por `.{attr}=`, de modo que `TipoSolicitud` muestre `.siglas=` en lugar de `.codigo=`

Closes #353
