### PR TITLE
[BE] #247 API CRUD organismos_expediente + automatismos #458 #459

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -23,6 +23,8 @@ from app.models.tipos_fases import TipoFase
 from app.models.tipos_tramites import TipoTramite
 from app.models.tipos_tareas import TipoTarea
 from app.models.documentos_tarea import DocumentoTarea
+from app.models.entidad import Entidad
+from app.models.organismos_expediente import OrganismoExpediente, ESTADOS_ORGANISMO, VIAS_ORGANISMO
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
 from app.services.invariantes_esftt import check_invariante, _check_cierre_fase
@@ -139,6 +141,7 @@ def crear_tramite(fase_id):
 
     tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
     db.session.add(tramite)
+    _hook_459_traslado_organismo(tipo_tramite, fase)
     db.session.commit()
 
     return jsonify({'ok': True, 'id': tramite.id, 'advertencia': _advertencia(res_eval)})
@@ -283,6 +286,7 @@ def editar_tarea(tarea_id):
                 DocumentoTarea(documento_id=id_producido, rol='PRODUCIDO'))
 
         tarea.notas = request.form.get('notas') or None
+        _hook_458_analizar_separata(tarea, id_producido)
         db.session.commit()
 
         return jsonify({'ok': True})
@@ -433,4 +437,157 @@ def finalizar_tarea(tarea_id):
         return _bloqueo(res_inv)
 
     return jsonify({'ok': True})
+
+
+# ============================================
+# HELPERS CRUD organismos (testables sin Flask)
+# ============================================
+
+def _serializar_org_exp(oe):
+    """Serializa OrganismoExpediente a dict para la API."""
+    return {
+        'id': oe.id,
+        'organismo_id': oe.organismo_id,
+        'nombre_completo': oe.organismo.nombre_completo if oe.organismo else None,
+        'nif': oe.organismo.nif if oe.organismo else None,
+        'via': oe.via,
+        'estado': oe.estado,
+        'num_iteraciones_organismo': oe.num_iteraciones_organismo,
+        'plazo_legal_dias': oe.plazo_legal_dias,
+        'tramite_id': oe.tramite_id,
+    }
+
+
+def _hook_458_analizar_separata(tarea, id_producido):
+    """Hook #458: al producir diagnóstico en CONSULTA_SEPARATA pasa el organismo a en_tramitacion."""
+    if (id_producido is not None
+            and tarea.tipo_tarea.codigo == 'ANALIZAR'
+            and tarea.tramite.tipo_tramite.codigo == 'CONSULTA_SEPARATA'):
+        org = OrganismoExpediente.query.filter_by(tramite_id=tarea.tramite_id).first()
+        if org:
+            org.estado = 'en_tramitacion'
+
+
+def _hook_459_traslado_organismo(tipo_tramite, fase):
+    """Hook #459: al crear CONSULTA_TRASLADO_ORGANISMO incrementa num_iteraciones si hay exactamente 1 organismo."""
+    if tipo_tramite.codigo != 'CONSULTA_TRASLADO_ORGANISMO':
+        return
+    cod_separata = TipoTramite.query.filter_by(codigo='CONSULTA_SEPARATA').first()
+    if not cod_separata:
+        return
+    tram_separatas = Tramite.query.filter_by(
+        fase_id=fase.id,
+        tipo_tramite_id=cod_separata.id,
+    ).all()
+    ids_sep = [t.id for t in tram_separatas]
+    if not ids_sep:
+        return
+    orgs = OrganismoExpediente.query.filter(
+        OrganismoExpediente.tramite_id.in_(ids_sep)
+    ).all()
+    if len(orgs) == 1:
+        orgs[0].num_iteraciones_organismo += 1
+
+
+# ============================================
+# ENDPOINTS — CRUD organismos_expediente (#247)
+# ============================================
+
+@bp.route('/expediente/<int:exp_id>/organismos', methods=['GET'])
+@login_required
+def listar_organismos(exp_id):
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    oes = OrganismoExpediente.query.filter_by(expediente_id=exp_id).all()
+    return jsonify({'ok': True, 'organismos': [_serializar_org_exp(oe) for oe in oes]})
+
+
+@bp.route('/expediente/<int:exp_id>/organismos', methods=['POST'])
+@login_required
+def crear_organismo(exp_id):
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    organismo_id = request.form.get('organismo_id', type=int)
+    via = request.form.get('via')
+    documento_id = request.form.get('documento_id', type=int)
+    plazo_legal_dias = request.form.get('plazo_legal_dias', type=int)
+
+    if not organismo_id:
+        return jsonify({'ok': False, 'error': 'organismo_id es obligatorio'}), 400
+
+    entidad = Entidad.query.get(organismo_id)
+    if not entidad or not entidad.rol_consultado:
+        return jsonify({'ok': False, 'error': 'El organismo no existe o no tiene rol consultado'}), 422
+
+    if via not in VIAS_ORGANISMO:
+        return jsonify({'ok': False, 'error': f'via debe ser uno de: {", ".join(VIAS_ORGANISMO)}'}), 400
+
+    duplicado = OrganismoExpediente.query.filter_by(
+        expediente_id=exp_id, organismo_id=organismo_id
+    ).first()
+    if duplicado:
+        return jsonify({'ok': False, 'error': 'Este organismo ya está añadido al expediente'}), 409
+
+    try:
+        oe = OrganismoExpediente(
+            expediente_id=exp_id,
+            organismo_id=organismo_id,
+            via=via,
+            documento_id=documento_id,
+            plazo_legal_dias=plazo_legal_dias,
+        )
+        db.session.add(oe)
+        db.session.commit()
+        return jsonify({'ok': True, 'id': oe.id}), 201
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@bp.route('/expediente/<int:exp_id>/organismos/<int:oid>', methods=['PATCH'])
+@login_required
+def editar_organismo(exp_id, oid):
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    oe = OrganismoExpediente.query.filter_by(id=oid, expediente_id=exp_id).first_or_404()
+
+    estado = request.form.get('estado')
+    if estado not in ESTADOS_ORGANISMO:
+        return jsonify({'ok': False, 'error': f'estado debe ser uno de: {", ".join(ESTADOS_ORGANISMO)}'}), 422
+
+    try:
+        oe.estado = estado
+        db.session.commit()
+        return jsonify({'ok': True})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@bp.route('/expediente/<int:exp_id>/organismos/<int:oid>', methods=['DELETE'])
+@login_required
+def borrar_organismo(exp_id, oid):
+    expediente = Expediente.query.get_or_404(exp_id)
+    resultado = verificar_acceso_expediente(expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    oe = OrganismoExpediente.query.filter_by(id=oid, expediente_id=exp_id).first_or_404()
+
+    try:
+        db.session.delete(oe)
+        db.session.commit()
+        return jsonify({'ok': True})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
 

--- a/tests/test_247_organismos_crud.py
+++ b/tests/test_247_organismos_crud.py
@@ -1,0 +1,94 @@
+"""
+Tests #247 — helper _serializar_org_exp y validaciones de CRUD organismos_expediente.
+
+Patrón: objetos Python puros (MagicMock), sin BD real ni cliente Flask.
+"""
+from unittest.mock import MagicMock
+
+
+def _oe_stub(id=1, organismo_id=5, via='consulta', estado='pendiente',
+             num_iteraciones=0, plazo_legal_dias=30, tramite_id=12):
+    oe = MagicMock()
+    oe.id = id
+    oe.organismo_id = organismo_id
+    oe.organismo = MagicMock(nombre_completo='Red Eléctrica de España, S.A.', nif='A78003662')
+    oe.via = via
+    oe.estado = estado
+    oe.num_iteraciones_organismo = num_iteraciones
+    oe.plazo_legal_dias = plazo_legal_dias
+    oe.tramite_id = tramite_id
+    return oe
+
+
+class TestSerializarOrgExp:
+
+    def test_get_organismos_ok(self):
+        from app.routes.api_bc import _serializar_org_exp
+        oe = _oe_stub()
+        result = _serializar_org_exp(oe)
+        assert result['id'] == 1
+        assert result['organismo_id'] == 5
+        assert result['nombre_completo'] == 'Red Eléctrica de España, S.A.'
+        assert result['nif'] == 'A78003662'
+        assert result['via'] == 'consulta'
+        assert result['estado'] == 'pendiente'
+        assert result['num_iteraciones_organismo'] == 0
+        assert result['plazo_legal_dias'] == 30
+        assert result['tramite_id'] == 12
+
+    def test_get_expediente_no_existe(self):
+        # get_or_404 gestiona la respuesta 404; sin organismo los campos vienen None
+        from app.routes.api_bc import _serializar_org_exp
+        oe = _oe_stub()
+        oe.organismo = None
+        result = _serializar_org_exp(oe)
+        assert result['nombre_completo'] is None
+        assert result['nif'] is None
+
+    def test_post_organismo_ok(self):
+        # Verifica que los campos del POST se serializan correctamente al crearse el registro
+        from app.routes.api_bc import _serializar_org_exp
+        oe = _oe_stub(id=7, organismo_id=5, via='consulta', plazo_legal_dias=None, tramite_id=None)
+        oe.organismo = MagicMock(nombre_completo='Endesa, S.A.', nif='A81947556')
+        result = _serializar_org_exp(oe)
+        assert result['id'] == 7
+        assert result['organismo_id'] == 5
+        assert result['via'] == 'consulta'
+        assert result['plazo_legal_dias'] is None
+
+    def test_post_organismo_sin_rol_consultado(self):
+        entidad = MagicMock()
+        entidad.rol_consultado = False
+        assert not entidad.rol_consultado
+
+    def test_post_organismo_via_invalida(self):
+        from app.models.organismos_expediente import VIAS_ORGANISMO
+        assert 'email' not in VIAS_ORGANISMO
+        assert 'consulta' in VIAS_ORGANISMO
+        assert 'declaracion_responsable' in VIAS_ORGANISMO
+
+    def test_post_organismo_duplicado(self):
+        # La BD lanza IntegrityError por uq_org_exp_expediente_organismo;
+        # aquí verificamos que la constraint está declarada en el modelo.
+        from app.models.organismos_expediente import OrganismoExpediente
+        nombres = [c.name for c in OrganismoExpediente.__table_args__[:-1]]
+        assert 'uq_org_exp_expediente_organismo' in nombres
+
+    def test_patch_estado_ok(self):
+        from app.models.organismos_expediente import ESTADOS_ORGANISMO
+        oe = MagicMock()
+        nuevo = 'separata_enviada'
+        assert nuevo in ESTADOS_ORGANISMO
+        oe.estado = nuevo
+        assert oe.estado == 'separata_enviada'
+
+    def test_patch_estado_invalido(self):
+        from app.models.organismos_expediente import ESTADOS_ORGANISMO
+        assert 'tramitado' not in ESTADOS_ORGANISMO
+
+    def test_delete_organismo_ok(self):
+        from app.routes.api_bc import _serializar_org_exp
+        oe = _oe_stub()
+        result = _serializar_org_exp(oe)
+        assert result is not None
+        assert result['id'] == 1

--- a/tests/test_458_estado_organismo.py
+++ b/tests/test_458_estado_organismo.py
@@ -1,0 +1,66 @@
+"""
+Tests #458 — hook _hook_458_analizar_separata en editar_tarea.
+
+Patrón: objetos Python puros (MagicMock), sin BD real ni cliente Flask.
+"""
+from unittest.mock import MagicMock, patch
+
+
+def _tarea_stub(codigo_tarea, codigo_tramite, tramite_id=5):
+    tarea = MagicMock()
+    tarea.tramite_id = tramite_id
+    tarea.tipo_tarea = MagicMock(codigo=codigo_tarea)
+    tarea.tramite = MagicMock()
+    tarea.tramite.tipo_tramite = MagicMock(codigo=codigo_tramite)
+    return tarea
+
+
+class TestHook458EstadoOrganismo:
+
+    def test_analizar_separata_pone_en_tramitacion(self):
+        from app.routes.api_bc import _hook_458_analizar_separata
+        tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=5)
+        org = MagicMock()
+        org.estado = 'separata_enviada'
+
+        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = org
+            _hook_458_analizar_separata(tarea, id_producido=10)
+
+        assert org.estado == 'en_tramitacion'
+        mock_cls.query.filter_by.assert_called_once_with(tramite_id=5)
+
+    def test_analizar_otro_tramite_no_cambia_estado(self):
+        from app.routes.api_bc import _hook_458_analizar_separata
+        tarea = _tarea_stub('ANALIZAR', 'REQUERIMIENTO_DE_MEJORA', tramite_id=5)
+        org = MagicMock()
+        org.estado = 'separata_enviada'
+
+        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = org
+            _hook_458_analizar_separata(tarea, id_producido=10)
+
+        assert org.estado == 'separata_enviada'
+        mock_cls.query.filter_by.assert_not_called()
+
+    def test_sin_organismo_no_falla(self):
+        from app.routes.api_bc import _hook_458_analizar_separata
+        tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=99)
+
+        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = None
+            # No debe lanzar excepción
+            _hook_458_analizar_separata(tarea, id_producido=10)
+
+    def test_sin_doc_producido_no_activa_hook(self):
+        from app.routes.api_bc import _hook_458_analizar_separata
+        tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=5)
+        org = MagicMock()
+        org.estado = 'separata_enviada'
+
+        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = org
+            _hook_458_analizar_separata(tarea, id_producido=None)
+
+        assert org.estado == 'separata_enviada'
+        mock_cls.query.filter_by.assert_not_called()

--- a/tests/test_459_iteraciones_organismo.py
+++ b/tests/test_459_iteraciones_organismo.py
@@ -1,0 +1,114 @@
+"""
+Tests #459 — hook _hook_459_traslado_organismo en crear_tramite.
+
+Patrón: objetos Python puros (MagicMock), sin BD real ni cliente Flask.
+"""
+from unittest.mock import MagicMock, patch, call
+
+
+def _tipo_tramite_stub(codigo):
+    tt = MagicMock()
+    tt.codigo = codigo
+    tt.id = 99
+    return tt
+
+
+def _fase_stub(fase_id=1):
+    fase = MagicMock()
+    fase.id = fase_id
+    return fase
+
+
+def _org_stub(tramite_id, num_iteraciones=0):
+    org = MagicMock()
+    org.tramite_id = tramite_id
+    org.num_iteraciones_organismo = num_iteraciones
+    return org
+
+
+class TestHook459IteracionesOrganismo:
+
+    def test_crear_traslado_organismo_incrementa(self):
+        from app.routes.api_bc import _hook_459_traslado_organismo
+        tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
+        fase = _fase_stub(1)
+        org = _org_stub(tramite_id=10, num_iteraciones=0)
+
+        cod_sep = MagicMock()
+        cod_sep.id = 7
+
+        tram_sep = MagicMock()
+        tram_sep.id = 10
+
+        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
+             patch('app.routes.api_bc.Tramite') as mock_tram, \
+             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+
+            mock_tt.query.filter_by.return_value.first.return_value = cod_sep
+            mock_tram.query.filter_by.return_value.all.return_value = [tram_sep]
+            mock_org.query.filter.return_value.all.return_value = [org]
+
+            _hook_459_traslado_organismo(tipo, fase)
+
+        assert org.num_iteraciones_organismo == 1
+
+    def test_crear_otro_tramite_no_incrementa(self):
+        from app.routes.api_bc import _hook_459_traslado_organismo
+        tipo = _tipo_tramite_stub('CONSULTA_SEPARATA')
+        fase = _fase_stub(1)
+        org = _org_stub(tramite_id=10, num_iteraciones=0)
+
+        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
+             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+
+            _hook_459_traslado_organismo(tipo, fase)
+
+            mock_tt.query.filter_by.assert_not_called()
+
+        assert org.num_iteraciones_organismo == 0
+
+    def test_sin_organismo_no_falla(self):
+        from app.routes.api_bc import _hook_459_traslado_organismo
+        tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
+        fase = _fase_stub(1)
+
+        cod_sep = MagicMock()
+        cod_sep.id = 7
+
+        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
+             patch('app.routes.api_bc.Tramite') as mock_tram, \
+             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+
+            mock_tt.query.filter_by.return_value.first.return_value = cod_sep
+            mock_tram.query.filter_by.return_value.all.return_value = []
+            mock_org.query.filter.return_value.all.return_value = []
+
+            # No debe lanzar excepción
+            _hook_459_traslado_organismo(tipo, fase)
+
+    def test_multiples_organismos_no_incrementa(self):
+        from app.routes.api_bc import _hook_459_traslado_organismo
+        tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
+        fase = _fase_stub(1)
+        org1 = _org_stub(tramite_id=10, num_iteraciones=0)
+        org2 = _org_stub(tramite_id=11, num_iteraciones=0)
+
+        cod_sep = MagicMock()
+        cod_sep.id = 7
+        tram1 = MagicMock()
+        tram1.id = 10
+        tram2 = MagicMock()
+        tram2.id = 11
+
+        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
+             patch('app.routes.api_bc.Tramite') as mock_tram, \
+             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+
+            mock_tt.query.filter_by.return_value.first.return_value = cod_sep
+            mock_tram.query.filter_by.return_value.all.return_value = [tram1, tram2]
+            mock_org.query.filter.return_value.all.return_value = [org1, org2]
+
+            _hook_459_traslado_organismo(tipo, fase)
+
+        assert org1.num_iteraciones_organismo == 0
+        assert org2.num_iteraciones_organismo == 0


### PR DESCRIPTION
## Cambios

- **4 endpoints REST** bajo `/api/bc/expediente/<id>/organismos`:
  - `GET` — lista organismos del expediente (serialización completa)
  - `POST` — añade organismo; valida `rol_consultado`, `via` y duplicado (409)
  - `PATCH` — cambio manual de estado por el tramitador
  - `DELETE` — elimina el registro
- **Hook #458** en `editar_tarea`: cuando se produce el diagnóstico (`id_producido` presente) en una tarea `ANALIZAR` de trámite `CONSULTA_SEPARATA`, pasa el organismo a `en_tramitacion`
- **Hook #459** en `crear_tramite`: al crear `CONSULTA_TRASLADO_ORGANISMO`, incrementa `num_iteraciones_organismo` si hay exactamente 1 organismo en la fase (0 o múltiples: sin cambio, D2 pendiente)
- **17 tests unitarios** (objetos Python puros, sin BD ni cliente Flask) en `test_247_organismos_crud.py`, `test_458_estado_organismo.py`, `test_459_iteraciones_organismo.py`

Closes #247
Closes #458
Closes #459
