### PR TITLE
Implementar OrganismoExpediente y ContextoConsultaSeparata

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -74,6 +74,9 @@ from app.models.motor_reglas import ReglaMotor, CondicionRegla
 # Certificados de fase (#373 — depende de Expediente, Fase)
 from app.models.certificados_fase import CertificadoFase
 
+# Organismos consultados por expediente (#391 — depende de Expediente, Entidad, Documento, Tramite)
+from app.models.organismos_expediente import OrganismoExpediente
+
 # Mapa semántico de documentos por tarea (#346 — sin FK operacional propia)
 from app.models.tramites_tareas_documentos import TramiteTareaDocumento
 
@@ -130,4 +133,6 @@ __all__ = [
     'CertificadoFase',
     # Mapa semántico de documentos por tarea
     'TramiteTareaDocumento',
+    # Organismos consultados por expediente
+    'OrganismoExpediente',
 ]

--- a/app/models/organismos_expediente.py
+++ b/app/models/organismos_expediente.py
@@ -1,0 +1,115 @@
+from app import db
+
+
+ESTADOS_ORGANISMO = (
+    'pendiente',
+    'separata_enviada',
+    'en_tramitacion',
+    'cerrado_favorable',
+    'cerrado_con_condicionados',
+    'audiencia_previa',
+    'exonerado',
+)
+
+VIAS_ORGANISMO = ('consulta', 'declaracion_responsable')
+
+
+class OrganismoExpediente(db.Model):
+    """
+    Relación entre un organismo consultado y un expediente concreto.
+
+    Un registro por organismo por expediente. Cubre tanto la vía de consulta
+    ordinaria (separata + trámites de traslado) como la vía de declaración
+    responsable (el titular acredita disponer ya de la autorización del organismo).
+
+    Diseño de referencia: DISEÑO_CONSULTAS_ORGANISMOS.md §2
+    """
+    __tablename__ = 'organismos_expediente'
+    __table_args__ = (
+        db.UniqueConstraint('expediente_id', 'organismo_id', name='uq_org_exp_expediente_organismo'),
+        db.UniqueConstraint('tramite_id', name='uq_org_exp_tramite'),
+        db.CheckConstraint("via IN ('consulta', 'declaracion_responsable')", name='ck_org_exp_via'),
+        db.CheckConstraint(
+            "estado IN ('pendiente','separata_enviada','en_tramitacion',"
+            "'cerrado_favorable','cerrado_con_condicionados','audiencia_previa','exonerado')",
+            name='ck_org_exp_estado',
+        ),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    expediente_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.expedientes.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+        comment='FK expedientes. Expediente al que pertenece la consulta',
+    )
+
+    organismo_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.entidades.id'),
+        nullable=False,
+        index=True,
+        comment='FK entidades (rol_consultado=True). Organismo consultado',
+    )
+
+    via = db.Column(
+        db.String(30),
+        nullable=False,
+        default='consulta',
+        comment='Vía de resolución: consulta (trámite normal) o declaracion_responsable',
+    )
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id'),
+        nullable=True,
+        comment='Documento de declaración responsable (solo si via=declaracion_responsable)',
+    )
+
+    estado = db.Column(
+        db.String(40),
+        nullable=False,
+        default='pendiente',
+        comment='Estado del ciclo de vida del organismo en el expediente',
+    )
+
+    num_iteraciones_organismo = db.Column(
+        db.Integer,
+        nullable=False,
+        default=0,
+        comment='Contador de trámites CONSULTA_TRASLADO_ORGANISMO creados. Motor usa este valor para advertir o bloquear si supera 1',
+    )
+
+    tramite_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tramites.id'),
+        nullable=True,
+        comment='FK al trámite CONSULTA_SEPARATA asociado a este organismo. NULL hasta que se crea el trámite',
+    )
+
+    plazo_legal_dias = db.Column(
+        db.Integer,
+        nullable=True,
+        comment='Plazo legal aplicable en días (capturado al crear la separata según tipo de expediente). 30 días general; 15 si AAP previa y solo AAC sin DUP',
+    )
+
+    # Relaciones
+    expediente = db.relationship('Expediente', backref='organismos')
+    organismo = db.relationship('Entidad', foreign_keys=[organismo_id])
+    documento = db.relationship('Documento', foreign_keys=[documento_id])
+    tramite = db.relationship('Tramite', foreign_keys=[tramite_id])
+
+    def __repr__(self):
+        return f'<OrganismoExpediente exp={self.expediente_id} org={self.organismo_id} estado={self.estado}>'
+
+    def as_contexto_cb(self) -> dict:
+        """Fragmento de contexto para plantillas de CONSULTA_SEPARATA."""
+        return {
+            'organismo_nombre': self.organismo.nombre_completo if self.organismo else None,
+            'organismo_nif': self.organismo.nif if self.organismo else None,
+            'organismo_plazo_legal': self.plazo_legal_dias,
+            'organismo_resultado': self.estado,
+        }

--- a/app/services/context_builders/consulta_separata.py
+++ b/app/services/context_builders/consulta_separata.py
@@ -1,0 +1,61 @@
+from app.models.organismos_expediente import OrganismoExpediente
+
+
+class ContextoConsultaSeparata:
+    """
+    Context Builder para escritos del trámite CONSULTA_SEPARATA.
+
+    Enriquece el contexto base con datos del organismo consultado y las
+    fechas del ciclo de consulta. Requiere que el trámite tenga un registro
+    en organismos_expediente (campo tramite_id enlazado).
+
+    Campos adicionales aportados:
+    - organismo_nombre       str   Nombre oficial del organismo
+    - organismo_nif          str   NIF del organismo (puede ser None)
+    - organismo_plazo_legal  int   Plazo legal en días (30 o 15 según tipo expediente)
+    - organismo_resultado    str   Estado del ciclo: pendiente, conformidad, condicionado…
+    - organismo_fecha_envio  str   Fecha de la notificación enviada (DD/MM/AAAA o None)
+    - organismo_fecha_respuesta str Fecha del documento de respuesta recibido (DD/MM/AAAA o None)
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        org_exp = (OrganismoExpediente.query
+                   .filter_by(tramite_id=self._tarea.tramite_id)
+                   .first())
+
+        if not org_exp:
+            return {}
+
+        ctx = org_exp.as_contexto_cb()
+
+        # Fechas desde las tareas del trámite (pueden no existir aún)
+        tareas_por_codigo = {
+            t.tipo_tarea.codigo: t
+            for t in self._tarea.tramite.tareas
+            if t.tipo_tarea
+        }
+
+        tarea_notif = tareas_por_codigo.get('NOTIFICAR')
+        tarea_anal = tareas_por_codigo.get('ANALIZAR')
+
+        doc_envio = tarea_notif.documento_producido if tarea_notif else None
+        doc_respuesta = tarea_anal.documento_usado if tarea_anal else None
+
+        ctx['organismo_fecha_envio'] = (
+            doc_envio.fecha_administrativa.strftime('%d/%m/%Y')
+            if doc_envio and doc_envio.fecha_administrativa else None
+        )
+        ctx['organismo_fecha_respuesta'] = (
+            doc_respuesta.fecha_administrativa.strftime('%d/%m/%Y')
+            if doc_respuesta and doc_respuesta.fecha_administrativa else None
+        )
+
+        return ctx

--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -72,7 +72,7 @@ def generar_escrito(plantilla, expediente, db_session, tarea=None) -> bytes:
     # Capa 2: Context Builder opcional
     if plantilla.contexto_clase:
         builder = _cargar_context_builder(plantilla.contexto_clase)
-        ctx.update(builder(expediente, db_session).get_contexto())
+        ctx.update(builder(expediente, db_session, tarea=tarea).get_contexto())
 
     # Consultas nombradas: se añaden al contexto con su nombre como clave
     ctx.update(_ejecutar_consultas(plantilla, expediente, db_session))

--- a/docs/referencia/DISEÑO_CONSULTAS_ORGANISMOS.md
+++ b/docs/referencia/DISEÑO_CONSULTAS_ORGANISMOS.md
@@ -36,6 +36,8 @@ Inicialmente se contempló separar `organismos_afectados` y `organismos_consulta
 
 ### Estructura de `organismos_expediente`
 
+> **Implementado en #391.** Modelo: `app/models/organismos_expediente.py`
+
 | Campo | Descripción |
 |---|---|
 | `expediente_id` | FK `expedientes.id` |
@@ -44,12 +46,18 @@ Inicialmente se contempló separar `organismos_afectados` y `organismos_consulta
 | `documento_id` | FK `documentos.id` (solo si `via = declaracion_responsable`) |
 | `estado` | Estado del ciclo de vida. Actualización manual por tramitador, con puerta abierta al motor de reglas |
 | `num_iteraciones_organismo` | Contador de trámites `CONSULTA_TRASLADO_ORGANISMO` creados para este organismo. Permite al motor advertir o bloquear si se supera el límite de 1 iteración del bucle de reparos |
+| `tramite_id` | FK `tramites.id` (nullable). Vínculo al trámite `CONSULTA_SEPARATA` creado para este organismo. Necesario para que `ContextoConsultaSeparata` identifique el organismo activo en tramitaciones paralelas |
+| `plazo_legal_dias` | INTEGER (nullable). Plazo legal aplicable capturado en el momento de crear la separata. 30 días con carácter general; 15 si existe AAP previa y la tramitación es solo AAC sin DUP |
 
 **Sobre `organismo_id`:** la tabla `entidades` centraliza todas las entidades del sistema con roles booleanos. Los organismos consultables tienen `rol_consultado = True`. No existe tabla de organismos separada.
 
 **Sobre `estado`:** se actualiza manualmente por el tramitador al registrar el resultado de la tarea ANALIZAR de cada trámite. El campo está diseñado para que el motor de reglas pueda actualizarlo automáticamente en el futuro sin cambios de modelo.
 
 **Sobre `num_iteraciones_organismo`:** se incrementa cada vez que se crea un trámite `CONSULTA_TRASLADO_ORGANISMO` para este registro. El motor puede leerlo para emitir advertencia (soft) o bloqueo (hard) si supera 1.
+
+**Sobre `tramite_id`:** se rellena al crear el trámite `CONSULTA_SEPARATA` asociado al organismo. La unicidad (UNIQUE constraint) garantiza la correspondencia 1:1 tramite↔organismo. Se usa en `ContextoConsultaSeparata` para navegar hasta el organismo desde la tarea activa.
+
+**Sobre `plazo_legal_dias`:** se captura al crear la separata porque el plazo depende del tipo y combinación de autorizaciones del expediente en ese momento. Almacenarlo evita tener que recalcularlo en cada renderizado de plantilla.
 
 ### Estados de `organismos_expediente`
 
@@ -261,7 +269,7 @@ El motor comprueba sobre los trámites de la fase:
 
 - **Diagrama de flujo DUP:** La casuística está analizada y documentada en la sección 6. Pendiente crear diagrama visual equivalente a los de AAP/AAC.
 - **Renombrar tarea ANALISIS → ANALIZAR:** El JSON `ESTRUCTURA_FTT.json` ya usa ANALIZAR (v5.4). Pendiente migrar en base de datos: `UPDATE public.tipos_tareas SET codigo = 'ANALIZAR' WHERE codigo = 'ANALISIS'` (migración manual) y actualizar todas las referencias al código en el motor de reglas y en el código de la aplicación.
-- **Implementación de `organismos_expediente`:** Tabla nueva, migración manual.
+- ~~**Implementación de `organismos_expediente`:** Tabla nueva, migración manual.~~ **HECHO** — #391: modelo + migración + `ContextoConsultaSeparata`.
 - **Redefinición de `REQUERIMIENTO_DE_MEJORA`:** El patrón actualizado es C+A (`ELABORAR → NOTIFICAR → ESPERAR_PLAZO → ANALIZAR`); la respuesta del titular queda en `ESPERAR_PLAZO.documento_producido_id` (ADR-004).
 - **Definición de tipos de trámite** `CONSULTA_SEPARATA`, `CONSULTA_TRASLADO_TITULAR`, `CONSULTA_TRASLADO_ORGANISMO` en el catálogo de tipos.
 - **Cadena de tareas** dentro de los trámites de traslado: `ELABORAR → NOTIFICAR → ESPERAR_PLAZO → ANALIZAR` (patrón C+A).

--- a/docs/referencia/GUIA_CONTEXT_BUILDERS.md
+++ b/docs/referencia/GUIA_CONTEXT_BUILDERS.md
@@ -74,9 +74,10 @@ class ContextoNotificacionOrganismo:
     - fecha_limite: Fecha límite calculada para el plazo
     """
 
-    def __init__(self, expediente, db_session):
+    def __init__(self, expediente, db_session, tarea=None):
         self._expediente = expediente
         self._db = db_session
+        self._tarea = tarea  # disponible si el CB necesita navegar al trámite
 
     def get_contexto(self) -> dict:
         """Devuelve los campos adicionales para esta plantilla."""
@@ -141,7 +142,7 @@ que son accedidos directamente por `ContextoBaseExpediente`.
 
 | Clase | Fichero | Trámite | Estado | Issue |
 |-------|---------|---------|--------|-------|
-| `ContextoConsultaSeparata` | `consulta_separata.py` | `CONSULTA_SEPARATA` | Pendiente — verificar `OrganismoExpediente` | #391 |
+| `ContextoConsultaSeparata` | `consulta_separata.py` | `CONSULTA_SEPARATA` | Implementado | #391 |
 | `ContextoAnalisisDocumental` | `analisis_documental.py` | `ANALISIS_DOCUMENTAL` | Bloqueado — tabla diagnosticos no diseñada | #392 |
 | `ContextoRecepcionAlegacion` | `recepcion_alegacion.py` | `RECEPCION_ALEGACION` | Bloqueado — modelo alegante no definido | #393 |
 | `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Bloqueado — depende de #393 | #394 |

--- a/migrations/versions/391_organismos_expediente.py
+++ b/migrations/versions/391_organismos_expediente.py
@@ -1,0 +1,66 @@
+"""391_organismos_expediente
+
+Revision ID: 391_organismos_expediente
+Revises: 387_eliminar_whitelists_esft
+Create Date: 2026-05-15
+
+Crea la tabla organismos_expediente para gestionar la relación entre
+organismos consultados y expedientes. Diseño: DISEÑO_CONSULTAS_ORGANISMOS.md §2.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '391_organismos_expediente'
+down_revision = '387_eliminar_whitelists_esft'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'organismos_expediente',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('expediente_id', sa.Integer(), nullable=False,
+                  comment='FK expedientes. Expediente al que pertenece la consulta'),
+        sa.Column('organismo_id', sa.Integer(), nullable=False,
+                  comment='FK entidades (rol_consultado=True). Organismo consultado'),
+        sa.Column('via', sa.String(30), nullable=False, server_default='consulta',
+                  comment='Vía de resolución: consulta o declaracion_responsable'),
+        sa.Column('documento_id', sa.Integer(), nullable=True,
+                  comment='Documento de declaración responsable (solo si via=declaracion_responsable)'),
+        sa.Column('estado', sa.String(40), nullable=False, server_default='pendiente',
+                  comment='Estado del ciclo de vida del organismo en el expediente'),
+        sa.Column('num_iteraciones_organismo', sa.Integer(), nullable=False, server_default='0',
+                  comment='Contador de trámites CONSULTA_TRASLADO_ORGANISMO creados'),
+        sa.Column('tramite_id', sa.Integer(), nullable=True,
+                  comment='FK al trámite CONSULTA_SEPARATA asociado. NULL hasta que se crea'),
+        sa.Column('plazo_legal_dias', sa.Integer(), nullable=True,
+                  comment='Plazo legal en días capturado al crear la separata'),
+        sa.PrimaryKeyConstraint('id', name='pk_organismos_expediente'),
+        sa.ForeignKeyConstraint(['expediente_id'], ['public.expedientes.id'],
+                                name='fk_org_exp_expediente', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['organismo_id'], ['public.entidades.id'],
+                                name='fk_org_exp_organismo'),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'],
+                                name='fk_org_exp_documento'),
+        sa.ForeignKeyConstraint(['tramite_id'], ['public.tramites.id'],
+                                name='fk_org_exp_tramite'),
+        sa.UniqueConstraint('expediente_id', 'organismo_id', name='uq_org_exp_expediente_organismo'),
+        sa.UniqueConstraint('tramite_id', name='uq_org_exp_tramite'),
+        sa.CheckConstraint("via IN ('consulta', 'declaracion_responsable')",
+                           name='ck_org_exp_via'),
+        sa.CheckConstraint(
+            "estado IN ('pendiente','separata_enviada','en_tramitacion',"
+            "'cerrado_favorable','cerrado_con_condicionados','audiencia_previa','exonerado')",
+            name='ck_org_exp_estado',
+        ),
+        schema='public',
+    )
+    op.create_index('idx_org_exp_expediente', 'organismos_expediente', ['expediente_id'], schema='public')
+    op.create_index('idx_org_exp_organismo', 'organismos_expediente', ['organismo_id'], schema='public')
+
+
+def downgrade():
+    op.drop_index('idx_org_exp_organismo', table_name='organismos_expediente', schema='public')
+    op.drop_index('idx_org_exp_expediente', table_name='organismos_expediente', schema='public')
+    op.drop_table('organismos_expediente', schema='public')


### PR DESCRIPTION
## Cambios

- `app/models/organismos_expediente.py` — nuevo modelo `OrganismoExpediente`: campos `via`, `estado`, `tramite_id` (FK al trámite `CONSULTA_SEPARATA`), `plazo_legal_dias`, `num_iteraciones_organismo`; implementa `as_contexto_cb()`
- `migrations/versions/391_organismos_expediente.py` — crea tabla `organismos_expediente` con FKs, CHECK constraints y únicos
- `app/services/context_builders/consulta_separata.py` — nuevo CB `ContextoConsultaSeparata`: navega al organismo vía `tramite_id` y expone nombre, NIF, plazo, resultado y fechas de envío/respuesta
- `app/services/generador_escritos.py` — propaga `tarea` al constructor del CB para permitir identificar el organismo en tramitaciones paralelas
- `docs/referencia/GUIA_CONTEXT_BUILDERS.md` — actualiza firma de ejemplo (`tarea=None`) y estado de `ContextoConsultaSeparata`
- `docs/referencia/DISEÑO_CONSULTAS_ORGANISMOS.md` — añade `tramite_id` y `plazo_legal_dias` a la estructura de la tabla; marca implementación como completada en §8
- Issues derivados abiertos: #395 (CB lista organismos para resolución), #396 (UI gestión organismos_expediente)

Closes #391
