### PR TITLE
Añadir CB ContextoAnalisisAlegaciones (#394)

### DIFF
--- a/app/services/context_builders/analisis_alegaciones.py
+++ b/app/services/context_builders/analisis_alegaciones.py
@@ -1,0 +1,81 @@
+class ContextoAnalisisAlegaciones:
+    """
+    Context Builder para documentos del trámite ANALISIS_ALEGACIONES.
+
+    Agrega los datos de todos los trámites RECEPCION_ALEGACION de la misma
+    solicitud que tengan alegante registrado. Navega via tarea → tramite →
+    fase → solicitud para acotar el alcance a la solicitud correcta.
+
+    Campos aportados en el contexto raíz:
+    - num_alegaciones          int   Total de alegaciones registradas
+    - alegaciones              list  Un dict por alegante (ver estructura abajo)
+    - resumen_clasificacion    dict  Conteo por tipo_interesado
+
+    Estructura de cada dict en alegaciones:
+    - alegante_nombre              str   Nombre (entidad si entidad_id, campo local si no)
+    - alegante_nif                 str   NIF (ídem; puede ser None)
+    - alegante_tipo_interesado     str   particular | administracion | asociacion | empresa
+    - alegacion_asunto             str   asunto del doc ALEGACION_IP (puede ser None)
+    - alegacion_fecha              str   fecha_administrativa de ALEGACION_IP (DD/MM/AAAA o None)
+    - respuesta_titular_recibida   bool  True si ESPERAR_PLAZO tiene documento_producido
+    - respuesta_titular_asunto     str   asunto de RESPUESTA_TITULAR_ALEGACION (puede ser None)
+    - respuesta_titular_fecha      str   fecha_administrativa de RESPUESTA_TITULAR_ALEGACION (DD/MM/AAAA o None)
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        solicitud = self._tarea.tramite.fase.solicitud
+
+        tramites_recepcion = [
+            t
+            for fase in solicitud.fases
+            for t in fase.tramites
+            if t.tipo_tramite
+            and t.tipo_tramite.codigo == 'RECEPCION_ALEGACION'
+            and t.alegante
+        ]
+
+        alegaciones = [self._datos_alegacion(t) for t in tramites_recepcion]
+
+        resumen = {}
+        for a in alegaciones:
+            tipo = a['alegante_tipo_interesado']
+            resumen[tipo] = resumen.get(tipo, 0) + 1
+
+        return {
+            'num_alegaciones': len(alegaciones),
+            'alegaciones': alegaciones,
+            'resumen_clasificacion': resumen,
+        }
+
+    def _datos_alegacion(self, tramite) -> dict:
+        tareas = {t.tipo_tarea.codigo: t for t in tramite.tareas if t.tipo_tarea}
+
+        tarea_analizar = tareas.get('ANALIZAR')
+        doc_alegacion = tarea_analizar.documento_usado if tarea_analizar else None
+
+        tarea_esperar = tareas.get('ESPERAR_PLAZO')
+        doc_respuesta = tarea_esperar.documento_producido if tarea_esperar else None
+
+        ctx = tramite.alegante.as_contexto_cb()
+        ctx.update({
+            'alegacion_asunto': doc_alegacion.asunto if doc_alegacion else None,
+            'alegacion_fecha': (
+                doc_alegacion.fecha_administrativa.strftime('%d/%m/%Y')
+                if doc_alegacion and doc_alegacion.fecha_administrativa else None
+            ),
+            'respuesta_titular_recibida': doc_respuesta is not None,
+            'respuesta_titular_asunto': doc_respuesta.asunto if doc_respuesta else None,
+            'respuesta_titular_fecha': (
+                doc_respuesta.fecha_administrativa.strftime('%d/%m/%Y')
+                if doc_respuesta and doc_respuesta.fecha_administrativa else None
+            ),
+        })
+        return ctx

--- a/docs/referencia/GUIA_CONTEXT_BUILDERS.md
+++ b/docs/referencia/GUIA_CONTEXT_BUILDERS.md
@@ -145,7 +145,7 @@ que son accedidos directamente por `ContextoBaseExpediente`.
 | `ContextoConsultaSeparata` | `consulta_separata.py` | `CONSULTA_SEPARATA` | Implementado | #391 |
 | `ContextoAnalisisDocumental` | `analisis_documental.py` | `ANALISIS_DOCUMENTAL` | Bloqueado — tabla diagnosticos no diseñada | #392 |
 | `ContextoRecepcionAlegacion` | `recepcion_alegacion.py` | `RECEPCION_ALEGACION` | Implementado | #393 |
-| `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Bloqueado — depende de #393 | #394 |
+| `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Implementado | #394 |
 
 ---
 

--- a/tests/test_394_analisis_alegaciones.py
+++ b/tests/test_394_analisis_alegaciones.py
@@ -1,0 +1,247 @@
+"""
+Tests issue #394 — ContextoAnalisisAlegaciones.
+
+Bloques:
+  A) get_contexto() sin datos
+  B) get_contexto() con una alegación (sin respuesta del titular)
+  C) get_contexto() con una alegación (con respuesta del titular)
+  D) get_contexto() con múltiples alegaciones — resumen_clasificacion
+  E) Alegante con entidad enlazada (entidad_id) — nombre y nif de entidad
+"""
+from datetime import date
+from unittest.mock import MagicMock
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _alegante(tipo='particular', nombre='Juan García', nif='12345678A', entidad=None):
+    from app.models.alegantes import Alegante
+    a = MagicMock()
+    a.tipo_interesado = tipo
+    a.nombre = nombre
+    a.nif = nif
+    a.entidad = entidad
+    a.as_contexto_cb = lambda: Alegante.as_contexto_cb(a)
+    return a
+
+
+def _entidad(nombre_completo='Endesa S.A.', nif='A28023430'):
+    e = MagicMock()
+    e.nombre_completo = nombre_completo
+    e.nif = nif
+    return e
+
+
+def _tipo_tarea(codigo):
+    t = MagicMock()
+    t.codigo = codigo
+    return t
+
+
+def _tarea(codigo, documento_usado=None, documento_producido=None):
+    t = MagicMock()
+    t.tipo_tarea = _tipo_tarea(codigo)
+    t.documento_usado = documento_usado
+    t.documento_producido = documento_producido
+    return t
+
+
+def _doc(asunto=None, fecha=None):
+    d = MagicMock()
+    d.asunto = asunto
+    d.fecha_administrativa = fecha
+    return d
+
+
+def _tramite_recepcion(alegante, tareas=None):
+    t = MagicMock()
+    t.tipo_tramite = MagicMock()
+    t.tipo_tramite.codigo = 'RECEPCION_ALEGACION'
+    t.alegante = alegante
+    t.tareas = tareas or []
+    return t
+
+
+def _tramite_otro():
+    t = MagicMock()
+    t.tipo_tramite = MagicMock()
+    t.tipo_tramite.codigo = 'OTRO_TRAMITE'
+    t.alegante = None
+    return t
+
+
+def _solicitud(tramites_por_fase):
+    """tramites_por_fase: lista de listas de trámites, uno por fase."""
+    fases = []
+    for tramites in tramites_por_fase:
+        fase = MagicMock()
+        fase.tramites = tramites
+        fases.append(fase)
+    s = MagicMock()
+    s.fases = fases
+    return s
+
+
+def _tarea_cb(solicitud):
+    """Stub de Tarea que permite navegar hasta la solicitud dada."""
+    tramite = MagicMock()
+    tramite.fase = MagicMock()
+    tramite.fase.solicitud = solicitud
+    tarea = MagicMock()
+    tarea.tramite = tramite
+    return tarea
+
+
+def _cb(solicitud):
+    from app.services.context_builders.analisis_alegaciones import ContextoAnalisisAlegaciones
+    return ContextoAnalisisAlegaciones(MagicMock(), MagicMock(), tarea=_tarea_cb(solicitud))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# A) Sin datos
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSinDatos:
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.analisis_alegaciones import ContextoAnalisisAlegaciones
+        cb = ContextoAnalisisAlegaciones(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_sin_alegaciones_estructura_vacia(self):
+        solicitud = _solicitud([[_tramite_otro()]])
+        ctx = _cb(solicitud).get_contexto()
+        assert ctx['num_alegaciones'] == 0
+        assert ctx['alegaciones'] == []
+        assert ctx['resumen_clasificacion'] == {}
+
+    def test_tramite_sin_alegante_se_ignora(self):
+        tramite = _tramite_recepcion(alegante=None)
+        solicitud = _solicitud([[tramite]])
+        ctx = _cb(solicitud).get_contexto()
+        assert ctx['num_alegaciones'] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# B) Una alegación sin respuesta del titular
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestUnaAlegacionSinRespuesta:
+
+    def _ctx(self):
+        doc_alg = _doc(asunto='Alegación sobre trazado', fecha=date(2026, 3, 10))
+        tareas = [_tarea('ANALIZAR', documento_usado=doc_alg)]
+        tramite = _tramite_recepcion(_alegante(), tareas=tareas)
+        return _cb(_solicitud([[tramite]])).get_contexto()
+
+    def test_num_alegaciones(self):
+        assert self._ctx()['num_alegaciones'] == 1
+
+    def test_campos_alegante(self):
+        a = self._ctx()['alegaciones'][0]
+        assert a['alegante_nombre'] == 'Juan García'
+        assert a['alegante_nif'] == '12345678A'
+        assert a['alegante_tipo_interesado'] == 'particular'
+
+    def test_campos_alegacion_doc(self):
+        a = self._ctx()['alegaciones'][0]
+        assert a['alegacion_asunto'] == 'Alegación sobre trazado'
+        assert a['alegacion_fecha'] == '10/03/2026'
+
+    def test_respuesta_titular_no_recibida(self):
+        a = self._ctx()['alegaciones'][0]
+        assert a['respuesta_titular_recibida'] is False
+        assert a['respuesta_titular_asunto'] is None
+        assert a['respuesta_titular_fecha'] is None
+
+    def test_resumen_clasificacion(self):
+        assert self._ctx()['resumen_clasificacion'] == {'particular': 1}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# C) Una alegación con respuesta del titular
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestUnaAlegacionConRespuesta:
+
+    def _ctx(self):
+        doc_alg = _doc(asunto='Alegación sobre impacto visual', fecha=date(2026, 3, 5))
+        doc_resp = _doc(asunto='Respuesta al alegante', fecha=date(2026, 4, 2))
+        tareas = [
+            _tarea('ANALIZAR', documento_usado=doc_alg),
+            _tarea('ESPERAR_PLAZO', documento_producido=doc_resp),
+        ]
+        tramite = _tramite_recepcion(_alegante(tipo='asociacion'), tareas=tareas)
+        return _cb(_solicitud([[tramite]])).get_contexto()
+
+    def test_respuesta_titular_recibida(self):
+        a = self._ctx()['alegaciones'][0]
+        assert a['respuesta_titular_recibida'] is True
+
+    def test_campos_respuesta_titular(self):
+        a = self._ctx()['alegaciones'][0]
+        assert a['respuesta_titular_asunto'] == 'Respuesta al alegante'
+        assert a['respuesta_titular_fecha'] == '02/04/2026'
+
+    def test_resumen_clasificacion(self):
+        assert self._ctx()['resumen_clasificacion'] == {'asociacion': 1}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# D) Múltiples alegaciones — resumen_clasificacion y num_alegaciones
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestMultiplesAlegaciones:
+
+    def _ctx(self):
+        t1 = _tramite_recepcion(_alegante(tipo='particular', nombre='Ana'))
+        t2 = _tramite_recepcion(_alegante(tipo='particular', nombre='Luis'))
+        t3 = _tramite_recepcion(_alegante(tipo='empresa', nombre='Iberdrola'))
+        t4 = _tramite_recepcion(_alegante(tipo='administracion', nombre='Ayto. Sevilla'))
+        solicitud = _solicitud([[t1, t2], [t3, t4]])
+        return _cb(solicitud).get_contexto()
+
+    def test_num_alegaciones(self):
+        assert self._ctx()['num_alegaciones'] == 4
+
+    def test_resumen_clasificacion(self):
+        r = self._ctx()['resumen_clasificacion']
+        assert r['particular'] == 2
+        assert r['empresa'] == 1
+        assert r['administracion'] == 1
+
+    def test_longitud_lista_alegaciones(self):
+        assert len(self._ctx()['alegaciones']) == 4
+
+    def test_tramites_de_distinto_tipo_se_ignoran(self):
+        t_alg = _tramite_recepcion(_alegante())
+        t_otro = _tramite_otro()
+        solicitud = _solicitud([[t_alg, t_otro]])
+        ctx = _cb(solicitud).get_contexto()
+        assert ctx['num_alegaciones'] == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# E) Alegante con entidad enlazada — nombre y nif proceden de la entidad
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestAleganteConEntidad:
+
+    def test_nombre_y_nif_de_entidad(self):
+        ent = _entidad(nombre_completo='Endesa S.A.', nif='A28023430')
+        alegante = _alegante(tipo='empresa', nombre='nombre_local', nif='nif_local', entidad=ent)
+        tramite = _tramite_recepcion(alegante)
+        ctx = _cb(_solicitud([[tramite]])).get_contexto()
+        a = ctx['alegaciones'][0]
+        assert a['alegante_nombre'] == 'Endesa S.A.'
+        assert a['alegante_nif'] == 'A28023430'
+
+    def test_campos_locales_cuando_sin_entidad(self):
+        alegante = _alegante(tipo='particular', nombre='Pedro Ruiz', nif='11111111H')
+        tramite = _tramite_recepcion(alegante)
+        ctx = _cb(_solicitud([[tramite]])).get_contexto()
+        a = ctx['alegaciones'][0]
+        assert a['alegante_nombre'] == 'Pedro Ruiz'
+        assert a['alegante_nif'] == '11111111H'


### PR DESCRIPTION
## Cambios

- Nuevo CB `ContextoAnalisisAlegaciones` en `app/services/context_builders/analisis_alegaciones.py`: agrega datos de todos los trámites `RECEPCION_ALEGACION` de la solicitud con alegante registrado
- Cada dict en `alegaciones` incluye datos del alegante (resueltos via entidad o campos locales), asunto y fecha de la `ALEGACION_IP`, y estado/datos de la `RESPUESTA_TITULAR_ALEGACION`
- 17 tests sin BD en `tests/test_394_analisis_alegaciones.py` (stubs MagicMock), todos en verde
- `GUIA_CONTEXT_BUILDERS.md` actualizada: `ContextoAnalisisAlegaciones` marcado como implementado

Closes #394
