### PR TITLE
Añadir tramites_tareas: catálogo formal de secuencias de tareas por trámite

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -53,6 +53,7 @@ from app.models.historico_titular_expediente import HistoricoTitularExpediente  
 from app.models.expedientes_solicitudes import ExpedienteSolicitud
 from app.models.solicitudes_fases import SolicitudFase
 from app.models.fases_tramites import FaseTramite
+from app.models.tramites_tareas import TramiteTarea
 from app.models.tipos_documentos_resultados_validos import TipoDocumentoResultadoValido
 
 # Modelos operacionales con dependencias múltiples
@@ -110,6 +111,7 @@ __all__ = [
     'ExpedienteSolicitud',
     'SolicitudFase',
     'FaseTramite',
+    'TramiteTarea',
     'TipoDocumentoResultadoValido',
     # Operacionales (continuación)
     'DocumentoProyecto',

--- a/app/models/tramites_tareas.py
+++ b/app/models/tramites_tareas.py
@@ -1,0 +1,33 @@
+from app import db
+
+
+class TramiteTarea(db.Model):
+    """Secuencia ordenada de tareas atómicas por tipo de trámite.
+
+    PK (tipo_tramite_id, orden) permite que un mismo tipo de tarea
+    aparezca en posiciones distintas del mismo trámite (p.ej. doble
+    ESPERAR_PLAZO en ANUNCIO_BOE: espera publicación + plazo alegaciones).
+
+    Seed desde ESTRUCTURA_FTT.json via migración 345_seed_tramites_tareas.
+    """
+    __tablename__ = 'tramites_tareas'
+    __table_args__ = {'schema': 'public'}
+
+    tipo_tramite_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tipos_tramites.id', name='fk_tram_tareas_tipo_tramite'),
+        primary_key=True,
+        nullable=False
+    )
+    orden = db.Column(db.SmallInteger, primary_key=True, nullable=False)
+    tipo_tarea_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tipos_tareas.id', name='fk_tram_tareas_tipo_tarea'),
+        nullable=False
+    )
+
+    tipo_tramite = db.relationship('TipoTramite')
+    tipo_tarea = db.relationship('TipoTarea')
+
+    def __repr__(self):
+        return f'<TramiteTarea tramite={self.tipo_tramite_id} orden={self.orden} tarea={self.tipo_tarea_id}>'

--- a/migrations/versions/345_seed_tramites_tareas.py
+++ b/migrations/versions/345_seed_tramites_tareas.py
@@ -1,0 +1,82 @@
+"""345_seed_tramites_tareas — secuencias de tareas por trámite
+
+Revision ID: 345_seed_tramites_tareas
+Revises: 345_tramites_tareas
+Create Date: 2026-05-08
+
+Issue #345 — Pobla tramites_tareas con las secuencias definidas en
+ESTRUCTURA_FTT.json (fuente de verdad). Falla ruidosamente si algún
+código de trámite o tarea no existe en BD.
+
+RECEPCION_INFORME aparece en dos fases del JSON (CONSULTA_MINISTERIO y
+COMPATIBILIDAD_AMBIENTAL) pero comparte el mismo registro en tipos_tramites;
+el seed inserta una sola vez con la secuencia [INCORPORAR, ANALIZAR].
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '345_seed_tramites_tareas'
+down_revision = '345_tramites_tareas'
+branch_labels = None
+depends_on = None
+
+# (tipo_tramite.codigo, [tipo_tarea.codigo en orden 1-based])
+# Fuente: ESTRUCTURA_FTT.json v5.6
+_SECUENCIAS = [
+    ('ANALISIS_DOCUMENTAL',        ['ANALIZAR']),
+    ('REQUERIMIENTO_SUBSANACION',  ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ANALIZAR']),
+    ('COMUNICACION_INICIO',        ['REDACTAR', 'FIRMAR', 'NOTIFICAR']),
+    ('SOLICITUD_INFORME',          ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('RECEPCION_INFORME',          ['INCORPORAR', 'ANALIZAR']),
+    ('SOLICITUD_COMPATIBILIDAD',   ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('AUDIENCIA',                  ['INCORPORAR', 'ANALIZAR', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('CONSULTA_SEPARATA',          ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ANALIZAR']),
+    ('CONSULTA_TRASLADO_TITULAR',  ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ANALIZAR']),
+    ('CONSULTA_TRASLADO_ORGANISMO',['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ANALIZAR']),
+    # ANUNCIO_*: doble ESPERAR_PLAZO (hasta publicación efectiva + plazo alegaciones)
+    ('ANUNCIO_BOE',                ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ESPERAR_PLAZO']),
+    ('ANUNCIO_BOP',                ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ESPERAR_PLAZO']),
+    ('ANUNCIO_PRENSA',             ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ESPERAR_PLAZO']),
+    ('TABLON_AYUNTAMIENTOS',       ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR']),
+    ('PORTAL_TRANSPARENCIA',       ['REDACTAR', 'FIRMAR', 'PUBLICAR', 'ESPERAR_PLAZO']),
+    ('RECEPCION_ALEGACION',        ['INCORPORAR', 'ANALIZAR', 'REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('ANALISIS_ALEGACIONES',       ['ANALIZAR']),
+    ('SOLICITUD_FIGURA',           ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('RECEPCION_FIGURA',           ['INCORPORAR', 'ANALIZAR']),
+    ('REMISION_MEDIO_AMBIENTE',    ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO']),
+    ('RECEPCION_DICTAMEN',         ['INCORPORAR', 'ANALIZAR']),
+    ('ELABORACION',                ['ANALIZAR', 'REDACTAR', 'FIRMAR']),
+    ('NOTIFICACION',               ['REDACTAR', 'NOTIFICAR']),
+    ('PUBLICACION',                ['REDACTAR', 'FIRMAR', 'PUBLICAR']),
+]
+
+
+def _get_id(conn, tabla, codigo):
+    result = conn.execute(
+        sa.text(f"SELECT id FROM public.{tabla} WHERE codigo = :c"),
+        {'c': codigo}
+    )
+    id_ = result.scalar()
+    if id_ is None:
+        raise ValueError(f"Código '{codigo}' no encontrado en {tabla} — migración abortada")
+    return id_
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for tramite_codigo, tareas in _SECUENCIAS:
+        tt_id = _get_id(conn, 'tipos_tramites', tramite_codigo)
+        for orden, tarea_codigo in enumerate(tareas, start=1):
+            ta_id = _get_id(conn, 'tipos_tareas', tarea_codigo)
+            conn.execute(sa.text("""
+                INSERT INTO public.tramites_tareas (tipo_tramite_id, orden, tipo_tarea_id)
+                VALUES (:tt_id, :orden, :ta_id)
+                ON CONFLICT DO NOTHING
+            """), {'tt_id': tt_id, 'orden': orden, 'ta_id': ta_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(sa.text("DELETE FROM public.tramites_tareas"))

--- a/migrations/versions/345_tramites_tareas.py
+++ b/migrations/versions/345_tramites_tareas.py
@@ -1,0 +1,40 @@
+"""345_tramites_tareas — tabla catálogo de secuencias de tareas por trámite
+
+Revision ID: 345_tramites_tareas
+Revises: 350_seed_catalogo_plazos
+Create Date: 2026-05-08
+
+Issue #345 — PK compuesta (tipo_tramite_id, orden) para admitir que
+ESPERAR_PLAZO aparezca dos veces en el mismo trámite (p.ej. ANUNCIO_BOE).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '345_tramites_tareas'
+down_revision = '350_seed_catalogo_plazos'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'tramites_tareas',
+        sa.Column('tipo_tramite_id', sa.Integer(), nullable=False),
+        sa.Column('orden', sa.SmallInteger(), nullable=False),
+        sa.Column('tipo_tarea_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['tipo_tramite_id'], ['public.tipos_tramites.id'],
+            name='fk_tram_tareas_tipo_tramite'
+        ),
+        sa.ForeignKeyConstraint(
+            ['tipo_tarea_id'], ['public.tipos_tareas.id'],
+            name='fk_tram_tareas_tipo_tarea'
+        ),
+        sa.PrimaryKeyConstraint('tipo_tramite_id', 'orden', name='pk_tramites_tareas'),
+        schema='public'
+    )
+
+
+def downgrade():
+    op.drop_table('tramites_tareas', schema='public')

--- a/tests/test_345_tramites_tareas.py
+++ b/tests/test_345_tramites_tareas.py
@@ -1,0 +1,114 @@
+"""Tests issue #345 — tramites_tareas: catálogo formal de secuencias de tareas.
+
+Requieren BD con migraciones 345 aplicadas:
+    345_tramites_tareas        (crea la tabla)
+    345_seed_tramites_tareas   (pobla las 24 secuencias)
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A) Sin BD — estructura del modelo
+# ---------------------------------------------------------------------------
+
+def test_modelo_importable():
+    from app.models.tramites_tareas import TramiteTarea
+    assert TramiteTarea.__tablename__ == 'tramites_tareas'
+
+
+def test_modelo_en_all():
+    import app.models as m
+    assert 'TramiteTarea' in m.__all__
+
+
+def test_pk_compuesta():
+    from app.models.tramites_tareas import TramiteTarea
+    pk_cols = {c.name for c in TramiteTarea.__table__.primary_key.columns}
+    assert pk_cols == {'tipo_tramite_id', 'orden'}
+
+
+def test_fk_tipo_tramite():
+    from app.models.tramites_tareas import TramiteTarea
+    col = TramiteTarea.__table__.c['tipo_tramite_id']
+    assert col.foreign_keys
+
+
+def test_fk_tipo_tarea():
+    from app.models.tramites_tareas import TramiteTarea
+    col = TramiteTarea.__table__.c['tipo_tarea_id']
+    assert col.foreign_keys
+
+
+# ---------------------------------------------------------------------------
+# B) Con BD — integridad del seed
+# ---------------------------------------------------------------------------
+
+def test_todos_tramites_tienen_tarea(app_ctx):
+    """Los 24 tipos de trámite del catálogo tienen al menos una tarea."""
+    from app import db
+    from app.models.tramites_tareas import TramiteTarea
+    from app.models.tipos_tramites import TipoTramite
+
+    total_tramites = db.session.query(TipoTramite).count()
+    tramites_con_tarea = (
+        db.session.query(TramiteTarea.tipo_tramite_id)
+        .distinct()
+        .count()
+    )
+    assert tramites_con_tarea == total_tramites
+
+
+def test_anuncio_boe_doble_esperar_plazo(app_ctx):
+    """ANUNCIO_BOE tiene exactamente 2 tareas ESPERAR_PLAZO en órdenes distintos."""
+    from app import db
+    from app.models.tramites_tareas import TramiteTarea
+    from app.models.tipos_tramites import TipoTramite
+    from app.models.tipos_tareas import TipoTarea
+
+    boe = db.session.query(TipoTramite).filter_by(codigo='ANUNCIO_BOE').one()
+    esperar = db.session.query(TipoTarea).filter_by(codigo='ESPERAR_PLAZO').one()
+
+    filas = (
+        db.session.query(TramiteTarea)
+        .filter_by(tipo_tramite_id=boe.id, tipo_tarea_id=esperar.id)
+        .order_by(TramiteTarea.orden)
+        .all()
+    )
+    assert len(filas) == 2
+    assert filas[0].orden != filas[1].orden
+
+
+def test_consulta_orm_secuencia_ordenada(app_ctx):
+    """Dado un TipoTramite, la secuencia de tareas devuelta está ordenada por orden."""
+    from app import db
+    from app.models.tramites_tareas import TramiteTarea
+    from app.models.tipos_tramites import TipoTramite
+
+    tramite = db.session.query(TipoTramite).filter_by(codigo='REQUERIMIENTO_SUBSANACION').one()
+    secuencia = (
+        db.session.query(TramiteTarea)
+        .filter_by(tipo_tramite_id=tramite.id)
+        .order_by(TramiteTarea.orden)
+        .all()
+    )
+
+    codigos = [tt.tipo_tarea.codigo for tt in secuencia]
+    assert codigos == ['REDACTAR', 'FIRMAR', 'NOTIFICAR', 'ESPERAR_PLAZO', 'INCORPORAR', 'ANALIZAR']
+
+
+def test_consulta_orm_relaciones_cargadas(app_ctx):
+    """TramiteTarea carga las relaciones tipo_tramite y tipo_tarea correctamente."""
+    from app import db
+    from app.models.tramites_tareas import TramiteTarea
+
+    primera = db.session.query(TramiteTarea).first()
+    assert primera is not None
+    assert primera.tipo_tramite is not None
+    assert primera.tipo_tarea is not None
+
+
+@pytest.mark.skip(reason="#345 — expedientes_solicitudes: seed pendiente de sesión de análisis normativo")
+def test_expedientes_solicitudes_no_vacia(app_ctx):
+    from app import db
+    from app.models.expedientes_solicitudes import ExpedienteSolicitud
+    assert db.session.query(ExpedienteSolicitud).count() > 0


### PR DESCRIPTION
## Cambios

- Nueva tabla `tramites_tareas` con PK compuesta `(tipo_tramite_id, orden)` que permite que un mismo tipo de tarea (p.ej. `ESPERAR_PLAZO`) aparezca en posiciones distintas del mismo trámite
- Seed de 24 trámites con sus secuencias completas derivadas de `ESTRUCTURA_FTT.json` v5.6; falla ruidosamente si algún código de trámite o tarea no existe en BD
- Modelo ORM `TramiteTarea` siguiendo el patrón de `FaseTramite`; registrado en `app/models/__init__.py`
- 9 tests: estructura del modelo (importación, PK, FKs), integridad del seed (todos los trámites tienen tarea, `ANUNCIO_BOE` con doble `ESPERAR_PLAZO`) y consulta ORM ordenada por `orden`
- Test de `expedientes_solicitudes` marcado como skip pendiente de sesión de análisis normativo

Closes #345
