### PR TITLE
Carga anual del calendario de días inhábiles desde la API de la Junta

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -91,18 +91,42 @@ def create_app(config_name='development'):
     from app.modules import ModuleRegistry
     ModuleRegistry.register_all(app)
 
+    # Registrar comandos CLI
+    from app.cli.inhabiles import inhabiles
+    app.cli.add_command(inhabiles)
+
     # Context processor — inyecta navegación de módulos en todos los templates
     @app.context_processor
     def inject_module_nav():
+        from datetime import date as _date
+        from sqlalchemy.exc import OperationalError, ProgrammingError
+
         user_roles = (
             [r.nombre for r in current_user.roles]
             if current_user.is_authenticated else []
         )
         nav = ModuleRegistry.get_navigation(user_roles)
 
+        # Alerta de calendario inhábil para admins: avisa si falta el año N+1
+        alerta_calendario = False
+        if current_user.is_authenticated and current_user.es_admin:
+            try:
+                from app.models.dias_inhabiles import DiaInhabil
+                anyo_siguiente = _date.today().year + 1
+                tiene_datos = db.session.query(
+                    DiaInhabil.query.filter(
+                        DiaInhabil.fecha >= _date(anyo_siguiente, 1, 1),
+                        DiaInhabil.fecha <= _date(anyo_siguiente, 12, 31),
+                    ).exists()
+                ).scalar()
+                alerta_calendario = not tiene_datos
+            except (OperationalError, ProgrammingError):
+                pass
+
         return {
-            'module_nav':    nav,
-            'active_module': request.blueprint,
+            'module_nav':        nav,
+            'active_module':     request.blueprint,
+            'alerta_calendario': alerta_calendario,
         }
 
     # Configuración de Jinja2

--- a/app/cli/inhabiles.py
+++ b/app/cli/inhabiles.py
@@ -1,0 +1,155 @@
+"""Comandos CLI para gestión del calendario de días inhábiles.
+
+Uso:
+    flask inhabiles importar --year 2027
+    flask inhabiles importar --year 2027 --province CÁDIZ --municipio CÁDIZ
+    flask inhabiles importar --year 2027 --dry-run
+
+Fuente: API pública de la Junta de Andalucía.
+Documentación: docs/guias/GUIA_ADMINISTRACION.md
+"""
+import json
+import logging
+import urllib.request
+import urllib.parse
+from datetime import date
+
+import click
+from flask.cli import with_appcontext
+
+log = logging.getLogger(__name__)
+
+_API_BASE = 'https://www.juntadeandalucia.es/ssdigitales/datasets/work-calendar'
+_ENDPOINT  = '/work-calendar/get/search_calendar_weekends'
+
+# Mapping de (province, municipality) de la API → código de AmbitoInhabilidad
+# Las entradas con province/municipality vacíos son nacionales+autonómicos andaluces.
+_AMBITO_VACIO = 'AUTONOMICO_AND'
+
+
+def _codigo_ambito(province: str, municipality: str, prov_param: str, mun_param: str) -> str:
+    """Devuelve el código de ámbito según los valores del registro de la API."""
+    if not province and not municipality:
+        return 'AUTONOMICO_AND'
+    p = province.upper().replace(' ', '_')[:10]
+    m = municipality.upper().replace(' ', '_')[:10]
+    if municipality:
+        return f'LOCAL_{p}_{m}'
+    return f'PROVINCIAL_{p}'
+
+
+def _obtener_o_crear_ambito(codigo: str, db):
+    """Devuelve AmbitoInhabilidad con ese código, creándolo si no existe."""
+    from app.models.ambitos_inhabilidad import AmbitoInhabilidad
+    ambito = AmbitoInhabilidad.query.filter_by(codigo=codigo).first()
+    if ambito is None:
+        nombre = codigo.replace('_', ' ').title()
+        ambito = AmbitoInhabilidad(codigo=codigo, nombre=nombre)
+        db.session.add(ambito)
+        db.session.flush()
+        click.echo(f'  [nuevo ámbito] {codigo}')
+    return ambito
+
+
+def _fetch_inhabiles(year: int, province: str, municipio: str) -> list:
+    """Llama a la API de la Junta y devuelve los registros del año."""
+    params = urllib.parse.urlencode({
+        'municipality': municipio,
+        'province': province,
+        'year': str(year),
+    })
+    url = f'{_API_BASE}{_ENDPOINT}?{params}'
+    click.echo(f'  GET {url}')
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        data = json.loads(resp.read().decode())
+    # La API devuelve {"results": [...]} o directamente una lista
+    if isinstance(data, dict):
+        return data.get('results', data.get('result', []))
+    return data
+
+
+def _parse_fecha(date_int: int) -> date:
+    """Convierte entero YYYYMMDD a date."""
+    s = str(date_int)
+    return date(int(s[:4]), int(s[4:6]), int(s[6:8]))
+
+
+@click.group()
+def inhabiles():
+    """Gestión del calendario de días inhábiles."""
+
+
+@inhabiles.command('importar')
+@click.option('--year', default=None, type=int,
+              help='Año a importar. Defecto: año siguiente al actual.')
+@click.option('--province', default='CÁDIZ', show_default=True,
+              help='Provincia (mayúsculas exactas según la API).')
+@click.option('--municipio', default='CÁDIZ', show_default=True,
+              help='Municipio (mayúsculas exactas según la API).')
+@click.option('--dry-run', is_flag=True, default=False,
+              help='Mostrar lo que se importaría sin modificar la BD.')
+@with_appcontext
+def importar(year, province, municipio, dry_run):
+    """Importa días inhábiles desde la API de la Junta de Andalucía.
+
+    Por defecto importa el año siguiente al actual con ámbito Cádiz capital.
+    Ejecutar cada año en noviembre tras la publicación del BOJA de festivos.
+
+    Ejemplos:\n
+        flask inhabiles importar\n
+        flask inhabiles importar --year 2027\n
+        flask inhabiles importar --year 2027 --dry-run
+    """
+    from app import db
+    from app.models.dias_inhabiles import DiaInhabil
+
+    year_importar = year or (date.today().year + 1)
+    click.echo(f'Importando año {year_importar} (province={province}, municipio={municipio})')
+    if dry_run:
+        click.echo('  [DRY RUN — no se modificará la BD]')
+
+    try:
+        registros = _fetch_inhabiles(year_importar, province, municipio)
+    except Exception as exc:
+        click.echo(f'ERROR al llamar a la API: {exc}', err=True)
+        raise SystemExit(1)
+
+    # Deduplicar por date (la API puede repetir autonómicos al consultar con municipio)
+    vistos: set[int] = set()
+    festivos = []
+    for r in registros:
+        d = r.get('date')
+        if d in vistos:
+            continue
+        vistos.add(d)
+        fecha = _parse_fecha(d)
+        # Excluir sábados (5) y domingos (6) — el motor los trata aparte
+        if fecha.weekday() >= 5:
+            continue
+        festivos.append((fecha, r.get('description', ''), r.get('province', ''), r.get('municipality', '')))
+
+    click.echo(f'  {len(festivos)} festivos laborables recibidos (excluidos fines de semana)')
+
+    if dry_run:
+        for fecha, desc, prov, mun in sorted(festivos):
+            codigo = _codigo_ambito(prov, mun, province, municipio)
+            click.echo(f'    {fecha}  [{codigo}]  {desc}')
+        return
+
+    insertados = actualizados = 0
+    for fecha, desc, prov, mun in festivos:
+        codigo = _codigo_ambito(prov, mun, province, municipio)
+        ambito = _obtener_o_crear_ambito(codigo, db)
+
+        existente = DiaInhabil.query.filter_by(fecha=fecha, ambito_id=ambito.id).first()
+        if existente:
+            if existente.descripcion != desc:
+                existente.descripcion = desc
+                actualizados += 1
+        else:
+            db.session.add(DiaInhabil(fecha=fecha, descripcion=desc, ambito_id=ambito.id))
+            insertados += 1
+
+    db.session.commit()
+    click.echo(f'  Insertados: {insertados}  Actualizados: {actualizados}')
+    click.echo('Importación completada.')

--- a/app/templates/layout/base_fullwidth.html
+++ b/app/templates/layout/base_fullwidth.html
@@ -50,6 +50,19 @@
             </div>
         </header>
 
+        <!-- Alerta admin: calendario inhábil año N+1 no cargado (#339) -->
+        {% if alerta_calendario %}
+        <div class="alert alert-warning alert-dismissible fade show mb-0 rounded-0 border-0 border-bottom"
+             role="alert" style="z-index:1040">
+            <i class="fas fa-exclamation-triangle me-2"></i>
+            <strong>Acción requerida:</strong>
+            No hay días inhábiles registrados para el año siguiente.
+            Ejecute <code>flask inhabiles importar</code> antes de que existan plazos que aterricen en ese año.
+            Consulte <code>docs/guias/GUIA_ADMINISTRACION.md</code> para el procedimiento completo.
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+        </div>
+        {% endif %}
+
         <!-- B.2: Main Content (scrollable si C.1+C.2+C.3 > espacio) -->
         <main class="app-main">
             {% block content %}{% endblock %}

--- a/docs/guias/GUIA_ADMINISTRACION.md
+++ b/docs/guias/GUIA_ADMINISTRACION.md
@@ -1,0 +1,89 @@
+# Guía de administración — BDDAT
+
+Procedimientos operativos para el administrador del sistema.
+
+---
+
+## 1. Carga anual del calendario de días inhábiles
+
+### Cuándo ejecutar
+
+Cada año en **noviembre**, tras la publicación de la Orden de la Junta de Andalucía
+que fija el calendario de festivos del año siguiente (BOJA, habitualmente en octubre-noviembre).
+
+Si el sistema detecta que no hay datos para el año siguiente, mostrará un banner de aviso
+visible solo para usuarios con rol ADMIN en todas las páginas.
+
+### Comando
+
+```bash
+# En el servidor, con el entorno virtual activado:
+flask inhabiles importar --year 2027
+```
+
+El año por defecto es el siguiente al actual, por lo que en noviembre de 2026 basta con:
+
+```bash
+flask inhabiles importar
+```
+
+### Verificar disponibilidad de datos antes de importar
+
+```bash
+flask inhabiles importar --year 2027 --dry-run
+```
+
+Muestra los festivos que se importarían sin modificar la base de datos.
+
+### Opciones
+
+| Opción | Defecto | Descripción |
+|--------|---------|-------------|
+| `--year` | año siguiente | Año a importar |
+| `--province` | `CÁDIZ` | Provincia (mayúsculas exactas de la API) |
+| `--municipio` | `CÁDIZ` | Municipio (mayúsculas exactas de la API) |
+| `--dry-run` | desactivado | Solo muestra sin insertar |
+
+### Fuente de datos
+
+API pública de la Junta de Andalucía, sin autenticación:
+
+```
+https://www.juntadeandalucia.es/ssdigitales/datasets/work-calendar/
+  work-calendar/get/search_calendar_weekends?province=CÁDIZ&municipality=CÁDIZ&year=2027
+```
+
+Los festivos autonómicos y nacionales se identifican porque `province` y `municipality`
+llegan vacíos en la respuesta. Los locales llevan la provincia/municipio rellenos.
+
+### Qué importa exactamente
+
+El comando importa todos los días inhábiles **laborables** del año para el ámbito
+provincia+municipio configurado (por defecto Cádiz capital):
+
+- Festivos nacionales
+- Festivos autonómicos andaluces
+- Festivos provinciales de Cádiz
+- Festivos locales de Cádiz capital
+
+Los sábados y domingos se descartan: el motor de plazos ya los excluye por cálculo.
+
+### Si la API no está disponible
+
+Usar los JSON estáticos de respaldo en `app/data/dias_inhabiles/` como referencia
+para carga manual. Son festivos autonómicos sin locales de Cádiz, válidos como
+aproximación hasta que la API vuelva a estar operativa.
+
+---
+
+## 2. Verificar el estado del calendario
+
+```sql
+-- En psql o flask shell:
+SELECT EXTRACT(year FROM fecha) AS anyo, COUNT(*) AS festivos
+FROM dias_inhabiles
+GROUP BY anyo
+ORDER BY anyo;
+```
+
+Un año típico de Andalucía (provincia Cádiz) tiene entre 12 y 14 festivos laborables.


### PR DESCRIPTION
## Cambios

- Nuevo comando CLI `flask inhabiles importar`: consume la API pública de la Junta de Andalucía y hace upsert en `dias_inhabiles`. Soporta `--year`, `--province`, `--municipio` y `--dry-run`. Crea ámbitos nuevos (PROVINCIAL_*, LOCAL_*) si no existen.
- Banner de aviso en `base_fullwidth.html` visible solo para admins cuando `dias_inhabiles` no tiene datos para el año siguiente. Implementa el "Aviso año N+1" del issue sin depender de #28.
- `GUIA_ADMINISTRACION.md`: documenta el procedimiento anual de carga (cuándo, cómo, qué importa, fallback si la API no está disponible).

Closes #339
