### PR TITLE
Invariante cierre de fase: bloquear resultado no-desfavorable con diagnóstico sin consumir

### DIFF
--- a/app/checks/catalogo_requerido.py
+++ b/app/checks/catalogo_requerido.py
@@ -36,17 +36,20 @@ REGISTROS_REQUERIDOS: dict = {
     ],
     # TipoSolicitud usa 'siglas' como identificador estable (no 'codigo')
     'TipoSolicitud': ['AAC', 'AAP'],
+    # TipoResultadoFase — código usado en invariantes_esftt (#419)
+    'TipoResultadoFase': ['DESFAVORABLE'],
     'TipoDocumento': ['CERT_FIN_INSTRUCCION'],
 }
 
 # Atributo del modelo que contiene el identificador estable.
 # TipoSolicitud usa 'siglas'; el resto usa 'codigo'.
 _CODIGO_ATTR: dict[str, str] = {
-    'TipoTramite':   'codigo',
-    'TipoTarea':     'codigo',
-    'TipoFase':      'codigo',
-    'TipoSolicitud': 'siglas',
-    'TipoDocumento': 'codigo',
+    'TipoTramite':        'codigo',
+    'TipoTarea':          'codigo',
+    'TipoFase':           'codigo',
+    'TipoSolicitud':      'siglas',
+    'TipoDocumento':      'codigo',
+    'TipoResultadoFase':  'codigo',
 }
 
 
@@ -62,11 +65,12 @@ def validar_catalogo() -> List[str]:
     from sqlalchemy.exc import OperationalError, ProgrammingError
 
     _MODELOS = {
-        'TipoTramite':   _importar('app.models.tipos_tramites',   'TipoTramite'),
-        'TipoTarea':     _importar('app.models.tipos_tareas',     'TipoTarea'),
-        'TipoFase':      _importar('app.models.tipos_fases',      'TipoFase'),
-        'TipoSolicitud': _importar('app.models.tipos_solicitudes', 'TipoSolicitud'),
-        'TipoDocumento': _importar('app.models.tipos_documentos', 'TipoDocumento'),
+        'TipoTramite':       _importar('app.models.tipos_tramites',         'TipoTramite'),
+        'TipoTarea':         _importar('app.models.tipos_tareas',           'TipoTarea'),
+        'TipoFase':          _importar('app.models.tipos_fases',            'TipoFase'),
+        'TipoSolicitud':     _importar('app.models.tipos_solicitudes',      'TipoSolicitud'),
+        'TipoDocumento':     _importar('app.models.tipos_documentos',       'TipoDocumento'),
+        'TipoResultadoFase': _importar('app.models.tipos_resultados_fases', 'TipoResultadoFase'),
     }
 
     faltantes: List[str] = []

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -25,7 +25,7 @@ from app.models.tipos_tareas import TipoTarea
 from app.models.documentos_tarea import DocumentoTarea
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
-from app.services.invariantes_esftt import check_invariante
+from app.services.invariantes_esftt import check_invariante, _check_cierre_fase
 
 bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
 
@@ -207,6 +207,14 @@ def editar_fase(fase_id):
         doc = Documento.query.get(nuevo_doc_resultado_id)
         if not doc or doc.expediente_id != fase.solicitud.expediente_id:
             return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
+
+        resultado_id_raw = request.form.get('resultado_fase_id')
+        if resultado_id_raw:
+            tipo_res = TipoResultadoFase.query.get(int(resultado_id_raw))
+            if tipo_res:
+                res_inv = _check_cierre_fase(fase_id, tipo_res.codigo)
+                if res_inv:
+                    return _bloqueo(res_inv)
 
     try:
         resultado_id = request.form.get('resultado_fase_id')

--- a/app/services/invariantes_esftt.py
+++ b/app/services/invariantes_esftt.py
@@ -200,6 +200,64 @@ def _check_finalizar_tramite(tramite_id: int) -> Optional[EvaluacionResult]:
     return None
 
 
+def _check_cierre_fase(fase_id: int, codigo_resultado: str) -> Optional[EvaluacionResult]:
+    """Bloquea el cierre de la fase si hay diagnóstico desfavorable sin consumir y el resultado no es DESFAVORABLE (#419).
+
+    El único resultado de cierre permitido cuando hay diagnósticos desfavorables
+    sin consumir es DESFAVORABLE. Cualquier otro resultado queda bloqueado.
+    Un diagnóstico se considera consumido cuando su documento aparece como
+    CONSUMIDO en cualquier otra tarea de la fase.
+    """
+    if codigo_resultado == 'DESFAVORABLE':
+        return None
+
+    from app.models.tipos_tareas import TipoTarea
+    from app.models.documentos_tarea import DocumentoTarea
+    from app.models.diagnosticos import Diagnostico
+
+    DT_cons      = db.aliased(DocumentoTarea)
+    Tarea_cons   = db.aliased(Tarea)
+    Tramite_cons = db.aliased(Tramite)
+
+    # Subquery: el documento producido está siendo consumido por alguna tarea de la fase
+    _consumido = (
+        db.session.query(DT_cons.id)
+        .join(Tarea_cons, DT_cons.tarea_id == Tarea_cons.id)
+        .join(Tramite_cons, Tarea_cons.tramite_id == Tramite_cons.id)
+        .filter(
+            Tramite_cons.fase_id == fase_id,
+            DT_cons.documento_id == DocumentoTarea.documento_id,
+            DT_cons.rol == 'CONSUMIDO',
+        )
+        .exists()
+    )
+
+    diagnostico_sin_consumir = (
+        db.session.query(Tarea)
+        .join(Tramite, Tarea.tramite_id == Tramite.id)
+        .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
+        .join(DocumentoTarea, db.and_(
+            DocumentoTarea.tarea_id == Tarea.id,
+            DocumentoTarea.rol == 'PRODUCIDO',
+        ))
+        .join(Diagnostico, Diagnostico.documento_id == DocumentoTarea.documento_id)
+        .filter(
+            Tramite.fase_id == fase_id,
+            TipoTarea.codigo == 'ANALIZAR',
+            Diagnostico.resultado == 'desfavorable',
+            ~_consumido,
+        )
+        .first()
+    )
+
+    if diagnostico_sin_consumir:
+        return _bloquear(
+            'Hay un diagnóstico desfavorable sin consumir en esta fase. '
+            'No es posible cerrarla con un resultado no desfavorable.'
+        )
+    return None
+
+
 def _check_finalizar_tarea(tarea_id: int) -> Optional[EvaluacionResult]:
     tarea = Tarea.query.get(tarea_id)
     if not tarea or not tarea.tipo_tarea:

--- a/tests/test_419_invariante_cierre_fase.py
+++ b/tests/test_419_invariante_cierre_fase.py
@@ -1,0 +1,67 @@
+"""Tests de _check_cierre_fase — invariante #419.
+
+Cubre los tres casos del check:
+  - Resultado DESFAVORABLE → siempre permitido (sin consulta BD)
+  - Resultado no-desfavorable + diagnóstico sin consumir → bloqueo
+  - Resultado no-desfavorable + sin diagnósticos sin consumir → paso limpio
+"""
+from unittest.mock import MagicMock, patch
+
+
+def _make_query_chain(first_returns):
+    q = MagicMock()
+    q.join.return_value = q
+    q.filter.return_value = q
+    q.exists.return_value = MagicMock()
+    q.first.side_effect = list(first_returns)
+    return q
+
+
+class TestCheckCierreFase:
+
+    def test_resultado_desfavorable_nunca_bloquea(self, app):
+        """Con resultado DESFAVORABLE no se ejecuta la query y nunca bloquea."""
+        from app.services.invariantes_esftt import _check_cierre_fase
+        with app.app_context():
+            resultado = _check_cierre_fase(fase_id=99, codigo_resultado='DESFAVORABLE')
+        assert resultado is None
+
+    def test_diagnostico_sin_consumir_bloquea(self, app):
+        """La query encuentra diagnóstico desfavorable sin consumir → bloqueo."""
+        from app.services.invariantes_esftt import _check_cierre_fase
+        with app.app_context():
+            with patch('app.services.invariantes_esftt.db') as mock_db:
+                mock_db.aliased.return_value = MagicMock()
+                mock_db.and_.return_value = MagicMock()
+                q = _make_query_chain([MagicMock()])
+                mock_db.session.query.return_value = q
+                resultado = _check_cierre_fase(fase_id=99, codigo_resultado='FAVORABLE')
+        assert resultado is not None
+        assert resultado.permitido is False
+        assert 'desfavorable' in resultado.norma_compilada.lower()
+
+    def test_diagnostico_consumido_no_bloquea(self, app):
+        """La query no encuentra diagnóstico sin consumir → paso limpio."""
+        from app.services.invariantes_esftt import _check_cierre_fase
+        with app.app_context():
+            with patch('app.services.invariantes_esftt.db') as mock_db:
+                mock_db.aliased.return_value = MagicMock()
+                mock_db.and_.return_value = MagicMock()
+                q = _make_query_chain([None])
+                mock_db.session.query.return_value = q
+                resultado = _check_cierre_fase(fase_id=99, codigo_resultado='FAVORABLE')
+        assert resultado is None
+
+    def test_cualquier_resultado_no_desfavorable_bloquea(self, app):
+        """FAVORABLE_CONDICIONADO, NO_PROCEDE, DESISTIDA y ARCHIVADA también bloquean."""
+        from app.services.invariantes_esftt import _check_cierre_fase
+        for codigo in ('FAVORABLE_CONDICIONADO', 'NO_PROCEDE', 'DESISTIDA', 'ARCHIVADA'):
+            with app.app_context():
+                with patch('app.services.invariantes_esftt.db') as mock_db:
+                    mock_db.aliased.return_value = MagicMock()
+                    mock_db.and_.return_value = MagicMock()
+                    q = _make_query_chain([MagicMock()])
+                    mock_db.session.query.return_value = q
+                    resultado = _check_cierre_fase(fase_id=99, codigo_resultado=codigo)
+            assert resultado is not None, f'Debería bloquear con resultado {codigo}'
+            assert resultado.permitido is False


### PR DESCRIPTION
## Cambios

- Nueva función `_check_cierre_fase(fase_id, codigo_resultado)` en `invariantes_esftt.py`: bloquea el cierre de la fase con cualquier resultado no-desfavorable si existe un diagnóstico `desfavorable` sin consumir en alguna tarea ANALIZAR de la fase
- `editar_fase` en `api_bc.py` invoca el check en la transición de cierre (`documento_resultado_id NULL → NOT NULL`), resolviendo el código de `TipoResultadoFase` antes de llamar al invariante
- `catalogo_requerido.py` registra `TipoResultadoFase.DESFAVORABLE` como código estructural requerido
- 4 tests nuevos en `test_419_invariante_cierre_fase.py`: bloqueo con resultado favorable, paso limpio con DESFAVORABLE, paso limpio con diagnóstico consumido, y bloqueo para todos los resultados no-desfavorables

Closes #419
