### PR TITLE
CB ContextoResolucion — escrito de resolución

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -87,6 +87,9 @@ from app.models.organismos_expediente import OrganismoExpediente
 # Interesados del expediente (#374 — depende de Expediente, Entidad, Documento)
 from app.models.interesados_expediente import InteresadoExpediente
 
+# Resolución de fase RESOLUCION (#403 — depende de Fase)
+from app.models.resolucion import Resolucion
+
 # Mapa semántico de documentos por tarea (#346 — sin FK operacional propia)
 from app.models.tramites_tareas_documentos import TramiteTareaDocumento
 
@@ -151,4 +154,6 @@ __all__ = [
     'Alegante',
     # Interesados del expediente
     'InteresadoExpediente',
+    # Resolución de fase RESOLUCION
+    'Resolucion',
 ]

--- a/app/models/resolucion.py
+++ b/app/models/resolucion.py
@@ -1,0 +1,84 @@
+from app import db
+
+
+class Resolucion(db.Model):
+    """
+    Contenido redaccional de la resolución de una fase RESOLUCION.
+
+    Un registro por fase. Almacena los cuatro bloques textuales que el técnico
+    redacta (con apoyo de las despensas #435 y #436) antes de generar el escrito.
+    Todos los campos son nullable: el registro puede existir vacío mientras se
+    redacta.
+
+    RELACIÓN CON FASE:
+        FK única a fases.id. Una fase RESOLUCION tiene como mucho una Resolucion.
+        Accesible desde Fase como fase.resolucion (uselist=False).
+
+    CAMPOS:
+        antecedentes  — Narración de hechos previos al acto. Puede construirse
+                        programáticamente vía consultas nombradas, pero este campo
+                        permite texto libre adicional o sustitutivo.
+        fundamentos   — Fundamentos jurídicos del acto. Compilable desde la
+                        despensa de fundamentos (#435).
+        resuelve      — Expresión verbal del sentido del acto. Margen de redacción
+                        para el técnico; no sistematizable automáticamente.
+        condicionado  — Condiciones impuestas. Compilable desde la despensa de
+                        condicionados (#436).
+    """
+    __tablename__ = 'resoluciones'
+    __table_args__ = (
+        db.UniqueConstraint('fase_id', name='uq_resoluciones_fase'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    fase_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.fases.id', name='fk_resoluciones_fase'),
+        nullable=False,
+        unique=True,
+        comment='FK fases. Una resolución por fase RESOLUCION.',
+    )
+
+    antecedentes = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Narración de antecedentes del expediente',
+    )
+
+    fundamentos = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Fundamentos jurídicos del acto (#435)',
+    )
+
+    resuelve = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Expresión verbal del sentido del acto',
+    )
+
+    condicionado = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Condicionado técnico de la autorización (#436)',
+    )
+
+    fase = db.relationship(
+        'Fase',
+        foreign_keys=[fase_id],
+        backref=db.backref('resolucion', uselist=False),
+    )
+
+    def __repr__(self):
+        return f'<Resolucion fase_id={self.fase_id}>'
+
+    def as_contexto_cb(self) -> dict:
+        """Fragmento de contexto para la plantilla de resolución."""
+        return {
+            'resolucion_antecedentes': self.antecedentes,
+            'resolucion_fundamentos':  self.fundamentos,
+            'resolucion_resuelve':     self.resuelve,
+            'resolucion_condicionado': self.condicionado,
+        }

--- a/app/services/context_builders/resolucion.py
+++ b/app/services/context_builders/resolucion.py
@@ -1,0 +1,53 @@
+from app.models.resolucion import Resolucion
+
+
+class ContextoResolucion:
+    """
+    Context Builder para escritos del trámite ELABORACION (fase RESOLUCION).
+
+    Enriquece el contexto base con el sentido del acto (desde Fase.resultado_fase)
+    y los cuatro bloques redaccionales de la tabla resoluciones.
+
+    Campos adicionales aportados:
+    - sentido_acto_codigo       str   Código del resultado: FAVORABLE, DESFAVORABLE…
+    - sentido_acto_nombre       str   Nombre legible del resultado de fase
+    - resolucion_antecedentes   str   Antecedentes del expediente (None si no redactado)
+    - resolucion_fundamentos    str   Fundamentos jurídicos (None si no redactado)
+    - resolucion_resuelve       str   Expresión verbal del sentido (None si no redactado)
+    - resolucion_condicionado   str   Condicionado técnico (None si no redactado)
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        fase = self._tarea.tramite.fase
+        if not fase:
+            return {}
+
+        resultado = fase.resultado_fase
+        if not resultado:
+            return {}
+
+        ctx = {
+            'sentido_acto_codigo': resultado.codigo,
+            'sentido_acto_nombre': resultado.nombre,
+        }
+
+        resolucion = fase.resolucion
+        if resolucion:
+            ctx.update(resolucion.as_contexto_cb())
+        else:
+            ctx.update({
+                'resolucion_antecedentes': None,
+                'resolucion_fundamentos':  None,
+                'resolucion_resuelve':     None,
+                'resolucion_condicionado': None,
+            })
+
+        return ctx

--- a/docs/referencia/GUIA_CONTEXT_BUILDERS.md
+++ b/docs/referencia/GUIA_CONTEXT_BUILDERS.md
@@ -147,6 +147,7 @@ que son accedidos directamente por `ContextoBaseExpediente`.
 | `ContextoRecepcionAlegacion` | `recepcion_alegacion.py` | `RECEPCION_ALEGACION` | Implementado | #393 |
 | `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Implementado | #394 |
 | `ContextoNotificacionOrganismo` | `notificacion_organismo.py` | `CONSULTA_TRASLADO_ORGANISMO` | Implementado | #402 |
+| `ContextoResolucion` | `resolucion.py` | `ELABORACION` (fase `RESOLUCION`) | Implementado | #403 |
 
 ---
 

--- a/migrations/versions/a6fef197271a_403_resolucion.py
+++ b/migrations/versions/a6fef197271a_403_resolucion.py
@@ -1,0 +1,60 @@
+"""403_resolucion
+
+Revision ID: 403_resolucion
+Revises: 402_notificacion_organismo
+Create Date: 2026-05-20
+
+Issue #403 — tabla resoluciones + seed plantilla RESOLUCION.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '403_resolucion'
+down_revision = '402_notificacion_organismo'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'resoluciones',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('fase_id', sa.Integer(), nullable=False,
+                  comment='FK fases. Una resolución por fase RESOLUCION.'),
+        sa.Column('antecedentes', sa.Text(), nullable=True,
+                  comment='Narración de antecedentes del expediente'),
+        sa.Column('fundamentos', sa.Text(), nullable=True,
+                  comment='Fundamentos jurídicos del acto (#435)'),
+        sa.Column('resuelve', sa.Text(), nullable=True,
+                  comment='Expresión verbal del sentido del acto'),
+        sa.Column('condicionado', sa.Text(), nullable=True,
+                  comment='Condicionado técnico de la autorización (#436)'),
+        sa.ForeignKeyConstraint(['fase_id'], ['public.fases.id'],
+                                name='fk_resoluciones_fase'),
+        sa.PrimaryKeyConstraint('id', name='pk_resoluciones'),
+        sa.UniqueConstraint('fase_id', name='uq_resoluciones_fase'),
+        schema='public',
+    )
+    op.execute("GRANT SELECT ON public.resoluciones TO claude_desktop")
+
+    # Seed plantilla RESOLUCION
+    # tipo_documento_id: se busca el id de RESOLUCION en tipos_documentos
+    op.execute("""
+        INSERT INTO public.plantillas
+            (codigo, nombre, descripcion, ruta_plantilla, contexto_clase,
+             tipo_documento_id, activo)
+        VALUES (
+            'RESOLUCION',
+            'Resolución',
+            'Escrito de resolución del expediente (favorable, condicionada o denegatoria)',
+            'escritos/resolucion.docx',
+            'ContextoResolucion',
+            (SELECT id FROM public.tipos_documentos WHERE codigo = 'RESOLUCION'),
+            TRUE
+        )
+    """)
+
+
+def downgrade():
+    op.execute("DELETE FROM public.plantillas WHERE codigo = 'RESOLUCION'")
+    op.drop_table('resoluciones', schema='public')

--- a/tests/test_403_resolucion.py
+++ b/tests/test_403_resolucion.py
@@ -1,0 +1,104 @@
+"""
+Tests issue #403 — ContextoResolucion.
+
+Bloque único: get_contexto() con stubs, sin BD ni app context.
+"""
+from unittest.mock import MagicMock
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _resultado_fase(codigo='FAVORABLE', nombre='Favorable'):
+    r = MagicMock()
+    r.codigo = codigo
+    r.nombre = nombre
+    return r
+
+
+def _fase(resultado=None, resolucion=None):
+    f = MagicMock()
+    f.resultado_fase = resultado
+    f.resolucion = resolucion
+    return f
+
+
+def _tramite(fase=None):
+    t = MagicMock()
+    t.fase = fase
+    return t
+
+
+def _tarea(tramite=None):
+    t = MagicMock()
+    t.tramite = tramite
+    return t
+
+
+def _resolucion_bd(antecedentes=None, fundamentos=None, resuelve=None, condicionado=None):
+    from app.models.resolucion import Resolucion
+    r = MagicMock(spec=Resolucion)
+    r.antecedentes = antecedentes
+    r.fundamentos = fundamentos
+    r.resuelve = resuelve
+    r.condicionado = condicionado
+    r.as_contexto_cb = lambda: Resolucion.as_contexto_cb(r)
+    return r
+
+
+def _cb(tarea):
+    from app.services.context_builders.resolucion import ContextoResolucion
+    return ContextoResolucion(MagicMock(), MagicMock(), tarea=tarea)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestContextoResolucion:
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.resolucion import ContextoResolucion
+        cb = ContextoResolucion(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_sin_resultado_fase_devuelve_vacio(self):
+        fase = _fase(resultado=None)
+        tarea = _tarea(_tramite(fase))
+        ctx = _cb(tarea).get_contexto()
+        assert ctx == {}
+
+    def test_sin_resolucion_bd_campos_none(self):
+        resultado = _resultado_fase('DESFAVORABLE', 'Desfavorable')
+        fase = _fase(resultado=resultado, resolucion=None)
+        tarea = _tarea(_tramite(fase))
+
+        ctx = _cb(tarea).get_contexto()
+
+        assert ctx['sentido_acto_codigo'] == 'DESFAVORABLE'
+        assert ctx['sentido_acto_nombre'] == 'Desfavorable'
+        assert ctx['resolucion_antecedentes'] is None
+        assert ctx['resolucion_fundamentos'] is None
+        assert ctx['resolucion_resuelve'] is None
+        assert ctx['resolucion_condicionado'] is None
+
+    def test_con_datos_completos(self):
+        resultado = _resultado_fase('FAVORABLE_CONDICIONADO', 'Favorable condicionado')
+        res_bd = _resolucion_bd(
+            antecedentes='Con fecha 01/01/2026 se presentó solicitud…',
+            fundamentos='Artículo 131 RD 1955/2000…',
+            resuelve='Conceder la autorización administrativa…',
+            condicionado='1. El promotor deberá…',
+        )
+        fase = _fase(resultado=resultado, resolucion=res_bd)
+        tarea = _tarea(_tramite(fase))
+
+        ctx = _cb(tarea).get_contexto()
+
+        assert ctx['sentido_acto_codigo'] == 'FAVORABLE_CONDICIONADO'
+        assert ctx['sentido_acto_nombre'] == 'Favorable condicionado'
+        assert ctx['resolucion_antecedentes'] == 'Con fecha 01/01/2026 se presentó solicitud…'
+        assert ctx['resolucion_fundamentos'] == 'Artículo 131 RD 1955/2000…'
+        assert ctx['resolucion_resuelve'] == 'Conceder la autorización administrativa…'
+        assert ctx['resolucion_condicionado'] == '1. El promotor deberá…'


### PR DESCRIPTION
## Cambios

- Nueva tabla `resoluciones` (1:1 con `Fase`): campos `antecedentes`, `fundamentos`, `resuelve`, `condicionado` (todos `text nullable`)
- Modelo `Resolucion` con `as_contexto_cb()` — sigue el patrón de `Diagnostico`
- CB `ContextoResolucion`: expone `sentido_acto_codigo`/`sentido_acto_nombre` desde `Fase.resultado_fase` y los cuatro campos de `resoluciones`
- Migración `403_resolucion`: CREATE TABLE + GRANT + seed plantilla `RESOLUCION` en `plantillas`
- 4 tests sin BD: sin tarea, sin resultado_fase, sin registro Resolucion, caso completo
- `GUIA_CONTEXT_BUILDERS.md` actualizada con la nueva entrada

Closes #403
