### PR TITLE
Añadir semáforo de plazo de fase en vistas BC tramitación

### DIFF
--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -37,6 +37,7 @@ from app.models.documentos import Documento
 from app.models.tipos_documentos import TipoDocumento
 from app.models.documentos_tarea import DocumentoTarea
 from app.decorators import role_required
+from app.services.plazos import obtener_estado_plazo
 from app.utils.permisos import (
     puede_cambiar_responsable,
     verificar_acceso_expediente
@@ -360,6 +361,8 @@ def tramitacion_bc_fase(exp_id, sol_id, fase_id):
     resultados_fase = TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
     tipos_tramite = TipoTramite.query.order_by(TipoTramite.nombre).all()
 
+    estado_plazo_fase = obtener_estado_plazo(fase, 'FASE')
+
     return render_template(
         'expedientes/tramitacion_bc_fase.html',
         expediente=expediente,
@@ -369,6 +372,7 @@ def tramitacion_bc_fase(exp_id, sol_id, fase_id):
         columnas=columnas,
         resultados_fase=resultados_fase,
         tipos_tramite=tipos_tramite,
+        estado_plazo_fase=estado_plazo_fase,
     )
 
 
@@ -455,6 +459,8 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
     doc_usado_opcional     = codigo_tipo in _TIPOS_DOC_USADO_OPCIONAL
     requiere_doc_producido = codigo_tipo in _TIPOS_REQUIEREN_DOC_PRODUCIDO
 
+    estado_plazo_fase = obtener_estado_plazo(fase, 'FASE')
+
     return render_template(
         'expedientes/tramitacion_bc_tarea.html',
         expediente=expediente,
@@ -465,6 +471,7 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         requiere_doc_usado=requiere_doc_usado,
         doc_usado_opcional=doc_usado_opcional,
         requiere_doc_producido=requiere_doc_producido,
+        estado_plazo_fase=estado_plazo_fase,
     )
 
 

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_fase.html
@@ -51,6 +51,21 @@
       </span>
       {% endif %}
       <span class="badge {{ fase_badge_class }} ms-1">{{ fase_badge_label }}</span>
+      {% if estado_plazo_fase.estado != 'SIN_PLAZO' %}
+      <span class="badge semaforo-plazo semaforo-{{ estado_plazo_fase.estado }}"
+            title="Plazo de fase{% if estado_plazo_fase.fecha_limite %} — vence {{ estado_plazo_fase.fecha_limite.strftime('%d/%m/%Y') }}{% endif %}">
+        <i class="fas fa-clock me-1"></i>
+        {%- if estado_plazo_fase.dias_restantes is not none -%}
+          {%- if estado_plazo_fase.dias_restantes >= 0 -%}
+            {{ estado_plazo_fase.dias_restantes }} d.h.
+          {%- else -%}
+            {{ -estado_plazo_fase.dias_restantes }} d.h. vencido
+          {%- endif -%}
+        {%- else -%}
+          {{ estado_plazo_fase.estado }}
+        {%- endif -%}
+      </span>
+      {% endif %}
     </span>
     <div class="bc-acciones-bar">
       <div data-modo-ver class="d-flex gap-1">

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -51,6 +51,21 @@
     <span class="fw-semibold d-flex align-items-center gap-2">
       <i class="fas fa-check-square fs-5 bc-icon-tarea"></i>
       <span>Tarea: {{ tarea.tipo_tarea.nombre if tarea.tipo_tarea else '#' ~ tarea.id }}</span>
+      {% if estado_plazo_fase.estado != 'SIN_PLAZO' %}
+      <span class="badge semaforo-plazo semaforo-{{ estado_plazo_fase.estado }}"
+            title="Plazo de fase{% if estado_plazo_fase.fecha_limite %} — vence {{ estado_plazo_fase.fecha_limite.strftime('%d/%m/%Y') }}{% endif %}">
+        <i class="fas fa-clock me-1"></i>
+        {%- if estado_plazo_fase.dias_restantes is not none -%}
+          {%- if estado_plazo_fase.dias_restantes >= 0 -%}
+            {{ estado_plazo_fase.dias_restantes }} d.h.
+          {%- else -%}
+            {{ -estado_plazo_fase.dias_restantes }} d.h. vencido
+          {%- endif -%}
+        {%- else -%}
+          {{ estado_plazo_fase.estado }}
+        {%- endif -%}
+      </span>
+      {% endif %}
     </span>
     <div class="bc-acciones-bar">
       <div data-modo-ver class="d-flex gap-1">

--- a/app/static/css/v3-breadcrumbs.css
+++ b/app/static/css/v3-breadcrumbs.css
@@ -126,6 +126,17 @@
     }
 }
 
+/* ── Semáforo de plazo (#386) ───────────────────────────────────────────── */
+
+.semaforo-plazo {
+    font-weight: 500;
+    font-size: 0.75rem;
+}
+
+.semaforo-EN_PLAZO       { background-color: #198754; color: #fff; }
+.semaforo-PROXIMO_VENCER { background-color: #fd7e14; color: #fff; }
+.semaforo-VENCIDO        { background-color: #dc3545; color: #fff; }
+
 /* ── Botones de acción en la cabecera (placeholders) ────────────────────── */
 
 .bc-acciones-bar {


### PR DESCRIPTION
## Cambios

- `routes.py`: calcula `obtener_estado_plazo(fase, 'FASE')` en `tramitacion_bc_tarea` y `tramitacion_bc_fase`; pasa `estado_plazo_fase` al template
- `tramitacion_bc_tarea.html`: badge semáforo en el card header de la tarea (días hábiles restantes o días vencido; tooltip con fecha límite); se oculta si `SIN_PLAZO`
- `tramitacion_bc_fase.html`: mismo badge junto al indicador de estado de la fase
- `v3-breadcrumbs.css`: clases `.semaforo-EN_PLAZO`, `.semaforo-PROXIMO_VENCER`, `.semaforo-VENCIDO`

Closes #386
