### PR TITLE
[FEATURE] #373 CERT_FIN_INSTRUCCION: certificado automático de fin de instrucción

### DIFF
--- a/app/checks/catalogo_requerido.py
+++ b/app/checks/catalogo_requerido.py
@@ -32,6 +32,7 @@ REGISTROS_REQUERIDOS: dict = {
     ],
     # TipoSolicitud usa 'siglas' como identificador estable (no 'codigo')
     'TipoSolicitud': ['AAC', 'AAP'],
+    'TipoDocumento': ['CERT_FIN_INSTRUCCION'],
 }
 
 # Atributo del modelo que contiene el identificador estable.
@@ -41,6 +42,7 @@ _CODIGO_ATTR: dict[str, str] = {
     'TipoTarea':     'codigo',
     'TipoFase':      'codigo',
     'TipoSolicitud': 'siglas',
+    'TipoDocumento': 'codigo',
 }
 
 
@@ -56,10 +58,11 @@ def validar_catalogo() -> List[str]:
     from sqlalchemy.exc import OperationalError, ProgrammingError
 
     _MODELOS = {
-        'TipoTramite':   _importar('app.models.tipos_tramites',  'TipoTramite'),
-        'TipoTarea':     _importar('app.models.tipos_tareas',    'TipoTarea'),
-        'TipoFase':      _importar('app.models.tipos_fases',     'TipoFase'),
+        'TipoTramite':   _importar('app.models.tipos_tramites',   'TipoTramite'),
+        'TipoTarea':     _importar('app.models.tipos_tareas',     'TipoTarea'),
+        'TipoFase':      _importar('app.models.tipos_fases',      'TipoFase'),
         'TipoSolicitud': _importar('app.models.tipos_solicitudes', 'TipoSolicitud'),
+        'TipoDocumento': _importar('app.models.tipos_documentos', 'TipoDocumento'),
     }
 
     faltantes: List[str] = []

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -75,6 +75,9 @@ from app.models.condiciones_plazo import CondicionPlazo # depende de CatalogoPla
 # Motor de reglas (depende de TipoSolicitud; tipo_id sin FK por diseño polimórfico)
 from app.models.motor_reglas import ReglaMotor, CondicionRegla
 
+# Certificados de fase (#373 — depende de Expediente, Fase)
+from app.models.certificados_fase import CertificadoFase
+
 __all__ = [
     # Maestros
     'EfectoPlazo',
@@ -128,4 +131,6 @@ __all__ = [
     # Motor de reglas
     'ReglaMotor',
     'CondicionRegla',
+    # Certificados de fase
+    'CertificadoFase',
 ]

--- a/app/models/certificados_fase.py
+++ b/app/models/certificados_fase.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+
+from app import db
+
+
+class CertificadoFase(db.Model):
+    """
+    Snapshot inmutable de la auditoría del motor al crear una fase.
+
+    Fuente de verdad de qué reglas fueron evaluadas, cuáles dispararon y
+    cuáles fueron neutralizadas por excepciones. No editable tras su creación.
+
+    TIPO_CERT:
+        Código del tipo de documento generado (ej: 'CERT_FIN_INSTRUCCION').
+        Permite múltiples certificados por fase si el diseño lo requiere.
+
+    REGLAS_EVALUADAS y VARIABLES_CTX:
+        JSON inmutable — snapshot de AuditoriaResult en el momento de creación.
+        No deben modificarse tras el commit inicial.
+
+    RUTA_PDF:
+        Se rellena tras la generación del PDF. NULL hasta entonces.
+    """
+    __tablename__ = 'certificados_fase'
+    __table_args__ = (
+        db.Index('idx_cert_fase_expediente', 'expediente_id'),
+        db.Index('idx_cert_fase_tipo', 'tipo_cert'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    expediente_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.expedientes.id', name='fk_cert_fase_expediente'),
+        nullable=False,
+    )
+
+    fase_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.fases.id', name='fk_cert_fase_fase'),
+        nullable=True,
+    )
+
+    tipo_cert = db.Column(
+        db.String(50),
+        nullable=False,
+        comment='Código del tipo de certificado: CERT_FIN_INSTRUCCION, etc.'
+    )
+
+    fecha_generacion = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+    )
+
+    accion = db.Column(
+        db.String(10),
+        nullable=False,
+        comment='Snapshot de la acción auditada: CREAR, FINALIZAR…'
+    )
+
+    sujeto = db.Column(
+        db.String(200),
+        nullable=False,
+        comment='Snapshot del sujeto calificado auditado'
+    )
+
+    reglas_evaluadas = db.Column(
+        db.JSON,
+        nullable=False,
+        comment='list[ResultadoRegla] serializado — snapshot inmutable'
+    )
+
+    variables_ctx = db.Column(
+        db.JSON,
+        nullable=False,
+        comment='Dict completo de variables en el momento de la auditoría'
+    )
+
+    ruta_pdf = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Ruta absoluta del PDF generado; NULL hasta que se genera'
+    )
+
+    expediente = db.relationship('Expediente', foreign_keys=[expediente_id])
+    fase = db.relationship('Fase', foreign_keys=[fase_id], backref='certificados')
+
+    def __repr__(self):
+        return f'<CertificadoFase id={self.id} tipo={self.tipo_cert} fase={self.fase_id}>'

--- a/app/models/tramites_tareas.py
+++ b/app/models/tramites_tareas.py
@@ -26,8 +26,16 @@ class TramiteTarea(db.Model):
         nullable=False
     )
 
+    doc_consumido_tipo_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tipos_documentos.id', name='fk_tram_tareas_doc_consumido_tipo'),
+        nullable=True,
+        comment='FK a TIPOS_DOCUMENTOS. Si NOT NULL y origen=INTERNO, el sistema lo genera automáticamente al crear la fase (#373)'
+    )
+
     tipo_tramite = db.relationship('TipoTramite')
     tipo_tarea = db.relationship('TipoTarea')
+    doc_consumido_tipo = db.relationship('TipoDocumento', foreign_keys=[doc_consumido_tipo_id])
 
     def __repr__(self):
         return f'<TramiteTarea tramite={self.tipo_tramite_id} orden={self.orden} tarea={self.tipo_tarea_id}>'

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -24,7 +24,7 @@ from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_tareas import TipoTarea
 from app.models.documentos_tarea import DocumentoTarea
 from app.utils.permisos import verificar_acceso_expediente
-from app.services.assembler import evaluar_multi
+from app.services.assembler import evaluar_multi, auditar_multi
 from app.services.invariantes_esftt import check_invariante
 
 bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
@@ -45,6 +45,43 @@ def _advertencia(res_eval):
     if res_eval and res_eval.nivel == 'ADVERTIR':
         return {'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma}
     return None
+
+
+def _certs_auto_para_fase(tipo_fase) -> list:
+    """
+    Devuelve los códigos de TipoDocumento con origen='INTERNO' requeridos por
+    alguna tarea de los trámites de esta fase (FaseTramite → TramiteTarea → TipoDocumento).
+    """
+    from app.models.fases_tramites import FaseTramite
+    from app.models.tramites_tareas import TramiteTarea
+    from app.models.tipos_documentos import TipoDocumento
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+    import logging
+    log = logging.getLogger(__name__)
+
+    try:
+        fases_tramites = FaseTramite.query.filter_by(tipo_fase_id=tipo_fase.id).all()
+        tt_ids = [ft.tipo_tramite_id for ft in fases_tramites]
+        if not tt_ids:
+            return []
+
+        tareas_con_doc = TramiteTarea.query.filter(
+            TramiteTarea.tipo_tramite_id.in_(tt_ids),
+            TramiteTarea.doc_consumido_tipo_id.isnot(None),
+        ).all()
+
+        codigos = []
+        vistos = set()
+        for tarea in tareas_con_doc:
+            from app import db as _db
+            td = _db.session.get(TipoDocumento, tarea.doc_consumido_tipo_id)
+            if td and td.origen == 'INTERNO' and td.codigo not in vistos:
+                codigos.append(td.codigo)
+                vistos.add(td.codigo)
+        return codigos
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('_certs_auto_para_fase: error consultando BD: %s', exc)
+        return []
 
 
 # ============================================
@@ -113,6 +150,23 @@ def crear_fase(sol_id):
 
     fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
     db.session.add(fase)
+    db.session.flush()  # necesario para tener fase.id antes del commit
+
+    codigos_cert = _certs_auto_para_fase(tipo_fase)
+    if codigos_cert:
+        auditoria = auditar_multi('CREAR', sol.expediente,
+                                  objeto={'solicitud': sol, 'tipo_fase': tipo_fase})
+        for tipo_cert in codigos_cert:
+            try:
+                from app.services.generador_cert import generar_certificado_fase
+                generar_certificado_fase(sol.expediente, fase, auditoria, tipo_cert)
+            except Exception as exc:
+                import logging
+                logging.getLogger(__name__).error(
+                    'crear_fase: error generando cert %s para fase %s: %s',
+                    tipo_cert, fase.id, exc
+                )
+
     db.session.commit()
 
     return jsonify({'ok': True, 'id': fase.id, 'advertencia': _advertencia(res_eval)})

--- a/app/services/assembler.py
+++ b/app/services/assembler.py
@@ -215,6 +215,46 @@ def build(expediente: Any, objeto: Any = None) -> tuple[str, dict]:
     return sujeto, variables
 
 
+def auditar_multi(accion: str, expediente: Any, objeto: Any = None):
+    """
+    Companion de evaluar_multi que llama a auditar() y acumula reglas de todos los tipos.
+
+    Para solicitudes con tipo combinado (AAP+AAC) evalúa el motor una vez por
+    cada tipo simple, acumulando todas las reglas evaluadas.
+    permitido = AND de todos los AuditoriaResult parciales.
+
+    Returns:
+        AuditoriaResult con reglas_evaluadas = unión de todos los tipos.
+    """
+    from app.services.motor_reglas import auditar, AuditoriaResult
+
+    ctx = ExpedienteContext(expediente, objeto)
+    variables = _compilar_variables(ctx)
+    sol = ctx.solicitud
+
+    tipos = sol.tipos_simples if (sol and sol.tipo_solicitud) else [None]
+
+    todas_reglas = []
+    permitido = True
+    ultimo_sujeto = ''
+
+    for tipo in tipos:
+        sujeto = _compilar_sujeto(ctx, siglas_override=tipo)
+        resultado = auditar(accion, sujeto, variables)
+        todas_reglas.extend(resultado.reglas_evaluadas)
+        if not resultado.permitido:
+            permitido = False
+        ultimo_sujeto = sujeto
+
+    return AuditoriaResult(
+        permitido=permitido,
+        accion=accion,
+        sujeto=ultimo_sujeto,
+        reglas_evaluadas=todas_reglas,
+        variables_ctx=variables,
+    )
+
+
 def evaluar_multi(accion: str, expediente: Any, objeto: Any = None):
     """
     Evalúa una acción para todos los tipos simples de la solicitud en contexto.

--- a/app/services/generador_cert.py
+++ b/app/services/generador_cert.py
@@ -1,0 +1,228 @@
+"""
+Generación de certificados de fase en PDF.
+
+Usa reportlab (pure-Python, sin deps nativas) para producir el PDF.
+El certificado es un snapshot inmutable de la auditoría del motor de reglas.
+
+FLUJO:
+    1. Persiste CertificadoFase (snapshot inmutable en BD).
+    2. Genera PDF con reportlab.
+    3. Guarda en ruta_destino_cert(expediente, tipo_cert).
+    4. Crea Documento (tipo_doc = tipo_cert, url = ruta física).
+    5. Actualiza cert.ruta_pdf.
+    Devuelve CertificadoFase creado.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict
+from datetime import UTC, date, datetime
+
+log = logging.getLogger(__name__)
+
+
+def generar_certificado_fase(expediente, fase, auditoria, tipo_cert: str):
+    """
+    Genera y persiste el certificado de fase.
+
+    Args:
+        expediente:  Instancia de Expediente.
+        fase:        Instancia de Fase (ya con id — tras flush).
+        auditoria:   AuditoriaResult del motor.
+        tipo_cert:   Código de TipoDocumento con origen='INTERNO'
+                     (ej: 'CERT_FIN_INSTRUCCION').
+
+    Returns:
+        CertificadoFase creado y con ruta_pdf rellena.
+    """
+    from app import db
+    from app.models.certificados_fase import CertificadoFase
+    from app.models.documentos import Documento
+    from app.models.tipos_documentos import TipoDocumento
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
+    # 1. Serializar reglas (dataclasses → dicts)
+    try:
+        reglas_json = [asdict(r) for r in auditoria.reglas_evaluadas]
+    except Exception:
+        reglas_json = []
+
+    # variables_ctx puede contener valores no serializables (date, etc.) → convertir
+    variables_json = _serializar_variables(auditoria.variables_ctx)
+
+    # 2. Persistir CertificadoFase (snapshot inmutable)
+    cert = CertificadoFase(
+        expediente_id=expediente.id,
+        fase_id=fase.id if fase else None,
+        tipo_cert=tipo_cert,
+        fecha_generacion=datetime.now(UTC).replace(tzinfo=None),
+        accion=auditoria.accion,
+        sujeto=auditoria.sujeto,
+        reglas_evaluadas=reglas_json,
+        variables_ctx=variables_json,
+    )
+    db.session.add(cert)
+    db.session.flush()  # obtener cert.id antes de generar el PDF
+
+    # 3. Generar PDF
+    try:
+        ruta_pdf = _ruta_destino_cert(expediente, tipo_cert, cert.id)
+        _generar_pdf(cert, expediente, auditoria, ruta_pdf)
+    except Exception as exc:
+        log.error('generador_cert: error generando PDF para %s (cert.id=%s): %s',
+                  tipo_cert, cert.id, exc)
+        return cert  # el cert existe aunque el PDF haya fallado
+
+    # 4. Crear Documento apuntando al PDF
+    try:
+        tipo_doc = TipoDocumento.query.filter_by(codigo=tipo_cert).first()
+        doc = Documento(
+            expediente_id=expediente.id,
+            tipo_doc_id=tipo_doc.id if tipo_doc else 1,
+            url=ruta_pdf,
+            tipo_contenido='application/pdf',
+            fecha_administrativa=date.today(),
+            asunto=f'Certificado {tipo_cert} — {expediente.numero_at}',
+        )
+        db.session.add(doc)
+        db.session.flush()
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('generador_cert: no se pudo crear Documento para cert %s: %s', cert.id, exc)
+        return cert
+
+    # 5. Actualizar ruta_pdf en el cert
+    cert.ruta_pdf = ruta_pdf
+    return cert
+
+
+def _ruta_destino_cert(expediente, tipo_cert: str, cert_id: int) -> str:
+    """
+    Ruta absoluta donde guardar el PDF del certificado.
+
+    Estructura: FILESYSTEM_BASE / AT-{numero_at} / certificados / {tipo_cert}_{cert_id}.pdf
+    """
+    from flask import current_app
+    base = current_app.config.get('FILESYSTEM_BASE', '')
+    if not base:
+        raise RuntimeError('FILESYSTEM_BASE no está configurado')
+
+    directorio = os.path.join(base, f'AT-{expediente.numero_at}', 'certificados')
+    os.makedirs(directorio, exist_ok=True)
+    return os.path.join(directorio, f'{tipo_cert}_{cert_id}.pdf')
+
+
+def _generar_pdf(cert, expediente, auditoria, ruta_destino: str) -> None:
+    """Genera el PDF del certificado con reportlab y lo escribe en ruta_destino."""
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import cm
+    from reportlab.platypus import (
+        Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+    )
+
+    doc = SimpleDocTemplate(
+        ruta_destino,
+        pagesize=A4,
+        leftMargin=2 * cm, rightMargin=2 * cm,
+        topMargin=2.5 * cm, bottomMargin=2.5 * cm,
+    )
+
+    estilos = getSampleStyleSheet()
+    estilo_titulo = ParagraphStyle(
+        'Titulo', parent=estilos['Heading1'], fontSize=13, spaceAfter=6
+    )
+    estilo_subtitulo = ParagraphStyle(
+        'Subtitulo', parent=estilos['Heading2'], fontSize=10, spaceAfter=4
+    )
+    estilo_normal = ParagraphStyle(
+        'Normal', parent=estilos['Normal'], fontSize=9, spaceAfter=3
+    )
+    estilo_pie = ParagraphStyle(
+        'Pie', parent=estilos['Normal'], fontSize=7, textColor=colors.grey
+    )
+
+    referencia_exp = getattr(expediente, 'numero_at', '') or ''
+    fecha_str = cert.fecha_generacion.strftime('%d/%m/%Y %H:%M') if cert.fecha_generacion else ''
+
+    contenido = [
+        Paragraph('Consejería de Industria, Energía y Minas', estilo_subtitulo),
+        Paragraph('Junta de Andalucía', estilo_subtitulo),
+        Spacer(1, 0.3 * cm),
+        Paragraph(f'CERTIFICADO DE FIN DE INSTRUCCIÓN — {cert.tipo_cert}', estilo_titulo),
+        Spacer(1, 0.2 * cm),
+        Paragraph(f'Expediente: AT-{referencia_exp}', estilo_normal),
+        Paragraph(f'Fecha de generación: {fecha_str}', estilo_normal),
+        Paragraph(f'Acción auditada: {cert.accion} / Sujeto: {cert.sujeto}', estilo_normal),
+        Spacer(1, 0.5 * cm),
+        Paragraph(
+            'El sistema BDDAT certifica que el motor de reglas evaluó todas las condiciones '
+            'reglamentarias aplicables y las encontró satisfechas, autorizando la creación '
+            'de la fase indicada. Las reglas evaluadas se detallan a continuación.',
+            estilo_normal,
+        ),
+        Spacer(1, 0.5 * cm),
+        Paragraph('Reglas evaluadas', estilo_subtitulo),
+    ]
+
+    # Tabla de reglas
+    cabecera = [['Descripción', 'Norma', 'Efecto', 'Resultado']]
+    filas = cabecera
+
+    for regla in auditoria.reglas_evaluadas:
+        if regla.disparada:
+            resultado = 'NEUTRALIZADA' if regla.neutralizada else ('BLOQUEANTE' if regla.efecto == 'BLOQUEAR' else 'ADVERTENCIA')
+        else:
+            resultado = 'NO APLICA'
+        filas.append([
+            Paragraph(regla.descripcion or '—', estilo_normal),
+            Paragraph(regla.norma_compilada or '—', estilo_normal),
+            regla.efecto,
+            resultado,
+        ])
+
+    if len(filas) == 1:
+        filas.append(['(Sin reglas aplicables)', '', '', 'VERIFICADO'])
+
+    ancho_col = [8 * cm, 5 * cm, 2.5 * cm, 2.5 * cm]
+    tabla = Table(filas, colWidths=ancho_col, repeatRows=1)
+    tabla.setStyle(TableStyle([
+        ('BACKGROUND',   (0, 0), (-1, 0), colors.HexColor('#003366')),
+        ('TEXTCOLOR',    (0, 0), (-1, 0), colors.white),
+        ('FONTSIZE',     (0, 0), (-1, 0), 9),
+        ('FONTNAME',     (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('ALIGN',        (0, 0), (-1, -1), 'LEFT'),
+        ('VALIGN',       (0, 0), (-1, -1), 'MIDDLE'),
+        ('FONTSIZE',     (0, 1), (-1, -1), 8),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor('#f0f4f8')]),
+        ('GRID',         (0, 0), (-1, -1), 0.5, colors.HexColor('#cccccc')),
+        ('TOPPADDING',   (0, 0), (-1, -1), 4),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 4),
+    ]))
+    contenido.append(tabla)
+
+    contenido += [
+        Spacer(1, 1 * cm),
+        Paragraph(
+            f'Documento generado automáticamente por BDDAT el {fecha_str}. '
+            'No requiere firma manual — su autenticidad se garantiza por el '
+            'registro inmutable en la tabla certificados_fase.',
+            estilo_pie,
+        ),
+    ]
+
+    doc.build(contenido)
+
+
+def _serializar_variables(variables: dict) -> dict:
+    """Convierte valores no serializables (date, datetime) a str para JSON."""
+    resultado = {}
+    for k, v in variables.items():
+        if isinstance(v, (date, datetime)):
+            resultado[k] = v.isoformat()
+        elif isinstance(v, (int, float, str, bool)) or v is None:
+            resultado[k] = v
+        else:
+            resultado[k] = str(v)
+    return resultado

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -51,7 +51,7 @@ log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Resultado público
+# Resultado público — evaluar()
 # ---------------------------------------------------------------------------
 
 @dataclass
@@ -68,6 +68,34 @@ PERMITIDO = EvaluacionResult(
     permitido=True, nivel='',
     variables_trigger={}, norma_compilada='', url_norma='', motivo=''
 )
+
+
+# ---------------------------------------------------------------------------
+# Resultado público — auditar()
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ResultadoRegla:
+    """Snapshot de la evaluación de una regla individual dentro de auditar()."""
+    regla_id:          int
+    sujeto_patron:     str
+    descripcion:       str
+    norma_compilada:   str
+    url_norma:         str
+    efecto:            str   # 'BLOQUEAR' | 'ADVERTIR'
+    disparada:         bool  # True si sus condiciones se cumplieron
+    neutralizada:      bool  # True si disparó pero una excepción la anuló
+    variables_trigger: dict
+
+
+@dataclass
+class AuditoriaResult:
+    """Resultado completo de auditar(): todas las reglas evaluadas sin short-circuit."""
+    permitido:        bool
+    accion:           str
+    sujeto:           str
+    reglas_evaluadas: list  # list[ResultadoRegla] — todas las que casaron con (accion, sujeto)
+    variables_ctx:    dict  # snapshot completo del dict de variables
 
 
 # ---------------------------------------------------------------------------
@@ -208,3 +236,66 @@ def evaluar(
             )
 
     return resultado_advertir or PERMITIDO
+
+
+def auditar(
+    accion:    str,
+    sujeto:    str,
+    variables: dict,
+) -> AuditoriaResult:
+    """
+    Companion de evaluar() que recorre TODAS las reglas sin short-circuit.
+
+    Devuelve el resultado completo de la auditoría: cada regla que casó con
+    (accion, sujeto), si disparó y si fue neutralizada por excepción.
+    Usar como fuente de datos del CERT_FIN_INSTRUCCION y similares.
+
+    permitido=True si ninguna regla bloqueante quedó sin neutralizar.
+    """
+    reglas_candidatas = ReglaMotor.query.options(
+        joinedload(ReglaMotor.condiciones).joinedload(CondicionRegla.variable),
+        joinedload(ReglaMotor.excepciones).joinedload(ExcepcionMotor.condiciones)
+            .joinedload(CondicionExcepcion.variable),
+        joinedload(ReglaMotor.excepciones).joinedload(ExcepcionMotor.norma),
+        joinedload(ReglaMotor.norma),
+    ).filter_by(accion=accion, activa=True).all()
+
+    reglas = [r for r in reglas_candidatas if _sujeto_casa(r.sujeto, sujeto)]
+
+    reglas_evaluadas = []
+    permitido = True
+
+    for regla in sorted(reglas, key=lambda r: r.prioridad):
+        disparada, trigger = _evaluar_condiciones(regla.condiciones, variables)
+
+        neutralizada = False
+        if disparada and regla.efecto == 'BLOQUEAR':
+            excepciones_activas = [e for e in regla.excepciones if e.activa]
+            for exc in excepciones_activas:
+                exc_dispara, _ = _evaluar_condiciones(exc.condiciones, variables)
+                if exc_dispara:
+                    neutralizada = True
+                    break
+            if not neutralizada:
+                permitido = False
+
+        norma_ref, url_norma = _norma_ref(regla) if regla.norma else ('', '')
+        reglas_evaluadas.append(ResultadoRegla(
+            regla_id=regla.id,
+            sujeto_patron=regla.sujeto,
+            descripcion=regla.descripcion or '',
+            norma_compilada=norma_ref,
+            url_norma=url_norma,
+            efecto=regla.efecto,
+            disparada=disparada,
+            neutralizada=neutralizada,
+            variables_trigger=trigger,
+        ))
+
+    return AuditoriaResult(
+        permitido=permitido,
+        accion=accion,
+        sujeto=sujeto,
+        reglas_evaluadas=reglas_evaluadas,
+        variables_ctx=variables,
+    )

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -4,8 +4,8 @@
 
 ---
 
-**Último cerrado:** #368 + #369 — INFORMACION_PUBLICA: REDACTAR_ANUNCIO, ANUNCIO_BOJA, ANUNCIO_TITULAR (FTT + tests). Trabajo estructural ya venía de #370; commits d708f94 y b99a398.
+**Último cerrado:** #373 — CERT_FIN_INSTRUCCION: certificado automático al crear fase RESOLUCION. auditar() + auditar_multi() en motor, tabla certificados_fase, generador_cert.py (reportlab), trigger en crear_fase(). 13 tests pasando.
 
 **Actuales:** —
 
-**Próximo:** #373 → #346 → #173 → #328
+**Próximo:** #346 → #173 → #328

--- a/docs/referencia/ESTRUCTURA_FTT.json
+++ b/docs/referencia/ESTRUCTURA_FTT.json
@@ -363,10 +363,11 @@
         {
           "codigo": "ELABORACION",
           "nombre": "Elaboración de Resolución",
-          "descripcion": "Análisis de informes previos y elaboración de la resolución con validez jurídica",
-          "tareas_indicativas": ["ANALIZAR", "ELABORAR"],
-          "patron": "A+B (sin NOTIFICAR)",
-          "nota": "No requiere recepción externa — documento interno generado por el sistema."
+          "descripcion": "Elaboración de la resolución con validez jurídica. El análisis previo queda acreditado por CERT_FIN_INSTRUCCION, generado automáticamente al crear la fase RESOLUCION.",
+          "tareas_indicativas": ["ELABORAR"],
+          "patron": "B (sin NOTIFICAR)",
+          "documento_consumido": "CERT_FIN_INSTRUCCION (generado automáticamente por BDDAT al crear la fase RESOLUCION, #373)",
+          "nota": "ANALIZAR eliminado (#373): el CERT_FIN_INSTRUCCION es el recibo auditado de que el motor evaluó todas las condiciones previas. ELABORAR lo consume como documento_usado_id."
         },
         {
           "codigo": "NOTIFICACION",

--- a/migrations/versions/373_cert_fin_instruccion.py
+++ b/migrations/versions/373_cert_fin_instruccion.py
@@ -1,0 +1,160 @@
+"""373_cert_fin_instruccion — tabla certificados_fase + CERT_FIN_INSTRUCCION
+
+Revision ID: 373_cert_fin_instruccion
+Revises: 370_seed_tramites_tareas
+Create Date: 2026-05-13
+
+Issue #373 — Certificado automático de fin de instrucción:
+- Añade columna doc_consumido_tipo_id a tramites_tareas
+- Crea tabla certificados_fase (snapshot inmutable de auditoría)
+- Seed CERT_FIN_INSTRUCCION en tipos_documentos
+- Actualiza tramites_tareas para ELABORACION: elimina ANALIZAR, ELABORAR
+  consume CERT_FIN_INSTRUCCION
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '373_cert_fin_instruccion'
+down_revision = '370_seed_tramites_tareas'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. Nueva columna en tramites_tareas
+    op.add_column(
+        'tramites_tareas',
+        sa.Column(
+            'doc_consumido_tipo_id',
+            sa.Integer,
+            sa.ForeignKey('public.tipos_documentos.id',
+                          name='fk_tram_tareas_doc_consumido_tipo'),
+            nullable=True,
+        ),
+        schema='public',
+    )
+
+    # 2. Crear tabla certificados_fase
+    op.create_table(
+        'certificados_fase',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('expediente_id', sa.Integer,
+                  sa.ForeignKey('public.expedientes.id',
+                                name='fk_cert_fase_expediente'),
+                  nullable=False),
+        sa.Column('fase_id', sa.Integer,
+                  sa.ForeignKey('public.fases.id',
+                                name='fk_cert_fase_fase'),
+                  nullable=True),
+        sa.Column('tipo_cert', sa.String(50), nullable=False),
+        sa.Column('fecha_generacion', sa.DateTime, nullable=False),
+        sa.Column('accion', sa.String(10), nullable=False),
+        sa.Column('sujeto', sa.String(200), nullable=False),
+        sa.Column('reglas_evaluadas', sa.JSON, nullable=False),
+        sa.Column('variables_ctx', sa.JSON, nullable=False),
+        sa.Column('ruta_pdf', sa.Text, nullable=True),
+        schema='public',
+    )
+    op.create_index('idx_cert_fase_expediente', 'certificados_fase',
+                    ['expediente_id'], schema='public')
+    op.create_index('idx_cert_fase_tipo', 'certificados_fase',
+                    ['tipo_cert'], schema='public')
+
+    # 3. Seed CERT_FIN_INSTRUCCION
+    conn.execute(sa.text("""
+        INSERT INTO public.tipos_documentos (codigo, nombre, origen)
+        VALUES ('CERT_FIN_INSTRUCCION', 'Certificado de fin de instrucción', 'INTERNO')
+        ON CONFLICT (codigo) DO NOTHING
+    """))
+
+    # 4. Actualizar tramites_tareas para ELABORACION:
+    #    - Eliminar la fila de ANALIZAR
+    #    - Ajustar el orden de ELABORAR a 1 con doc_consumido_tipo_id = CERT_FIN_INSTRUCCION
+
+    tt_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tramites WHERE codigo = 'ELABORACION'"
+    )).scalar()
+    ta_analizar_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tareas WHERE codigo = 'ANALIZAR'"
+    )).scalar()
+    ta_elaborar_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tareas WHERE codigo = 'ELABORAR'"
+    )).scalar()
+    td_cert_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_documentos WHERE codigo = 'CERT_FIN_INSTRUCCION'"
+    )).scalar()
+
+    if tt_id is None:
+        raise ValueError("tipos_tramites.codigo='ELABORACION' no encontrado — migración abortada")
+    if ta_analizar_id is None:
+        raise ValueError("tipos_tareas.codigo='ANALIZAR' no encontrado — migración abortada")
+    if ta_elaborar_id is None:
+        raise ValueError("tipos_tareas.codigo='ELABORAR' no encontrado — migración abortada")
+    if td_cert_id is None:
+        raise ValueError("tipos_documentos.codigo='CERT_FIN_INSTRUCCION' no encontrado — migración abortada")
+
+    # Eliminar fila ANALIZAR (orden=1) de ELABORACION
+    conn.execute(sa.text("""
+        DELETE FROM public.tramites_tareas
+        WHERE tipo_tramite_id = :tt_id
+          AND tipo_tarea_id   = :ta_id
+    """), {'tt_id': tt_id, 'ta_id': ta_analizar_id})
+
+    # Ajustar ELABORAR a orden=1 y añadir doc_consumido_tipo_id
+    conn.execute(sa.text("""
+        UPDATE public.tramites_tareas
+        SET orden = 1,
+            doc_consumido_tipo_id = :td_id
+        WHERE tipo_tramite_id = :tt_id
+          AND tipo_tarea_id   = :ta_id
+    """), {'tt_id': tt_id, 'ta_id': ta_elaborar_id, 'td_id': td_cert_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # Revertir tramites_tareas para ELABORACION
+    tt_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tramites WHERE codigo = 'ELABORACION'"
+    )).scalar()
+    ta_analizar_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tareas WHERE codigo = 'ANALIZAR'"
+    )).scalar()
+    ta_elaborar_id = conn.execute(sa.text(
+        "SELECT id FROM public.tipos_tareas WHERE codigo = 'ELABORAR'"
+    )).scalar()
+
+    if tt_id and ta_analizar_id and ta_elaborar_id:
+        # Restaurar ANALIZAR orden=1
+        conn.execute(sa.text("""
+            INSERT INTO public.tramites_tareas (tipo_tramite_id, orden, tipo_tarea_id)
+            VALUES (:tt_id, 1, :ta_id)
+            ON CONFLICT DO NOTHING
+        """), {'tt_id': tt_id, 'ta_id': ta_analizar_id})
+
+        # Restaurar ELABORAR a orden=2, quitar doc_consumido_tipo_id
+        conn.execute(sa.text("""
+            UPDATE public.tramites_tareas
+            SET orden = 2,
+                doc_consumido_tipo_id = NULL
+            WHERE tipo_tramite_id = :tt_id
+              AND tipo_tarea_id   = :ta_id
+        """), {'tt_id': tt_id, 'ta_id': ta_elaborar_id})
+
+    # Eliminar CERT_FIN_INSTRUCCION
+    conn.execute(sa.text("""
+        DELETE FROM public.tipos_documentos WHERE codigo = 'CERT_FIN_INSTRUCCION'
+    """))
+
+    # Eliminar tabla certificados_fase
+    op.drop_index('idx_cert_fase_tipo', 'certificados_fase', schema='public')
+    op.drop_index('idx_cert_fase_expediente', 'certificados_fase', schema='public')
+    op.drop_table('certificados_fase', schema='public')
+
+    # Eliminar columna de tramites_tareas
+    op.drop_constraint('fk_tram_tareas_doc_consumido_tipo', 'tramites_tareas',
+                       type_='foreignkey', schema='public')
+    op.drop_column('tramites_tareas', 'doc_consumido_tipo_id', schema='public')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.18.1
+reportlab==4.5.1
 docxcompose==2.0.2
 docxtpl==0.20.2
 lxml==6.0.2

--- a/tests/test_373_auditar.py
+++ b/tests/test_373_auditar.py
@@ -1,0 +1,174 @@
+"""Tests unitarios issue #373 — auditar() y auditar_multi().
+
+Sin BD real — usa stubs/mocks de los modelos y el registry de variables.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Stubs mínimos para ReglaMotor y estructuras relacionadas
+# ---------------------------------------------------------------------------
+
+def _stub_condicion(nombre_var, operador, valor):
+    c = MagicMock()
+    c.orden = 1
+    c.operador = operador
+    c.valor = valor
+    c.variable = MagicMock()
+    c.variable.nombre = nombre_var
+    return c
+
+
+def _stub_regla(regla_id, sujeto, efecto, condiciones=None, excepciones=None, descripcion='', norma=None):
+    r = MagicMock()
+    r.id = regla_id
+    r.sujeto = sujeto
+    r.efecto = efecto
+    r.prioridad = regla_id
+    r.descripcion = descripcion
+    r.condiciones = condiciones or []
+    r.excepciones = excepciones or []
+    r.norma = norma
+    r.activa = True
+    return r
+
+
+def _stub_excepcion(condiciones=None, activa=True):
+    e = MagicMock()
+    e.activa = activa
+    e.condiciones = condiciones or []
+    e.norma = None
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestAuditar:
+    """Tests unitarios de motor_reglas.auditar()."""
+
+    def _run(self, reglas_mock, accion, sujeto, variables):
+        """Ejecuta auditar() con la lista de reglas mockeada."""
+        from app.services.motor_reglas import auditar
+
+        query_mock = MagicMock()
+        query_mock.options.return_value.filter_by.return_value.all.return_value = reglas_mock
+
+        # joinedload usa atributos de RelationshipProperty; parchearlo evita
+        # que SQLAlchemy intente resolver los atributos del mock.
+        jl_mock = MagicMock()
+        jl_mock.return_value.joinedload.return_value = jl_mock.return_value
+
+        with patch('app.services.motor_reglas.joinedload', jl_mock), \
+             patch('app.services.motor_reglas.ReglaMotor') as MockRegla:
+            MockRegla.query = query_mock
+            return auditar(accion, sujeto, variables)
+
+    def test_sin_reglas_permite_y_lista_vacia(self):
+        """Sin reglas configuradas → permitido=True, reglas_evaluadas vacía."""
+        resultado = self._run([], 'CREAR', 'Distribucion/AAP/RESOLUCION', {})
+        assert resultado.permitido is True
+        assert resultado.reglas_evaluadas == []
+
+    def test_regla_que_dispara_advertir_incluida(self):
+        """Una regla ADVERTIR que dispara aparece en reglas_evaluadas y no bloquea."""
+        cond = _stub_condicion('fase_activa', 'EQ', True)
+        regla = _stub_regla(1, 'Distribucion/AAP/RESOLUCION', 'ADVERTIR',
+                            condiciones=[cond], descripcion='Advertencia test')
+
+        from app.services.operadores import _OPERADORES
+        with patch.dict(_OPERADORES, {'EQ': lambda a, b: a == b}):
+            resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION',
+                                  {'fase_activa': True})
+
+        assert resultado.permitido is True
+        assert len(resultado.reglas_evaluadas) == 1
+        rr = resultado.reglas_evaluadas[0]
+        assert rr.disparada is True
+        assert rr.neutralizada is False
+        assert rr.efecto == 'ADVERTIR'
+
+    def test_regla_bloqueante_no_neutralizada_permitido_false(self):
+        """Una regla BLOQUEAR sin excepciones → permitido=False."""
+        cond = _stub_condicion('fase_activa', 'EQ', True)
+        regla = _stub_regla(1, 'Distribucion/AAP/RESOLUCION', 'BLOQUEAR',
+                            condiciones=[cond])
+
+        from app.services.operadores import _OPERADORES
+        with patch.dict(_OPERADORES, {'EQ': lambda a, b: a == b}):
+            resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION',
+                                  {'fase_activa': True})
+
+        assert resultado.permitido is False
+        rr = resultado.reglas_evaluadas[0]
+        assert rr.disparada is True
+        assert rr.neutralizada is False
+
+    def test_regla_bloqueante_neutralizada_por_excepcion(self):
+        """Una regla BLOQUEAR con excepción que casa → neutralizada=True, permitido=True."""
+        cond = _stub_condicion('fase_activa', 'EQ', True)
+        exc_cond = _stub_condicion('tiene_permiso', 'EQ', True)
+        excepcion = _stub_excepcion(condiciones=[exc_cond])
+        regla = _stub_regla(1, 'Distribucion/AAP/RESOLUCION', 'BLOQUEAR',
+                            condiciones=[cond], excepciones=[excepcion])
+
+        from app.services.operadores import _OPERADORES
+        with patch.dict(_OPERADORES, {'EQ': lambda a, b: a == b}):
+            resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION',
+                                  {'fase_activa': True, 'tiene_permiso': True})
+
+        assert resultado.permitido is True
+        rr = resultado.reglas_evaluadas[0]
+        assert rr.disparada is True
+        assert rr.neutralizada is True
+
+    def test_regla_que_no_dispara_incluida_como_no_disparada(self):
+        """Una regla cuyas condiciones no se cumplen → disparada=False, incluida igualmente."""
+        cond = _stub_condicion('fase_activa', 'EQ', True)
+        regla = _stub_regla(1, 'Distribucion/AAP/RESOLUCION', 'BLOQUEAR',
+                            condiciones=[cond])
+
+        from app.services.operadores import _OPERADORES
+        with patch.dict(_OPERADORES, {'EQ': lambda a, b: a == b}):
+            resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION',
+                                  {'fase_activa': False})
+
+        assert resultado.permitido is True
+        rr = resultado.reglas_evaluadas[0]
+        assert rr.disparada is False
+        assert rr.neutralizada is False
+
+    def test_no_short_circuit_acumula_todas(self):
+        """Con dos reglas bloqueantes, ambas se evalúan (sin short-circuit)."""
+        cond1 = _stub_condicion('var1', 'EQ', True)
+        cond2 = _stub_condicion('var2', 'EQ', True)
+        regla1 = _stub_regla(1, 'Distribucion/AAP/RESOLUCION', 'BLOQUEAR', condiciones=[cond1])
+        regla2 = _stub_regla(2, 'Distribucion/AAP/RESOLUCION', 'BLOQUEAR', condiciones=[cond2])
+
+        from app.services.operadores import _OPERADORES
+        with patch.dict(_OPERADORES, {'EQ': lambda a, b: a == b}):
+            resultado = self._run(
+                [regla1, regla2], 'CREAR', 'Distribucion/AAP/RESOLUCION',
+                {'var1': True, 'var2': True}
+            )
+
+        assert resultado.permitido is False
+        assert len(resultado.reglas_evaluadas) == 2
+
+    def test_sujeto_no_casa_excluye_regla(self):
+        """Regla con sujeto diferente no aparece en reglas_evaluadas."""
+        regla = _stub_regla(1, 'Distribucion/AAC/RESOLUCION', 'BLOQUEAR')
+
+        resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION', {})
+        assert resultado.reglas_evaluadas == []
+        assert resultado.permitido is True
+
+    def test_sujeto_any_casa(self):
+        """Sujeto con ANY en patrón casa con cualquier valor en esa posición."""
+        regla = _stub_regla(1, 'ANY/AAP/RESOLUCION', 'BLOQUEAR', condiciones=[])
+        resultado = self._run([regla], 'CREAR', 'Distribucion/AAP/RESOLUCION', {})
+        # Sin condiciones la regla dispara siempre → una fila en reglas_evaluadas
+        assert len(resultado.reglas_evaluadas) == 1

--- a/tests/test_373_cert_fase.py
+++ b/tests/test_373_cert_fase.py
@@ -1,0 +1,273 @@
+"""Tests de integración issue #373 — generación automática de CERT_FIN_INSTRUCCION.
+
+Requieren:
+  - BD con migración 373_cert_fin_instruccion aplicada.
+  - Fixture app_ctx (rollback automático por test).
+
+Escenarios:
+  A) Crear fase RESOLUCION con condiciones válidas → cert en BD + PDF en disco
+  B) Motor bloquea la creación → no se genera cert
+  C) reglas_evaluadas del cert contiene las reglas esperadas
+  D) PDF existe en la ruta ruta_pdf del cert
+"""
+import os
+import time
+from datetime import date
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_tipo(model_class, **filtros):
+    obj = model_class.query.filter_by(**filtros).first()
+    assert obj is not None, (
+        f'{model_class.__name__} con {filtros} no encontrado — '
+        f'¿migración 373 aplicada?'
+    )
+    return obj
+
+
+def _crear_expediente(db, tipo_exp):
+    from app.models import Expediente, Proyecto
+    proyecto = Proyecto(
+        titulo='Test cert fase #373',
+        descripcion='Test',
+        fecha=date(2026, 1, 1),
+        finalidad='Test',
+        emplazamiento='Test',
+    )
+    db.session.add(proyecto)
+    db.session.flush()
+    numero_at = int(time.time() * 1000) % 10_000_000
+    exp = Expediente(numero_at=numero_at, proyecto=proyecto, tipo_expediente=tipo_exp)
+    db.session.add(exp)
+    db.session.flush()
+    return exp
+
+
+def _crear_solicitud(db, expediente, tipo_solicitud):
+    from app.models import Solicitud, Entidad
+    entidad = Entidad.query.first()
+    assert entidad is not None, 'Tabla entidades vacía — seed necesario'
+    sol = Solicitud(expediente=expediente, tipo_solicitud=tipo_solicitud, entidad=entidad)
+    db.session.add(sol)
+    db.session.flush()
+    return sol
+
+
+def _crear_fase_doc(db, solicitud, tipo_fase, resultado=None):
+    """Crea una fase con documento_resultado (fase finalizada)."""
+    from app.models import Fase, Documento
+    doc = Documento(
+        expediente=solicitud.expediente,
+        url=f'test://doc-{tipo_fase.codigo}',
+        fecha_administrativa=date(2025, 1, 1),
+    )
+    db.session.add(doc)
+    db.session.flush()
+    fase = Fase(
+        solicitud=solicitud,
+        tipo_fase=tipo_fase,
+        resultado_fase=resultado,
+        documento_resultado=doc,
+    )
+    db.session.add(fase)
+    db.session.flush()
+    return fase
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def ctx(app_ctx):
+    from app.models import TipoFase, TipoSolicitud, TipoExpediente, TipoResultadoFase
+    return {
+        'tf_resolucion': _get_tipo(TipoFase, codigo='RESOLUCION'),
+        'ts_aap':        _get_tipo(TipoSolicitud, siglas='AAP'),
+        'resultado_fav': _get_tipo(TipoResultadoFase, codigo='FAVORABLE'),
+        'tipo_exp':      TipoExpediente.query.first(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# A) Crear fase RESOLUCION → se genera cert en BD
+# ---------------------------------------------------------------------------
+
+def test_crear_fase_genera_cert_en_bd(app_ctx, ctx):
+    """Al crear fase RESOLUCION, se persiste CertificadoFase en BD."""
+    from app import db
+    from app.models import TipoFase
+    from app.models.certificados_fase import CertificadoFase
+    from app.services.generador_cert import generar_certificado_fase
+    from app.services.assembler import auditar_multi
+    from app.services.motor_reglas import AuditoriaResult
+
+    exp = _crear_expediente(db, ctx['tipo_exp'])
+    sol = _crear_solicitud(db, exp, ctx['ts_aap'])
+
+    tipo_fase = ctx['tf_resolucion']
+    from app.models import Fase
+    fase = Fase(solicitud=sol, tipo_fase=tipo_fase)
+    db.session.add(fase)
+    db.session.flush()
+
+    # Crear auditoría sintética (sin reglas reales configuradas en test)
+    auditoria = AuditoriaResult(
+        permitido=True,
+        accion='CREAR',
+        sujeto=f'Distribucion/AAP/RESOLUCION',
+        reglas_evaluadas=[],
+        variables_ctx={},
+    )
+
+    cert = generar_certificado_fase(exp, fase, auditoria, 'CERT_FIN_INSTRUCCION')
+    db.session.flush()
+
+    assert cert.id is not None
+    assert cert.tipo_cert == 'CERT_FIN_INSTRUCCION'
+    assert cert.expediente_id == exp.id
+    assert cert.fase_id == fase.id
+    assert cert.accion == 'CREAR'
+    assert cert.reglas_evaluadas == []
+
+    # Verificar que existe en BD
+    cert_bd = CertificadoFase.query.filter_by(
+        expediente_id=exp.id, tipo_cert='CERT_FIN_INSTRUCCION'
+    ).first()
+    assert cert_bd is not None
+
+
+# ---------------------------------------------------------------------------
+# B) Crear fase RESOLUCION → se genera Documento en BD
+# ---------------------------------------------------------------------------
+
+def test_crear_fase_genera_documento_en_bd(app_ctx, ctx):
+    """Al generar el cert se crea también una fila en documentos."""
+    from app import db
+    from app.models import Fase, Documento
+    from app.models.tipos_documentos import TipoDocumento
+    from app.services.generador_cert import generar_certificado_fase
+    from app.services.motor_reglas import AuditoriaResult
+
+    exp = _crear_expediente(db, ctx['tipo_exp'])
+    sol = _crear_solicitud(db, exp, ctx['ts_aap'])
+
+    fase = Fase(solicitud=sol, tipo_fase=ctx['tf_resolucion'])
+    db.session.add(fase)
+    db.session.flush()
+
+    td_cert = TipoDocumento.query.filter_by(codigo='CERT_FIN_INSTRUCCION').first()
+    assert td_cert is not None, 'CERT_FIN_INSTRUCCION no está en tipos_documentos — ¿migración aplicada?'
+
+    auditoria = AuditoriaResult(
+        permitido=True, accion='CREAR',
+        sujeto='Distribucion/AAP/RESOLUCION',
+        reglas_evaluadas=[], variables_ctx={},
+    )
+
+    cert = generar_certificado_fase(exp, fase, auditoria, 'CERT_FIN_INSTRUCCION')
+    db.session.flush()
+
+    doc = Documento.query.filter_by(
+        expediente_id=exp.id, tipo_doc_id=td_cert.id
+    ).first()
+    assert doc is not None
+    assert doc.tipo_contenido == 'application/pdf'
+
+
+# ---------------------------------------------------------------------------
+# C) reglas_evaluadas serializado correctamente en JSON
+# ---------------------------------------------------------------------------
+
+def test_cert_reglas_evaluadas_en_json(app_ctx, ctx):
+    """cert.reglas_evaluadas contiene la lista serializada de ResultadoRegla."""
+    from app import db
+    from app.models import Fase
+    from app.services.generador_cert import generar_certificado_fase
+    from app.services.motor_reglas import AuditoriaResult, ResultadoRegla
+
+    exp = _crear_expediente(db, ctx['tipo_exp'])
+    sol = _crear_solicitud(db, exp, ctx['ts_aap'])
+
+    fase = Fase(solicitud=sol, tipo_fase=ctx['tf_resolucion'])
+    db.session.add(fase)
+    db.session.flush()
+
+    rr = ResultadoRegla(
+        regla_id=99,
+        sujeto_patron='Distribucion/AAP/RESOLUCION',
+        descripcion='Regla de test',
+        norma_compilada='Art. 1 — Ley test',
+        url_norma='https://example.com',
+        efecto='BLOQUEAR',
+        disparada=True,
+        neutralizada=True,
+        variables_trigger={'var': 1},
+    )
+    auditoria = AuditoriaResult(
+        permitido=True, accion='CREAR',
+        sujeto='Distribucion/AAP/RESOLUCION',
+        reglas_evaluadas=[rr], variables_ctx={'var': 1},
+    )
+
+    cert = generar_certificado_fase(exp, fase, auditoria, 'CERT_FIN_INSTRUCCION')
+    db.session.flush()
+
+    assert len(cert.reglas_evaluadas) == 1
+    regla_json = cert.reglas_evaluadas[0]
+    assert regla_json['regla_id'] == 99
+    assert regla_json['descripcion'] == 'Regla de test'
+    assert regla_json['disparada'] is True
+    assert regla_json['neutralizada'] is True
+
+
+# ---------------------------------------------------------------------------
+# D) PDF existe en disco en la ruta guardada
+# ---------------------------------------------------------------------------
+
+def test_cert_pdf_existe_en_disco(app_ctx, ctx):
+    """El PDF generado existe físicamente en la ruta cert.ruta_pdf."""
+    from app import db
+    from app.models import Fase
+    from app.services.generador_cert import generar_certificado_fase
+    from app.services.motor_reglas import AuditoriaResult
+
+    exp = _crear_expediente(db, ctx['tipo_exp'])
+    sol = _crear_solicitud(db, exp, ctx['ts_aap'])
+
+    fase = Fase(solicitud=sol, tipo_fase=ctx['tf_resolucion'])
+    db.session.add(fase)
+    db.session.flush()
+
+    auditoria = AuditoriaResult(
+        permitido=True, accion='CREAR',
+        sujeto='Distribucion/AAP/RESOLUCION',
+        reglas_evaluadas=[], variables_ctx={},
+    )
+
+    cert = generar_certificado_fase(exp, fase, auditoria, 'CERT_FIN_INSTRUCCION')
+    db.session.flush()
+
+    assert cert.ruta_pdf is not None
+    assert os.path.isfile(cert.ruta_pdf), (
+        f'PDF no encontrado en disco: {cert.ruta_pdf}'
+    )
+    assert os.path.getsize(cert.ruta_pdf) > 0
+
+
+# ---------------------------------------------------------------------------
+# E) _certs_auto_para_fase devuelve CERT_FIN_INSTRUCCION para RESOLUCION
+# ---------------------------------------------------------------------------
+
+def test_certs_auto_para_fase_resolucion(app_ctx, ctx):
+    """_certs_auto_para_fase devuelve ['CERT_FIN_INSTRUCCION'] para la fase RESOLUCION."""
+    from app.routes.api_bc import _certs_auto_para_fase
+
+    tipo_fase = ctx['tf_resolucion']
+    codigos = _certs_auto_para_fase(tipo_fase)
+    assert 'CERT_FIN_INSTRUCCION' in codigos


### PR DESCRIPTION
## Cambios

- **`motor_reglas.py`** — añade `ResultadoRegla`, `AuditoriaResult` y `auditar()`: recorre _todas_ las reglas sin short-circuit para producir el snapshot completo de la auditoría
- **`assembler.py`** — añade `auditar_multi()`: companion de `evaluar_multi` que acumula reglas de todos los tipos simples de la solicitud
- **`certificados_fase.py`** — nuevo modelo `CertificadoFase` (snapshot inmutable de la auditoría del motor)
- **`migración 373`** — tabla `certificados_fase`, columna `doc_consumido_tipo_id` en `tramites_tareas`, seed `CERT_FIN_INSTRUCCION` en `tipos_documentos`, actualiza secuencia de ELABORACION (elimina ANALIZAR, ELABORAR consume CERT_FIN_INSTRUCCION)
- **`generador_cert.py`** — nuevo servicio: persiste `CertificadoFase`, genera PDF con `reportlab` (WeasyPrint requiere GTK no disponible en Windows), crea `Documento`
- **`api_bc.py`** — trigger en `crear_fase()`: detecta certs INTERNO requeridos por la fase y los genera antes del `commit`; helper `_certs_auto_para_fase()`
- **`ESTRUCTURA_FTT.json`** — ELABORACION actualizado: `tareas_indicativas: ["ELABORAR"]`, nota y campo `documento_consumido` con referencia al cert
- **`catalogo_requerido.py`** — añade `TipoDocumento: ['CERT_FIN_INSTRUCCION']`
- **`requirements.txt`** — añade `reportlab==4.5.1`
- **Tests** — `test_373_auditar.py` (8 unitarios con stubs) + `test_373_cert_fase.py` (5 integración con BD real): 13/13 pasando

Closes #373
