### PR TITLE
Tabla notificaciones: documento vitaminado para NOTIFICAR (ADR-008)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -23,7 +23,6 @@ from app.models.tipos_solicitudes import TipoSolicitud
 from app.models.tipos_tareas import TipoTarea
 from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_documentos import TipoDocumento
-from app.models.tipos_resultado_documentos import TipoResultadoDocumento
 from app.models.consultas_nombradas import ConsultaNombrada
 from app.models.plantillas import Plantilla
 
@@ -50,7 +49,6 @@ from app.models.solicitudes import Solicitud  # Depende de Expediente
 from app.models.historico_titular_expediente import HistoricoTitularExpediente  # Depende de Expediente, Entidad, Solicitud
 
 from app.models.tramites_tareas import TramiteTarea
-from app.models.tipos_documentos_resultados_validos import TipoDocumentoResultadoValido
 
 # Modelos operacionales con dependencias múltiples
 from app.models.documentos_proyecto import DocumentoProyecto  # Depende de Documento, Proyecto
@@ -61,7 +59,7 @@ from app.models.municipios_proyecto import MunicipioProyecto  # Depende de Munic
 from app.models.tramites import Tramite  # Depende de Fase, TipoTramite
 from app.models.tareas import Tarea  # Depende de Tramite, TipoTarea, Documento
 from app.models.documentos_tarea import DocumentoTarea  # Depende de Tarea, Documento
-from app.models.resultados_documentos import ResultadoDocumento  # Depende de Documento, TipoResultadoDocumento
+from app.models.notificaciones import Notificacion  # Depende de Documento (#418)
 
 # Plazos — maestros sin dependencias operacionales (efectos_plazo, ambitos ya importados arriba)
 from app.models.dias_inhabiles import DiaInhabil        # depende de AmbitoInhabilidad
@@ -101,7 +99,6 @@ __all__ = [
     'TipoTarea',
     'TipoTramite',
     'TipoDocumento',
-    'TipoResultadoDocumento',
     'ConsultaNombrada',
     'Plantilla',
     # Metadata del sistema
@@ -119,7 +116,6 @@ __all__ = [
     # Histórico
     'HistoricoTitularExpediente',
     'TramiteTarea',
-    'TipoDocumentoResultadoValido',
     # Operacionales (continuación)
     'DocumentoProyecto',
     'Fase',
@@ -127,7 +123,7 @@ __all__ = [
     'Tramite',
     'Tarea',
     'DocumentoTarea',
-    'ResultadoDocumento',
+    'Notificacion',
     # Plazos
     'DiaInhabil',
     'CatalogoPlazo',

--- a/app/models/notificaciones.py
+++ b/app/models/notificaciones.py
@@ -1,0 +1,48 @@
+from app import db
+
+
+class Notificacion(db.Model):
+    """Documento vitaminado para los justificantes de la tarea NOTIFICAR (ADR-008, #418).
+
+    Relación 1:1 con Documento: un justificante = una notificación.
+    Sin fila → la tarea está ejecutada pero el resultado no ha sido registrado aún.
+    """
+    __tablename__ = 'notificaciones'
+    __table_args__ = {'schema': 'public'}
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,
+    )
+
+    resultado = db.Column(
+        db.String(12),
+        nullable=False,
+        comment='CORRECTA | INCORRECTA',
+    )
+
+    canal = db.Column(
+        db.String(10),
+        nullable=False,
+        comment='NOTIFICA | BANDEJA | SIR | POSTAL',
+    )
+
+    fecha_notificacion = db.Column(db.Date, nullable=False)
+
+    numero_intento = db.Column(
+        db.SmallInteger,
+        nullable=False,
+        default=1,
+        comment='1 o 2 — habilita regla LPACAP de dos intentos',
+    )
+
+    observaciones = db.Column(db.Text, nullable=True)
+
+    documento = db.relationship(
+        'Documento',
+        backref=db.backref('notificacion', uselist=False),
+    )

--- a/app/models/tareas.py
+++ b/app/models/tareas.py
@@ -146,15 +146,14 @@ class Tarea(db.Model):
 
     @property
     def resultado(self):
-        """Efecto de resultado: INDIFERENTE | CORRECTA | INCORRECTA.
+        """Resultado de la notificación: CORRECTA | INCORRECTA | INDIFERENTE.
 
-        Deriva del documento producido vía resultados_documentos.
-        Sin fila en resultados_documentos → INDIFERENTE.
-        Solo NOTIFICAR puede producir INCORRECTA (#296).
+        Solo aplica a tareas NOTIFICAR. Lee de notificaciones (ADR-008, #418).
+        Sin fila en notificaciones → INDIFERENTE (resultado no registrado aún).
         """
         doc = self.documento_producido
-        if doc and doc.resultado_doc:
-            return doc.resultado_doc.tipo_resultado.efecto_tarea
+        if doc and doc.notificacion:
+            return doc.notificacion.resultado
         return 'INDIFERENTE'
 
     @property

--- a/app/models/tramites.py
+++ b/app/models/tramites.py
@@ -94,9 +94,10 @@ class Tramite(db.Model):
     @property
     def finalizado(self):
         """True si todas las tareas con tipos documentales tienen documento producido
-        y ninguna tarea NOTIFICAR tiene resultado INCORRECTA (#296).
+        y toda tarea NOTIFICAR tiene resultado CORRECTA registrado en notificaciones.
 
         ESPERAR_PLAZO se excluye — su completitud la evalúa plazos.py via ContextAssembler.
+        NOTIFICAR ejecutada sin fila en notificaciones → INDIFERENTE → no finalizado (#418).
         """
         _requieren = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR'}
         for t in self.tareas:
@@ -105,7 +106,7 @@ class Tramite(db.Model):
             codigo = t.tipo_tarea.codigo
             if codigo in _requieren and not t.ejecutada:
                 return False
-            if codigo == 'NOTIFICAR' and t.resultado == 'INCORRECTA':
+            if codigo == 'NOTIFICAR' and t.ejecutada and t.resultado != 'CORRECTA':
                 return False
         return True
 

--- a/app/services/invariantes_esftt.py
+++ b/app/services/invariantes_esftt.py
@@ -112,8 +112,7 @@ def _check_finalizar(sujeto: str, entidad_id: int) -> Optional[EvaluacionResult]
 def _check_finalizar_fase(fase_id: int) -> Optional[EvaluacionResult]:
     from app.models.tipos_tareas import TipoTarea
     from app.models.documentos_tarea import DocumentoTarea
-    from app.models.resultados_documentos import ResultadoDocumento
-    from app.models.tipos_resultado_documentos import TipoResultadoDocumento
+    from app.models.notificaciones import Notificacion
 
     # Una tarea está completa si tiene un vínculo PRODUCIDO en documentos_tarea (ADR-010)
     _tiene_producido = (
@@ -136,19 +135,18 @@ def _check_finalizar_fase(fase_id: int) -> Optional[EvaluacionResult]:
     if tarea_incompleta:
         return _bloquear('Hay tareas sin documento producido en esta fase. Finalice todas las tareas antes de cerrar la fase.')
 
-    # Tarea NOTIFICAR con resultado INCORRECTA bloquea el cierre de la fase (#296)
+    # Tarea NOTIFICAR con resultado INCORRECTA bloquea el cierre de la fase (#418)
     notificar_incorrecta = (
         db.session.query(Tarea)
         .join(Tramite, Tarea.tramite_id == Tramite.id)
         .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
         .join(DocumentoTarea, db.and_(DocumentoTarea.tarea_id == Tarea.id,
                                       DocumentoTarea.rol == 'PRODUCIDO'))
-        .join(ResultadoDocumento, ResultadoDocumento.documento_id == DocumentoTarea.documento_id)
-        .join(TipoResultadoDocumento, TipoResultadoDocumento.id == ResultadoDocumento.tipo_resultado_documento_id)
+        .join(Notificacion, Notificacion.documento_id == DocumentoTarea.documento_id)
         .filter(
             Tramite.fase_id == fase_id,
             TipoTarea.codigo == 'NOTIFICAR',
-            TipoResultadoDocumento.efecto_tarea == 'INCORRECTA',
+            Notificacion.resultado == 'INCORRECTA',
         )
         .first()
     )
@@ -161,8 +159,7 @@ def _check_finalizar_fase(fase_id: int) -> Optional[EvaluacionResult]:
 def _check_finalizar_tramite(tramite_id: int) -> Optional[EvaluacionResult]:
     from app.models.tipos_tareas import TipoTarea
     from app.models.documentos_tarea import DocumentoTarea
-    from app.models.resultados_documentos import ResultadoDocumento
-    from app.models.tipos_resultado_documentos import TipoResultadoDocumento
+    from app.models.notificaciones import Notificacion
 
     _tiene_producido = (
         db.session.query(DocumentoTarea.id)
@@ -183,18 +180,17 @@ def _check_finalizar_tramite(tramite_id: int) -> Optional[EvaluacionResult]:
     if tarea_incompleta:
         return _bloquear('Hay tareas sin ejecutar. Finalice todas las tareas antes de cerrar el trámite.')
 
-    # Tarea NOTIFICAR con resultado INCORRECTA bloquea el cierre del trámite (#296)
+    # Tarea NOTIFICAR con resultado INCORRECTA bloquea el cierre del trámite (#418)
     notificar_incorrecta = (
         db.session.query(Tarea)
         .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
         .join(DocumentoTarea, db.and_(DocumentoTarea.tarea_id == Tarea.id,
                                       DocumentoTarea.rol == 'PRODUCIDO'))
-        .join(ResultadoDocumento, ResultadoDocumento.documento_id == DocumentoTarea.documento_id)
-        .join(TipoResultadoDocumento, TipoResultadoDocumento.id == ResultadoDocumento.tipo_resultado_documento_id)
+        .join(Notificacion, Notificacion.documento_id == DocumentoTarea.documento_id)
         .filter(
             Tarea.tramite_id == tramite_id,
             TipoTarea.codigo == 'NOTIFICAR',
-            TipoResultadoDocumento.efecto_tarea == 'INCORRECTA',
+            Notificacion.resultado == 'INCORRECTA',
         )
         .first()
     )

--- a/app/services/seguimiento.py
+++ b/app/services/seguimiento.py
@@ -53,26 +53,32 @@ PISTAS_OBLIGATORIAS = {'SOL'}
 
 # Color canónico de cada estado (§4.1)
 COLOR: dict[str, str] = {
-    'PENDIENTE_TRAMITAR':  'rojo',
-    'PENDIENTE_ESTUDIO':   'rojo',
-    'PENDIENTE_ELABORAR':  'amarillo',
-    'PENDIENTE_NOTIFICAR': 'azul',
-    'PENDIENTE_SUBSANAR':  'gris',
-    'PENDIENTE_PLAZOS':    'gris',
-    'PENDIENTE_CERRAR':    'naranja',
-    'FIN':                 'verde',
+    'PENDIENTE_TRAMITAR':               'rojo',
+    'PENDIENTE_ESTUDIO':                'rojo',
+    'NOTIFICACION_AGOTADA':             'rojo',
+    'PENDIENTE_ELABORAR':               'amarillo',
+    'NOTIFICACION_FALLIDA':             'naranja',
+    'PENDIENTE_CERRAR':                 'naranja',
+    'PENDIENTE_NOTIFICAR':              'azul',
+    'PENDIENTE_RESULTADO_NOTIFICACION': 'azul',
+    'PENDIENTE_SUBSANAR':               'gris',
+    'PENDIENTE_PLAZOS':                 'gris',
+    'FIN':                              'verde',
 }
 
 # Prioridad numérica por §4.2 (1 = más urgente, 10 = menos urgente)
 PRIORIDAD: dict[str, int] = {
-    'PENDIENTE_TRAMITAR':  1,
-    'PENDIENTE_ESTUDIO':   2,
-    'PENDIENTE_ELABORAR':  3,
-    'PENDIENTE_CERRAR':    4,
-    'PENDIENTE_NOTIFICAR': 5,
-    'PENDIENTE_SUBSANAR':  6,
-    'PENDIENTE_PLAZOS':    7,
-    'FIN':                 8,
+    'PENDIENTE_TRAMITAR':               1,
+    'PENDIENTE_ESTUDIO':                2,
+    'NOTIFICACION_AGOTADA':             3,
+    'PENDIENTE_ELABORAR':               3,
+    'NOTIFICACION_FALLIDA':             4,
+    'PENDIENTE_CERRAR':                 4,
+    'PENDIENTE_NOTIFICAR':              5,
+    'PENDIENTE_RESULTADO_NOTIFICACION': 5,
+    'PENDIENTE_SUBSANAR':               6,
+    'PENDIENTE_PLAZOS':                 7,
+    'FIN':                              8,
 }
 
 
@@ -182,14 +188,31 @@ def _estado_tramite(tramite, pista: str) -> tuple[str, int]:
         return ('PENDIENTE_TRAMITAR', 1)
 
     tareas = list(tramite.tareas)
-    tareas_pendientes = [t for t in tareas if not t.ejecutada]
+    tareas_sin_ejecutar = [t for t in tareas if not t.ejecutada]
 
-    if not tareas_pendientes:
-        # Todas las tareas completadas — trámite pendiente de cerrar (transitorio)
-        return ('PENDIENTE_CERRAR', 1)
+    if not tareas_sin_ejecutar:
+        # Todas ejecutadas — verificar notificaciones pendientes o fallidas (#418)
+        estado_notif = _estado_notificaciones_tramite(tareas)
+        if estado_notif:
+            return (estado_notif, 1)
+        return ('PENDIENTE_CERRAR', 1)  # fallback: no debería alcanzarse
 
-    acc = _acumular([_estado_tarea(t, pista) for t in tareas_pendientes])
+    acc = _acumular([_estado_tarea(t, pista) for t in tareas_sin_ejecutar])
     return _mayor_prioridad(acc)
+
+
+def _estado_notificaciones_tramite(tareas) -> Optional[str]:
+    """Detecta tareas NOTIFICAR ejecutadas sin resultado registrado o con resultado fallido."""
+    for t in tareas:
+        if not (t.tipo_tarea and t.tipo_tarea.codigo == 'NOTIFICAR' and t.ejecutada):
+            continue
+        doc = t.documento_producido
+        notif = getattr(doc, 'notificacion', None) if doc else None
+        if notif is None:
+            return 'PENDIENTE_RESULTADO_NOTIFICACION'
+        if notif.resultado == 'INCORRECTA':
+            return 'NOTIFICACION_AGOTADA' if notif.numero_intento == 2 else 'NOTIFICACION_FALLIDA'
+    return None
 
 
 def _estado_tarea(tarea, pista: str) -> tuple[str, int]:
@@ -205,23 +228,16 @@ def _estado_tarea(tarea, pista: str) -> tuple[str, int]:
 
     if tipo == 'ANALIZAR':
         if not tarea.documentos_consumidos:
-            return ('PENDIENTE_TRAMITAR', 1)   # sin doc de entrada: hay que tramitar
-        if not tarea.ejecutada:
-            return ('PENDIENTE_ESTUDIO', 1)    # doc recibido, hay que estudiar y redactar informe
-        return ('PENDIENTE_CERRAR', 1)         # entrada y salida presentes
+            return ('PENDIENTE_TRAMITAR', 1)
+        return ('PENDIENTE_ESTUDIO', 1)    # doc recibido, hay que analizar y redactar informe
 
     if tipo == 'ELABORAR':
-        # Entrada opcional → no hay estado "en espera de documento de entrada"
-        if tarea.ejecutada:
-            return ('PENDIENTE_CERRAR', 1)
         return ('PENDIENTE_ELABORAR', 1)
 
     if tipo == 'NOTIFICAR':
         if not tarea.documentos_consumidos:
             return ('PENDIENTE_TRAMITAR', 1)   # falta doc firmado
-        if not tarea.ejecutada:
-            return ('PENDIENTE_NOTIFICAR', 1)  # doc firmado, falta justificante
-        return ('PENDIENTE_CERRAR', 1)
+        return ('PENDIENTE_NOTIFICAR', 1)      # doc firmado, falta justificante
 
     if tipo == 'ESPERAR_PLAZO':
         return (_estado_esperar_plazo(tarea, pista), 1)

--- a/migrations/versions/a4d067a1d5bf_418_tabla_notificaciones.py
+++ b/migrations/versions/a4d067a1d5bf_418_tabla_notificaciones.py
@@ -1,0 +1,90 @@
+"""418_tabla_notificaciones
+
+Revision ID: a4d067a1d5bf
+Revises: 420_modelo_nm_documento_tarea
+Create Date: 2026-05-17 20:20:26.737011
+
+Crea tabla notificaciones (documento vitaminado para NOTIFICAR) y elimina
+las tres tablas del diseño previo, que estaban vacías (ADR-008, #418).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a4d067a1d5bf'
+down_revision = '420_modelo_nm_documento_tarea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'notificaciones',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('documento_id', sa.Integer(), nullable=False),
+        sa.Column('resultado', sa.String(12), nullable=False),
+        sa.Column('canal', sa.String(10), nullable=False),
+        sa.Column('fecha_notificacion', sa.Date(), nullable=False),
+        sa.Column('numero_intento', sa.SmallInteger(), nullable=False, server_default='1'),
+        sa.Column('observaciones', sa.Text(), nullable=True),
+        sa.CheckConstraint("resultado IN ('CORRECTA', 'INCORRECTA')", name='ck_notificaciones_resultado'),
+        sa.CheckConstraint("canal IN ('NOTIFICA', 'BANDEJA', 'SIR', 'POSTAL')", name='ck_notificaciones_canal'),
+        sa.CheckConstraint('numero_intento IN (1, 2)', name='ck_notificaciones_numero_intento'),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id', name='pk_notificaciones'),
+        sa.UniqueConstraint('documento_id', name='uq_notificaciones_documento'),
+        schema='public',
+    )
+    op.execute("GRANT SELECT ON public.notificaciones TO claude_desktop")
+
+    # Eliminar tablas del diseño previo (vacías — ADR-008 §"Tablas eliminadas")
+    # Orden: primero las que tienen FK a tipos_resultado_documentos
+    op.drop_table('tipos_documentos_resultados_validos', schema='public')
+    op.drop_table('resultados_documentos', schema='public')
+    op.drop_table('tipos_resultado_documentos', schema='public')
+
+
+def downgrade():
+    op.drop_table('notificaciones', schema='public')
+
+    op.create_table(
+        'tipos_resultado_documentos',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('codigo', sa.String(50), nullable=False),
+        sa.Column('nombre', sa.String(200), nullable=False),
+        sa.Column('efecto_tarea', sa.String(20), nullable=False),
+        sa.UniqueConstraint('codigo', name='uq_tipos_resultado_documentos_codigo'),
+        sa.PrimaryKeyConstraint('id'),
+        schema='public',
+    )
+    op.create_table(
+        'resultados_documentos',
+        sa.Column('documento_id', sa.Integer(), nullable=False),
+        sa.Column('tipo_resultado_documento_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(
+            ['tipo_resultado_documento_id'],
+            ['public.tipos_resultado_documentos.id'],
+            ondelete='RESTRICT',
+        ),
+        sa.PrimaryKeyConstraint('documento_id', name='pk_resultados_documentos'),
+        schema='public',
+    )
+    op.create_table(
+        'tipos_documentos_resultados_validos',
+        sa.Column('tipo_documento_id', sa.Integer(), nullable=False),
+        sa.Column('tipo_resultado_documento_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['tipo_documento_id'], ['public.tipos_documentos.id'], ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(
+            ['tipo_resultado_documento_id'],
+            ['public.tipos_resultado_documentos.id'],
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint(
+            'tipo_documento_id', 'tipo_resultado_documento_id',
+            name='pk_tipos_documentos_resultados_validos',
+        ),
+        schema='public',
+    )

--- a/tests/test_296_senal_resultado.py
+++ b/tests/test_296_senal_resultado.py
@@ -20,17 +20,18 @@ def _tipo_tarea(codigo):
     return MagicMock(codigo=codigo)
 
 
-def _resultado_doc(efecto):
-    """Stub de ResultadoDocumento con efecto_tarea dado."""
-    rd = MagicMock()
-    rd.tipo_resultado = MagicMock(efecto_tarea=efecto)
-    return rd
+def _notificacion_stub(resultado):
+    """Stub de Notificacion con resultado dado."""
+    n = MagicMock()
+    n.resultado = resultado
+    n.numero_intento = 1
+    return n
 
 
-def _doc_producido(efecto=None):
-    """Stub de Documento con resultado_doc opcional."""
+def _doc_producido(resultado=None):
+    """Stub de Documento con notificacion opcional (ADR-008, #418)."""
     doc = MagicMock()
-    doc.resultado_doc = _resultado_doc(efecto) if efecto else None
+    doc.notificacion = _notificacion_stub(resultado) if resultado else None
     return doc
 
 
@@ -146,8 +147,9 @@ class TestTareaResultado:
         t = _StubTarea('NOTIFICAR', doc_producido=None)
         assert _tarea_resultado(t) == 'INDIFERENTE'
 
-    def test_doc_sin_resultado_doc_es_indiferente(self):
-        t = _StubTarea('NOTIFICAR', doc_producido=_doc_producido(efecto=None))
+    def test_doc_sin_notificacion_es_indiferente(self):
+        # Justificante cargado pero sin fila en notificaciones → INDIFERENTE
+        t = _StubTarea('NOTIFICAR', doc_producido=_doc_producido(resultado=None))
         assert _tarea_resultado(t) == 'INDIFERENTE'
 
     def test_doc_con_resultado_incorrecta(self):
@@ -159,8 +161,8 @@ class TestTareaResultado:
         assert _tarea_resultado(t) == 'CORRECTA'
 
     def test_analisis_siempre_indiferente(self):
-        # ANALISIS no puede tener resultado != INDIFERENTE por diseño
-        t = _StubTarea('ANALIZAR', doc_producido=_doc_producido(efecto=None))
+        # ANALIZAR no tiene notificacion — siempre INDIFERENTE
+        t = _StubTarea('ANALIZAR', doc_producido=_doc_producido(resultado=None))
         assert _tarea_resultado(t) == 'INDIFERENTE'
 
 
@@ -199,10 +201,11 @@ class TestTramiteFinalizadoConResultado:
         tr = _StubTramite(tareas=[])
         assert _tramite_finalizado(tr) is True
 
-    def test_notificar_doc_producido_indiferente_finalizado(self):
+    def test_notificar_doc_producido_sin_resultado_no_finalizado(self):
+        # NOTIFICAR ejecutada sin resultado registrado (INDIFERENTE) no finaliza (#418)
         t = _StubTareaConResultado('NOTIFICAR', doc_producido_id=10, resultado='INDIFERENTE')
         tr = _StubTramite(tareas=[t])
-        assert _tramite_finalizado(tr) is True
+        assert _tramite_finalizado(tr) is False
 
     def test_notificar_doc_producido_correcta_finalizado(self):
         t = _StubTareaConResultado('NOTIFICAR', doc_producido_id=10, resultado='CORRECTA')


### PR DESCRIPTION
## Cambios

- **Migración Alembic**: crea `public.notificaciones` (documento vitaminado para NOTIFICAR, ADR-008) y elimina las tres tablas del diseño previo vacías: `tipos_resultado_documentos`, `tipos_documentos_resultados_validos`, `resultados_documentos`
- **Modelo `Notificacion`**: nuevo `app/models/notificaciones.py`; backref `notificacion` en `Documento` (1:1); importado en `__init__.py` sustituyendo los tres modelos eliminados
- **`Tarea.resultado`**: lee de `doc.notificacion.resultado` en lugar de `resultados_documentos`; sin fila → `INDIFERENTE`
- **`Tramite.finalizado`**: NOTIFICAR ejecutada sin fila en `notificaciones` (INDIFERENTE) ya no permite finalizar el trámite; requiere `resultado == 'CORRECTA'`
- **Invariantes**: `_check_finalizar_fase` y `_check_finalizar_tramite` usan join directo a `Notificacion` eliminando el join doble anterior
- **Seguimiento**: tres estados nuevos (`NOTIFICACION_AGOTADA` rojo p3, `NOTIFICACION_FALLIDA` naranja p4, `PENDIENTE_RESULTADO_NOTIFICACION` azul p5); nueva función `_estado_notificaciones_tramite` con distinción por `numero_intento`; eliminado código muerto (`PENDIENTE_CERRAR` inalcanzable en `_estado_tarea`)
- **Tests**: stubs actualizados a `Notificacion`; semántica de `test_notificar_doc_producido_indiferente_finalizado` corregida; 35/35 passed, suite completa 314/314

Closes #418
