### PR TITLE
Añadir catálogo de requerimientos y tabla de requerimientos por tarea

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -26,6 +26,9 @@ from app.models.tipos_documentos import TipoDocumento
 from app.models.consultas_nombradas import ConsultaNombrada
 from app.models.plantillas import Plantilla
 
+# Catálogo de requerimientos de subsanación (#405 — sin FK operacionales)
+from app.models.catalogo_requerimientos import CatalogoRequerimiento
+
 # Modelo de metadata del sistema (issue #85)
 from app.models.tabla_metadata import TablaMetadata
 
@@ -93,6 +96,9 @@ from app.models.resolucion import Resolucion
 # Anuncio de información pública (#404 — depende de Fase)
 from app.models.informacion_publica import InformacionPublica
 
+# Requerimientos de tarea ANALIZAR (#405 — depende de Tarea y CatalogoRequerimiento)
+from app.models.requerimientos_tarea import RequerimientoTarea
+
 # Mapa semántico de documentos por tarea (#346 — sin FK operacional propia)
 from app.models.tramites_tareas_documentos import TramiteTareaDocumento
 
@@ -113,6 +119,8 @@ __all__ = [
     'TipoDocumento',
     'ConsultaNombrada',
     'Plantilla',
+    # Catálogo de requerimientos
+    'CatalogoRequerimiento',
     # Metadata del sistema
     'TablaMetadata',
     # Arquitectura Entidades (simplificada en issue #103)
@@ -161,4 +169,6 @@ __all__ = [
     'Resolucion',
     # Anuncio de información pública
     'InformacionPublica',
+    # Requerimientos de tarea ANALIZAR
+    'RequerimientoTarea',
 ]

--- a/app/models/catalogo_requerimientos.py
+++ b/app/models/catalogo_requerimientos.py
@@ -1,0 +1,73 @@
+from app import db
+
+
+class CatalogoRequerimiento(db.Model):
+    """
+    Catálogo de defectos tipo reutilizables en la tarea ANALIZAR.
+
+    Cada fila representa un defecto habitual en expedientes AT (falta de
+    documento, deficiencia técnica, tasas incorrectas, etc.) que el técnico
+    puede seleccionar en lugar de redactarlo desde cero. Garantiza imagen
+    homogénea de la administración.
+
+    Texto puede incluir huecos {placeholder} para completar en cada uso.
+    Los defectos archivados (activo=False) no aparecen en el selector pero
+    se conservan para no romper registros históricos en requerimientos_tarea.
+
+    CATEGORÍAS (categoria):
+        documental    — documentos faltantes o incompletos
+        tecnica       — deficiencias de contenido del proyecto
+        administrativa — requisitos formales del procedimiento
+        tasas          — defectos relacionados con la tasa
+
+    RELACIONES:
+        usos ← REQUERIMIENTOS_TAREA (todas las veces que se ha seleccionado)
+    """
+    __tablename__ = 'catalogo_requerimientos'
+    __table_args__ = (
+        db.CheckConstraint(
+            "categoria IN ('documental', 'tecnica', 'administrativa', 'tasas')",
+            name='ck_catalogo_requerimientos_categoria'
+        ),
+        db.Index('idx_catalogo_requerimientos_categoria', 'categoria'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    texto = db.Column(
+        db.Text,
+        nullable=False,
+        comment='Texto del defecto. Puede contener huecos {placeholder} para completar'
+    )
+
+    categoria = db.Column(
+        db.String(20),
+        nullable=False,
+        comment='Categoría: documental | tecnica | administrativa | tasas'
+    )
+
+    activo = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        comment='False = archivado; no aparece en el selector pero conserva historial'
+    )
+
+    # Relaciones
+    usos = db.relationship(
+        'RequerimientoTarea',
+        back_populates='catalogo_requerimiento',
+        lazy='dynamic',
+    )
+
+    def __repr__(self):
+        return f'<CatalogoRequerimiento id={self.id} categoria={self.categoria}>'
+
+    def __str__(self):
+        return self.texto[:60] + ('…' if len(self.texto) > 60 else '')

--- a/app/models/requerimientos_tarea.py
+++ b/app/models/requerimientos_tarea.py
@@ -1,0 +1,109 @@
+from app import db
+
+
+class RequerimientoTarea(db.Model):
+    """
+    Defectos detectados en una tarea ANALIZAR, para el escrito de subsanación.
+
+    Cada fila representa un requerimiento concreto que el técnico añade a la
+    tarea ANALIZAR de ANÁLISIS_DOCUMENTAL o REQUERIMIENTO_SUBSANACIÓN. La
+    lista ordenada alimenta el context builder de ContextoSubsanacion, que la
+    inyecta en la plantilla del escrito.
+
+    ORIGEN DEL TEXTO (exactamente uno de los dos campos tiene valor):
+        catalogo_requerimientos_id — defecto del catálogo reutilizable (#405)
+        texto_libre                — redacción manual del técnico
+
+    El campo `texto` (property) abstrae el origen y devuelve siempre el texto
+    efectivo, listo para renderizar en la plantilla ({{ r.texto }}).
+
+    CAMPO ORDEN:
+        Posición 1-based en el listado final. El técnico puede reordenar los
+        ítems en el selector shuttle; el backend persiste el orden resultante.
+
+    RELACIONES:
+        tarea               → TAREAS.id (FK CASCADE, tarea ANALIZAR contenedora)
+        catalogo_requerimiento → CATALOGO_REQUERIMIENTOS.id (FK, nullable)
+
+    REGLAS DE NEGOCIO:
+        - Exactamente uno de catalogo_requerimientos_id o texto_libre ≠ NULL
+          (garantizado por CHECK constraint en la BD).
+        - Solo tareas de tipo ANALIZAR deberían tener filas asociadas
+          (responsabilidad de la capa de servicio, no de FK).
+    """
+    __tablename__ = 'requerimientos_tarea'
+    __table_args__ = (
+        db.CheckConstraint(
+            "(catalogo_requerimientos_id IS NOT NULL AND texto_libre IS NULL) OR "
+            "(catalogo_requerimientos_id IS NULL AND texto_libre IS NOT NULL)",
+            name='ck_requerimientos_tarea_exactamente_uno'
+        ),
+        db.Index('idx_requerimientos_tarea_tarea', 'tarea_id'),
+        db.Index('idx_requerimientos_tarea_catalogo', 'catalogo_requerimientos_id'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    tarea_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tareas.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a TAREAS. Tarea ANALIZAR a la que pertenece este requerimiento'
+    )
+
+    catalogo_requerimientos_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.catalogo_requerimientos.id'),
+        nullable=True,
+        comment='FK a CATALOGO_REQUERIMIENTOS. NULL si el origen es texto libre'
+    )
+
+    texto_libre = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Texto redactado manualmente. NULL si el origen es el catálogo'
+    )
+
+    orden = db.Column(
+        db.Integer,
+        nullable=False,
+        comment='Posición 1-based en el listado del escrito'
+    )
+
+    # Relaciones
+    tarea = db.relationship(
+        'Tarea',
+        backref=db.backref(
+            'requerimientos',
+            order_by='RequerimientoTarea.orden',
+            cascade='all, delete-orphan',
+        ),
+    )
+    catalogo_requerimiento = db.relationship(
+        'CatalogoRequerimiento',
+        back_populates='usos',
+    )
+
+    # --- Accesores ---
+
+    @property
+    def texto(self):
+        """Texto efectivo: del catálogo o texto libre, listo para la plantilla."""
+        if self.catalogo_requerimiento is not None:
+            return self.catalogo_requerimiento.texto
+        return self.texto_libre
+
+    @property
+    def desde_catalogo(self):
+        """True si el origen es el catálogo; False si es texto libre."""
+        return self.catalogo_requerimientos_id is not None
+
+    def __repr__(self):
+        origen = f'cat={self.catalogo_requerimientos_id}' if self.desde_catalogo else 'libre'
+        return f'<RequerimientoTarea id={self.id} tarea={self.tarea_id} orden={self.orden} [{origen}]>'

--- a/migrations/versions/405_catalogo_requerimientos.py
+++ b/migrations/versions/405_catalogo_requerimientos.py
@@ -1,0 +1,73 @@
+"""405_catalogo_requerimientos
+
+Revision ID: 405_catalogo_requerimientos
+Revises: 404_informacion_publica
+Create Date: 2026-05-20
+
+Issue #405 — tablas catalogo_requerimientos y requerimientos_tarea.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '405_catalogo_requerimientos'
+down_revision = '404_informacion_publica'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'catalogo_requerimientos',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('texto', sa.Text(), nullable=False,
+                  comment='Texto del defecto. Puede contener huecos {placeholder}'),
+        sa.Column('categoria', sa.String(20), nullable=False,
+                  comment='Categoría: documental | tecnica | administrativa | tasas'),
+        sa.Column('activo', sa.Boolean(), nullable=False, server_default='true',
+                  comment='False = archivado; no aparece en el selector'),
+        sa.CheckConstraint(
+            "categoria IN ('documental', 'tecnica', 'administrativa', 'tasas')",
+            name='ck_catalogo_requerimientos_categoria'
+        ),
+        sa.PrimaryKeyConstraint('id', name='pk_catalogo_requerimientos'),
+        schema='public',
+    )
+    op.create_index('idx_catalogo_requerimientos_categoria',
+                    'catalogo_requerimientos', ['categoria'], schema='public')
+    op.execute("GRANT SELECT ON public.catalogo_requerimientos TO claude_desktop")
+
+    op.create_table(
+        'requerimientos_tarea',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('tarea_id', sa.Integer(), nullable=False,
+                  comment='FK tareas. Tarea ANALIZAR contenedora'),
+        sa.Column('catalogo_requerimientos_id', sa.Integer(), nullable=True,
+                  comment='FK catalogo_requerimientos. NULL si origen es texto libre'),
+        sa.Column('texto_libre', sa.Text(), nullable=True,
+                  comment='Texto manual. NULL si origen es catálogo'),
+        sa.Column('orden', sa.Integer(), nullable=False,
+                  comment='Posición 1-based en el listado del escrito'),
+        sa.CheckConstraint(
+            "(catalogo_requerimientos_id IS NOT NULL AND texto_libre IS NULL) OR "
+            "(catalogo_requerimientos_id IS NULL AND texto_libre IS NOT NULL)",
+            name='ck_requerimientos_tarea_exactamente_uno'
+        ),
+        sa.ForeignKeyConstraint(['tarea_id'], ['public.tareas.id'],
+                                name='fk_requerimientos_tarea_tarea',
+                                ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['catalogo_requerimientos_id'],
+                                ['public.catalogo_requerimientos.id'],
+                                name='fk_requerimientos_tarea_catalogo'),
+        sa.PrimaryKeyConstraint('id', name='pk_requerimientos_tarea'),
+        schema='public',
+    )
+    op.create_index('idx_requerimientos_tarea_tarea',
+                    'requerimientos_tarea', ['tarea_id'], schema='public')
+    op.create_index('idx_requerimientos_tarea_catalogo',
+                    'requerimientos_tarea', ['catalogo_requerimientos_id'], schema='public')
+    op.execute("GRANT SELECT ON public.requerimientos_tarea TO claude_desktop")
+
+
+def downgrade():
+    op.drop_table('requerimientos_tarea', schema='public')
+    op.drop_table('catalogo_requerimientos', schema='public')

--- a/tests/test_405_requerimientos_tarea.py
+++ b/tests/test_405_requerimientos_tarea.py
@@ -1,0 +1,132 @@
+"""
+Tests issue #405 — CatalogoRequerimiento y RequerimientoTarea.
+
+Sin BD ni app context. Valida lógica de modelos con stubs.
+"""
+from unittest.mock import MagicMock
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _catalogo(texto='Falta memoria de cálculo', categoria='tecnica', activo=True):
+    from app.models.catalogo_requerimientos import CatalogoRequerimiento
+    cat = MagicMock(spec=CatalogoRequerimiento)
+    cat.texto = texto
+    cat.categoria = categoria
+    cat.activo = activo
+    return cat
+
+
+def _req_desde_catalogo(cat, orden=1):
+    from app.models.requerimientos_tarea import RequerimientoTarea
+    r = MagicMock(spec=RequerimientoTarea)
+    r.catalogo_requerimientos_id = 1
+    r.catalogo_requerimiento = cat
+    r.texto_libre = None
+    r.orden = orden
+    r.texto = RequerimientoTarea.texto.fget(r)
+    r.desde_catalogo = RequerimientoTarea.desde_catalogo.fget(r)
+    return r
+
+
+def _req_texto_libre(texto='Falta el visado colegial en el proyecto', orden=1):
+    from app.models.requerimientos_tarea import RequerimientoTarea
+    r = MagicMock(spec=RequerimientoTarea)
+    r.catalogo_requerimientos_id = None
+    r.catalogo_requerimiento = None
+    r.texto_libre = texto
+    r.orden = orden
+    r.texto = RequerimientoTarea.texto.fget(r)
+    r.desde_catalogo = RequerimientoTarea.desde_catalogo.fget(r)
+    return r
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CatalogoRequerimiento
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCatalogoRequerimiento:
+
+    def test_str_trunca_a_60(self):
+        from app.models.catalogo_requerimientos import CatalogoRequerimiento
+        cat = CatalogoRequerimiento()
+        cat.texto = 'a' * 80
+        assert str(cat) == 'a' * 60 + '…'
+
+    def test_str_sin_truncar(self):
+        from app.models.catalogo_requerimientos import CatalogoRequerimiento
+        cat = CatalogoRequerimiento()
+        cat.texto = 'Texto corto'
+        assert str(cat) == 'Texto corto'
+
+    def test_repr(self):
+        from app.models.catalogo_requerimientos import CatalogoRequerimiento
+        cat = CatalogoRequerimiento()
+        cat.id = 7
+        cat.categoria = 'documental'
+        assert 'id=7' in repr(cat)
+        assert 'documental' in repr(cat)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RequerimientoTarea — propiedad texto
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestRequerimientoTareaTexto:
+
+    def test_texto_desde_catalogo(self):
+        cat = _catalogo(texto='Falta memoria de cálculo')
+        r = _req_desde_catalogo(cat)
+        assert r.texto == 'Falta memoria de cálculo'
+
+    def test_texto_libre(self):
+        r = _req_texto_libre(texto='Falta el visado colegial en el proyecto')
+        assert r.texto == 'Falta el visado colegial en el proyecto'
+
+    def test_texto_catalogo_ignora_texto_libre(self):
+        """El catálogo tiene precedencia (texto_libre debería ser NULL por constraint)."""
+        from app.models.requerimientos_tarea import RequerimientoTarea
+        r = MagicMock(spec=RequerimientoTarea)
+        r.catalogo_requerimiento = _catalogo(texto='Texto del catálogo')
+        r.catalogo_requerimientos_id = 1
+        r.texto_libre = None
+        assert RequerimientoTarea.texto.fget(r) == 'Texto del catálogo'
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RequerimientoTarea — propiedad desde_catalogo
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestRequerimientoTareaOrigen:
+
+    def test_desde_catalogo_true(self):
+        cat = _catalogo()
+        r = _req_desde_catalogo(cat)
+        assert r.desde_catalogo is True
+
+    def test_desde_catalogo_false_para_texto_libre(self):
+        r = _req_texto_libre()
+        assert r.desde_catalogo is False
+
+    def test_repr_catalogo(self):
+        from app.models.requerimientos_tarea import RequerimientoTarea
+        r = RequerimientoTarea()
+        r.id = 3
+        r.tarea_id = 10
+        r.catalogo_requerimientos_id = 5
+        r.texto_libre = None
+        r.orden = 2
+        assert 'cat=5' in repr(r)
+        assert 'orden=2' in repr(r)
+
+    def test_repr_libre(self):
+        from app.models.requerimientos_tarea import RequerimientoTarea
+        r = RequerimientoTarea()
+        r.id = 4
+        r.tarea_id = 10
+        r.catalogo_requerimientos_id = None
+        r.texto_libre = 'Texto manual'
+        r.orden = 1
+        assert 'libre' in repr(r)


### PR DESCRIPTION
## Cambios

- Modelo `CatalogoRequerimiento` — tabla maestra de defectos tipo reutilizables en la tarea ANALIZAR, con campo `texto`, `categoria` (documental/tecnica/administrativa/tasas) y `activo`.
- Modelo `RequerimientoTarea` — enriquecimiento de tareas ANALIZAR; FK a `tareas` (CASCADE) y a `catalogo_requerimientos` (nullable); campo `texto_libre` (nullable); CHECK constraint que garantiza exactamente uno de los dos orígenes de texto; property `texto` que abstrae el origen para las plantillas.
- Migración `405_catalogo_requerimientos` — crea ambas tablas con índices, constraints y GRANT al usuario MCP de desarrollo.
- 10 tests sin BD con MagicMock (modelos, properties `texto` y `desde_catalogo`, repr).

Closes #405
