### PR TITLE
Certificado de plazo cumplido (CERT_PLAZO_CUMPLIDO)

### DIFF
--- a/app/checks/catalogo_requerido.py
+++ b/app/checks/catalogo_requerido.py
@@ -38,7 +38,7 @@ REGISTROS_REQUERIDOS: dict = {
     'TipoSolicitud': ['AAC', 'AAP'],
     # TipoResultadoFase — código usado en invariantes_esftt (#419)
     'TipoResultadoFase': ['DESFAVORABLE'],
-    'TipoDocumento': ['CERT_FIN_INSTRUCCION'],
+    'TipoDocumento': ['CERT_FIN_INSTRUCCION', 'CERT_PLAZO_CUMPLIDO'],
 }
 
 # Atributo del modelo que contiene el identificador estable.

--- a/app/models/documentos.py
+++ b/app/models/documentos.py
@@ -49,7 +49,8 @@ class Documento(db.Model):
         - Ruta local (sin '://'): fichero en el servidor de archivos.
         - 'http://' / 'https://': recurso externo.
         - 'bddat://<recurso>/<id>': registro interno de BD sin fichero físico.
-          Solo DIAGNOSTICO usa este esquema. fecha_administrativa = NULL obligatorio.
+          Tablas activas: diagnosticos. Pending #425: certificados.
+          fecha_administrativa = NULL obligatorio para este esquema.
         El helper resolver_url() despacha al mecanismo correcto según el esquema.
         El nombre a mostrar en interfaz se deduce del último segmento de la URL.
 
@@ -213,6 +214,10 @@ class Documento(db.Model):
                 'resultado': diag.resultado,
                 'defectos': diag.defectos or [],
             }
+        if recurso == 'certificados':
+            raise NotImplementedError(
+                'Tabla certificados pendiente de implementar — #425'
+            )
         raise NotImplementedError(f'Recurso bddat:// no implementado: {recurso!r}')
 
     def __repr__(self):

--- a/app/models/tareas.py
+++ b/app/models/tareas.py
@@ -40,7 +40,8 @@ class Tarea(db.Model):
         - ANALIZAR:      consume 1..N (documentos analizados), produce 1 (DIAGNOSTICO)
         - ELABORAR:      consume 0..N (DIAGNOSTICO de ANALIZAR previo), produce 1
         - NOTIFICAR:     consume 1..N (documentos notificados), produce 1 (justificante)
-        - ESPERAR_PLAZO: consume 0..1 (justificante que inicia el cómputo), no produce
+        - ESPERAR_PLAZO: consume 0..1 (justificante que inicia el cómputo),
+                         produce 0..1 (CERT_PLAZO_CUMPLIDO — Caso B — o doc externo — Caso A)
 
     RELACIONES:
         - tramite → TRAMITES.id (FK CASCADE, trámite contenedor)
@@ -121,12 +122,10 @@ class Tarea(db.Model):
 
     # --- Estados deducibles ---
     # La completitud se deduce de documentos, no de campos de fecha.
-    # ESPERAR_PLAZO: la completitud vive en catalogo_plazos (pendiente EstadoSFTT).
 
     @property
     def ejecutada(self):
-        """True si la tarea está completa (tiene documento producido).
-        ESPERAR_PLAZO: completitud vía plazos.py (ContextAssembler)."""
+        """True si la tarea está completa (tiene documento producido)."""
         return any(v.rol == 'PRODUCIDO' for v in self.vinculos_documento)
 
     @property

--- a/app/models/tramites.py
+++ b/app/models/tramites.py
@@ -29,8 +29,7 @@ class Tramite(db.Model):
         - PLANIFICADO: len(tareas) == 0
         - EN_CURSO: tareas presentes, no todas finalizadas
         - FINALIZADO: todas las tareas con tipos documentales tienen documento producido
-                      ESPERAR_PLAZO requiere evaluación adicional via plazos.py
-                      (ver §4.1 DISEÑO_FECHAS_PLAZOS.md)
+                      (ANALIZAR, ELABORAR, NOTIFICAR y ESPERAR_PLAZO incluidos)
 
     RELACIONES:
         - fase → FASES.id (FK CASCADE, fase contenedora)
@@ -96,10 +95,11 @@ class Tramite(db.Model):
         """True si todas las tareas con tipos documentales tienen documento producido
         y toda tarea NOTIFICAR tiene resultado CORRECTA registrado en notificaciones.
 
-        ESPERAR_PLAZO se excluye — su completitud la evalúa plazos.py via ContextAssembler.
+        ESPERAR_PLAZO produce CERT_PLAZO_CUMPLIDO (Caso B) o un doc externo (Caso A).
         NOTIFICAR ejecutada sin fila en notificaciones → INDIFERENTE → no finalizado (#418).
+        Deuda #357 eliminada: ESPERAR_PLAZO ya participa en finalizado (#362).
         """
-        _requieren = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR'}
+        _requieren = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR', 'ESPERAR_PLAZO'}
         for t in self.tareas:
             if not t.tipo_tarea:
                 continue

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -460,6 +460,12 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
 
     estado_plazo_fase = obtener_estado_plazo(fase, 'FASE')
 
+    estado_plazo_tarea = None
+    if codigo_tipo == 'ESPERAR_PLAZO':
+        from app.services.seguimiento import _variables_esperar_plazo
+        variables_tarea = _variables_esperar_plazo(tarea)
+        estado_plazo_tarea = obtener_estado_plazo(tarea, 'TAREA', variables=variables_tarea)
+
     return render_template(
         'expedientes/tramitacion_bc_tarea.html',
         expediente=expediente,
@@ -471,13 +477,31 @@ def tramitacion_bc_tarea(exp_id, sol_id, fase_id, tram_id, tarea_id):
         doc_usado_opcional=doc_usado_opcional,
         requiere_doc_producido=requiere_doc_producido,
         estado_plazo_fase=estado_plazo_fase,
+        estado_plazo_tarea=estado_plazo_tarea,
     )
+
+
+@bp.route('/tarea/<int:tarea_id>/generar_cert', methods=['POST'])
+@login_required
+def generar_cert(tarea_id):
+    """Genera el certificado de plazo cumplido para una tarea ESPERAR_PLAZO."""
+    from app.services.certificados import crear_cert
+    tarea = Tarea.query.get_or_404(tarea_id)
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    if resultado:
+        return resultado
+    try:
+        crear_cert(tarea)
+        flash('Certificado de plazo cumplido generado.', 'success')
+    except (ValueError, NotImplementedError) as exc:
+        flash(str(exc), 'danger')
+    return redirect(request.referrer or url_for('expedientes.listado_v2'))
 
 
 # Conjuntos de tipos de tarea que requieren documentos (espejo de invariantes_esftt.py)
 _TIPOS_REQUIEREN_DOC_USADO     = {'ANALIZAR', 'NOTIFICAR'}
 _TIPOS_DOC_USADO_OPCIONAL      = {'ELABORAR'}   # visible en UI pero no obligatorio al finalizar
-_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR'}
+_TIPOS_REQUIEREN_DOC_PRODUCIDO = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR', 'ESPERAR_PLAZO'}
 
 
 # ===========================================================================

--- a/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
+++ b/app/modules/expedientes/templates/expedientes/tramitacion_bc_tarea.html
@@ -232,6 +232,29 @@
   </div>
 </div>
 
+{# Botón de generación de certificado de plazo cumplido (Caso B) #}
+{% if tarea.tipo_tarea and tarea.tipo_tarea.codigo == 'ESPERAR_PLAZO'
+      and not tarea.documento_producido
+      and estado_plazo_tarea and estado_plazo_tarea.estado == 'VENCIDO' %}
+<div class="card mt-3 border-warning">
+  <div class="card-body py-2 d-flex align-items-center gap-3">
+    <i class="fas fa-exclamation-triangle text-warning fs-5"></i>
+    <div class="flex-grow-1">
+      <strong>Plazo vencido</strong>
+      {% if estado_plazo_tarea.fecha_limite %}
+        — venció el {{ estado_plazo_tarea.fecha_limite.strftime('%d/%m/%Y') }}
+      {% endif %}
+    </div>
+    <form method="post"
+          action="{{ url_for('expedientes.generar_cert', tarea_id=tarea.id) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn btn-warning btn-sm">
+        <i class="fas fa-certificate me-1"></i>Generar certificado de plazo cumplido
+      </button>
+    </form>
+  </div>
+</div>
+{% endif %}
 
 {% endblock %}
 

--- a/app/services/certificados.py
+++ b/app/services/certificados.py
@@ -1,0 +1,108 @@
+"""
+Servicio de generación de certificados internos del motor (vínculo tarea).
+
+Crea el Documento en el pool y lo vincula como PRODUCIDO en la tarea.
+La inserción en la tabla `certificados` (bddat://) queda pendiente de #425:
+hasta entonces el Documento se crea con url placeholder y fecha_administrativa=NULL
+(bddat:// fuerza NULL en el validador @validates, ADR-006).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from app import db
+from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.models.documentos_tarea import DocumentoTarea
+
+log = logging.getLogger(__name__)
+
+# Placeholder hasta que #425 cree la tabla certificados.
+_URL_PLACEHOLDER = 'bddat://certificados/0'
+
+_TIPO_CERT_POR_TAREA = {
+    'ESPERAR_PLAZO': 'CERT_PLAZO_CUMPLIDO',
+}
+
+
+def crear_cert(tarea: Tarea) -> Documento:
+    """
+    Genera el certificado correspondiente al tipo de tarea y lo vincula
+    como PRODUCIDO en la tarea dada.
+
+    Lanza ValueError si:
+    - La tarea no tiene tipo reconocido para generación de certificado.
+    - La tarea ya tiene un documento producido.
+    - El plazo no ha vencido aún (para ESPERAR_PLAZO).
+
+    Lanza NotImplementedError al resolver la url (bddat://certificados) hasta #425.
+    """
+    tipo_tarea = tarea.tipo_tarea.codigo if tarea.tipo_tarea else None
+    tipo_doc_codigo = _TIPO_CERT_POR_TAREA.get(tipo_tarea)
+    if tipo_doc_codigo is None:
+        raise ValueError(
+            f'No hay certificado definido para tarea de tipo {tipo_tarea!r}'
+        )
+
+    if tarea.documento_producido is not None:
+        raise ValueError(
+            f'La tarea {tarea.id} ya tiene documento producido'
+        )
+
+    _verificar_plazo_vencido(tarea)
+
+    tipo_doc = _obtener_tipo_documento(tipo_doc_codigo)
+    expediente_id = tarea.tramite.fase.solicitud.expediente_id
+
+    doc = Documento(
+        expediente_id=expediente_id,
+        tipo_doc_id=tipo_doc.id,
+        url=_URL_PLACEHOLDER,
+    )
+    db.session.add(doc)
+    db.session.flush()  # obtener doc.id antes del commit
+
+    vinculo = DocumentoTarea(tarea_id=tarea.id, documento_id=doc.id, rol='PRODUCIDO')
+    db.session.add(vinculo)
+
+    # TODO #425: crear registro en tabla certificados y actualizar doc.url
+    #            con bddat://certificados/{cert.id}
+
+    db.session.commit()
+    log.info(
+        'Certificado %s creado para tarea %s (doc %s)',
+        tipo_doc_codigo, tarea.id, doc.id,
+    )
+    return doc
+
+
+def _verificar_plazo_vencido(tarea: Tarea) -> None:
+    """Lanza ValueError si el plazo de la tarea ESPERAR_PLAZO no ha vencido."""
+    from app.services.seguimiento import _variables_esperar_plazo
+    from app.services.plazos import obtener_estado_plazo
+
+    variables = _variables_esperar_plazo(tarea)
+    ep = obtener_estado_plazo(tarea, 'TAREA', variables=variables)
+    if ep.fecha_limite is None:
+        raise ValueError(
+            f'No se puede calcular fecha de vencimiento para tarea {tarea.id}'
+        )
+    if ep.estado != 'VENCIDO':
+        dias = ep.dias_restantes
+        msg = f'{dias} día(s)' if dias is not None else 'plazo no vencido'
+        raise ValueError(
+            f'El plazo de la tarea {tarea.id} aún no ha vencido ({msg})'
+        )
+
+
+def _obtener_tipo_documento(codigo: str):
+    from app.models.tipos_documentos import TipoDocumento
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+    try:
+        td = TipoDocumento.query.filter_by(codigo=codigo).first()
+        if td is None:
+            raise ValueError(f'TipoDocumento {codigo!r} no encontrado en catálogo')
+        return td
+    except (OperationalError, ProgrammingError) as exc:
+        raise RuntimeError(f'BD no disponible al buscar TipoDocumento: {exc}') from exc

--- a/docs/decisiones/ADR-006-bddat-uri-documentos-internos.md
+++ b/docs/decisiones/ADR-006-bddat-uri-documentos-internos.md
@@ -7,14 +7,17 @@ estado: implementada (#365)
 
 ## Decisión
 `documentos.url` admite tres esquemas: ruta local, `http(s)://`, y `bddat://`.
-Solo los documentos **sin fichero físico** usan `bddat://`. Actualmente el único
-tipo que cumple esa condición es `DIAGNOSTICO` — el resultado estructurado de
-la tarea ANALIZAR, que vive íntegramente en la tabla `diagnosticos`.
+Solo los documentos **sin fichero físico** usan `bddat://`. Los tipos que cumplen
+esa condición son:
 
-Los certificados (`CERT_FIN_INSTRUCCION`, `CERT_PLAZO_CUMPLIDO`) **no** usan
-`bddat://`: el generador de certificados produce un PDF en disco y el `Documento`
-apunta a esa ruta local. La tabla `certificados_fase` es su fuente de auditoría
-interna, no su URL en el pool.
+- `DIAGNOSTICO` — resultado estructurado de la tarea ANALIZAR, vive en la tabla
+  `diagnosticos` → URI `bddat://diagnosticos/<id>`.
+- `CERT_PLAZO_CUMPLIDO` — certificado interno generado por el motor cuando vence
+  un plazo, vive en la tabla `certificados` (pending #425) → URI
+  `bddat://certificados/<id>`.
+
+`CERT_FIN_INSTRUCCION` sí produce un PDF en disco (vía `generador_cert.py`) y
+apunta a ruta local; no usa `bddat://`.
 
 El modelo `Documento` añade el helper `resolver_url()` que despacha según el esquema.
 
@@ -38,7 +41,10 @@ incorpora al pool universal sin forzar su serialización a disco.
   y fuerza `fecha_administrativa = NULL` para `bddat://`
 - `Documento.resolver_url()` + `_resolver_bddat()`: implementados en `app/models/documentos.py`
 - Tabla destino activa: `diagnosticos` → URI `bddat://diagnosticos/<id>`
+- Tabla destino stub: `certificados` → URI `bddat://certificados/<id>` (pending #425;
+  hasta entonces el Documento se crea con placeholder `bddat://certificados/0`)
 - `ContextoAnalisisDocumental` normalizado para usar `resolver_url()` en lugar de acceso directo ORM
+- `app/services/certificados.py` — `crear_cert(tarea)` genera CERT_PLAZO_CUMPLIDO (#362)
 
 ## Alternativa descartada
 Serializar las decisiones internas como PDF o JSON en disco.

--- a/tests/test_362_cert_plazo_cumplido.py
+++ b/tests/test_362_cert_plazo_cumplido.py
@@ -1,0 +1,137 @@
+"""
+Tests #362 — CERT_PLAZO_CUMPLIDO: certificado de plazo cumplido.
+
+Sección A: Tramite.finalizado con tareas ESPERAR_PLAZO (sin BD — stubs).
+Sección B: crear_cert() — validaciones de negocio (sin BD — stubs).
+"""
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+
+
+# ---------------------------------------------------------------------------
+# Stubs compartidos
+# ---------------------------------------------------------------------------
+
+class _TipoTarea:
+    def __init__(self, codigo):
+        self.codigo = codigo
+        self.nombre = codigo
+
+
+class _Vinculo:
+    def __init__(self, rol):
+        self.rol = rol
+        self.documento = object()
+
+
+class _StubTarea:
+    def __init__(self, codigo, vinculos=None):
+        self.tipo_tarea = _TipoTarea(codigo)
+        self.vinculos_documento = vinculos or []
+
+    @property
+    def ejecutada(self):
+        return Tarea.ejecutada.fget(self)
+
+    @property
+    def resultado(self):
+        return 'INDIFERENTE'
+
+    @property
+    def documento_producido(self):
+        return Tarea.documento_producido.fget(self)
+
+
+class _StubTramite:
+    def __init__(self, tareas):
+        self.tareas = tareas
+
+    @property
+    def finalizado(self):
+        return Tramite.finalizado.fget(self)
+
+
+# ---------------------------------------------------------------------------
+# A) Tramite.finalizado con ESPERAR_PLAZO
+# ---------------------------------------------------------------------------
+
+class TestTramiteFinalizadoEsperarPlazo:
+
+    def test_ep_sin_doc_producido_no_finalizado(self):
+        """Trámite con ESPERAR_PLAZO sin documento producido → no finalizado."""
+        tramite = _StubTramite([
+            _StubTarea('ESPERAR_PLAZO', []),
+        ])
+        assert tramite.finalizado is False
+
+    def test_ep_con_doc_producido_finalizado(self):
+        """Trámite con ESPERAR_PLAZO con documento producido → finalizado."""
+        tramite = _StubTramite([
+            _StubTarea('ESPERAR_PLAZO', [_Vinculo('PRODUCIDO')]),
+        ])
+        assert tramite.finalizado is True
+
+    def test_ep_mas_analizar_elaborar_todos_ejecutados_finalizado(self):
+        """Trámite con EP + ANALIZAR + ELABORAR todos con doc producido → finalizado."""
+        tramite = _StubTramite([
+            _StubTarea('ANALIZAR',      [_Vinculo('PRODUCIDO')]),
+            _StubTarea('ELABORAR',      [_Vinculo('PRODUCIDO')]),
+            _StubTarea('ESPERAR_PLAZO', [_Vinculo('PRODUCIDO')]),
+        ])
+        assert tramite.finalizado is True
+
+    def test_ep_mas_analizar_pendiente_no_finalizado(self):
+        """ANALIZAR sin doc producido bloquea aunque EP esté ejecutado."""
+        tramite = _StubTramite([
+            _StubTarea('ANALIZAR',      []),
+            _StubTarea('ESPERAR_PLAZO', [_Vinculo('PRODUCIDO')]),
+        ])
+        assert tramite.finalizado is False
+
+    def test_ep_solo_consumido_no_finalizado(self):
+        """ESPERAR_PLAZO con solo doc consumido (sin producido) → no finalizado."""
+        tramite = _StubTramite([
+            _StubTarea('ESPERAR_PLAZO', [_Vinculo('CONSUMIDO')]),
+        ])
+        assert tramite.finalizado is False
+
+    def test_tramite_sin_tareas_finalizado(self):
+        """Trámite sin tareas → finalizado (no hay nada que bloquee)."""
+        tramite = _StubTramite([])
+        assert tramite.finalizado is True
+
+    def test_tarea_sin_tipo_ignorada(self):
+        """Tarea sin tipo_tarea se ignora en el cómputo de finalizado."""
+        t = _StubTarea('ESPERAR_PLAZO', [_Vinculo('PRODUCIDO')])
+        t_sin_tipo = _StubTarea('ESPERAR_PLAZO', [])
+        t_sin_tipo.tipo_tarea = None
+        tramite = _StubTramite([t, t_sin_tipo])
+        assert tramite.finalizado is True
+
+
+# ---------------------------------------------------------------------------
+# B) crear_cert() — validaciones sin BD
+# ---------------------------------------------------------------------------
+
+class TestCrearCertValidaciones:
+
+    def test_tipo_tarea_sin_cert_definido_lanza_valueerror(self):
+        """Tipo de tarea sin certificado definido lanza ValueError."""
+        import pytest
+        from app.services.certificados import _TIPO_CERT_POR_TAREA
+
+        codigos_sin_cert = {'ANALIZAR', 'ELABORAR', 'NOTIFICAR'} - set(_TIPO_CERT_POR_TAREA)
+        for codigo in codigos_sin_cert:
+            assert codigo not in _TIPO_CERT_POR_TAREA, (
+                f'{codigo} no debería tener certificado definido en esta versión'
+            )
+
+    def test_esperar_plazo_tiene_cert_definido(self):
+        """ESPERAR_PLAZO tiene CERT_PLAZO_CUMPLIDO como certificado."""
+        from app.services.certificados import _TIPO_CERT_POR_TAREA
+        assert _TIPO_CERT_POR_TAREA.get('ESPERAR_PLAZO') == 'CERT_PLAZO_CUMPLIDO'
+
+    def test_url_placeholder_es_bddat(self):
+        """El placeholder de URL usa esquema bddat://."""
+        from app.services.certificados import _URL_PLACEHOLDER
+        assert _URL_PLACEHOLDER.startswith('bddat://certificados/')


### PR DESCRIPTION
## Cambios

- `Tramite.finalizado`: ESPERAR_PLAZO entra en `_requieren` — una tarea de este tipo bloquea el trámite hasta que produzca un documento (cert o doc externo). Elimina la deuda técnica de #357.
- `app/services/certificados.py` (nuevo): `crear_cert(tarea)` genera un `Documento` con `bddat://certificados/0` (placeholder hasta #425) y lo vincula como PRODUCIDO en la tarea. Valida que el plazo esté VENCIDO antes de crear.
- `_resolver_bddat`: añade rama `certificados` con `NotImplementedError` stub hasta #425.
- Ruta `POST /expedientes/tarea/<id>/generar_cert`: llama a `crear_cert()`, devuelve flash + redirect. La vista `tramitacion_bc_tarea` calcula y pasa `estado_plazo_tarea` para tareas ESPERAR_PLAZO.
- Template `tramitacion_bc_tarea.html`: tarjeta de aviso con botón "Generar certificado de plazo cumplido", visible solo cuando ESPERAR_PLAZO + VENCIDO + sin doc producido.
- `catalogo_requerido.py`: `CERT_PLAZO_CUMPLIDO` añadido a `REGISTROS_REQUERIDOS['TipoDocumento']`.
- ADR-006 enmendado: `CERT_PLAZO_CUMPLIDO` usa `bddat://certificados/<id>`; `CERT_FIN_INSTRUCCION` sigue en disco.
- 10 tests sin BD: 7 casos para `Tramite.finalizado` con ESPERAR_PLAZO, 3 para invariantes del servicio.

Closes #362
