### PR TITLE
#448 HOTFIX seed catalogo_plazos para fase RESOLUCION (rediseño con condiciones_plazo)

### DIFF
--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -90,6 +90,22 @@ def _(ctx) -> str | None:
     return tipo.codigo if tipo else None
 
 
+@variable('tipo_solicitud')
+def _(ctx) -> str | None:
+    """
+    Siglas (literal, sin descomponer) del tipo de solicitud en contexto.
+
+    Devuelve 'AAP', 'AAC', 'AAP+AAC', 'AAP+AAC+DUP', 'CIERRE'… exactamente como
+    están en tipos_solicitudes.siglas. Las condiciones de `catalogo_plazos`
+    usan operador IN con el array de combinaciones cubiertas por una misma
+    cita normativa (ver seed 448_seed_plazos_resolucion).
+    """
+    solicitud = ctx.solicitud
+    if solicitud is None or solicitud.tipo_solicitud is None:
+        return None
+    return solicitud.tipo_solicitud.siglas
+
+
 @variable('es_solicitud_aac_pura')
 def _(ctx) -> bool:
     """

--- a/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
+++ b/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
@@ -711,16 +711,24 @@ Estos valores son el seed del `catalogo_plazos` para las fases y trámites del p
 
 > **Nota 2026-04-19:** Las entradas que usan `campo_inicio = fecha_inicio` o `campo_inicio = fecha_solicitud (solicitud)` requieren reconceptualización conforme al rediseño de `campo_fecha` (§3.2). `fecha_solicitud` desaparece del modelo `Solicitud`; pasa a `Documento.fecha_administrativa` del doc de solicitud (`{"fk": "documento_solicitud_id"}`). `fecha_inicio` de Fase/Trámite tampoco existe: la referencia de inicio pasa al Documento navegable desde el elemento. **Marcar como PENDIENTE DE REDISEÑO `campo_fecha`** hasta confirmar el documento fuente en cada caso.
 
-| Tipo elemento ID | Campo inicio cómputo | Valor | Unidad | Efecto vencimiento | Norma origen |
+> **Nota 2026-05-22 (hotfix #448):** Los identificadores `RESOLUCION_AAP`, `RESOLUCION_AAC`, `RESOLUCION_AE_*`, `RESOLUCION_TRANSMISION`, `RESOLUCION_CIERRE`, `RESOLUCION_DUP` de la tabla siguiente son **etiquetas conceptuales** de cada plazo — **no códigos de `tipos_fases`**. En BD existe un único `tipos_fases.codigo = 'RESOLUCION'` (id=8). Los 7 plazos se modelan como 7 filas en `catalogo_plazos` con `tipo_elemento_codigo = 'RESOLUCION'`, diferenciadas por una condición en `condiciones_plazo` que usa la variable `tipo_solicitud` (texto, siglas literal) con operador `IN` enumerando las combinaciones cubiertas por la misma cita normativa. El seed real está en la migración `448_seed_plazos_resolucion`.
+
+| Etiqueta conceptual | `tipo_solicitud IN` (condición) | Valor | Unidad | Efecto vencimiento | Norma origen |
 |---|---|---|---|---|---|
-| RESOLUCION_AAP | `{"fk":"documento_solicitud_id"}` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 128 RD 1955/2000 |
-| RESOLUCION_AAC | `{"fk":"documento_solicitud_id"}` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 131.7 RD 1955/2000 |
-| RESOLUCION_AE (transporte/distribución) | `{"fk":"documento_solicitud_id"}` | 1 | MESES | SILENCIO_DESESTIMATORIO | Art. 132 RD 1955/2000 + DA 3ª LSE |
-| RESOLUCION_AE_PROVISIONAL (generación) | `{"fk":"documento_solicitud_id"}` | 1 | MESES | SILENCIO_DESESTIMATORIO | Art. 132 bis RD 1955/2000 + DA 3ª LSE |
-| RESOLUCION_AE_DEFINITIVA (generación) | `{"fk":"documento_solicitud_id"}` | 1 | MESES | SILENCIO_DESESTIMATORIO | Art. 132 ter RD 1955/2000 + DA 3ª LSE |
-| RESOLUCION_TRANSMISION | `{"fk":"documento_solicitud_id"}` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 133 RD 1955/2000 |
-| RESOLUCION_CIERRE | `{"fk":"documento_solicitud_id"}` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 138 RD 1955/2000 (mod. RD 88/2026) |
+| RESOLUCION_AE_PROVISIONAL | `['AE_PROVISIONAL']` | 1 | MESES | SILENCIO_DESESTIMATORIO | Art. 132 bis RD 1955/2000 + DA 3ª LSE |
+| RESOLUCION_AE_DEFINITIVA | `['AE_DEFINITIVA','AE_DEFINITIVA+AAT']` | 1 | MESES | SILENCIO_DESESTIMATORIO | Art. 132 ter RD 1955/2000 + DA 3ª LSE |
+| RESOLUCION_AAP | `['AAP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 128 RD 1955/2000 |
+| RESOLUCION_AAC | `['AAC','AAP+AAC','AAP+AAC+DUP','AAC+DUP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 131.7 RD 1955/2000 |
+| RESOLUCION_TRANSMISION | `['AAT']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 133 RD 1955/2000 |
+| RESOLUCION_CIERRE | `['CIERRE']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 138 RD 1955/2000 (mod. RD 88/2026) |
+| RESOLUCION_DUP | `['DUP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 145.4 RD 1955/2000 |
 | INFORMACION_PUBLICA | **[PENDIENTE REDISEÑO campo_fecha]** | 30 | DIAS_NATURALES | SIN_EFECTO_AUTOMATICO | Art. 125 RD 1955/2000 |
+
+`campo_fecha` para todas las filas RESOLUCION_*: `{"fk": "documento_solicitud_id"}`.
+
+**Diferencias respecto al seed previo (172, código muerto):** descartado `RESOLUCION_AE` (sin sufijo — no existe ese tipo_solicitud); añadido `RESOLUCION_DUP` (procedimiento DUP autónomo, ausente del 172); CIERRE corregido (art. 137 → art. 138, mod. RD 88/2026); combinadas con AAC (`AAP+AAC`, `AAP+AAC+DUP`, `AAC+DUP`) consolidadas en la fila AAC porque art. 131.7 fija el plazo conjunto; `AE_DEFINITIVA+AAT` consume el plazo de AE_DEFINITIVA.
+
+**Fuera de scope del hotfix (deuda de #247):** plazos de RESOLUCION para `RAIPEE_PREVIA`, `RAIPEE_DEFINITIVA`, `RADNE`, `AMPLIACION_PLAZO`, `CORRECCION_ERRORES`, `DESISTIMIENTO`, `RENUNCIA`, `RECURSO`, `INTERESADO`, `OTRO`.
 
 > **Nota INFORMACION_PUBLICA:** trámite condicional. Suprimido bajo Decreto 9/2011 DA 1ª (AT 3ª categoría ≤ 30 kV, línea subterránea o CT interior, suelo urbano/urbanizable, sin DUP) y bajo DL 26/2021 DF 4ª (cualquier instalación del Título VII sin DUP y sin AAU). Ver `NORMATIVA_EXCEPCIONES_AT.md §3.1` y `§4.1`.
 

--- a/migrations/versions/448_seed_plazos_resolucion.py
+++ b/migrations/versions/448_seed_plazos_resolucion.py
@@ -1,0 +1,175 @@
+"""448_seed_plazos_resolucion
+
+Revision ID: 448_seed_plazos_resolucion
+Revises: 449_grant_organismos_expediente
+Create Date: 2026-05-22
+
+Issue #448 — HOTFIX del seed `catalogo_plazos` para la fase RESOLUCION.
+
+CONTEXTO DEL BUG
+================
+
+La migración `c9379e09ae01_172_plazos_tablas_catalogo.py` (mayo 2026) intentó
+seedar 7 plazos para la fase RESOLUCION pero el JOIN final con `tipos_fases`
+usaba códigos compuestos (`RESOLUCION_AAP`, `RESOLUCION_AAC`, …) que **nunca
+han existido** en BD — `tipos_fases` solo contiene el código genérico
+`RESOLUCION`. El INSERT-SELECT devolvió 0 filas sin producir error y dejó
+`catalogo_plazos` sin ningún plazo para la fase RESOLUCION.
+
+Detalle en auditoría exhaustiva del 22/05/2026 y en el cuerpo del issue #448.
+
+DISEÑO DEL FIX
+==============
+
+Modelado correcto:
+  - Un único `tipos_fases.codigo='RESOLUCION'` (ya existe, id=8)
+  - 7 entradas en `catalogo_plazos` con `tipo_elemento_codigo='RESOLUCION'`
+  - Cada entrada cita una norma distinta del RD 1955/2000 (o derivadas)
+  - Las condiciones diferencian por `tipo_solicitud` usando operador IN
+
+Nueva variable `tipo_solicitud` (texto): devuelve la siglas literal del
+tipo de solicitud en contexto (ej. 'AAP', 'AAP+AAC', 'CIERRE'). Las
+condiciones de cada plazo enumeran con IN las combinaciones cubiertas
+por la misma cita normativa.
+
+Diferencias respecto al seed original (172):
+  - Descartado `RESOLUCION_AE` (sin sufijo): no existe ese tipo_solicitud
+    en BD (solo AE_PROVISIONAL y AE_DEFINITIVA).
+  - Añadido DUP (3 meses, art. 145.4 RD 1955/2000): el procedimiento DUP
+    autónomo no estaba en el seed 172.
+  - Corregido CIERRE: art. 137 → art. 138 RD 1955/2000 (mod. RD 88/2026).
+    Art. 137 corresponde al informe del operador, no a la resolución.
+  - AAC consolida sus combinadas en una sola entrada (art. 131.7 fija el
+    plazo conjunto): `IN ('AAC','AAP+AAC','AAP+AAC+DUP','AAC+DUP')`.
+  - AE_DEFINITIVA+AAT consume el plazo del AE_DEFINITIVA (art. 132 ter).
+
+Fuera de scope del hotfix (deuda de #247): plazos de RESOLUCION para
+RAIPEE_PREVIA, RAIPEE_DEFINITIVA, RADNE, AMPLIACION_PLAZO, CORRECCION_ERRORES,
+DESISTIMIENTO, RENUNCIA, RECURSO, INTERESADO, OTRO.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '448_seed_plazos_resolucion'
+down_revision = '449_grant_organismos_expediente'
+branch_labels = None
+depends_on = None
+
+
+# (orden, plazo_valor, plazo_unidad, norma_origen, IN-list de siglas)
+_PLAZOS_RESOLUCION = [
+    (10, 1, 'MESES', 'Art. 132 bis RD 1955/2000 + DA 3ª LSE',
+     ['AE_PROVISIONAL']),
+    (20, 1, 'MESES', 'Art. 132 ter RD 1955/2000 + DA 3ª LSE',
+     ['AE_DEFINITIVA', 'AE_DEFINITIVA+AAT']),
+    (30, 3, 'MESES', 'Art. 128 RD 1955/2000',
+     ['AAP']),
+    (40, 3, 'MESES', 'Art. 131.7 RD 1955/2000',
+     ['AAC', 'AAP+AAC', 'AAP+AAC+DUP', 'AAC+DUP']),
+    (50, 3, 'MESES', 'Art. 133 RD 1955/2000',
+     ['AAT']),
+    (60, 3, 'MESES', 'Art. 138 RD 1955/2000 (mod. RD 88/2026)',
+     ['CIERRE']),
+    (70, 3, 'MESES', 'Art. 145.4 RD 1955/2000',
+     ['DUP']),
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. Crear variable tipo_solicitud si no existe
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES (
+            'tipo_solicitud',
+            'Siglas (literal) del tipo de solicitud en contexto. Combinaciones se mantienen unidas con +',
+            'texto',
+            NULL,
+            TRUE
+        )
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+    # 2. Insertar los 7 plazos + sus condiciones IN
+    for orden, valor, unidad, norma, siglas_in in _PLAZOS_RESOLUCION:
+        # Insertar plazo y recuperar id
+        plazo_id = conn.execute(sa.text("""
+            INSERT INTO public.catalogo_plazos
+                (tipo_elemento, tipo_elemento_id, tipo_elemento_codigo, campo_fecha,
+                 plazo_valor, plazo_unidad,
+                 efecto_vencimiento_id, norma_origen, orden, activo)
+            SELECT
+                'FASE',
+                tf.id,
+                'RESOLUCION',
+                '{"fk": "documento_solicitud_id"}'::jsonb,
+                :valor,
+                :unidad,
+                ep.id,
+                :norma,
+                :orden,
+                TRUE
+            FROM public.tipos_fases tf
+            CROSS JOIN public.efectos_plazo ep
+            WHERE tf.codigo = 'RESOLUCION'
+              AND ep.codigo = 'SILENCIO_DESESTIMATORIO'
+            RETURNING id
+        """), {
+            'valor': valor,
+            'unidad': unidad,
+            'norma': norma,
+            'orden': orden,
+        }).scalar()
+
+        if plazo_id is None:
+            raise RuntimeError(
+                f"No se pudo insertar plazo RESOLUCION orden={orden}; "
+                "verificar existencia de tipos_fases.RESOLUCION y "
+                "efectos_plazo.SILENCIO_DESESTIMATORIO"
+            )
+
+        # Insertar la condición IN con la variable tipo_solicitud
+        import json
+        conn.execute(sa.text("""
+            INSERT INTO public.condiciones_plazo
+                (catalogo_plazo_id, variable_id, operador, valor, orden)
+            SELECT
+                :plazo_id,
+                cv.id,
+                'IN',
+                CAST(:siglas_json AS jsonb),
+                1
+            FROM public.catalogo_variables cv
+            WHERE cv.nombre = 'tipo_solicitud'
+        """), {
+            'plazo_id': plazo_id,
+            'siglas_json': json.dumps(siglas_in),
+        })
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    # 1. Eliminar condiciones de los plazos RESOLUCION sembrados aquí
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_plazo
+        WHERE catalogo_plazo_id IN (
+            SELECT cp.id FROM public.catalogo_plazos cp
+            WHERE cp.tipo_elemento = 'FASE'
+              AND cp.tipo_elemento_codigo = 'RESOLUCION'
+        )
+    """))
+
+    # 2. Eliminar las entradas de catalogo_plazos para FASE/RESOLUCION
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_plazos
+        WHERE tipo_elemento = 'FASE'
+          AND tipo_elemento_codigo = 'RESOLUCION'
+    """))
+
+    # 3. Eliminar la variable tipo_solicitud
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_variables WHERE nombre = 'tipo_solicitud'
+    """))

--- a/tests/test_448_seed_plazos_resolucion.py
+++ b/tests/test_448_seed_plazos_resolucion.py
@@ -1,0 +1,197 @@
+"""Tests issue #448 — seed catalogo_plazos para fase RESOLUCION.
+
+Verifica el resultado de la migración `448_seed_plazos_resolucion`:
+  A) Variable tipo_solicitud activa en catalogo_variables.
+  B) 7 entradas en catalogo_plazos con tipo_elemento_codigo='RESOLUCION',
+     cada una con su norma_origen y la condición IN sobre tipo_solicitud.
+  C) Para cada combinación de tipo_solicitud cubierta por el seed,
+     _seleccionar_catalogo devuelve exactamente la entrada correcta.
+  D) Para combinaciones fuera de scope (RAIPEE_*, RADNE, DESISTIMIENTO, …),
+     _seleccionar_catalogo devuelve None.
+
+Requieren BD con migración 448 aplicada y fixture app_ctx (conftest.py).
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Combinaciones cubiertas y mapeo esperado (siglas → (valor, unidad, norma))
+# ---------------------------------------------------------------------------
+
+_COMBINACIONES_CUBIERTAS = {
+    'AE_PROVISIONAL':     (1, 'MESES', 'Art. 132 bis RD 1955/2000 + DA 3ª LSE'),
+    'AE_DEFINITIVA':      (1, 'MESES', 'Art. 132 ter RD 1955/2000 + DA 3ª LSE'),
+    'AE_DEFINITIVA+AAT':  (1, 'MESES', 'Art. 132 ter RD 1955/2000 + DA 3ª LSE'),
+    'AAP':                (3, 'MESES', 'Art. 128 RD 1955/2000'),
+    'AAC':                (3, 'MESES', 'Art. 131.7 RD 1955/2000'),
+    'AAP+AAC':            (3, 'MESES', 'Art. 131.7 RD 1955/2000'),
+    'AAP+AAC+DUP':        (3, 'MESES', 'Art. 131.7 RD 1955/2000'),
+    'AAC+DUP':            (3, 'MESES', 'Art. 131.7 RD 1955/2000'),
+    'AAT':                (3, 'MESES', 'Art. 133 RD 1955/2000'),
+    'CIERRE':             (3, 'MESES', 'Art. 138 RD 1955/2000 (mod. RD 88/2026)'),
+    'DUP':                (3, 'MESES', 'Art. 145.4 RD 1955/2000'),
+}
+
+_FUERA_DE_SCOPE = [
+    'RAIPEE_PREVIA', 'RAIPEE_DEFINITIVA', 'RADNE',
+    'AMPLIACION_PLAZO', 'CORRECCION_ERRORES',
+    'DESISTIMIENTO', 'RENUNCIA', 'RECURSO', 'INTERESADO', 'OTRO',
+]
+
+
+# ---------------------------------------------------------------------------
+# A) Variable tipo_solicitud
+# ---------------------------------------------------------------------------
+
+def test_variable_tipo_solicitud_existe_y_esta_activa(app_ctx):
+    from app.models.motor_reglas import CatalogoVariable
+    var = CatalogoVariable.query.filter_by(nombre='tipo_solicitud').first()
+    assert var is not None, 'Variable tipo_solicitud no existe en catalogo_variables'
+    assert var.activa is True
+    assert var.tipo_dato == 'texto'
+
+
+# ---------------------------------------------------------------------------
+# B) Las 7 entradas del seed están presentes con sus normas
+# ---------------------------------------------------------------------------
+
+def test_hay_exactamente_7_entradas_resolucion(app_ctx):
+    from app.models.catalogo_plazos import CatalogoPlazo
+    entradas = (
+        CatalogoPlazo.query
+        .filter_by(tipo_elemento='FASE', tipo_elemento_codigo='RESOLUCION', activo=True)
+        .all()
+    )
+    assert len(entradas) == 7, (
+        f'Esperadas 7 entradas RESOLUCION, hay {len(entradas)}: '
+        f'{[e.norma_origen for e in entradas]}'
+    )
+
+
+def test_cada_entrada_tiene_efecto_silencio_desestimatorio(app_ctx):
+    from app.models.catalogo_plazos import CatalogoPlazo
+    entradas = (
+        CatalogoPlazo.query
+        .filter_by(tipo_elemento='FASE', tipo_elemento_codigo='RESOLUCION', activo=True)
+        .all()
+    )
+    for e in entradas:
+        assert e.efecto_plazo.codigo == 'SILENCIO_DESESTIMATORIO', (
+            f'Entrada {e.id} ({e.norma_origen}) tiene efecto inesperado '
+            f'{e.efecto_plazo.codigo}'
+        )
+
+
+def test_normas_origen_esperadas_presentes(app_ctx):
+    from app.models.catalogo_plazos import CatalogoPlazo
+    normas_bd = {
+        e.norma_origen
+        for e in CatalogoPlazo.query
+        .filter_by(tipo_elemento='FASE', tipo_elemento_codigo='RESOLUCION', activo=True)
+        .all()
+    }
+    normas_esperadas = {
+        'Art. 132 bis RD 1955/2000 + DA 3ª LSE',
+        'Art. 132 ter RD 1955/2000 + DA 3ª LSE',
+        'Art. 128 RD 1955/2000',
+        'Art. 131.7 RD 1955/2000',
+        'Art. 133 RD 1955/2000',
+        'Art. 138 RD 1955/2000 (mod. RD 88/2026)',
+        'Art. 145.4 RD 1955/2000',
+    }
+    assert normas_bd == normas_esperadas
+
+
+def test_cierre_cita_art_138_mod_rd88_2026(app_ctx):
+    """Salvaguarda regresión: la cita de CIERRE debe ser 138 (mod), NO 137."""
+    from app.models.catalogo_plazos import CatalogoPlazo
+    entradas = CatalogoPlazo.query.filter_by(
+        tipo_elemento='FASE', tipo_elemento_codigo='RESOLUCION', activo=True
+    ).all()
+    citas_cierre = [e.norma_origen for e in entradas if 'CIERRE' in str(e.condiciones[0].valor) if e.condiciones]
+    assert any('138' in c for c in citas_cierre), (
+        f'No hay entrada que cite art. 138 para CIERRE: {citas_cierre}'
+    )
+    assert not any('137' in c and '138' not in c for c in citas_cierre), (
+        f'Aún hay cita de art. 137 para CIERRE: {citas_cierre}'
+    )
+
+
+def test_no_existe_resolucion_ae_sin_sufijo_codigo_muerto_del_172(app_ctx):
+    """Salvaguarda: el seed 172 incluía 'RESOLUCION_AE' (sin sufijo); no debe
+    haber ninguna condición IN que contenga el literal 'AE' sin sufijo."""
+    from app.models.condiciones_plazo import CondicionPlazo
+    from app.models.catalogo_plazos import CatalogoPlazo
+    conds = (
+        CondicionPlazo.query
+        .join(CatalogoPlazo, CondicionPlazo.catalogo_plazo_id == CatalogoPlazo.id)
+        .filter(CatalogoPlazo.tipo_elemento_codigo == 'RESOLUCION')
+        .all()
+    )
+    for c in conds:
+        valor = c.valor if isinstance(c.valor, list) else [c.valor]
+        assert 'AE' not in valor, (
+            f"Condición {c.id} incluye literal 'AE' sin sufijo "
+            f"(código muerto del seed 172): {valor}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# C) _seleccionar_catalogo devuelve la entrada correcta para cada combinación
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('siglas,esperado', list(_COMBINACIONES_CUBIERTAS.items()))
+def test_seleccionar_catalogo_resolucion_para_combinacion_cubierta(app_ctx, siglas, esperado):
+    from app.services.plazos import _seleccionar_catalogo
+    valor_esp, unidad_esp, norma_esp = esperado
+    entrada = _seleccionar_catalogo(
+        'FASE', 'RESOLUCION', {'tipo_solicitud': siglas}
+    )
+    assert entrada is not None, (
+        f'Sin plazo para tipo_solicitud={siglas} — el seed no cubre la combinación'
+    )
+    assert entrada.plazo_valor == valor_esp
+    assert entrada.plazo_unidad == unidad_esp
+    assert entrada.norma_origen == norma_esp
+
+
+# ---------------------------------------------------------------------------
+# D) Combinaciones fuera de scope → None (deuda de #247)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('siglas', _FUERA_DE_SCOPE)
+def test_seleccionar_catalogo_resolucion_fuera_de_scope(app_ctx, siglas):
+    """Plazos no cubiertos por el hotfix 448 (deuda controlada de #247)."""
+    from app.services.plazos import _seleccionar_catalogo
+    entrada = _seleccionar_catalogo(
+        'FASE', 'RESOLUCION', {'tipo_solicitud': siglas}
+    )
+    assert entrada is None, (
+        f'tipo_solicitud={siglas} no debería tener plazo de RESOLUCION '
+        f'todavía (deuda de #247); recibido entrada id={getattr(entrada, "id", "?")}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# E) Coherencia con ESF.json — toda combinación válida está cubierta o
+#    documentada como fuera de scope
+# ---------------------------------------------------------------------------
+
+def test_cobertura_de_combinaciones_es_completa():
+    """No requiere BD — solo coherencia conceptual: las claves de los dos
+    diccionarios cubren todas las siglas de tipos_solicitudes que tienen
+    fase RESOLUCION en su procedimiento."""
+    todas = set(_COMBINACIONES_CUBIERTAS) | set(_FUERA_DE_SCOPE)
+    # Todas las siglas en BD (ver tipos_solicitudes tras paso6.5):
+    siglas_bd = {
+        'AAC', 'AAC+DUP', 'AAP', 'AAP+AAC', 'AAP+AAC+DUP',
+        'AAT', 'AE_DEFINITIVA', 'AE_DEFINITIVA+AAT', 'AE_PROVISIONAL',
+        'AMPLIACION_PLAZO', 'CIERRE', 'CORRECCION_ERRORES',
+        'DESISTIMIENTO', 'DUP', 'INTERESADO', 'OTRO',
+        'RADNE', 'RAIPEE_DEFINITIVA', 'RAIPEE_PREVIA',
+        'RECURSO', 'RENUNCIA',
+    }
+    faltantes = siglas_bd - todas
+    assert not faltantes, (
+        f'Combinaciones no clasificadas (cubiertas ni fuera de scope): {faltantes}'
+    )


### PR DESCRIPTION
## Resumen

- **Bug detectado en auditoría 22/05/2026:** la migración 172 (`c9379e09ae01`) intentaba seedar 7 plazos para la fase RESOLUCION pero su JOIN final usaba códigos compuestos (`RESOLUCION_AAP`, `RESOLUCION_AAC`, …) que nunca existieron en `tipos_fases` (donde solo está `RESOLUCION`). El INSERT-SELECT devolvía 0 filas **sin error** → `catalogo_plazos` quedó sin plazos de resolución.
- **Fix:** nueva variable `tipo_solicitud` + nueva migración `448_seed_plazos_resolucion` con 7 entradas + condiciones `IN`; doc sincronizada; test de 28 casos.

## Diseño aplicado (Forma A — IN consolidado por norma)

7 filas en `catalogo_plazos` con `tipo_elemento_codigo='RESOLUCION'`, diferenciadas por `tipo_solicitud IN [...]`:

| orden | Etiqueta | Plazo | Norma | `tipo_solicitud IN` |
|---|---|---|---|---|
| 10 | AE_PROVISIONAL | 1m | Art. 132 bis (+DA 3ª LSE) | `['AE_PROVISIONAL']` |
| 20 | AE_DEFINITIVA | 1m | Art. 132 ter (+DA 3ª LSE) | `['AE_DEFINITIVA','AE_DEFINITIVA+AAT']` |
| 30 | AAP | 3m | Art. 128 | `['AAP']` |
| 40 | AAC y combinadas | 3m | Art. 131.7 | `['AAC','AAP+AAC','AAP+AAC+DUP','AAC+DUP']` |
| 50 | AAT | 3m | Art. 133 | `['AAT']` |
| 60 | CIERRE | 3m | Art. 138 (mod. RD 88/2026) | `['CIERRE']` |
| 70 | DUP | 3m | Art. 145.4 | `['DUP']` |

Efecto en todas: `SILENCIO_DESESTIMATORIO`. `campo_fecha = {"fk":"documento_solicitud_id"}`.

## Diferencias respecto al seed 172 (código muerto)

- Descartado `RESOLUCION_AE` (sin sufijo): no existe ese `tipo_solicitud` en BD.
- Añadido DUP (procedimiento autónomo, ausente del 172).
- CIERRE: art. 137 → art. 138 RD 1955/2000 (mod. RD 88/2026) — art. 137 corresponde al informe del operador, no a la resolución.
- Combinadas con AAC consolidadas (art. 131.7 fija el plazo conjunto).
- `AE_DEFINITIVA+AAT` consume el plazo del AE_DEFINITIVA.

## Fuera de scope (deuda de #247)

Plazos de RESOLUCION para `RAIPEE_PREVIA`, `RAIPEE_DEFINITIVA`, `RADNE`, `AMPLIACION_PLAZO`, `CORRECCION_ERRORES`, `DESISTIMIENTO`, `RENUNCIA`, `RECURSO`, `INTERESADO`, `OTRO`.

## Cambios

- `migrations/versions/448_seed_plazos_resolucion.py` — nueva migración (variable + 7 plazos + 7 condiciones IN)
- `app/services/variables/calculado.py` — `@variable('tipo_solicitud')` que devuelve `ctx.solicitud.tipo_solicitud.siglas`
- `docs/referencia/DISEÑO_FECHAS_PLAZOS.md` §5.2 — aclaratoria: `RESOLUCION_AAP`, … son etiquetas conceptuales; modelado real por `condiciones_plazo`
- `tests/test_448_seed_plazos_resolucion.py` — 28 tests

## Test plan

- [x] `pytest tests/test_448_seed_plazos_resolucion.py` → 28/28 PASS
- [x] Resto de tests de plazos (172, 190, 341, 350, 362) → sin regresiones (5 fallos pre-existentes ajenos a este PR, validador URL post-#365 — chip spawneada)
- [x] Migración aplica/revierte limpiamente
- [x] BD verificada: 7 entradas + 7 condiciones IN + variable `tipo_solicitud` activa (id=10)

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)