### PR TITLE
#449 fix GRANT SELECT olvidado en organismos_expediente

### DIFF
--- a/migrations/versions/449_grant_organismos_expediente.py
+++ b/migrations/versions/449_grant_organismos_expediente.py
@@ -1,0 +1,36 @@
+"""449_grant_organismos_expediente
+
+Revision ID: 449_grant_organismos_expediente
+Revises: 405_catalogo_requerimientos
+Create Date: 2026-05-22
+
+Issue #449 — Fix de la migración 391_organismos_expediente.py, que olvidó
+otorgar GRANT SELECT al rol claude_desktop sobre la tabla recién creada.
+
+Es la única tabla del proyecto sin ese GRANT; el resto de migraciones
+equivalentes (392, 393, 402, 403, 418, 420, 425, …) sí lo incluyen.
+
+Consecuencia previa al fix:
+- El rol claude_desktop no puede leer organismos_expediente.
+- La consulta nombrada `organismos_consulta` (seed #395) queda inutilizable
+  desde claude_desktop / MCP postgres.
+- Auditorías vía claude_desktop dan falsos negativos sobre la existencia
+  de la tabla.
+
+Detectado en auditoría exhaustiva de migraciones, 22 mayo 2026.
+"""
+from alembic import op
+
+
+revision = '449_grant_organismos_expediente'
+down_revision = '405_catalogo_requerimientos'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("GRANT SELECT ON public.organismos_expediente TO claude_desktop")
+
+
+def downgrade():
+    op.execute("REVOKE SELECT ON public.organismos_expediente FROM claude_desktop")


### PR DESCRIPTION
## Resumen

- Nueva migración `449_grant_organismos_expediente.py` que ejecuta el `GRANT SELECT ON public.organismos_expediente TO claude_desktop` que la migración `391_organismos_expediente.py` olvidó.
- Era la única tabla del proyecto sin ese GRANT.

## Verificación post-migración

```sql
SELECT c.relname AS tabla_sin_grant
FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
WHERE n.nspname='public' AND c.relkind='r' AND c.relname NOT LIKE 'pg_%'
  AND NOT has_table_privilege('claude_desktop', n.nspname||'.'||c.relname, 'SELECT');
-- → 0 filas
```

`has_table_privilege('claude_desktop', 'public.organismos_expediente', 'SELECT')` = TRUE.

`alembic_version` = `449_grant_organismos_expediente` (head única).

## Test plan

- [x] Migración aplica sin error
- [x] `claude_desktop` lee `organismos_expediente`
- [x] No queda ninguna tabla `public.*` sin GRANT SELECT a `claude_desktop`
- [x] Downgrade definido (REVOKE)

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)