### PR TITLE
Migrar ESPERAR_PLAZO de regex en notas a catalogo_plazos

### DIFF
--- a/app/services/plazos.py
+++ b/app/services/plazos.py
@@ -79,6 +79,11 @@ _SIN_PLAZO = EstadoPlazo(
 # API pública
 # ---------------------------------------------------------------------------
 
+def tiene_plazo_configurado(tipo_elemento: str, tipo_codigo: str, variables: dict) -> bool:
+    """True si existe al menos una entrada activa en catalogo_plazos que supera sus condiciones."""
+    return _seleccionar_catalogo(tipo_elemento, tipo_codigo, variables) is not None
+
+
 def obtener_estado_plazo(
     elemento,
     tipo_elemento: str,

--- a/app/services/seguimiento.py
+++ b/app/services/seguimiento.py
@@ -20,9 +20,7 @@ Uso:
 """
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
-from datetime import date, timedelta
 from typing import Optional
 
 import logging
@@ -258,52 +256,39 @@ def _estado_tarea(tarea, pista: str) -> tuple[str, int]:
 
 def _estado_esperar_plazo(tarea, pista: str) -> str:
     """
-    ESPERAR_PLAZO: §4.4
-    - documento_usado_id IS NULL (plazo=0 o aún sin configurar) → PENDIENTE_PLAZOS / PENDIENTE_SUBSANAR
-    - documento_usado_id IS NOT NULL y plazo=0 → espera indefinida
-    - documento_usado_id IS NOT NULL y plazo>0 con plazo activo → PENDIENTE_PLAZOS / PENDIENTE_SUBSANAR
-    - documento_usado_id IS NOT NULL y plazo vencido → PENDIENTE_ESTUDIO
-
-    El inicio del cómputo es documento_usado.fecha_administrativa (no fecha_inicio de la tarea).
+    ESPERAR_PLAZO: §4.4 — consulta catalogo_plazos en lugar de parsear Tarea.notas.
+    Sin entrada configurada → PENDIENTE_TRAMITAR (tarea sin configurar).
+    Con entrada pero sin documento_usado aún → estado_espera (esperando inicio de cómputo).
+    Plazo vencido → PENDIENTE_ESTUDIO.
     """
-    plazo = _parse_plazo_dias(tarea.notas)
+    from app.services.plazos import obtener_estado_plazo, tiene_plazo_configurado
 
-    if plazo is None:
-        return 'PENDIENTE_TRAMITAR'  # PLAZO_DIAS no presente en notas: tarea sin configurar
+    variables = _variables_esperar_plazo(tarea)
+
+    if not tiene_plazo_configurado('TAREA', 'ESPERAR_PLAZO', variables):
+        return 'PENDIENTE_TRAMITAR'
 
     estado_espera = 'PENDIENTE_SUBSANAR' if pista == 'SOL' else 'PENDIENTE_PLAZOS'
 
-    if plazo == 0:
-        return estado_espera  # espera indefinida: siempre activo
+    ep = obtener_estado_plazo(tarea, 'TAREA', variables=variables)
 
-    fecha_inicio_computo = (
-        tarea.documento_usado.fecha_administrativa
-        if tarea.documento_usado and tarea.documento_usado.fecha_administrativa
-        else None
-    )
+    if ep.estado == 'VENCIDO':
+        return 'PENDIENTE_ESTUDIO'
+    return estado_espera   # SIN_PLAZO (sin doc), EN_PLAZO, PROXIMO_VENCER
 
-    if fecha_inicio_computo:
-        vencimiento = fecha_inicio_computo + timedelta(days=plazo)
-        if vencimiento < date.today():
-            return 'PENDIENTE_ESTUDIO'  # plazo vencido: hay que estudiar la respuesta
 
-    return estado_espera
+def _variables_esperar_plazo(tarea) -> dict:
+    try:
+        tt = tarea.tramite.tipo_tramite
+        return {'tipo_tramite': tt.codigo} if tt else {}
+    except Exception:
+        log.warning('seguimiento: no se pudo acceder a tipo_tramite de tarea %s', getattr(tarea, 'id', '?'))
+        return {}
 
 
 # ---------------------------------------------------------------------------
 # Helpers internos
 # ---------------------------------------------------------------------------
-
-def _parse_plazo_dias(notas: Optional[str]) -> Optional[int]:
-    """
-    Extrae PLAZO_DIAS=N de notas.
-    Devuelve None si la clave no está presente (tarea sin configurar).
-    Devuelve 0 si PLAZO_DIAS=0 (espera indefinida).
-    """
-    if not notas:
-        return None
-    m = re.search(r'PLAZO_DIAS=(\d+)', notas)
-    return int(m.group(1)) if m else None
 
 
 def _nota_activa(fases_abiertas) -> Optional[str]:

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -4,8 +4,8 @@
 
 ---
 
-**Último cerrado:** #353 — Corregir `catalogo_requerido.py`: añadir `RECONOCIMIENTO_INTERESADO` a `TipoFase` y corregir mensaje de error (`.codigo=` → `.{attr}=`).
+**Último cerrado:** #350 — Migrar `_estado_esperar_plazo` en `seguimiento.py` de `_parse_plazo_dias` a `catalogo_plazos`; seed de 6 plazos ESPERAR_PLAZO; añadir `tipo_tramite` a `catalogo_variables`.
 
-**Actuales:** #350
+**Actuales:** #337 + #345
 
-**Próximo:** #337 + #345 → #346 → #173 → #328
+**Próximo:** #346 → #173 → #328

--- a/migrations/versions/350_seed_catalogo_plazos.py
+++ b/migrations/versions/350_seed_catalogo_plazos.py
@@ -1,0 +1,115 @@
+"""350_seed_catalogo_plazos
+
+Revision ID: 350_seed_catalogo_plazos
+Revises: 350_variable_tipo_tramite
+Create Date: 2026-05-07
+
+Issue #350 — Seed de plazos para tareas ESPERAR_PLAZO.
+Seis entradas condicionadas por tipo_tramite (EQ), una por tipo de
+trámite que genera espera de respuesta de interesado o de AAPP.
+
+norma_origen con PLACEHOLDER donde la cita exacta de artículo está pendiente.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '350_seed_catalogo_plazos'
+down_revision = '350_variable_tipo_tramite'
+branch_labels = None
+depends_on = None
+
+# (tipo_tramite_codigo, plazo_valor, plazo_unidad, efecto_codigo, norma_origen)
+_PLAZOS = [
+    (
+        'REQUERIMIENTO_SUBSANACION', 10, 'DIAS_HABILES', 'PERDIDA_TRAMITE',
+        'PLACEHOLDER - pendiente cita exacta (Art. 68.1 LPACAP)',
+    ),
+    (
+        'AUDIENCIA', 15, 'DIAS_HABILES', 'NINGUNO',
+        'PLACEHOLDER - pendiente cita exacta (Art. 82.2 LPACAP)',
+    ),
+    (
+        'SOLICITUD_INFORME', 10, 'DIAS_HABILES', 'SIN_EFECTO_AUTOMATICO',
+        'PLACEHOLDER - pendiente cita exacta (Art. 80.2 LPACAP)',
+    ),
+    (
+        'ANUNCIO_BOE', 30, 'DIAS_NATURALES', 'SIN_EFECTO_AUTOMATICO',
+        'PLACEHOLDER - pendiente cita exacta (Art. 83 LPACAP / Art. 131 RD1955/2000)',
+    ),
+    (
+        'ANUNCIO_BOP', 30, 'DIAS_NATURALES', 'SIN_EFECTO_AUTOMATICO',
+        'PLACEHOLDER - pendiente cita exacta (Art. 131 RD1955/2000 ANUNCIO_BOP)',
+    ),
+    (
+        'ANUNCIO_PRENSA', 30, 'DIAS_NATURALES', 'SIN_EFECTO_AUTOMATICO',
+        'PLACEHOLDER - pendiente cita exacta (Art. 131 RD1955/2000 ANUNCIO_PRENSA)',
+    ),
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for tt_codigo, plazo_valor, plazo_unidad, efecto_codigo, norma in _PLAZOS:
+        result = conn.execute(sa.text("""
+            INSERT INTO public.catalogo_plazos
+                (tipo_elemento, tipo_elemento_id, tipo_elemento_codigo, campo_fecha,
+                 plazo_valor, plazo_unidad,
+                 efecto_vencimiento_id, norma_origen, orden, activo)
+            SELECT
+                'TAREA',
+                tt.id,
+                'ESPERAR_PLAZO',
+                '{"fk": "documento_usado_id"}'::jsonb,
+                :plazo_valor,
+                :plazo_unidad,
+                ep.id,
+                :norma,
+                10,
+                TRUE
+            FROM public.tipos_tareas tt
+            CROSS JOIN public.efectos_plazo ep
+            WHERE tt.codigo = 'ESPERAR_PLAZO'
+              AND ep.codigo = :efecto_codigo
+            RETURNING id
+        """), {
+            'plazo_valor': plazo_valor,
+            'plazo_unidad': plazo_unidad,
+            'efecto_codigo': efecto_codigo,
+            'norma': norma,
+        })
+        plazo_id = result.scalar()
+
+        if plazo_id:
+            conn.execute(sa.text("""
+                INSERT INTO public.condiciones_plazo
+                    (catalogo_plazo_id, variable_id, operador, valor, orden)
+                SELECT
+                    :plazo_id,
+                    cv.id,
+                    'EQ',
+                    to_jsonb(CAST(:tt_codigo AS TEXT)),
+                    1
+                FROM public.catalogo_variables cv
+                WHERE cv.nombre = 'tipo_tramite'
+            """), {'plazo_id': plazo_id, 'tt_codigo': tt_codigo})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_plazo
+        WHERE catalogo_plazo_id IN (
+            SELECT id FROM public.catalogo_plazos
+            WHERE tipo_elemento = 'TAREA'
+              AND tipo_elemento_codigo = 'ESPERAR_PLAZO'
+        )
+    """))
+
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_plazos
+        WHERE tipo_elemento = 'TAREA'
+          AND tipo_elemento_codigo = 'ESPERAR_PLAZO'
+    """))

--- a/migrations/versions/350_variable_tipo_tramite.py
+++ b/migrations/versions/350_variable_tipo_tramite.py
@@ -1,0 +1,40 @@
+"""350_variable_tipo_tramite
+
+Revision ID: 350_variable_tipo_tramite
+Revises: 347a0b1c2d3e
+Create Date: 2026-05-07
+
+Issue #350 — Registra la variable tipo_tramite en catalogo_variables.
+Necesaria para que _seleccionar_catalogo pueda discriminar el plazo
+según el tipo de trámite en tareas ESPERAR_PLAZO.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '350_variable_tipo_tramite'
+down_revision = '347a0b1c2d3e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES (
+            'tipo_tramite',
+            'Código del tipo de trámite activo en el contexto evaluado',
+            'texto',
+            NULL,
+            TRUE
+        )
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "DELETE FROM public.catalogo_variables WHERE nombre = 'tipo_tramite'"
+    ))

--- a/tests/test_350_seguimiento_esperar_plazo.py
+++ b/tests/test_350_seguimiento_esperar_plazo.py
@@ -1,0 +1,143 @@
+"""Tests issue #350 — _estado_esperar_plazo consulta catalogo_plazos.
+
+Requieren:
+  - BD con migraciones 350 aplicadas:
+      350_variable_tipo_tramite  (tipo_tramite en catalogo_variables)
+      350_seed_catalogo_plazos   (6 entradas ESPERAR_PLAZO en catalogo_plazos)
+  - Fixture app_ctx (rollback automático por test).
+
+Escenarios:
+  A) tipo_tramite sin entrada en catálogo → PENDIENTE_TRAMITAR
+  B) tipo_tramite configurado, plazo activo, pista no SOL → PENDIENTE_PLAZOS
+  C) tipo_tramite configurado, plazo vencido → PENDIENTE_ESTUDIO
+  D) tipo_tramite configurado, sin documento (inicio cómputo no disponible) → PENDIENTE_PLAZOS
+  E) tipo_tramite configurado, plazo activo, pista SOL → PENDIENTE_SUBSANAR
+
+Fechas de referencia (REQUERIMIENTO_SUBSANACION, 10 días hábiles, sin festivos):
+  doc_fecha      = 2026-01-05 (lun)
+  fecha_limite   = 2026-01-19 (lun)  — 10.º día hábil
+  HOY_EN_PLAZO   = 2026-01-12 (lun)  — 6 hábiles restantes → EN_PLAZO
+  HOY_VENCIDO    = 2026-01-20 (mar)  — 1 día tras vencimiento → VENCIDO
+"""
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+
+DOC_FECHA    = date(2026, 1, 5)
+HOY_EN_PLAZO = date(2026, 1, 12)
+HOY_VENCIDO  = date(2026, 1, 20)
+
+
+def _mock_tarea(tipo_tramite_codigo, doc_fecha=None):
+    """Mock mínimo de Tarea para _estado_esperar_plazo.
+
+    - tipo_tarea.codigo = 'ESPERAR_PLAZO'  (requerido por _get_tipo_elemento_codigo)
+    - tramite.tipo_tramite.codigo          (requerido por _variables_esperar_plazo)
+    - documento_usado.fecha_administrativa (requerido por _resolver_campo_fecha)
+    """
+    tarea = MagicMock()
+    tarea.tipo_tarea = MagicMock(codigo='ESPERAR_PLAZO')
+    tarea.tramite = MagicMock()
+    tarea.tramite.tipo_tramite = MagicMock(codigo=tipo_tramite_codigo)
+    if doc_fecha is not None:
+        doc = MagicMock()
+        doc.fecha_administrativa = doc_fecha
+        tarea.documento_usado = doc
+    else:
+        tarea.documento_usado = None
+    return tarea
+
+
+# ---------------------------------------------------------------------------
+# A) Sin entrada en catálogo → PENDIENTE_TRAMITAR
+# ---------------------------------------------------------------------------
+
+def test_sin_entrada_catalogo_devuelve_pendiente_tramitar(app_ctx):
+    """SOLICITUD_COMPATIBILIDAD no tiene plazo configurado en el seed de #350.
+    Debe devolver PENDIENTE_TRAMITAR independientemente de fechas.
+    """
+    from app.services.seguimiento import _estado_esperar_plazo
+
+    tarea = _mock_tarea('SOLICITUD_COMPATIBILIDAD', doc_fecha=DOC_FECHA)
+
+    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        resultado = _estado_esperar_plazo(tarea, 'MA')
+
+    assert resultado == 'PENDIENTE_TRAMITAR'
+
+
+# ---------------------------------------------------------------------------
+# B) Plazo activo, pista no SOL → PENDIENTE_PLAZOS
+# ---------------------------------------------------------------------------
+
+def test_plazo_activo_pista_ma_devuelve_pendiente_plazos(app_ctx):
+    """REQUERIMIENTO_SUBSANACION con 6 días hábiles restantes.
+    Pista 'MA' (no SOL) → PENDIENTE_PLAZOS.
+    """
+    from app.services.seguimiento import _estado_esperar_plazo
+
+    tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
+
+    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        resultado = _estado_esperar_plazo(tarea, 'MA')
+
+    assert resultado == 'PENDIENTE_PLAZOS'
+
+
+# ---------------------------------------------------------------------------
+# C) Plazo vencido → PENDIENTE_ESTUDIO
+# ---------------------------------------------------------------------------
+
+def test_plazo_vencido_devuelve_pendiente_estudio(app_ctx):
+    """REQUERIMIENTO_SUBSANACION con plazo vencido (hoy > fecha_limite).
+    El técnico debe actuar → PENDIENTE_ESTUDIO.
+    """
+    from app.services.seguimiento import _estado_esperar_plazo
+
+    tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
+
+    with patch('app.services.plazos._hoy', return_value=HOY_VENCIDO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        resultado = _estado_esperar_plazo(tarea, 'MA')
+
+    assert resultado == 'PENDIENTE_ESTUDIO'
+
+
+# ---------------------------------------------------------------------------
+# D) Sin documento de inicio de cómputo → estado_espera (SIN_PLAZO)
+# ---------------------------------------------------------------------------
+
+def test_sin_documento_devuelve_pendiente_plazos(app_ctx):
+    """REQUERIMIENTO_SUBSANACION con entrada en catálogo pero sin documento_usado.
+    obtener_estado_plazo devuelve SIN_PLAZO → estado_espera → PENDIENTE_PLAZOS.
+    """
+    from app.services.seguimiento import _estado_esperar_plazo
+
+    tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=None)
+
+    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        resultado = _estado_esperar_plazo(tarea, 'MA')
+
+    assert resultado == 'PENDIENTE_PLAZOS'
+
+
+# ---------------------------------------------------------------------------
+# E) Plazo activo, pista SOL → PENDIENTE_SUBSANAR
+# ---------------------------------------------------------------------------
+
+def test_plazo_activo_pista_sol_devuelve_pendiente_subsanar(app_ctx):
+    """REQUERIMIENTO_SUBSANACION en pista SOL (solicitud del interesado).
+    Plazo activo → PENDIENTE_SUBSANAR en lugar de PENDIENTE_PLAZOS.
+    """
+    from app.services.seguimiento import _estado_esperar_plazo
+
+    tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
+
+    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        resultado = _estado_esperar_plazo(tarea, 'SOL')
+
+    assert resultado == 'PENDIENTE_SUBSANAR'


### PR DESCRIPTION
## Cambios

- Nueva migración `350_variable_tipo_tramite`: añade `tipo_tramite` a `catalogo_variables` para que `_seleccionar_catalogo` pueda discriminar plazos por tipo de trámite
- Nueva migración `350_seed_catalogo_plazos`: 6 entradas ESPERAR_PLAZO con condición `tipo_tramite EQ` (REQUERIMIENTO_SUBSANACION, AUDIENCIA, SOLICITUD_INFORME, ANUNCIO_BOE/BOP/PRENSA)
- `plazos.py`: expone `tiene_plazo_configurado()` como función pública
- `seguimiento.py`: reemplaza `_parse_plazo_dias` (regex sobre `Tarea.notas`) por consulta a `catalogo_plazos`; añade `_variables_esperar_plazo`; elimina import `re`, `date`, `timedelta`
- 5 tests contra la BD seedeada con fecha mockeada: sin catálogo, plazo activo, plazo vencido, sin documento, pista SOL

Closes #350
