### PR TITLE
Incrustar imágenes en plantillas con función img() en contexto Jinja2

### DIFF
--- a/app/services/generador_escritos.py
+++ b/app/services/generador_escritos.py
@@ -80,6 +80,12 @@ def generar_escrito(plantilla, expediente, db_session, tarea=None) -> bytes:
     # Renderizado
     tpl = DocxTemplate(plantilla_path)
 
+    # Función img() para incrustar imágenes desde PLANTILLAS_BASE/recursos/
+    # Uso en plantilla: {{ img('logo.png', '3.5', '1.98') }}
+    from flask import current_app
+    _recursos = os.path.join(current_app.config.get('PLANTILLAS_BASE', ''), 'recursos')
+    ctx['img'] = _fn_imagen(tpl, _recursos)
+
     # Fragmentos insertables: {{r NombreFragmento}} → tpl.new_subdoc(ruta)
     ctx.update(_cargar_fragmentos(tpl, plantilla_path))
 
@@ -190,6 +196,34 @@ def guardar_docx(docx_bytes, ruta_destino) -> str:
 # ------------------------------------------------------------------
 # Helpers privados
 # ------------------------------------------------------------------
+
+def _fn_imagen(tpl, recursos_dir: str):
+    """
+    Devuelve la función img() que las plantillas Jinja2 usan para incrustar imágenes.
+
+    Uso en plantilla .docx:
+        {{ img('logo_portada.png', '3.5', '1.98') }}   — ancho y alto en cm
+        {{ img('firma.png', '4.0') }}                  — solo ancho; alto proporcional
+        {{ img('sello.png') }}                         — tamaño original del fichero
+
+    El fichero se busca en PLANTILLAS_BASE/recursos/<nombre_fichero>.
+    El anclaje lo controla la plantilla (inline, dentro de cuadro de texto, etc.),
+    no esta función — ver ADR-009.
+    """
+    from docxtpl import InlineImage
+    from docx.shared import Cm
+
+    def img(nombre_fichero: str, ancho=None, alto=None) -> InlineImage:
+        ruta = os.path.join(recursos_dir, nombre_fichero)
+        kwargs = {}
+        if ancho is not None:
+            kwargs['width'] = Cm(float(ancho))
+        if alto is not None:
+            kwargs['height'] = Cm(float(alto))
+        return InlineImage(tpl, ruta, **kwargs)
+
+    return img
+
 
 def _ruta_plantilla(ruta_relativa: str) -> str:
     """Resuelve la ruta absoluta de la plantilla dentro de PLANTILLAS_BASE."""

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -1,11 +1,62 @@
 # Contexto actual — BDDAT
 
-> Actualizar al cerrar cada issue. Una entrada por sección, no listas.
+> Actualizar al cerrar cada issue. La sección de estado lleva una entrada por línea.
+> La hoja de ruta es la propuesta de orden para las próximas sesiones — el detalle y
+> el porqué de cada decisión está en `docs/historial/REVISION_VALIDEZ_ISSUES_MAYO_2026.md`.
 
 ---
 
-**Último cerrado:** #394 — CB `ContextoAnalisisAlegaciones` (agrega alegaciones de la solicitud: alegante, doc ALEGACION_IP, RESPUESTA_TITULAR_ALEGACION; 17 tests sin BD).
+**Último cerrado:** #386 — semáforo de plazo de fase en vistas BC de tarea y fase.
 
 **Actuales:** —
 
-**Próximo:** #386 (semáforos de plazo en vista BC de tramitación, M3).
+**Próximo:** #300 (primer ítem de la hoja de ruta).
+
+---
+
+## Hoja de ruta — orden propuesto para próximas sesiones
+
+> Una sesión limpia por ítem. Las dependencias se indican con «(tras #X)».
+> Antes de arrancar: limpieza de GitHub según §4.1 del documento de revisión
+> (cerrar #318, #153, #357, #364; trocear #248; cerrar y reabrir #276; reescribir
+> cuerpos de #297, #324, #365; reetiquetar #365; asignar M3 a #374).
+
+### Bloque 1 — Correcciones M2 inmediatas
+
+1. **#300** — dirección de notificación del titular en escritos
+2. **#297** — logotipo de la Junta incrustado en escritos
+3. **#366** — eliminar trámite AUDIENCIA de COMPATIBILIDAD_AMBIENTAL
+
+### Bloque 2 — Catálogo y documentos internos (fundacional)
+
+4. **#377** — seed de tipos_documentos del catálogo ESFTT
+5. **#378** — seed de resultados válidos de notificación (tras #377)
+6. **#380** — ADR-008: decisión sobre la tabla documentos_tarea
+7. **#365** — implementar URI `bddat://` y helper `resolver_url()` (ADR-006)
+8. **#362** — certificado de plazo cumplido (tras #365; absorbe la limpieza de #357)
+
+### Bloque 3 — Modelo de interesados y Context Builders de escritos
+
+9. **#374** — tabla de interesados del expediente y trámite REGISTRO_INTERESADOS
+10. **#nuevo1** — CB `ContextoNotificacionOrganismo` (notificación a organismo consultado)
+11. **#nuevo2** — CB `ContextoResolucion` (escrito de resolución)
+12. **#nuevo3** — CB `ContextoInformacionPublica` (anuncio de información pública)
+13. **#nuevo4** — tablas `catalogo_requerimientos` y `requerimientos_tarea`
+14. **#nuevo5** — CB `ContextoSubsanacion` (requerimiento de subsanación; tras #nuevo4)
+
+### Bloque 4 — Motor de reglas
+
+15. **#323** — modo global del motor + tabla configuracion_sistema
+16. **#324** — mecanismo de escape con bitácora (tras #323)
+
+### Bloque 5 — Análisis heurístico de PDF
+
+17. **#304** — script de detección del tipo de solicitud
+18. **#305** — script de detección del tipo de expediente
+19. **#306** — helper de cálculo de tasa y extracción de presupuesto (tras #304)
+
+### Bloque 6 — Issues con rediseño previo necesario
+
+20. **#276** — compatibilidad de tipos de solicitud como reglas del motor
+21. **#192** — requisitos documentales por procedimiento
+22. **#174** — permisos blandos con traza en bitácora

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -17,9 +17,9 @@
 ## Hoja de ruta — orden propuesto para próximas sesiones
 
 > Una sesión limpia por ítem. Las dependencias se indican con «(tras #X)».
-> Antes de arrancar: limpieza de GitHub según §4.1 del documento de revisión
-> (cerrar #318, #153, #357, #364; trocear #248; cerrar y reabrir #276; reescribir
-> cuerpos de #297, #324, #365; reetiquetar #365; asignar M3 a #374).
+> Limpieza de GitHub §4.1 completada el 2026-05-16: cerrados #318, #153, #357, #364,
+> #248, #276; reescritos los cuerpos de #297, #332, #283, #324, #365, #247;
+> creados #402-#410; #374 asignado a M3.
 
 ### Bloque 1 — Correcciones M2 inmediatas
 
@@ -38,11 +38,11 @@
 ### Bloque 3 — Modelo de interesados y Context Builders de escritos
 
 9. **#374** — tabla de interesados del expediente y trámite REGISTRO_INTERESADOS
-10. **#nuevo1** — CB `ContextoNotificacionOrganismo` (notificación a organismo consultado)
-11. **#nuevo2** — CB `ContextoResolucion` (escrito de resolución)
-12. **#nuevo3** — CB `ContextoInformacionPublica` (anuncio de información pública)
-13. **#nuevo4** — tablas `catalogo_requerimientos` y `requerimientos_tarea`
-14. **#nuevo5** — CB `ContextoSubsanacion` (requerimiento de subsanación; tras #nuevo4)
+10. **#402** — CB `ContextoNotificacionOrganismo` (notificación a organismo consultado)
+11. **#403** — CB `ContextoResolucion` (escrito de resolución)
+12. **#404** — CB `ContextoInformacionPublica` (anuncio de información pública)
+13. **#405** — tablas `catalogo_requerimientos` y `requerimientos_tarea`
+14. **#406** — CB `ContextoSubsanacion` (requerimiento de subsanación; tras #405)
 
 ### Bloque 4 — Motor de reglas
 
@@ -57,6 +57,12 @@
 
 ### Bloque 6 — Issues con rediseño previo necesario
 
-20. **#276** — compatibilidad de tipos de solicitud como reglas del motor
+20. **#410** — compatibilidad de tipos de solicitud como reglas del motor
 21. **#192** — requisitos documentales por procedimiento
 22. **#174** — permisos blandos con traza en bitácora
+
+### Backlog M3 sin posición en la ruta
+
+Troceo de #248 fuera del recorrido priorizado: **#407** (campo `siglas_escritos`),
+**#408** (checklist documental — posible post-producción), **#409** (regla de tasas;
+tras #408).

--- a/docs/decisiones/ADR-009-incrustacion-imagenes-plantillas.md
+++ b/docs/decisiones/ADR-009-incrustacion-imagenes-plantillas.md
@@ -1,0 +1,74 @@
+---
+id: ADR-009
+título: Incrustación de imágenes en plantillas mediante función img() en contexto Jinja2
+fecha: 2026-05-16
+estado: decidida — implementada (#297)
+---
+
+## Decisión
+
+Las imágenes (logotipos, sellos, firmas…) se incrustan en los escritos generados mediante
+una función `img()` inyectada en el contexto Jinja2 de cada renderizado.
+
+Uso en plantilla `.docx`:
+
+```
+{{ img('logo_portada.png', '3.5', '1.98') }}   — ancho y alto en cm
+{{ img('firma_director.png', '4.0') }}          — solo ancho; alto proporcional
+{{ img('sello.png') }}                          — tamaño original del fichero
+```
+
+Los ficheros de imagen se almacenan en `PLANTILLAS_BASE/recursos/` y se referencian
+por nombre desde la plantilla. El posicionamiento (inline, dentro de cuadro de texto
+anclado, etc.) lo define la propia plantilla, no el código.
+
+## Por qué
+
+**Problema previo:** las plantillas heredadas (.doc, Word 2000) tenían los logotipos
+incrustados directamente. Al cambiar la identidad corporativa de la Junta (2017) fue
+necesario actualizar más de 30 plantillas manualmente.
+
+**Por qué no variables hardcodeadas** (`ctx['logo_portada'] = InlineImage(...)`):
+ata el nombre del fichero y las dimensiones al código Python. Añadir un nuevo logotipo
+o usarlo en otro lugar requeriría cambio de código.
+
+**Por qué no fragmentos subdoc** (`{{r Logo}}`): docxtpl/docxcompose no reasigna
+correctamente los `rId` de imagen al mezclar subdocumentos — las imágenes quedan
+como referencias rotas en el output.
+
+**Por qué `img()` callable en contexto:** Jinja2 evalúa la llamada en tiempo de
+renderizado, `InlineImage` queda embebida en el `.docx` resultante, y no existe
+dependencia entre el nombre de la variable y el código del generador. Cualquier imagen
+en `PLANTILLAS_BASE/recursos/` es incrustable desde cualquier plantilla y en cualquier
+posición sin modificar código.
+
+## Anclaje
+
+El token `{{ img(...) }}` produce contenido **inline** (anclado como carácter).
+El posicionamiento real en el documento lo controla la plantilla:
+
+- **Cabecera páginas 2+:** token en párrafo de cabecera → imagen inline en el flujo de texto.
+- **Logos de primera página:** token dentro de un cuadro de texto (`wps:txbx`) que está
+  anclado con posición absoluta a la página. La imagen es inline dentro del cuadro;
+  el cuadro provee el anclaje absoluto.
+- **Pie de primera página:** ídem cuadro de texto anclado.
+
+Esta separación de responsabilidades (el código embebe, la plantilla posiciona) permite
+que el diseñador de plantillas controle la maquetación sin intervención del desarrollador.
+
+## Cómo implementar
+
+- `app/services/generador_escritos.py`: función `_fn_imagen(tpl, recursos_dir)` que
+  devuelve el callable `img()`. Se inyecta como `ctx['img']` antes de `tpl.render(ctx)`.
+- Directorio de recursos: `PLANTILLAS_BASE/recursos/` (misma variable de entorno que
+  las plantillas, sin variable adicional).
+- Plantilla base de carta: `plantilla_base_297.docx` con los tres tokens ya configurados.
+
+## Alternativas descartadas
+
+- **Variables hardcodeadas por nombre** (`logo_portada`, `logo_cabecera`, `logo_pie`):
+  descartada por acoplar nombres de fichero al código.
+- **Fragmentos subdoc** (`{{r Logo}}`): descartada por bug de reasignación de `rId`
+  en docxtpl/docxcompose que deja imágenes sin resolver.
+- **Logo vinculado en plantilla + incrustado en generador**: descartada por fragilidad
+  de rutas absolutas en vínculos de plantilla y complejidad de la cirugía ZIP necesaria.

--- a/docs/guias/REGLAS_BASH.md
+++ b/docs/guias/REGLAS_BASH.md
@@ -21,6 +21,7 @@ ni el modo "accept edits". Evitarlos cambiando el patrón.
 | `cd with two or more directory arguments` | `cd ruta1 ruta2` — ocurre al partir una ruta por espacios o pasar dos argumentos accidentalmente | Un solo argumento; entrecomillar si hay espacios: `cd "/d/ruta con espacios"` |
 | `contains shell syntax that cannot be statically analyzed` | Bucle `while/for/until` en una sola línea con `;` como separador, **o** variable expandida dentro de patrón con comillas mixtas (`"...'$var'..."`) | `Write` el script completo a `docs_prueba/temp/script.sh` → `bash /d/BDDAT/docs_prueba/temp/script.sh` |
 | `Contains shell syntax (string) that cannot be statically analyzed` | `$()` dentro del valor de un flag de `gh` u otro comando: `gh ... --comment "$(cat fichero)"` | Separar: `gh issue comment N --body-file fichero` (añade el comentario) + `gh issue close N` (cierra sin comentario) |
+| `contains ansi_c_string` | Sintaxis `$'\t'`, `$'\n'` u otras secuencias ANSI C en argumentos Bash | Usar Python para procesar JSON/TSV: `Write` script → `python script.py`; o reformular sin `$'...'` |
 
 ---
 

--- a/docs/historial/ANALISIS_ESTADO_MAYO_2026.md
+++ b/docs/historial/ANALISIS_ESTADO_MAYO_2026.md
@@ -1,15 +1,20 @@
 # Análisis de estado BDDAT — mayo 2026
 
 > **Tipo:** Snapshot de situación. Congelado en la fecha de creación.
-> **Fecha:** 2026-05-13
-> **Alcance:** Código en rama `develop` + issues abiertos en GitHub.
+> **Fecha original:** 2026-05-13 — **Actualizado:** 2026-05-16
+> **Alcance:** Código en rama `develop` + issues cerrados entre 13/05 y 16/05.
 > **Método:** Lectura directa del código (modelos, servicios, rutas, templates) cruzada con issues abiertos.
+> **Documento hermano:** `REVISION_VALIDEZ_ISSUES_MAYO_2026.md` — dictamen de validez issue a issue
+> (cuáles están obsoletos, requieren rediseño o están ya implementados). Consultarlo antes de
+> planificar cualquier issue listado en la sección 5.
 
 ---
 
 ## 1. Imagen general
 
 El proyecto está más avanzado de lo que sugiere el historial de issues cerrados. El core técnico (motor de reglas, plazos, generador de escritos, API de tramitación BC) es sólido y bien integrado. Lo que falta tiende a ser: datos de catálogo configurados normativamente, partes específicas de UI de segundo orden, e infraestructura de despliegue.
+
+**Desde el 13/05** se cerraron los issues #391–#394 (4 Context Builders nuevos), #395 (seed organismos_consulta), #386 (semáforos de plazo BC — era el hueco de mayor gravedad identificado el 13/05) y el ADR-007 elimina definitivamente las whitelists E-S-F-T junto con los verbos INICIAR/FINALIZAR del motor (#387).
 
 ---
 
@@ -19,13 +24,13 @@ El proyecto está más avanzado de lo que sugiere el historial de issues cerrado
 
 **Implementado:**
 - Modelos completos: Expediente, Solicitud, Fase, Trámite, Tarea con relaciones bidireccionales
-- API BC completa (`api_bc.py`): crear, editar, borrar e iniciar/finalizar para los 5 niveles ESFTT, integrado con motor de reglas e invariantes
+- API BC completa (`api_bc.py`): crear, editar, borrar para los 5 niveles ESFTT, integrado con motor de reglas e invariantes
 - Vistas BC (5 niveles) con templates HTML
 - Wizard de alta de expediente (3 pasos)
-- El estado de tarea/trámite/fase es **deducido** del árbol documental (sin campo estado explícito, por diseño ADR-002); las acciones iniciar/finalizar son validaciones, la mutación real es por `editar_tarea`/`editar_fase`
+- El estado de tarea/trámite/fase es **deducido** del árbol documental (sin campo estado explícito, por diseño ADR-002); las acciones de validación son por `editar_tarea`/`editar_fase`
+- **[NUEVO 16/05]** ADR-007: eliminadas whitelists E-S-F-T y verbos INICIAR/FINALIZAR del motor (#387). El motor ya no valida relaciones de tipo entre niveles — la lógica de qué tipos son válidos pasa a ser responsabilidad de la UI/formularios.
 
 **Pendiente:**
-- Las whitelists de relación E→S, S→F, F→T no están completas normativamente en BD: sin esos datos el tramitador no sabe qué tipos de fase puede crear en qué tipo de solicitud (#360, #335 — M3)
 - Tareas multi-documento: cada tarea solo admite un documento_usado y uno documento_producido; extender está pendiente (#376, sin milestone)
 
 ### ÁREA 2 — Sistema documental (Bloque 2, M1)
@@ -36,24 +41,31 @@ El proyecto está más avanzado de lo que sugiere el historial de issues cerrado
 - Asociación documento↔tarea (documento_usado_id, documento_producido_id en la edición de tarea)
 
 **Pendiente:**
-- Sin selector funcional de tipo de documento en la UI al registrar (#379, M4 — posiblemente mal clasificado)
+- Sin selector funcional de tipo de documento en la UI al registrar (#379, M4)
 - Flujo de asociación fragmentado: subir al pool → ir a la tarea → asignar; sin posibilidad de hacerlo en un solo gesto (#367, M3)
-- Tabla `documentos_tarea` (multi-documento) con diseño abierto sin destino claro tras eliminar INCORPORAR (#380, M3)
+- Tabla `documentos_tarea` (multi-documento) con diseño abierto (#380, M3)
 
 ### ÁREA 3 — Generación de escritos (Bloque 3, M2)
 
 **Implementado:**
 - Servicio generador completo (docxtpl + corrección de párrafos anidados en cabeceras/pies, ZIP parcheado)
-- Capa 1 de contexto (ContextoBaseExpediente)
+- Capa 1 de contexto (`ContextoBaseExpediente`)
 - CRUD de plantillas para Supervisor con explorador de ficheros
 - Consultas nombradas como contexto dinámico
 - Fragmentos reutilizables (`{{r Nombre}}`)
 - API de escritos (`api_escritos.py`) para generar desde la vista de tarea
+- **[NUEVO 16/05]** Context Builders (Capa 2) — paquete `app/services/context_builders/` estructurado (#289):
+  - `ContextoConsultaSeparata` (#391) — consulta a organismo + `OrganismoExpediente`
+  - `ContextoAnalisisDocumental` (#392) — análisis documental + modelo `Diagnostico`
+  - `ContextoRecepcionAlegacion` (#393) — recepción de alegación + modelo `Alegante`
+  - `ContextoAnalisisAlegaciones` (#394) — análisis de alegaciones
+  - Seed `organismos_consulta` en ConsultaNombrada (#395)
 
 **Pendiente:**
-- **Context Builders (Capa 2)** no implementados (#289, M2) — sin ellos las plantillas solo usan datos genéricos del expediente, no los específicos por tipo de solicitud/fase/trámite
 - Bug en resolución de dirección de notificación del titular (#300, M2)
 - Logotipo de la Junta enlazado en lugar de incrustado (#297, M2) — afecta a documentos oficiales
+- CBs pendientes de implementar: tipos de escrito para fases de resolución (RES), información pública (IP), subsanación — sin issues creados aún
+- `ContextoAnalisisDocumental` marcado como "Bloqueado" en la guía (tabla `diagnosticos` diseñada pero pendiente de validar integración)
 
 ### ÁREA 4 — Motor de reglas (Bloque 4, M3)
 
@@ -61,7 +73,8 @@ El proyecto está más avanzado de lo que sugiere el historial de issues cerrado
 - Motor agnóstico completo: sujeto con wildcards ANY, condiciones AND, excepciones, prioridades
 - `evaluar()` y `auditar()` (para certificados)
 - ContextAssembler compilando variables desde el árbol ESFTT
-- Integrado en la API BC en todas las acciones CREAR/INICIAR/FINALIZAR/BORRAR
+- Variable `tipo_sujeto_solicitado` añadida al catálogo (#388)
+- **[NUEVO 16/05]** Eliminadas whitelists E-S-F-T y verbos INICIAR/FINALIZAR del motor (ADR-007, #387). Motor simplificado.
 
 **Pendiente:**
 - Las reglas en BD son mínimas o inexistentes — el motor dice PERMITIDO sin reglas configuradas (intencionado: arranque en modo suave)
@@ -72,13 +85,13 @@ El proyecto está más avanzado de lo que sugiere el historial de issues cerrado
 
 **Implementado:**
 - Cálculo completo art. 30 LPACAP: días hábiles, naturales, meses y años
-- Suspensiones inferidas del árbol documental (art. 22 LPACAP) — sin tabla propia
+- Suspensiones inferidas del árbol documental (art. 22 LPACAP) — sin tabla propia (#173)
 - Catálogo de plazos en BD con condiciones
 - Integrado en el servicio de seguimiento (pistas PENDIENTE_PLAZOS, PENDIENTE_SUBSANAR)
-- CLI de importación de inhábiles; alerta de calendario en el header para admins
+- CLI de importación de inhábiles + banner de alerta en el header para admins (#339)
+- **[NUEVO 16/05]** Semáforos de plazo en vistas BC de tarea y fase (#386) — era el hueco de mayor gravedad identificado el 13/05
 
 **Pendiente:**
-- Sin semáforos en la vista BC de tramitación — el estado de plazo no es visible al tramitar, solo en el listado de seguimiento
 - Tarea ESPERAR_PLAZO sin mecanismo de cierre formal (#357, M3)
 - Sin UI de gestión del catálogo de plazos (sin issue específico)
 
@@ -101,13 +114,13 @@ El proyecto está más avanzado de lo que sugiere el historial de issues cerrado
 **Implementado:**
 - CRUD de usuarios (con validaciones de seguridad: no autodesactivación, no quitar último ADMIN)
 - CRUD de plantillas de escritos
-- Días inhábiles: CLI (`flask inhabiles importar`), sin UI web
+- Días inhábiles: CLI (`flask inhabiles importar`) + banner de aviso (#339)
 
 **Pendiente:**
 - Sin CRUD web de tipos ESFTT (#171, M3)
 - Sin CRUD de reglas del motor (#170, M3)
 - Sin CRUD de catálogo de plazos (sin issue)
-- Sin CRUD de tablas de whitelist ESFTT (expedientes_solicitudes, solicitudes_fases, fases_tramites)
+- ~~Sin CRUD de tablas de whitelist ESFTT~~ — **eliminadas por ADR-007**
 
 ### ÁREA 8 — Gestión de carga y usuarios (Bloque 9, M2)
 
@@ -136,10 +149,12 @@ Sin tocar en su totalidad: `SECRET_KEY` (#45), HTTPS (#177), backup (#178), ENS 
 
 | Hueco | Gravedad para MVP | Observación |
 |---|---|---|
-| Semáforos de plazo en la vista BC | Alta | El #74 (M5) solo cubre el dashboard. El tramitador trabajando en una tarea no ve el estado de plazo de su fase. |
+| ~~Semáforos de plazo en la vista BC~~ | ~~Alta~~ | **RESUELTO — #386 cerrado el 15/05** |
+| CBs de fases RES, IP, subsanación | Alta | El sistema solo tiene CBs para consultas y alegaciones. Sin CBs no hay escritos específicos para resolución e información pública. Sin issues. |
 | UI de configuración del catálogo de plazos | Media | El Supervisor solo puede configurarlo directamente en BD. Sin UI ni issue. |
 | Asignación masiva de expedientes por Supervisor | Media | Solo se puede hacer uno a uno desde la edición del expediente. Sin vista dedicada ni issue. |
 | Elementos técnicos del proyecto (líneas, CT, subestaciones) | Baja (M3+) | Sin diseño ni issue. Necesario para Proyectos e instalaciones avanzado. |
+| `titular_direccion` en escritos (#300) | Media | Bug conocido pero sin solución aún. Afecta todos los escritos generados. |
 
 ---
 
@@ -147,21 +162,115 @@ Sin tocar en su totalidad: `SECRET_KEY` (#45), HTTPS (#177), backup (#178), ENS 
 
 | Issue | Milestone actual | Posible reclasificación | Motivo |
 |---|---|---|---|
-| #379 — Tipos documentos en UI | M4 | M2 | Sin tipos de documento seleccionables, la gestión documental queda incompleta desde el primer día |
-| #74 — Semáforos en dashboard | M5 | M2 | Los plazos son información operativa diaria del tramitador |
+| #300 — Bug dirección titular en escritos | M2 | — | Sigue pendiente; afecta todos los documentos |
+| #297 — Logotipo incrustado | M2 | — | Sigue pendiente; afecta documentos oficiales |
+| #379 — Tipos documentos en UI | M4 | M2 | Sin tipos seleccionables, la gestión documental queda incompleta desde el primer día |
 | #376 — UI multi-documento | sin milestone | M3 | Relacionado con tipos de tarea; necesita clasificarse |
 | #374 — Tabla interesados | sin milestone | diseño previo + M3 | Modelo de datos que puede afectar la arquitectura de ESFTT |
 | #344 — SETUP_PC desactualizado | sin milestone | M4 | Afecta a la reproducción del entorno de desarrollo |
 
 ---
 
-## 5. Síntesis
+## 5. Tareas de backend y migración pendientes (sin UI) — inventario completo
 
-**El motor técnico está construido.** Lo más sofisticado (motor de reglas con excepciones, plazos con suspensiones, generador de escritos con subdocs, seguimiento con pistas) está implementado y bien integrado entre sí.
+> Esta sección se añade el 16/05 para orientar las próximas sesiones hacia trabajo
+> de backend puro antes de abordar nuevas vistas.
+> Fuente: listado completo de issues abiertos en GitHub a 16/05/2026.
 
-**El cuello de botella para producción mínima es de datos y UI de segundo orden:**
-- Las whitelists normativas ESFTT (qué tipos de solicitud/fase/trámite son válidos en cada contexto) están en BD pero incompletas normativamente.
-- Varios issues M2 críticos para la usabilidad real (Context Builders, diagrama de tramitación, semáforos de plazo) están a medias.
-- La infraestructura de producción (M4) está sin tocar.
+### Grupo A — Context Builders restantes (sin issue abierto aún)
 
-**El camino más corto a producción mínima:** completar datos de catálogo ESFTT → resolver issues M2 críticos (CB Capa 2, dirección, logotipo) → preparar infraestructura M4 → importación legacy.
+Continuación natural de #289. Cada CB es una sesión: modelo + migración + CB + tests.
+
+| CB pendiente | Trámite / fase | Datos nuevos previsibles |
+|---|---|---|
+| `ContextoNotificacionOrganismo` | CONSULTAS — notificación | Organismo, plazo legal, fecha límite — ejemplo ya en GUIA_CONTEXT_BUILDERS |
+| `ContextoResolucion` | RES | Campos de acuerdo/denegación |
+| `ContextoInformacionPublica` | IP | Fechas publicación, BOE/BOJA, período de exposición |
+| `ContextoSubsanacion` | SOL — subsanación | Requerimientos, plazo concedido |
+
+### Grupo B — Bugs M2 sin tocar
+
+| Issue | Descripción |
+|---|---|
+| #300 | ContextoBaseExpediente: dirección de notificación del titular resuelta incorrectamente |
+| #297 | Logotipo de la Junta enlazado en lugar de incrustado (cambio en el generador) |
+
+### Grupo C — Diseño pendiente de ADR / decisión técnica (M3)
+
+Estos no se pueden implementar hasta tener el diseño acordado. Son bloqueantes para lo que viene después.
+
+| Issue | Descripción |
+|---|---|
+| #362 | ESPERAR_PLAZO: certificado de plazo cumplido como documento_producido_id |
+| #364 | PUBLICAR vs NOTIFICAR: distinción BOE/BOP/BOJA/prensa vs destinatario identificado |
+| #365 | Extender documentos.url a URI de BD para decisiones de ANALIZAR |
+| #366 | Eliminar trámite AUDIENCIA de COMPATIBILIDAD_AMBIENTAL (duplicado de RECEPCION_INFORME) |
+| #380 | Decidir destino de tabla documentos_tarea tras eliminar INCORPORAR |
+| #247 | Diseño completo de la fase de consultas a organismos y análisis técnico |
+| #248 | Diseño de la fase ANÁLISIS_SOLICITUD: checklist documental e ítems de requerimiento |
+| #374 | Diseño de tabla de interesados y trámite REGISTRO_INTERESADOS (sin milestone) |
+
+### Grupo D — Seeds y migraciones de catálogo (M3, pure backend)
+
+No requieren UI. Desbloquean el funcionamiento real del sistema.
+
+| Issue | Descripción |
+|---|---|
+| #377 | Seed de tipos_documentos del catálogo ESFTT (migración Alembic) |
+| #378 | Seed de tipos_documentos_resultados_validos por tipo de notificación |
+| #276 | Poblar tipos_solicitudes_compatibles con el técnico del servicio |
+| — | Añadir reglas reales al motor (actualmente vacío → siempre PERMITIDO) |
+| — | Completar datos normativos en catálogo de plazos |
+
+### Grupo E — Motor de reglas y servicios M3 (pure backend)
+
+| Issue | Descripción |
+|---|---|
+| #323 | Motor: modo global INACTIVO / SOLO_ADVERTIR / BLOQUEAR |
+| #357 | ESPERAR_PLAZO: mecanismo de cierre formal (tarea huérfana de invariante documental) |
+| #324 | Motor: mecanismo de escape con justificación y bitácora (DB + lógica) |
+| #192 | Modelo: requisitos documentales por procedimiento (documentos_procedimiento) |
+| #318 | Tipos combinados: regla del tipo más restrictivo al poblar metadatos_fechas y motor |
+
+### Grupo F — Modelos y diseño de datos (M3, sin milestone)
+
+| Issue | Descripción |
+|---|---|
+| #376 | Generalizar multi-documento a todos los tipos de tarea que lo necesitan |
+| #174 | Permisos granulares por acción y expediente |
+
+### Grupo G — Scripts y servicios avanzados (M3)
+
+Trabajo de backend independiente, sin bloqueo de UI.
+
+| Issue | Descripción |
+|---|---|
+| #304 | Script de detección del tipo de solicitud por análisis del PDF |
+| #305 | Script de detección del tipo de expediente por análisis del proyecto |
+| #306 | Helper de cálculo de tasa y extracción de presupuesto del proyecto |
+
+### No clasificado como backend pero relevante (M2)
+
+| Issue | Descripción | Nota |
+|---|---|---|
+| #318 | Tipos combinados: regla del tipo más restrictivo | Afecta al motor, posiblemente solo datos |
+| #332 | CI: ejecutar tests en GitHub Actions | Infra, independiente del resto |
+
+---
+
+## 6. Síntesis actualizada (16/05)
+
+**El motor técnico está construido.** Lo más sofisticado (motor de reglas con excepciones, plazos con suspensiones art. 22, generador de escritos con subdocs, seguimiento con pistas) está implementado y bien integrado entre sí. El ADR-007 simplificó el motor eliminando la complejidad de las whitelists.
+
+**Avances significativos desde el 13/05:**
+- Semáforo de plazo en vistas BC resuelto (era el hueco de mayor gravedad para el tramitador)
+- 4 Context Builders nuevos — los más complejos (organismos, alegaciones) ya están
+- Modelo de datos enriquecido: `OrganismoExpediente`, `Diagnostico`, `Alegante`
+- Motor simplificado con ADR-007
+
+**El cuello de botella sigue siendo backend antes que UI:**
+- Los CBs restantes (RES, IP, subsanación) son la prioridad natural — sin ellos el generador de escritos no sirve para los tipos de escrito más frecuentes
+- Los bugs M2 (#300, #297) son simples y deberían cerrarse antes de cualquier nueva UI
+- La UI pendiente (CRUD de reglas, diagrama ReactFlow, cola de trabajo) no aporta valor hasta que el backend esté completo
+
+**Estrategia recomendada para próximas sesiones:** Grupo A (CBs) → Grupo B (bugs M2) → Grupo C (motor, M3) → UI.

--- a/docs/historial/REVISION_VALIDEZ_ISSUES_MAYO_2026.md
+++ b/docs/historial/REVISION_VALIDEZ_ISSUES_MAYO_2026.md
@@ -1,0 +1,292 @@
+# Revisión de validez de issues — mayo 2026
+
+> **Tipo:** Snapshot de auditoría arquitectónica. Congelado en la fecha de creación.
+> **Fecha:** 2026-05-16
+> **Alcance:** 31 issues abiertos no puramente de UI (milestones M2, M3, M4 parcial, sin-milestone).
+> **Método:** Lectura del cuerpo completo de cada issue, cruzada con código en `develop`,
+> las ADR-001 a ADR-007 y el historial de commits desde el 11/05/2026.
+> **Documento hermano:** `ANALISIS_ESTADO_MAYO_2026.md` (estado por área).
+
+---
+
+## 1. Criterios de clasificación
+
+| Situación | Significado |
+|---|---|
+| **Válido** | Alcance real, viable y alineado con las decisiones recientes. Implementar tal cual. |
+| **Válido — reescribir cuerpo** | La necesidad es real, pero el texto del issue tiene referencias muertas o premisas desactualizadas. Reescribir antes de planificar. |
+| **Requiere rediseño** | Una decisión posterior (ADR) invalida el enfoque del issue. Hay que rehacer el diseño. |
+| **Parcialmente implementado** | Parte del alcance ya está cubierto por trabajo posterior. Recortar el issue a lo que falta. |
+| **Para cerrar** | Superado por otro issue/ADR, o no es trabajo de desarrollo. Cerrar. |
+| **Estudiar** | La premisa es dudosa o solapa con otro issue. Verificar/decidir antes de planificar. |
+
+---
+
+## 2. Tabla de dictamen
+
+| # | Descripción corta | Milestone | Situación |
+|---|---|---|---|
+| #300 | Dirección de notificación del titular mal resuelta en escritos | M2 | **Válido** |
+| #297 | Logotipo de la Junta: vinculado → incrustado | M2 | **Válido — reescribir cuerpo** |
+| #318 | Tipos combinados: regla del tipo más restrictivo en metadatos/motor | M2 | **Para cerrar** |
+| #332 | CI: ejecutar tests en GitHub Actions | M2 | **Válido — reescribir cuerpo** |
+| #181 | Inspección automática de documentos / preclasificación | M2 | **Estudiar** |
+| #362 | ESPERAR_PLAZO: certificado de plazo cumplido como doc. producido | M3 | **Válido** (→ ADR) |
+| #364 | PUBLICAR cubre BOE/BOP/BOJA/prensa; NOTIFICAR solo destinatario | M3 | **Para cerrar** |
+| #365 | Extender documentos.url a URI `bddat://` para decisiones ANALIZAR | M3 | **Válido — reconvertir a implementación** |
+| #366 | Eliminar trámite AUDIENCIA de COMPATIBILIDAD_AMBIENTAL | M3 | **Válido** |
+| #380 | Decidir destino de tabla `documentos_tarea` tras quitar INCORPORAR | M3 | **Válido — decisión bloqueante** |
+| #247 | Fase de consultas a organismos y análisis técnico | M3 | **Parcialmente implementado** |
+| #248 | Fase ANÁLISIS_SOLICITUD, checklist documental, requerimientos | M3 | **Requiere rediseño** |
+| #374 | Tabla de interesados y trámite REGISTRO_INTERESADOS | sin-ms | **Válido** (asignar M3) |
+| #377 | Seed de tipos_documentos del catálogo ESFTT (Alembic) | M3 | **Válido** |
+| #378 | Seed de tipos_documentos_resultados_validos | M3 | **Válido** |
+| #276 | Poblar tipos_solicitudes_compatibles | M3 | **Requiere rediseño** |
+| #323 | Motor: modo global INACTIVO/SOLO_ADVERTIR/BLOQUEAR | M3 | **Válido** |
+| #357 | ESPERAR_PLAZO: mecanismo de cierre formal | M3 | **Para cerrar** |
+| #324 | Motor: mecanismo de escape con justificación y bitácora | M3 | **Válido — reescribir cuerpo** |
+| #192 | Requisitos documentales por procedimiento | M3 | **Requiere rediseño** |
+| #174 | Permisos granulares por acción y expediente | M3 | **Requiere rediseño** |
+| #376 | Generalizar UI multi-documento a más tipos de tarea | sin-ms | **Válido — bloqueado por #380** |
+| #304 | Script de detección del tipo de solicitud por PDF | M3 | **Válido** |
+| #305 | Script de detección del tipo de expediente por PDF | M3 | **Válido** |
+| #306 | Helper de cálculo de tasa y extracción de presupuesto | M3 | **Válido** |
+| #294 | Estrategia: pivot normativa → motor en modo suave | M3 | **Estudiar** (mayormente ejecutado) |
+| #283 | Ampliar ESTRUCTURA_FTT a todos los tipos de expediente | M3 | **Válido — reescribir cuerpo** |
+| #153 | [DRAFT] Consultas en separatas — tabla entidades_consultadas | M3 | **Para cerrar** |
+| #106 | Listado de códigos DIR3 | M3 | **Válido** (revisar milestone) |
+
+**Resumen:** 11 válidos · 4 reescribir cuerpo · 4 requieren rediseño · 1 parcialmente implementado ·
+4 para cerrar · 2 estudiar · #365 reconvertir a implementación · #380 decisión bloqueante ·
+#376 bloqueado por #380.
+
+---
+
+## 3. Dictamen detallado
+
+### 3.1 Para cerrar
+
+**#318 — Tipos combinados: regla del tipo más restrictivo.**
+No es un issue de implementación: es una nota de diseño. El comportamiento en tiempo de
+ejecución (evaluar una vez por tipo simple, primer BLOQUEAR gana) ya está implementado en
+`evaluar_multi()` de `app/services/assembler.py` y cubierto por tests (#328). El issue solo
+recuerda que, al poblar `metadatos_fechas` y `reglas_motor`, las reglas deben definirse sobre
+tipos simples (`AAP`, no `AAP+AAC`). **Acción:** trasladar esa advertencia a la guía del motor
+o al cuerpo de #377/#378 como checklist, y cerrar #318.
+
+**#153 — [DRAFT] entidades_consultadas.**
+Superado por completo. La tabla `entidades_consultadas` que proponía es exactamente la tabla
+`organismos_expediente`, ya creada e implementada en #391 (`OrganismoExpediente`, CB
+`ContextoConsultaSeparata`). El trámite `SEPARATAS` que menciona se renombró a
+`CONSULTA_SEPARATA` (visible en `ESTRUCTURA_FTT.json`). El propio issue admite que "la regla
+TRAMITE — CREAR SEPARATAS ha sido eliminada". **Acción:** cerrar como superado por #391/#247.
+
+**#357 — Cierre de ESPERAR_PLAZO.**
+El issue parte de una premisa hoy falsa: que ESPERAR_PLAZO *"no produce ningún documento y por
+tanto nunca puede cerrarse"*. Tras ADR-004 y el diseño de #362, **toda tarea produce documento**.
+ESPERAR_PLAZO cierra de dos formas: con el documento recibido como `documento_producido_id`
+(Caso A — había una recepción esperada), o, si vence sin respuesta, con el `CERT_PLAZO_CUMPLIDO`
+emitido como documento `bddat://` (Caso B). En ningún caso queda "huérfana de la invariante
+documental". El único residuo real es de limpieza: el campo `"salida": "Ninguno"` de
+ESPERAR_PLAZO en `ESTRUCTURA_FTT.json` está desactualizado —su propia nota ya cita ADR-004— y
+existe un parche en `Tramite.finalizado` que excluye la tarea del cálculo. Ambas correcciones
+son parte natural de la implementación de #362. **Acción:** cerrar #357; absorber las dos
+correcciones de limpieza en el alcance de #362.
+
+**#364 — PUBLICAR vs NOTIFICAR.**
+La tarea atómica `PUBLICAR` **ya no existe**: fue eliminada en #371. `ESTRUCTURA_FTT.json` v6.0
+lo confirma de forma explícita en dos notas (*"PUBLICAR eliminado → patrón C (#371)"*) y su
+catálogo `TAREAS_ATOMICAS` tiene hoy exactamente cuatro tareas: ANALIZAR, ELABORAR, NOTIFICAR,
+ESPERAR_PLAZO. #364 propone *"redefinir la semántica de las tareas atómicas NOTIFICAR y
+PUBLICAR"* y mover los trámites `ANUNCIO_BOE/BOP/PRENSA` a PUBLICAR — pero esos trámites ya
+están reestructurados al patrón C por #371. El cambio estructural que pedía #364 está hecho.
+La distinción jurídica que plantea (notificación a destinatario identificado vs. publicación a
+destinatarios difusos) sigue siendo correcta, pero hoy se expresa en los TIPOS de trámite y de
+documento, no en las tareas atómicas. **Acción:** cerrar #364 como superado por #371; si queda
+algún matiz jurídico de denominación sin cubrir, abrir un issue acotado.
+
+### 3.2 Requieren rediseño
+
+**#192 — Requisitos documentales por procedimiento.**
+ADR-007 lo dice de forma explícita en su sección "Consecuencias": *"#192 requiere rediseño:
+usa FINALIZAR como punto de anclaje y propone tabla `procedimientos` que solapa con tipos
+existentes."* El verbo FINALIZAR ya no existe en el motor (ADR-007 lo eliminó). La tabla
+`procedimientos` que propone duplica el catálogo de tipos de solicitud. **Acción:** rediseñar
+sobre el modelo actual — anclar la verificación al evento `CREAR` de la fase siguiente, y usar
+los tipos ESFTT existentes en lugar de una tabla `procedimientos` nueva.
+
+**#248 — Fase ANÁLISIS_SOLICITUD.**
+El issue es un macro-issue que mezcla 6 bloques, varios ya resueltos o invalidados:
+- Referencia rutas `docs/fuentesIA/` que **ya no existen** (movidas a `docs/referencia/`).
+- Propone "crear tabla `documentos_tarea`" — **ya existe** (modelo `DocumentoTarea`).
+- Propone tarea `INCORPORAR` multi-documento con `fecha_fin` — `INCORPORAR` fue **eliminada**
+  (ADR-004) y las fechas explícitas de tarea no existen (ADR-002).
+- Propone tabla `documentos_analizar` — se materializó como tabla `diagnosticos` (#392, ADR-005).
+- El trámite `ANÁLISIS_DOCUMENTAL` ya tiene su CB (`ContextoAnalisisDocumental`, #392).
+Lo que sigue vivo: el catálogo de requerimientos (`catalogo_requerimientos`/`requerimientos_tarea`),
+el checklist documental y el campo `siglas_escritos` en `Usuario`. **Acción:** cerrar #248 y
+trocearlo en issues nuevos pequeños solo para lo no implementado.
+
+**#276 — Poblar tipos_solicitudes_compatibles.**
+La tabla `tipos_solicitudes_compatibles` **ya no existe**. La creó la migración `5c4f7a4bf22d`
+y la **eliminó** la migración `e40ce8475305` (Paso 6.5, #301), con el comentario explícito en
+su cabecera: *"DROP TABLE tipos_solicitudes_compatibles (vacía, reemplazada por separador + en
+siglas)"*. No hay modelo en `app/models` ni tabla en BD (verificado). El issue —que pide
+"poblar la tabla"— carece de objeto: el mecanismo que referencia está muerto. La necesidad de
+fondo sigue siendo real (declarar qué tipos de solicitud pueden coexistir activos en un mismo
+expediente), pero el mecanismo correcto hoy es una **regla CREAR del motor**: el motor ya
+recibe el sujeto de la acción como variable, de modo que la incompatibilidad se expresa como
+regla con referencia normativa visible al técnico, no como tabla whitelist —coherente además
+con la dirección de ADR-007. **Acción:** cerrar #276 y reabrir su necesidad como regla(s) del
+motor dentro del trabajo de carga de reglas (#294).
+
+**#174 — Permisos granulares.**
+Reclasificado de "válido" a rediseño por una **decisión de negocio**, no por código: la
+jefatura, en la presentación de la herramienta, indicó que la tramitación de un expediente
+**no** debe restringirse de forma dura al usuario asignado. Cualquier persona puede tramitar
+cualquier expediente; es el **cuaderno de bitácora** el que deja constancia de que alguien
+ajeno a la asignación ha actuado. #174 propone lo contrario —"restricción por responsable
+asignado" como permiso duro—. El enfoque debe invertirse: de control de acceso restrictivo a
+**registro en bitácora** de la actuación fuera de asignación. Conecta con #1 (cuaderno de
+bitácora) y con la `bitacora_escapes` de #324. **Acción:** rediseñar #174 — el modelo es
+permiso blando con traza en bitácora, no permiso duro por expediente.
+
+### 3.3 Parcialmente implementado
+
+**#247 — Fase de consultas a organismos.**
+Núcleo ya entregado por #391: tabla `organismos_expediente`, modelo `OrganismoExpediente`,
+CB `ContextoConsultaSeparata`. El renombrado `ANALISIS → ANALIZAR` está hecho (visible en
+`ESTRUCTURA_FTT.json`). El issue referencia rutas muertas `docs/fuentesIA/` y la tarea
+`INCORPORAR` eliminada por ADR-004. Sigue pendiente: tipos de trámite `CONSULTA_TRASLADO_TITULAR`
+y `CONSULTA_TRASLADO_ORGANISMO`, y las reglas de cierre de las fases CONSULTAS y ANALISIS_TECNICO.
+**Acción:** reescribir el cuerpo eliminando lo hecho y las referencias muertas; recortar a las
+reglas de cierre de fase y los trámites de traslado.
+
+### 3.4 Válido — reescribir cuerpo / reconvertir
+
+**#297 — Logotipo incrustado.**
+La necesidad es real y clara (los escritos oficiales deben llevar el logo incrustado, no
+enlazado). Pero el cuerpo del issue es un volcado de una conversación sobre LibreOffice Writer,
+sin especificación accionable. **Acción:** sustituir el cuerpo por una spec breve: el servicio
+generador (`generador_escritos.py`) debe incrustar el logo en el `.docx` producido.
+
+**#332 — CI en GitHub Actions.**
+La tarea raíz es válida. Pero referencia `tests/test_290_documentos_tarea.py` y endpoints
+`/api/bc/tarea/*/incorporar/*` que #376 va a renombrar (INCORPORAR eliminado). **Acción:**
+actualizar las referencias de ficheros/endpoints cuando se planifique, o redactar el workflow
+de forma agnóstica al nombre de los tests.
+
+**#365 — URI `bddat://`.**
+El **diseño ya está decidido**: es la ADR-006 (fechada 11/05). El issue se etiquetó `[DISEÑO]`
+pero la parte de diseño está cerrada. La implementación **no** está hecha: no existe
+`resolver_url()` ni validación de esquema en el modelo `Documento` (verificado por grep).
+**Acción:** reconvertir #365 de `[DISEÑO]` a `[MODELO]` — implementación de ADR-006: helper
+`resolver_url()`, validación de los tres esquemas, tabla(s) destino.
+
+**#324 — Mecanismo de escape.**
+Diseño sólido, pero la tabla `bitacora_escapes` define `accion` como `CREAR | INICIAR |
+FINALIZAR | BORRAR`. ADR-007 eliminó `INICIAR` y `FINALIZAR`: el enum debe quedar en
+`CREAR | BORRAR`. Además, ADR-007 §Consecuencias ya describe una UX de escape (checkbox
+"mostrar opciones no permitidas" en los selectores ESFTT) que conviene reconciliar con el
+modal de justificación de #324. **Acción:** reescribir el cuerpo alineándolo con ADR-007.
+
+**#283 — Ampliar ESTRUCTURA_FTT.**
+El objetivo (cubrir todos los tipos de expediente) sigue válido. Pero el cuerpo referencia
+`docs/ESTRUCTURA_FTT.md` (ahora en `docs/referencia/`) y lista las tareas atómicas como
+`ANALIZAR, REDACTAR, FIRMAR, NOTIFICAR, PUBLICAR, ESPERAR_PLAZO, INCORPORAR`. Catálogo real
+hoy (`ESTRUCTURA_FTT.json` v6.0): **cuatro tareas** — `ANALIZAR, ELABORAR, NOTIFICAR,
+ESPERAR_PLAZO`. Las diferencias respecto al issue:
+- `REDACTAR` + `FIRMAR` → fusionados en `ELABORAR` (ADR-003).
+- `INCORPORAR` → eliminada (ADR-004); la recepción es `documento_producido` de ESPERAR_PLAZO.
+- `PUBLICAR` → eliminada (#371) al detectarse que no es una tarea atómica sino una
+  super-tarea representable por la secuencia `ELABORAR → NOTIFICAR → ESPERAR_PLAZO`.
+
+**Acción:** actualizar la premisa al catálogo de cuatro tareas antes de planificar el issue.
+
+### 3.5 Estudiar
+
+**#181 — Inspección automática de documentos.**
+Solapa fuertemente con #304 (detección de tipo de solicitud por PDF) y #305 (tipo de
+expediente por PDF): los tres son análisis heurístico de PDFs con validación humana. #181
+añade detección de patrón `AT-nnnnn` y detección de firma. **Acción:** decidir si #181 se
+fusiona con #304/#305 como una familia única "análisis heurístico de PDF", o se mantiene
+acotado a la detección de firma y de número AT.
+
+**#294 — Estrategia pivot normativa → motor.**
+Issue de estrategia, en gran parte **ya ejecutado**: de su "orden de trabajo propuesto", los
+puntos 1 (plazos.py), 2 (ContextAssembler) y 3 (motor agnóstico) están implementados y
+probados. Queda el punto 4 (CRUD de reglas, #170/#171) y el punto 5 (reglas una a una, que
+depende de poblar `reglas_motor`). **Acción:** decidir si se cierra como ejecutado dejando
+#170/#171 como herederos, o se recorta a un issue de seguimiento de la fase de carga de reglas.
+
+**#380 — Destino de `documentos_tarea`.**
+Es una **decisión de diseño bloqueante**, no resuelta: el modelo `DocumentoTarea` sigue
+marcado literalmente *"NO USAR hasta que la decisión esté documentada en un ADR"*. Atención a
+la contradicción: #376 da por hecho que la tabla "se conserva" (opción C del propio #380),
+pero esa opción todavía no está decidida ni hay ADR. **Acción:** resolver #380 primero
+(emitir ADR-008) — desbloquea #376 y aclara #357. Es prerrequisito de ambos.
+
+### 3.6 Válidos sin reservas
+
+- **#300** — bug concreto, código localizado (`_direccion_titular()` en `escritos.py`),
+  solución descrita. Listo para implementar.
+- **#362, #366** — issues de diseño coherentes con las ADR vigentes; deberían materializarse
+  como ADR al resolverse. #362, además, absorbe la limpieza de #357 (ver sección 3.1).
+- **#374** — diseño coherente (usa `bddat://interesados/{id}`, alineado con ADR-006).
+  Sin milestone: asignar **M3**, ya que el modelo de datos puede afectar a la resolución.
+- **#377, #378** — seeds en migración Alembic; dependencia (#337) cerrada. Backend puro.
+- **#323** — diseño limpio; crea la tabla genérica `configuracion_sistema`. Sin dependencias.
+- **#304, #305, #306** — scripts de análisis de PDF; backend puro. #306 depende de #304.
+  Ver solape con #181 (sección 3.5).
+- **#106** — alcance pequeño y autónomo (importar códigos DIR3). Revisar si M3 es su sitio
+  o encaja mejor como dato de catálogo en M4.
+- **#376** — trabajo válido, pero **bloqueado por #380** y mayoritariamente de UI
+  (template + JS); no es candidato a las sesiones de backend.
+
+---
+
+## 4. Recomendaciones de acción
+
+### 4.1 Acciones inmediatas sobre GitHub (limpieza, sin código)
+
+1. **Cerrar #318, #153, #357 y #364** — superados por trabajo posterior o sin objeto (ver §3.1).
+   En #318 trasladar antes su advertencia a la guía del motor; en #357 absorber su limpieza en #362.
+2. **Cerrar y trocear #248** en issues pequeños solo para lo no implementado.
+3. **Cerrar #276 y reabrir su necesidad como regla(s) del motor** — la tabla ya no existe.
+4. **Reescribir el cuerpo** de #297, #332, #283, #324 y #365 (#365, además, reetiquetar de
+   `[DISEÑO]` a implementación de ADR-006).
+5. **Reescribir #247** recortándolo a lo no implementado.
+6. **Marcar para rediseño** #192 (según ADR-007) y #174 (según la decisión de jefatura: permiso
+   blando + bitácora, no permiso duro por expediente).
+7. **Asignar milestone M3** a #374.
+
+### 4.2 Orden sugerido de trabajo de backend (post-limpieza)
+
+1. **#380** — emitir ADR-008 sobre `documentos_tarea`. Desbloquea #376. Decisión, no código.
+2. **#377 → #378** — seeds de catálogo. Backend puro, dependencia cerrada.
+3. **#365** — implementar ADR-006 (`resolver_url()`, esquemas de URL).
+4. **#362** — resolver como ADR (certificado de plazo) y aplicar las correcciones en
+   `ESTRUCTURA_FTT.json`; absorbe la limpieza que describía #357 (campo `salida` de
+   ESPERAR_PLAZO, parche en `Tramite.finalizado`). **#366** — eliminar trámite AUDIENCIA.
+5. **#323** — modo global del motor + tabla `configuracion_sistema`.
+6. **CBs restantes** (RES, IP, subsanación, notificación a organismo) — sin issue aún.
+7. **#304/#305/#306** — scripts de análisis de PDF, tras decidir el solape con #181.
+8. **#192, #324** — rediseñar/alinear antes de implementar. **#174 y #276** — requieren una
+   decisión previa (modelo de bitácora / reglas del motor) antes de cualquier código.
+
+### 4.3 Observación arquitectónica
+
+El patrón dominante de obsolescencia es claro: los issues de diseño anteriores al 11/05
+(#192, #247, #248, #153, #283) quedaron desfasados por la ráfaga de ADRs 002-007. Las ADR
+consolidaron decisiones que esos issues aún no reflejan: eliminación de INCORPORAR (004),
+fusión REDACTAR+FIRMAR (003), ESFTT sin fechas (002), eliminación de whitelists y verbos
+INICIAR/FINALIZAR (007). **Antes de planificar cualquier issue de diseño previo a esa fecha,
+contrastarlo con las siete ADR.** Los issues posteriores al 11/05 (#362, #365, #374) sí nacen
+alineados.
+
+El caso de **#364** es un aviso adicional: nació alineado, pero un issue posterior (#371)
+eliminó la tarea atómica `PUBLICAR` sobre la que se apoyaba. No solo las ADR invalidan issues
+abiertos — también el trabajo reciente puede hacerlo. La regla práctica se amplía: contrastar
+todo issue de diseño contra las ADR **y** contra los issues estructurales cerrados después de
+su creación. La tarea `PUBLICAR` y la tabla `tipos_solicitudes_compatibles` (#276) son los dos
+elementos que más issues abiertos arrastran como referencia obsoleta.


### PR DESCRIPTION
## Cambios

- `app/services/generador_escritos.py`: función `_fn_imagen(tpl, recursos_dir)` que devuelve el callable `img()` inyectado en el contexto Jinja2 como `ctx['img']` antes de cada renderizado.
- `docs/decisiones/ADR-009-incrustacion-imagenes-plantillas.md`: decisión arquitectónica que fija el mecanismo, el anclaje y las alternativas descartadas (variables hardcodeadas, fragmentos subdoc, logo vinculado).

**Uso en plantilla .docx:**
```
{{ img('logo_portada.png', '3.5', '1.98') }}
{{ img('logo_cabecera.png', '1.57', '1.47') }}
{{ img('logo_pie.png', '1.30', '1.89') }}
```

Los ficheros viven en `PLANTILLAS_BASE/recursos/`. El posicionamiento (inline o dentro de cuadro de texto anclado) lo controla la plantilla, no el código.

Closes #297
