### PR TITLE
Modelo Alegante + CB ContextoRecepcionAlegacion

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -77,6 +77,9 @@ from app.models.certificados_fase import CertificadoFase
 # Diagnóstico documental de tareas ANALIZAR (#392 — depende de Documento)
 from app.models.diagnosticos import Diagnostico
 
+# Alegante en trámites RECEPCION_ALEGACION (#393 — depende de Tramite, Entidad)
+from app.models.alegantes import Alegante
+
 # Organismos consultados por expediente (#391 — depende de Expediente, Entidad, Documento, Tramite)
 from app.models.organismos_expediente import OrganismoExpediente
 
@@ -140,4 +143,6 @@ __all__ = [
     'Diagnostico',
     # Organismos consultados por expediente
     'OrganismoExpediente',
+    # Alegante en trámites RECEPCION_ALEGACION
+    'Alegante',
 ]

--- a/app/models/alegantes.py
+++ b/app/models/alegantes.py
@@ -1,0 +1,82 @@
+from app import db
+
+
+class Alegante(db.Model):
+    """
+    Persona u organismo que presenta una alegación en un trámite RECEPCION_ALEGACION.
+
+    Un alegante por trámite (UNIQUE en tramite_id).
+
+    Si entidad_id está relleno, nombre y nif se toman de Entidad (evita duplicación).
+    Si entidad_id es NULL, se usan los campos locales nombre y nif (alegante ocasional
+    no registrado en el sistema).
+    """
+    __tablename__ = 'alegantes'
+    __table_args__ = (
+        db.UniqueConstraint('tramite_id', name='uq_alegante_tramite'),
+        db.CheckConstraint(
+            "tipo_interesado IN ('particular', 'administracion', 'asociacion', 'empresa')",
+            name='ck_alegante_tipo_interesado',
+        ),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    tramite_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tramites.id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,
+        comment='FK tramites. Trámite RECEPCION_ALEGACION al que pertenece',
+    )
+
+    entidad_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.entidades.id'),
+        nullable=True,
+        comment='FK entidades. Relleno si el alegante ya existe como entidad del sistema',
+    )
+
+    nombre = db.Column(
+        db.String(255),
+        nullable=True,
+        comment='Nombre del alegante cuando entidad_id es NULL',
+    )
+
+    nif = db.Column(
+        db.String(20),
+        nullable=True,
+        comment='NIF del alegante cuando entidad_id es NULL',
+    )
+
+    tipo_interesado = db.Column(
+        db.String(50),
+        nullable=False,
+        comment='Tipo de interesado: particular, administracion, asociacion, empresa',
+    )
+
+    tramite = db.relationship(
+        'Tramite',
+        foreign_keys=[tramite_id],
+        backref=db.backref('alegante', uselist=False),
+    )
+
+    entidad = db.relationship(
+        'Entidad',
+        foreign_keys=[entidad_id],
+        backref=db.backref('alegaciones', lazy='dynamic'),
+    )
+
+    def __repr__(self):
+        return f'<Alegante tramite={self.tramite_id} tipo={self.tipo_interesado}>'
+
+    def as_contexto_cb(self) -> dict:
+        """Fragmento de contexto para plantillas de RECEPCION_ALEGACION."""
+        nombre = self.entidad.nombre_completo if self.entidad else self.nombre
+        nif = self.entidad.nif if self.entidad else self.nif
+        return {
+            'alegante_nombre': nombre,
+            'alegante_nif': nif,
+            'alegante_tipo_interesado': self.tipo_interesado,
+        }

--- a/app/services/context_builders/recepcion_alegacion.py
+++ b/app/services/context_builders/recepcion_alegacion.py
@@ -1,0 +1,26 @@
+class ContextoRecepcionAlegacion:
+    """
+    Context Builder para documentos del trámite RECEPCION_ALEGACION.
+
+    Enriquece el contexto con los datos del alegante registrado en el trámite.
+
+    Campos aportados:
+    - alegante_nombre          str   Nombre completo del alegante
+    - alegante_nif             str   NIF del alegante (puede ser None)
+    - alegante_tipo_interesado str   'particular', 'administracion', 'asociacion' o 'empresa'
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        alegante = self._tarea.tramite.alegante
+        if not alegante:
+            return {}
+
+        return alegante.as_contexto_cb()

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -4,8 +4,8 @@
 
 ---
 
-**Último cerrado:** #395 — `ConsultaNombrada` `organismos_consulta` (migración seed + SQL corregido para evitar producto cartesiano en JOIN tareas + 11 tests con fixture SAVEPOINT).
+**Último cerrado:** #392 — modelo `Diagnostico` + CB `ContextoAnalisisDocumental` (tabla diagnosticos, `as_contexto_cb()`, 8 tests sin BD).
 
 **Actuales:** —
 
-**Próximo:** #392 (ContextoAnalisisDocumental) · #393 (ContextoRecepcionAlegacion) · #394 (ContextoAnalisisAlegaciones) → desbloqueo #386 (semáforos de plazo en vista BC, M3).
+**Próximo:** #393 (ContextoRecepcionAlegacion) · #394 (ContextoAnalisisAlegaciones) → desbloqueo #386 (semáforos de plazo en vista BC, M3).

--- a/docs/referencia/GUIA_CONTEXT_BUILDERS.md
+++ b/docs/referencia/GUIA_CONTEXT_BUILDERS.md
@@ -144,7 +144,7 @@ que son accedidos directamente por `ContextoBaseExpediente`.
 |-------|---------|---------|--------|-------|
 | `ContextoConsultaSeparata` | `consulta_separata.py` | `CONSULTA_SEPARATA` | Implementado | #391 |
 | `ContextoAnalisisDocumental` | `analisis_documental.py` | `ANALISIS_DOCUMENTAL` | Bloqueado — tabla diagnosticos no diseñada | #392 |
-| `ContextoRecepcionAlegacion` | `recepcion_alegacion.py` | `RECEPCION_ALEGACION` | Bloqueado — modelo alegante no definido | #393 |
+| `ContextoRecepcionAlegacion` | `recepcion_alegacion.py` | `RECEPCION_ALEGACION` | Implementado | #393 |
 | `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Bloqueado — depende de #393 | #394 |
 
 ---

--- a/migrations/versions/393_alegantes.py
+++ b/migrations/versions/393_alegantes.py
@@ -1,0 +1,54 @@
+"""393_alegantes
+
+Revision ID: 393_alegantes
+Revises: 392_diagnosticos
+Create Date: 2026-05-15
+
+Issue #393 — Crea la tabla alegantes para almacenar el alegante de cada
+trámite RECEPCION_ALEGACION, con referencia opcional a la tabla entidades.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '393_alegantes'
+down_revision = '392_diagnosticos'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'alegantes',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('tramite_id', sa.Integer(), nullable=False,
+                  comment='FK tramites. Trámite RECEPCION_ALEGACION al que pertenece'),
+        sa.Column('entidad_id', sa.Integer(), nullable=True,
+                  comment='FK entidades. Relleno si el alegante ya existe como entidad del sistema'),
+        sa.Column('nombre', sa.String(255), nullable=True,
+                  comment='Nombre del alegante cuando entidad_id es NULL'),
+        sa.Column('nif', sa.String(20), nullable=True,
+                  comment='NIF del alegante cuando entidad_id es NULL'),
+        sa.Column('tipo_interesado', sa.String(50), nullable=False,
+                  comment='Tipo de interesado: particular, administracion, asociacion, empresa'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('tramite_id', name='uq_alegante_tramite'),
+        sa.CheckConstraint(
+            "tipo_interesado IN ('particular', 'administracion', 'asociacion', 'empresa')",
+            name='ck_alegante_tipo_interesado',
+        ),
+        sa.ForeignKeyConstraint(
+            ['tramite_id'], ['public.tramites.id'],
+            name='fk_alegante_tramite', ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['entidad_id'], ['public.entidades.id'],
+            name='fk_alegante_entidad',
+        ),
+        schema='public',
+    )
+
+    op.execute("GRANT SELECT ON public.alegantes TO claude_desktop")
+
+
+def downgrade():
+    op.drop_table('alegantes', schema='public')

--- a/tests/test_393_alegante.py
+++ b/tests/test_393_alegante.py
@@ -1,0 +1,112 @@
+"""
+Tests issue #393 — Alegante.as_contexto_cb() y ContextoRecepcionAlegacion.
+
+Bloques:
+  A) Alegante.as_contexto_cb()  — stubs, sin BD ni app context.
+  B) ContextoRecepcionAlegacion.get_contexto() — stubs.
+"""
+from unittest.mock import MagicMock
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _alegante(tipo='particular', nombre='Juan García', nif='12345678A', entidad=None):
+    """Stub de Alegante con as_contexto_cb() delegando al método real."""
+    from app.models.alegantes import Alegante
+    a = MagicMock()
+    a.tipo_interesado = tipo
+    a.nombre = nombre
+    a.nif = nif
+    a.entidad = entidad
+    a.as_contexto_cb = lambda: Alegante.as_contexto_cb(a)
+    return a
+
+
+def _entidad(nombre_completo='Ayuntamiento de Málaga', nif='P2900900B'):
+    e = MagicMock()
+    e.nombre_completo = nombre_completo
+    e.nif = nif
+    return e
+
+
+def _tramite_con_alegante(alegante=None):
+    t = MagicMock()
+    t.alegante = alegante
+    return t
+
+
+def _tarea_con_tramite(tramite):
+    t = MagicMock()
+    t.tramite = tramite
+    return t
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A) Alegante.as_contexto_cb()
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestAleganteAsContextoCb:
+
+    def test_campos_ocasional(self):
+        a = _alegante(tipo='particular', nombre='Juan García', nif='12345678A')
+        ctx = a.as_contexto_cb()
+        assert ctx['alegante_nombre'] == 'Juan García'
+        assert ctx['alegante_nif'] == '12345678A'
+        assert ctx['alegante_tipo_interesado'] == 'particular'
+
+    def test_entidad_tiene_prioridad_sobre_campos_locales(self):
+        ent = _entidad(nombre_completo='Ayuntamiento de Málaga', nif='P2900900B')
+        a = _alegante(nombre='nombre_local', nif='nif_local', entidad=ent)
+        ctx = a.as_contexto_cb()
+        assert ctx['alegante_nombre'] == 'Ayuntamiento de Málaga'
+        assert ctx['alegante_nif'] == 'P2900900B'
+
+    def test_nif_none_permitido(self):
+        a = _alegante(nombre='Sin NIF', nif=None)
+        ctx = a.as_contexto_cb()
+        assert ctx['alegante_nif'] is None
+
+    def test_tipo_interesado_pasa_sin_transformacion(self):
+        for tipo in ('particular', 'administracion', 'asociacion', 'empresa'):
+            a = _alegante(tipo=tipo)
+            assert a.as_contexto_cb()['alegante_tipo_interesado'] == tipo
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# B) ContextoRecepcionAlegacion.get_contexto()
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestContextoRecepcionAlegacion:
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.recepcion_alegacion import ContextoRecepcionAlegacion
+        cb = ContextoRecepcionAlegacion(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_tramite_sin_alegante_devuelve_vacio(self):
+        from app.services.context_builders.recepcion_alegacion import ContextoRecepcionAlegacion
+        tarea = _tarea_con_tramite(_tramite_con_alegante(alegante=None))
+        cb = ContextoRecepcionAlegacion(MagicMock(), MagicMock(), tarea=tarea)
+        assert cb.get_contexto() == {}
+
+    def test_con_alegante_ocasional_campos_correctos(self):
+        from app.services.context_builders.recepcion_alegacion import ContextoRecepcionAlegacion
+        a = _alegante(tipo='particular', nombre='María López', nif='87654321B')
+        tarea = _tarea_con_tramite(_tramite_con_alegante(alegante=a))
+        cb = ContextoRecepcionAlegacion(MagicMock(), MagicMock(), tarea=tarea)
+        ctx = cb.get_contexto()
+        assert ctx['alegante_nombre'] == 'María López'
+        assert ctx['alegante_nif'] == '87654321B'
+        assert ctx['alegante_tipo_interesado'] == 'particular'
+
+    def test_con_alegante_vinculado_a_entidad(self):
+        from app.services.context_builders.recepcion_alegacion import ContextoRecepcionAlegacion
+        ent = _entidad(nombre_completo='Endesa S.A.', nif='A28023430')
+        a = _alegante(tipo='empresa', nombre='ignorar', nif='ignorar', entidad=ent)
+        tarea = _tarea_con_tramite(_tramite_con_alegante(alegante=a))
+        cb = ContextoRecepcionAlegacion(MagicMock(), MagicMock(), tarea=tarea)
+        ctx = cb.get_contexto()
+        assert ctx['alegante_nombre'] == 'Endesa S.A.'
+        assert ctx['alegante_nif'] == 'A28023430'


### PR DESCRIPTION
## Cambios

- Modelo `Alegante` con patrón híbrido: `entidad_id` nullable para reutilizar entidades del sistema; campos locales `nombre`/`nif` para alegantes ocasionales
- `as_contexto_cb()` con prioridad Entidad sobre campos locales
- Migración `393_alegantes`: tabla `alegantes` con FK a tramites (UNIQUE) y entidades (nullable), CHECK en tipo_interesado
- CB `ContextoRecepcionAlegacion` en `app/services/context_builders/recepcion_alegacion.py`
- 8 tests sin BD (stubs): modelo + CB, incluyendo caso entidad vinculada vs alegante ocasional

Closes #393
