### PR TITLE
Implementar tabla certificados y resolver bddat://certificados

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -75,6 +75,9 @@ from app.models.certificados_fase import CertificadoFase
 # Diagnóstico documental de tareas ANALIZAR (#392 — depende de Documento)
 from app.models.diagnosticos import Diagnostico
 
+# Certificados internos del motor vinculados al pool (#425 — depende de Documento)
+from app.models.certificados import Certificado
+
 # Alegante en trámites RECEPCION_ALEGACION (#393 — depende de Tramite, Entidad)
 from app.models.alegantes import Alegante
 
@@ -137,6 +140,8 @@ __all__ = [
     'TramiteTareaDocumento',
     # Diagnóstico documental
     'Diagnostico',
+    # Certificados internos del motor
+    'Certificado',
     # Organismos consultados por expediente
     'OrganismoExpediente',
     # Alegante en trámites RECEPCION_ALEGACION

--- a/app/models/certificados.py
+++ b/app/models/certificados.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app import db
+
+
+class Certificado(db.Model):
+    """
+    Certificado interno generado por el motor, vinculado al pool de documentos.
+
+    Un registro por Documento de tipo CERT_*. El tipo concreto se deduce de
+    documento.tipo_documento.codigo. El campo datos almacena el contenido
+    tipo-específico en JSONB; su estructura varía por tipo:
+
+        CERT_PLAZO_CUMPLIDO — tarea_id, fecha_vencimiento, documento_inicio_id,
+            tipo_tramite, normativa, plazo_valor, plazo_unidad, fecha_inicio_computo
+        CERT_FIN_INSTRUCCION — fase_id, tipo_expediente, fases_completadas,
+            fundamento_juridico  (producido en #373)
+        CERT_FIN_IP_CONSULTAS — fases_habilitantes, fecha_fin_ultima_fase
+            (producido en issue futuro)
+
+    URI: bddat://certificados/{id}  →  resolver_url() devuelve dict completo.
+    """
+    __tablename__ = 'certificados'
+    __table_args__ = (
+        db.UniqueConstraint('documento_id', name='uq_certificado_documento'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id', name='fk_certificado_documento'),
+        nullable=False,
+        unique=True,
+        comment='FK documentos. Tipo deducido de tipo_documento.codigo',
+    )
+
+    generado_en = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        server_default=db.text('now()'),
+        comment='Momento de creación del registro',
+    )
+
+    datos = db.Column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default='{}',
+        comment='Contenido tipo-específico del certificado',
+    )
+
+    documento = db.relationship(
+        'Documento',
+        foreign_keys=[documento_id],
+        backref=db.backref('certificado', uselist=False),
+    )
+
+    def __repr__(self):
+        return f'<Certificado id={self.id} doc={self.documento_id}>'

--- a/app/models/documentos.py
+++ b/app/models/documentos.py
@@ -215,9 +215,15 @@ class Documento(db.Model):
                 'defectos': diag.defectos or [],
             }
         if recurso == 'certificados':
-            raise NotImplementedError(
-                'Tabla certificados pendiente de implementar — #425'
-            )
+            from app.models.certificados import Certificado
+            cert = Certificado.query.get(registro_id)
+            if cert is None:
+                raise LookupError(f'Certificado id={registro_id} no encontrado')
+            return {
+                'id': cert.id,
+                'generado_en': cert.generado_en.isoformat(),
+                'datos': cert.datos,
+            }
         raise NotImplementedError(f'Recurso bddat:// no implementado: {recurso!r}')
 
     def __repr__(self):

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -498,6 +498,37 @@ def generar_cert(tarea_id):
     return redirect(request.referrer or url_for('expedientes.listado_v2'))
 
 
+@bp.route('/cert/<int:cert_id>/pdf')
+@login_required
+def cert_pdf(cert_id):
+    """Genera y devuelve el PDF de un certificado interno (bddat://)."""
+    from app.models.certificados import Certificado
+    from app.services.cert_pdf import generar_pdf_certificado
+
+    cert = Certificado.query.get_or_404(cert_id)
+    expediente = cert.documento.solicitud_expediente if hasattr(cert.documento, 'solicitud_expediente') else None
+
+    # Acceder al expediente vía documento → expediente
+    from app.models.expedientes import Expediente
+    expediente = Expediente.query.get_or_404(cert.documento.expediente_id)
+
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return resultado
+
+    tipo_cert = cert.documento.tipo_documento.codigo if cert.documento.tipo_documento else ''
+    pdf_bytes = generar_pdf_certificado(cert, expediente, tipo_cert)
+
+    from flask import Response
+    return Response(
+        pdf_bytes,
+        mimetype='application/pdf',
+        headers={
+            'Content-Disposition': f'inline; filename="cert_{tipo_cert}_{cert.id}.pdf"'
+        },
+    )
+
+
 # Conjuntos de tipos de tarea que requieren documentos (espejo de invariantes_esftt.py)
 _TIPOS_REQUIEREN_DOC_USADO     = {'ANALIZAR', 'NOTIFICAR'}
 _TIPOS_DOC_USADO_OPCIONAL      = {'ELABORAR'}   # visible en UI pero no obligatorio al finalizar

--- a/app/services/cert_pdf.py
+++ b/app/services/cert_pdf.py
@@ -1,0 +1,120 @@
+"""
+Generación on-demand de PDFs para certificados internos (bddat://).
+
+Despacha por tipo de certificado y genera el PDF con reportlab.
+Devuelve bytes — la ruta no escribe a disco (a diferencia de generador_cert.py).
+"""
+from __future__ import annotations
+
+import io
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def generar_pdf_certificado(cert, expediente, tipo_cert: str) -> bytes:
+    """
+    Genera y devuelve el PDF del certificado como bytes.
+
+    Args:
+        cert:        Instancia de Certificado.
+        expediente:  Instancia de Expediente.
+        tipo_cert:   Código de TipoDocumento (ej: 'CERT_PLAZO_CUMPLIDO').
+
+    Returns:
+        Bytes del PDF generado.
+
+    Lanza NotImplementedError si tipo_cert no tiene plantilla definida.
+    """
+    if tipo_cert == 'CERT_PLAZO_CUMPLIDO':
+        return _pdf_plazo_cumplido(cert, expediente)
+    raise NotImplementedError(f'Sin plantilla PDF para tipo {tipo_cert!r}')
+
+
+def _pdf_plazo_cumplido(cert, expediente) -> bytes:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import cm
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=2 * cm, rightMargin=2 * cm,
+        topMargin=2.5 * cm, bottomMargin=2.5 * cm,
+    )
+
+    estilos = getSampleStyleSheet()
+    estilo_cab = ParagraphStyle('Cab', parent=estilos['Heading2'], fontSize=10, spaceAfter=2)
+    estilo_titulo = ParagraphStyle('Titulo', parent=estilos['Heading1'], fontSize=13, spaceAfter=8)
+    estilo_normal = ParagraphStyle('Normal', parent=estilos['Normal'], fontSize=9, spaceAfter=3)
+    estilo_pie = ParagraphStyle('Pie', parent=estilos['Normal'], fontSize=7,
+                                textColor=colors.grey, spaceBefore=20)
+
+    datos = cert.datos or {}
+    numero_at = getattr(expediente, 'numero_at', '') or ''
+    generado_en = cert.generado_en.strftime('%d/%m/%Y %H:%M') if cert.generado_en else ''
+
+    fecha_venc = datos.get('fecha_vencimiento', '')
+    fecha_inicio = datos.get('fecha_inicio_computo', '')
+    plazo_valor = datos.get('plazo_valor', '')
+    plazo_unidad = datos.get('plazo_unidad', '')
+    normativa = datos.get('normativa', '')
+    tipo_tramite = datos.get('tipo_tramite', '')
+
+    _unidad_legible = {
+        'DIAS_HABILES': 'días hábiles',
+        'DIAS_NATURALES': 'días naturales',
+        'MESES': 'meses',
+        'ANOS': 'años',
+    }
+    unidad_str = _unidad_legible.get(str(plazo_unidad), str(plazo_unidad))
+
+    filas_tabla = [
+        ['Expediente', f'AT-{numero_at}'],
+        ['Tipo de trámite', tipo_tramite],
+        ['Plazo legal', f'{plazo_valor} {unidad_str}'],
+        ['Normativa aplicable', normativa],
+        ['Inicio del cómputo', fecha_inicio],
+        ['Fecha de vencimiento', fecha_venc],
+    ]
+
+    tabla = Table(filas_tabla, colWidths=[5 * cm, 12 * cm])
+    tabla.setStyle(TableStyle([
+        ('BACKGROUND', (0, 0), (0, -1), colors.lightgrey),
+        ('FONTSIZE', (0, 0), (-1, -1), 9),
+        ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+        ('LEFTPADDING', (0, 0), (-1, -1), 4),
+        ('RIGHTPADDING', (0, 0), (-1, -1), 4),
+        ('TOPPADDING', (0, 0), (-1, -1), 3),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 3),
+    ]))
+
+    contenido = [
+        Paragraph('Consejería de Industria, Energía y Minas', estilo_cab),
+        Paragraph('Junta de Andalucía', estilo_cab),
+        Spacer(1, 0.4 * cm),
+        Paragraph('CERTIFICADO DE PLAZO CUMPLIDO', estilo_titulo),
+        Spacer(1, 0.3 * cm),
+        Paragraph(
+            'El sistema BDDAT certifica que el plazo legal asociado a la tramitación '
+            'del expediente indicado ha vencido conforme a los datos siguientes:',
+            estilo_normal,
+        ),
+        Spacer(1, 0.3 * cm),
+        tabla,
+        Spacer(1, 0.6 * cm),
+        Paragraph(
+            'Este certificado ha sido generado automáticamente por el sistema de tramitación '
+            'BDDAT en la fecha indicada y tiene carácter meramente informativo del estado del '
+            'procedimiento.',
+            estilo_normal,
+        ),
+        Paragraph(f'Generado: {generado_en}  ·  Certificado interno #{cert.id}', estilo_pie),
+    ]
+
+    doc.build(contenido)
+    return buffer.getvalue()

--- a/app/services/certificados.py
+++ b/app/services/certificados.py
@@ -1,15 +1,13 @@
 """
 Servicio de generación de certificados internos del motor (vínculo tarea).
 
-Crea el Documento en el pool y lo vincula como PRODUCIDO en la tarea.
-La inserción en la tabla `certificados` (bddat://) queda pendiente de #425:
-hasta entonces el Documento se crea con url placeholder y fecha_administrativa=NULL
-(bddat:// fuerza NULL en el validador @validates, ADR-006).
+Crea el Documento en el pool, inserta en la tabla certificados y vincula
+el Documento como PRODUCIDO en la tarea. La URL final es bddat://certificados/{id}.
 """
 from __future__ import annotations
 
 import logging
-from datetime import date
+from datetime import datetime
 
 from app import db
 from app.models.tareas import Tarea
@@ -17,9 +15,6 @@ from app.models.documentos import Documento
 from app.models.documentos_tarea import DocumentoTarea
 
 log = logging.getLogger(__name__)
-
-# Placeholder hasta que #425 cree la tabla certificados.
-_URL_PLACEHOLDER = 'bddat://certificados/0'
 
 _TIPO_CERT_POR_TAREA = {
     'ESPERAR_PLAZO': 'CERT_PLAZO_CUMPLIDO',
@@ -35,8 +30,6 @@ def crear_cert(tarea: Tarea) -> Documento:
     - La tarea no tiene tipo reconocido para generación de certificado.
     - La tarea ya tiene un documento producido.
     - El plazo no ha vencido aún (para ESPERAR_PLAZO).
-
-    Lanza NotImplementedError al resolver la url (bddat://certificados) hasta #425.
     """
     tipo_tarea = tarea.tipo_tarea.codigo if tarea.tipo_tarea else None
     tipo_doc_codigo = _TIPO_CERT_POR_TAREA.get(tipo_tarea)
@@ -50,7 +43,7 @@ def crear_cert(tarea: Tarea) -> Documento:
             f'La tarea {tarea.id} ya tiene documento producido'
         )
 
-    _verificar_plazo_vencido(tarea)
+    datos = _datos_plazo_vencido(tarea)
 
     tipo_doc = _obtener_tipo_documento(tipo_doc_codigo)
     expediente_id = tarea.tramite.fase.solicitud.expediente_id
@@ -58,32 +51,47 @@ def crear_cert(tarea: Tarea) -> Documento:
     doc = Documento(
         expediente_id=expediente_id,
         tipo_doc_id=tipo_doc.id,
-        url=_URL_PLACEHOLDER,
+        url='bddat://certificados/0',  # placeholder hasta tener cert.id
     )
     db.session.add(doc)
-    db.session.flush()  # obtener doc.id antes del commit
+    db.session.flush()
+
+    from app.models.certificados import Certificado
+    cert = Certificado(documento_id=doc.id, datos=datos, generado_en=datetime.utcnow())
+    db.session.add(cert)
+    db.session.flush()
+
+    doc.url = f'bddat://certificados/{cert.id}'
 
     vinculo = DocumentoTarea(tarea_id=tarea.id, documento_id=doc.id, rol='PRODUCIDO')
     db.session.add(vinculo)
 
-    # TODO #425: crear registro en tabla certificados y actualizar doc.url
-    #            con bddat://certificados/{cert.id}
-
     db.session.commit()
     log.info(
-        'Certificado %s creado para tarea %s (doc %s)',
-        tipo_doc_codigo, tarea.id, doc.id,
+        'Certificado %s creado para tarea %s (doc %s, cert %s)',
+        tipo_doc_codigo, tarea.id, doc.id, cert.id,
     )
     return doc
 
 
-def _verificar_plazo_vencido(tarea: Tarea) -> None:
-    """Lanza ValueError si el plazo de la tarea ESPERAR_PLAZO no ha vencido."""
+def _datos_plazo_vencido(tarea: Tarea) -> dict:
+    """
+    Verifica que el plazo de la tarea ESPERAR_PLAZO ha vencido y construye
+    el dict datos para el JSONB del certificado.
+
+    Lanza ValueError si el plazo no ha vencido o no se puede calcular.
+    """
     from app.services.seguimiento import _variables_esperar_plazo
-    from app.services.plazos import obtener_estado_plazo
+    from app.services.plazos import (
+        obtener_estado_plazo,
+        _seleccionar_catalogo,
+        _get_tipo_elemento_codigo,
+        _primer_consumido,
+    )
 
     variables = _variables_esperar_plazo(tarea)
     ep = obtener_estado_plazo(tarea, 'TAREA', variables=variables)
+
     if ep.fecha_limite is None:
         raise ValueError(
             f'No se puede calcular fecha de vencimiento para tarea {tarea.id}'
@@ -94,6 +102,27 @@ def _verificar_plazo_vencido(tarea: Tarea) -> None:
         raise ValueError(
             f'El plazo de la tarea {tarea.id} aún no ha vencido ({msg})'
         )
+
+    tipo_codigo = _get_tipo_elemento_codigo(tarea, 'TAREA')
+    catalogo = _seleccionar_catalogo('TAREA', tipo_codigo, variables)
+
+    doc_inicio = _primer_consumido(tarea)
+    fecha_inicio = (
+        doc_inicio.fecha_administrativa.isoformat()
+        if (doc_inicio and doc_inicio.fecha_administrativa)
+        else None
+    )
+
+    return {
+        'tarea_id': tarea.id,
+        'fecha_vencimiento': ep.fecha_limite.isoformat(),
+        'documento_inicio_id': doc_inicio.id if doc_inicio else None,
+        'tipo_tramite': variables.get('tipo_tramite'),
+        'normativa': catalogo.norma_origen if catalogo else None,
+        'plazo_valor': catalogo.plazo_valor if catalogo else None,
+        'plazo_unidad': catalogo.plazo_unidad if catalogo else None,
+        'fecha_inicio_computo': fecha_inicio,
+    }
 
 
 def _obtener_tipo_documento(codigo: str):

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #365 — URI `bddat://` y helper `resolver_url()` (ADR-006): validación de esquemas, `fecha_administrativa=NULL` para `bddat://`, despacho a ORM/fichero/http; `ContextoAnalisisDocumental` normalizado; ADR-006 enmendado (CERT_* no son `bddat://`).
+**Último cerrado:** #362 — certificado de plazo cumplido (CERT_PLAZO_CUMPLIDO): `Tramite.finalizado` incluye ESPERAR_PLAZO, servicio `crear_cert(tarea)`, endpoint + botón en UI, stub `bddat://certificados/0` pending #425, ADR-006 enmendado.
 
 **Actuales:** —
 
-**Próximo:** #362.
+**Próximo:** #425 — tabla `certificados` (cierre del stub bddat://certificados/ introducido en #362).
 
 ---
 
@@ -30,7 +30,7 @@
 6. ~~**#418** — tabla `notificaciones`: documento vitaminado para NOTIFICAR (tras #420; sustituye a #378; ver ADR-008)~~ ✓
 7. ~~**#419** — invariante ANALIZAR: bloquear cierre si diagnóstico desfavorable no consumido (tras #418)~~ ✓
 8. ~~**#365** — implementar URI `bddat://` y helper `resolver_url()` (ADR-006)~~ ✓
-9. **#362** — certificado de plazo cumplido (tras #365; absorbe la limpieza de #357)
+9. ~~**#362** — certificado de plazo cumplido (tras #365; absorbe la limpieza de #357)~~ ✓
 
 ### Bloque 3 — Modelo de interesados y Context Builders de escritos
 

--- a/docs/decisiones/ADR-006-bddat-uri-documentos-internos.md
+++ b/docs/decisiones/ADR-006-bddat-uri-documentos-internos.md
@@ -2,7 +2,7 @@
 id: ADR-006
 título: URI bddat:// para documentos internos del sistema en el pool de documentos
 fecha: 2026-05-11
-estado: implementada (#365)
+estado: implementada (#365, enmendada #425)
 ---
 
 ## Decisión
@@ -12,12 +12,15 @@ esa condición son:
 
 - `DIAGNOSTICO` — resultado estructurado de la tarea ANALIZAR, vive en la tabla
   `diagnosticos` → URI `bddat://diagnosticos/<id>`.
-- `CERT_PLAZO_CUMPLIDO` — certificado interno generado por el motor cuando vence
-  un plazo, vive en la tabla `certificados` (pending #425) → URI
-  `bddat://certificados/<id>`.
+- `CERT_*` — certificados internos generados por el motor, viven en la tabla
+  `certificados` → URI `bddat://certificados/<id>`. El tipo concreto se deduce de
+  `documento.tipo_documento.codigo`. Tipos implementados o previstos:
+    - `CERT_PLAZO_CUMPLIDO` — generado por `crear_cert()` al vencer ESPERAR_PLAZO (#362, #425).
+    - `CERT_FIN_INSTRUCCION` — producido al cerrar la fase de instrucción (#373).
+    - `CERT_FIN_IP_CONSULTAS` — producido al cerrar IP/consultas (issue futuro).
 
-`CERT_FIN_INSTRUCCION` sí produce un PDF en disco (vía `generador_cert.py`) y
-apunta a ruta local; no usa `bddat://`.
+Los certificados `CERT_*` no generan PDF a disco; el PDF se genera on-demand vía
+`GET /expedientes/cert/<cert_id>/pdf` usando reportlab (`app/services/cert_pdf.py`).
 
 El modelo `Documento` añade el helper `resolver_url()` que despacha según el esquema.
 
@@ -41,10 +44,10 @@ incorpora al pool universal sin forzar su serialización a disco.
   y fuerza `fecha_administrativa = NULL` para `bddat://`
 - `Documento.resolver_url()` + `_resolver_bddat()`: implementados en `app/models/documentos.py`
 - Tabla destino activa: `diagnosticos` → URI `bddat://diagnosticos/<id>`
-- Tabla destino stub: `certificados` → URI `bddat://certificados/<id>` (pending #425;
-  hasta entonces el Documento se crea con placeholder `bddat://certificados/0`)
+- Tabla destino activa: `certificados` → URI `bddat://certificados/<id>` (#425)
 - `ContextoAnalisisDocumental` normalizado para usar `resolver_url()` en lugar de acceso directo ORM
-- `app/services/certificados.py` — `crear_cert(tarea)` genera CERT_PLAZO_CUMPLIDO (#362)
+- `app/services/certificados.py` — `crear_cert(tarea)` genera CERT_PLAZO_CUMPLIDO (#362, #425)
+- `app/services/cert_pdf.py` — genera PDF on-demand por tipo de certificado (#425)
 
 ## Alternativa descartada
 Serializar las decisiones internas como PDF o JSON en disco.

--- a/migrations/versions/425_certificados.py
+++ b/migrations/versions/425_certificados.py
@@ -1,0 +1,41 @@
+"""425_certificados
+
+Revision ID: 425_certificados
+Revises: a4d067a1d5bf
+Create Date: 2026-05-18
+
+Issue #425 — Crea la tabla certificados: almacén bddat:// para documentos
+internos generados por el motor (CERT_PLAZO_CUMPLIDO, CERT_FIN_INSTRUCCION, …).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = '425_certificados'
+down_revision = 'a4d067a1d5bf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'certificados',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('documento_id', sa.Integer(), nullable=False,
+                  comment='FK documentos. Determina el tipo vía tipo_documento.codigo'),
+        sa.Column('generado_en', sa.DateTime(), nullable=False,
+                  server_default=sa.text('now()'),
+                  comment='Momento de creación del registro'),
+        sa.Column('datos', JSONB(), nullable=False, server_default='{}',
+                  comment='Contenido tipo-específico del certificado'),
+        sa.PrimaryKeyConstraint('id', name='pk_certificados'),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id'],
+                                name='fk_certificado_documento'),
+        sa.UniqueConstraint('documento_id', name='uq_certificado_documento'),
+        schema='public',
+    )
+    op.execute("GRANT SELECT ON public.certificados TO claude_desktop")
+
+
+def downgrade():
+    op.drop_table('certificados', schema='public')

--- a/tests/test_362_cert_plazo_cumplido.py
+++ b/tests/test_362_cert_plazo_cumplido.py
@@ -131,7 +131,14 @@ class TestCrearCertValidaciones:
         from app.services.certificados import _TIPO_CERT_POR_TAREA
         assert _TIPO_CERT_POR_TAREA.get('ESPERAR_PLAZO') == 'CERT_PLAZO_CUMPLIDO'
 
-    def test_url_placeholder_es_bddat(self):
-        """El placeholder de URL usa esquema bddat://."""
-        from app.services.certificados import _URL_PLACEHOLDER
-        assert _URL_PLACEHOLDER.startswith('bddat://certificados/')
+    def test_crear_cert_usa_bddat_uri(self):
+        """crear_cert() genera URLs bddat://certificados/<id> (no placeholder fijo)."""
+        # La lógica real requiere BD; este test verifica que _URL_PLACEHOLDER
+        # ya no existe (se eliminó en #425) y que la URL final la asigna el servicio
+        # tras insertar en la tabla certificados.
+        import importlib
+        import app.services.certificados as mod
+        assert not hasattr(mod, '_URL_PLACEHOLDER'), (
+            '_URL_PLACEHOLDER debe haberse eliminado en #425; '
+            'crear_cert() ahora asigna bddat://certificados/{cert.id} tras el INSERT'
+        )


### PR DESCRIPTION
## Cambios

- Nueva tabla `certificados` con FK a `documentos`, `generado_en` y `datos` JSONB (migración `425_certificados`)
- Modelo `Certificado` en `app/models/certificados.py`, importado en `__init__.py`
- `_resolver_bddat()` completo para el recurso `certificados` (elimina `NotImplementedError`)
- `crear_cert()` inserta en `certificados` y asigna `bddat://certificados/{id}` como URL final; elimina `_URL_PLACEHOLDER`
- `_datos_plazo_vencido()` construye el JSONB con tarea_id, fecha_vencimiento, normativa, plazo y fecha de inicio de cómputo
- Nuevo servicio `app/services/cert_pdf.py`: genera PDF on-demand con reportlab para `CERT_PLAZO_CUMPLIDO`
- Ruta `GET /expedientes/cert/<cert_id>/pdf` en el blueprint `expedientes`
- ADR-006 enmendado: `certificados` pasa de stub a tabla activa; se documenta la ruta PDF y los tipos previstos
- Test `test_362` actualizado: sustituye aserción sobre `_URL_PLACEHOLDER` por verificación de su eliminación

Closes #425
