### PR TITLE
Modelo Diagnostico y CB ContextoAnalisisDocumental

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -74,6 +74,9 @@ from app.models.motor_reglas import ReglaMotor, CondicionRegla
 # Certificados de fase (#373 — depende de Expediente, Fase)
 from app.models.certificados_fase import CertificadoFase
 
+# Diagnóstico documental de tareas ANALIZAR (#392 — depende de Documento)
+from app.models.diagnosticos import Diagnostico
+
 # Organismos consultados por expediente (#391 — depende de Expediente, Entidad, Documento, Tramite)
 from app.models.organismos_expediente import OrganismoExpediente
 
@@ -133,6 +136,8 @@ __all__ = [
     'CertificadoFase',
     # Mapa semántico de documentos por tarea
     'TramiteTareaDocumento',
+    # Diagnóstico documental
+    'Diagnostico',
     # Organismos consultados por expediente
     'OrganismoExpediente',
 ]

--- a/app/models/diagnosticos.py
+++ b/app/models/diagnosticos.py
@@ -1,0 +1,68 @@
+from sqlalchemy.dialects.postgresql import JSONB
+from app import db
+
+
+class Diagnostico(db.Model):
+    """
+    Diagnóstico documental resultante de una tarea ANALIZAR.
+
+    Un registro por documento de tipo DIAGNOSTICO. Almacena el resultado
+    (favorable/condicionado/desfavorable) y la lista de defectos detectados.
+    Cualifica cualquier Documento producido por cualquier tarea ANALIZAR
+    de cualquier trámite.
+
+    CAMPO DEFECTOS:
+        JSONB. Lista de dicts. Items pueden incluir un 'catalogo_id' opcional
+        cuando exista la tabla de catálogo de defectos (diseño futuro).
+    """
+    __tablename__ = 'diagnosticos'
+    __table_args__ = (
+        db.UniqueConstraint('documento_id', name='uq_diagnostico_documento'),
+        db.CheckConstraint(
+            "resultado IN ('favorable', 'condicionado', 'desfavorable')",
+            name='ck_diagnostico_resultado',
+        ),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id'),
+        nullable=False,
+        unique=True,
+        comment='FK documentos. Documento de tipo DIAGNOSTICO producido por ANALIZAR',
+    )
+
+    resultado = db.Column(
+        db.String(20),
+        nullable=False,
+        comment='Resultado: favorable, condicionado o desfavorable',
+    )
+
+    defectos = db.Column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default='[]',
+        comment='Lista de defectos detectados',
+    )
+
+    documento = db.relationship(
+        'Documento',
+        foreign_keys=[documento_id],
+        backref=db.backref('diagnostico', uselist=False),
+    )
+
+    def __repr__(self):
+        return f'<Diagnostico doc={self.documento_id} resultado={self.resultado}>'
+
+    def as_contexto_cb(self) -> dict:
+        """Fragmento de contexto para plantillas de ANALISIS_DOCUMENTAL."""
+        defectos = self.defectos or []
+        return {
+            'diagnostico_resultado': self.resultado,
+            'diagnostico_defectos': defectos,
+            'diagnostico_tiene_defectos': len(defectos) > 0,
+        }

--- a/app/services/context_builders/analisis_documental.py
+++ b/app/services/context_builders/analisis_documental.py
@@ -1,0 +1,40 @@
+class ContextoAnalisisDocumental:
+    """
+    Context Builder para documentos del trámite ANALISIS_DOCUMENTAL.
+
+    Enriquece el contexto con el diagnóstico del documento producido
+    por la tarea ANALIZAR del mismo trámite.
+
+    Campos aportados:
+    - diagnostico_resultado        str   'favorable', 'condicionado' o 'desfavorable'
+    - diagnostico_defectos         list  Lista de defectos detectados
+    - diagnostico_tiene_defectos   bool  True si hay al menos un defecto
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        tareas_por_codigo = {
+            t.tipo_tarea.codigo: t
+            for t in self._tarea.tramite.tareas
+            if t.tipo_tarea
+        }
+
+        tarea_analizar = tareas_por_codigo.get('ANALIZAR')
+        if not tarea_analizar:
+            return {}
+
+        doc = tarea_analizar.documento_producido
+        if not doc:
+            return {}
+
+        if not doc.diagnostico:
+            return {}
+
+        return doc.diagnostico.as_contexto_cb()

--- a/migrations/versions/392_diagnosticos.py
+++ b/migrations/versions/392_diagnosticos.py
@@ -1,0 +1,44 @@
+"""392_diagnosticos
+
+Revision ID: 392_diagnosticos
+Revises: 395_seed_organismos_consulta
+Create Date: 2026-05-15
+
+Issue #392 — Crea la tabla diagnosticos para almacenar el resultado del
+análisis documental producido por las tareas ANALIZAR.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = '392_diagnosticos'
+down_revision = '395_seed_organismos_consulta'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'diagnosticos',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('documento_id', sa.Integer(), nullable=False,
+                  comment='FK documentos. Documento de tipo DIAGNOSTICO producido por ANALIZAR'),
+        sa.Column('resultado', sa.String(20), nullable=False,
+                  comment='Resultado del diagnóstico: favorable, condicionado o desfavorable'),
+        sa.Column('defectos', JSONB(), nullable=False, server_default='[]',
+                  comment='Lista de defectos detectados. Items pueden incluir catalogo_id cuando exista ese catálogo'),
+        sa.PrimaryKeyConstraint('id', name='pk_diagnosticos'),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'],
+                                name='fk_diagnostico_documento'),
+        sa.UniqueConstraint('documento_id', name='uq_diagnostico_documento'),
+        sa.CheckConstraint(
+            "resultado IN ('favorable', 'condicionado', 'desfavorable')",
+            name='ck_diagnostico_resultado',
+        ),
+        schema='public',
+    )
+    op.execute("GRANT SELECT ON public.diagnosticos TO claude_desktop")
+
+
+def downgrade():
+    op.drop_table('diagnosticos', schema='public')

--- a/tests/test_392_diagnostico.py
+++ b/tests/test_392_diagnostico.py
@@ -1,0 +1,113 @@
+"""
+Tests issue #392 — Diagnostico.as_contexto_cb() y ContextoAnalisisDocumental.
+
+Bloques:
+  A) Diagnostico.as_contexto_cb()  — stubs, sin BD ni app context.
+  B) ContextoAnalisisDocumental.get_contexto() — stubs.
+"""
+from unittest.mock import MagicMock
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _diagnostico(resultado='favorable', defectos=None):
+    """Stub de Diagnostico con as_contexto_cb() delegando al método real."""
+    from app.models.diagnosticos import Diagnostico
+    d = MagicMock()
+    d.resultado = resultado
+    d.defectos = defectos if defectos is not None else []
+    d.as_contexto_cb = lambda: Diagnostico.as_contexto_cb(d)
+    return d
+
+
+def _tarea_stub(codigo, doc_producido=None, tramite_id=1):
+    t = MagicMock()
+    t.tramite_id = tramite_id
+    t.tipo_tarea = MagicMock(codigo=codigo)
+    t.documento_producido = doc_producido
+    return t
+
+
+def _tramite_con_tareas(tareas):
+    tr = MagicMock()
+    tr.tareas = tareas
+    return tr
+
+
+def _doc(diagnostico=None):
+    d = MagicMock()
+    d.diagnostico = diagnostico
+    return d
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A) Diagnostico.as_contexto_cb()
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestAsContextoCb:
+
+    def test_campos_completos(self):
+        diag = _diagnostico(resultado='condicionado', defectos=[{'texto': 'Falta plano'}])
+        ctx = diag.as_contexto_cb()
+        assert ctx['diagnostico_resultado'] == 'condicionado'
+        assert ctx['diagnostico_defectos'] == [{'texto': 'Falta plano'}]
+        assert ctx['diagnostico_tiene_defectos'] is True
+
+    def test_sin_defectos(self):
+        diag = _diagnostico(resultado='favorable', defectos=[])
+        ctx = diag.as_contexto_cb()
+        assert ctx['diagnostico_tiene_defectos'] is False
+        assert ctx['diagnostico_defectos'] == []
+
+    def test_defectos_none_tratado_como_lista_vacia(self):
+        diag = _diagnostico(resultado='favorable', defectos=None)
+        ctx = diag.as_contexto_cb()
+        assert ctx['diagnostico_tiene_defectos'] is False
+        assert ctx['diagnostico_defectos'] == []
+
+    def test_resultado_pasa_sin_transformacion(self):
+        diag = _diagnostico(resultado='desfavorable')
+        ctx = diag.as_contexto_cb()
+        assert ctx['diagnostico_resultado'] == 'desfavorable'
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# B) ContextoAnalisisDocumental.get_contexto()
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestContextoAnalisisDocumental:
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.analisis_documental import ContextoAnalisisDocumental
+        cb = ContextoAnalisisDocumental(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_sin_tarea_analizar_devuelve_vacio(self):
+        from app.services.context_builders.analisis_documental import ContextoAnalisisDocumental
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+        cb = ContextoAnalisisDocumental(MagicMock(), MagicMock(), tarea=tarea_elab)
+        assert cb.get_contexto() == {}
+
+    def test_analizar_sin_documento_producido_devuelve_vacio(self):
+        from app.services.context_builders.analisis_documental import ContextoAnalisisDocumental
+        tarea_anal = _tarea_stub('ANALIZAR', doc_producido=None, tramite_id=1)
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab, tarea_anal])
+        cb = ContextoAnalisisDocumental(MagicMock(), MagicMock(), tarea=tarea_elab)
+        assert cb.get_contexto() == {}
+
+    def test_con_diagnostico_completo_campos_correctos(self):
+        from app.services.context_builders.analisis_documental import ContextoAnalisisDocumental
+        diag = _diagnostico(resultado='condicionado', defectos=[{'texto': 'Falta memoria'}])
+        doc = _doc(diagnostico=diag)
+        tarea_anal = _tarea_stub('ANALIZAR', doc_producido=doc, tramite_id=1)
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab, tarea_anal])
+        cb = ContextoAnalisisDocumental(MagicMock(), MagicMock(), tarea=tarea_elab)
+        ctx = cb.get_contexto()
+        assert ctx['diagnostico_resultado'] == 'condicionado'
+        assert ctx['diagnostico_defectos'] == [{'texto': 'Falta memoria'}]
+        assert ctx['diagnostico_tiene_defectos'] is True


### PR DESCRIPTION
## Cambios

- Migración `392_diagnosticos`: tabla `public.diagnosticos` (id, documento_id FK UNIQUE, resultado VARCHAR20, defectos JSONB) con check constraint y GRANT al usuario MCP
- Modelo `Diagnostico` con método `as_contexto_cb()` que devuelve resultado, lista de defectos y shortcut `tiene_defectos`
- Context Builder `ContextoAnalisisDocumental`: navega `tramite.tareas → ANALIZAR → documento_producido → diagnostico` y devuelve `{}` en cualquier ausencia
- 8 tests sin BD ni app context (4 para `as_contexto_cb`, 4 para `get_contexto`)

Closes #392
