### PR TITLE
Limpiar referencias a tareas obsoletas v6.0 en seed y guía

### DIFF
--- a/docs/guias/GUIA_GENERAL.md
+++ b/docs/guias/GUIA_GENERAL.md
@@ -429,7 +429,7 @@ Tras la revisión detallada de los tipos de trámites en uno de los diagramas de
 
 Estos 3 datos diferenciales (secuencia, actores y documentos) se deberían poder deducir de la combinación `TIPO_TRAMITE` y de la tarea en si, así como de las reglas de negocio.
 
-Por ejemplo, del trámite `ANUNCIO_BOP` se debería deducir que la secuencia es del tipo `REDACTAR→FIRMA→NOTIFICAR→PUBLICAR→ESPERAR`, que las tareas `REDACTAR` y `FIRMA` los documentos son el anuncio y el oficio que lo acompaña, que la tarea `NOTIFICAR` es al titular y a la Diputación encargada del BOP y que la tarea `ESPERAR` es el transcurso de tiempo.
+Por ejemplo, del trámite `ANUNCIO_BOP` se debería deducir que la secuencia es del tipo `ELABORAR → NOTIFICAR → ESPERAR_PLAZO × 2`, que la tarea `ELABORAR` produce el anuncio y el oficio que lo acompaña, que la tarea `NOTIFICAR` es al titular y a la Diputación encargada del BOP y que las dos tareas `ESPERAR_PLAZO` son el plazo de publicación en BOP y el plazo de exposición pública.
 
 Es por esto que un trámite es solo un **contenedor temporal y organizativo de tareas** dentro de una fase.
 
@@ -462,7 +462,7 @@ La tarea es la unidad de trabajo registrable con entrada de documento y salida d
 - **Un documento, un productor:** Un documento solo puede ser producido por una tarea (índice único)
 - **Un documento, múltiples consumidores:** Varias tareas pueden usar el mismo documento de entrada
 
-Tras la revisión de las fases, trámites y tareas se concluye que solo hay **7 tipos de tareas**: `INCORPORAR`, `ANALISIS`, `REDACTAR`, `FIRMAR`, `NOTIFICAR`, `PUBLICAR` y `ESPERARPLAZO`.
+Tras la revisión de las fases, trámites y tareas se concluye que solo hay **4 tipos de tareas**: `ANALIZAR`, `ELABORAR`, `NOTIFICAR` y `ESPERAR_PLAZO`.
 
 La tarea tiene claves foráneas hacia documentos (documento usado y documento producido). Pueden ser nulas pero son sometidas a las comprobaciones de las reglas de negocio.
 

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -244,10 +244,8 @@ with app.app_context():
 
     # --- Atajos tareas ---
     TAREA_ANAL = TTAREA.get('ANALIZAR') or TTAREA.get('ANALISIS')
-    TAREA_RED  = TTAREA['REDACTAR']
-    TAREA_FIR  = TTAREA['FIRMAR']
+    TAREA_ELAB = TTAREA['ELABORAR']
     TAREA_NOT  = TTAREA['NOTIFICAR']
-    TAREA_PUB  = TTAREA['PUBLICAR']
     TAREA_ESP  = TTAREA['ESPERAR_PLAZO']
 
     # Modo aditivo — no se borra nada
@@ -394,8 +392,8 @@ with app.app_context():
         t01 = crear_tramite(f01, TT_ANAL)
         crear_tarea(t01, TAREA_ANAL, doc_usado=sol01_entrada)
         t01b = crear_tramite(f01, TT_REQ)
-        crear_tarea(t01b, TAREA_RED, doc_usado=sol01_mem)
-        print('AT-2001 OK — Renovable, AAP+AAC, fase SOL pendiente redactar req.')
+        crear_tarea(t01b, TAREA_ELAB, doc_usado=sol01_mem)
+        print('AT-2001 OK — Renovable, AAP+AAC, fase SOL pendiente elaborar req.')
     else:
         print('AT-2001 ya existe — omitido')
 
@@ -461,8 +459,8 @@ with app.app_context():
         fase_fin(sol03, TF_MA, TRES_FAV)
         f03_ip = crear_fase(sol03, TF_IP)
         t03_bop = crear_tramite(f03_ip, TT_BOP)
-        crear_tarea(t03_bop, TAREA_PUB, doc_usado=sol03_anuncio)
-        print('AT-2003 OK — Eólico, AAP+AAC+DUP+AAE, IP pendiente publicar BOP')
+        crear_tarea(t03_bop, TAREA_NOT, doc_usado=sol03_anuncio)
+        print('AT-2003 OK — Eólico, AAP+AAC+DUP+AAE, IP pendiente notificar BOP')
     else:
         print('AT-2003 ya existe — omitido')
 
@@ -577,8 +575,8 @@ with app.app_context():
         t07a = crear_tramite(f07, TT_ANAL)
         crear_tarea(t07a, TAREA_ANAL, doc_usado=sol07_sol)
         t07b = crear_tramite(f07, TT_REQ)
-        crear_tarea(t07b, TAREA_FIR, doc_usado=sol07_req)
-        print('AT-2007 OK — Distribución cedida Sevillana, AAC, SOL pendiente firma req.')
+        crear_tarea(t07b, TAREA_ELAB, doc_usado=sol07_req)
+        print('AT-2007 OK — Distribución cedida Sevillana, AAC, SOL pendiente elaborar req.')
     else:
         print('AT-2007 ya existe — omitido')
 


### PR DESCRIPTION
## Cambios

- `scripts/seed_demo.py`: elimina los atajos `TAREA_RED`, `TAREA_FIR` y `TAREA_PUB` (tipos `REDACTAR`, `FIRMAR`, `PUBLICAR` inexistentes → `KeyError` al ejecutar el script) y sustituye sus tres usos por `TAREA_ELAB` (`ELABORAR`) o `TAREA_NOT` (`NOTIFICAR`) según corresponde al catálogo actual de 4 tareas atómicas.
- `docs/guias/GUIA_GENERAL.md`: actualiza la sección «La Tarea y sus Tipos» — catálogo de 7 tipos obsoletos → 4 tipos actuales (`ANALIZAR`, `ELABORAR`, `NOTIFICAR`, `ESPERAR_PLAZO`) y corrige el ejemplo de secuencia de `ANUNCIO_BOP` (`REDACTAR→FIRMA→NOTIFICAR→PUBLICAR→ESPERAR` → `ELABORAR → NOTIFICAR → ESPERAR_PLAZO × 2`).

Closes #417
