### PR TITLE
#456 tramites_organismos + condicionados_doc_id + criterios completitud CONSULTAS (ADR-011)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -86,6 +86,8 @@ from app.models.alegantes import Alegante
 
 # Organismos consultados por expediente (#391 — depende de Expediente, Entidad, Documento, Tramite)
 from app.models.organismos_expediente import OrganismoExpediente
+# Vínculo trámites↔organismos (#456 — depende de Tramite, OrganismoExpediente)
+from app.models.tramites_organismos import TramiteOrganismo
 
 # Interesados del expediente (#374 — depende de Expediente, Entidad, Documento)
 from app.models.interesados_expediente import InteresadoExpediente
@@ -161,6 +163,8 @@ __all__ = [
     'Certificado',
     # Organismos consultados por expediente
     'OrganismoExpediente',
+    # Vínculo trámites↔organismos
+    'TramiteOrganismo',
     # Alegante en trámites RECEPCION_ALEGACION
     'Alegante',
     # Interesados del expediente

--- a/app/models/organismos_expediente.py
+++ b/app/models/organismos_expediente.py
@@ -22,12 +22,14 @@ class OrganismoExpediente(db.Model):
     ordinaria (separata + trámites de traslado) como la vía de declaración
     responsable (el titular acredita disponer ya de la autorización del organismo).
 
-    Diseño de referencia: DISEÑO_CONSULTAS_ORGANISMOS.md §2
+    Los trámites del ciclo de consulta se vinculan a este registro mediante
+    la tabla `tramites_organismos` (ADR-011 §1).
+
+    Diseño de referencia: DISEÑO_CONSULTAS_ORGANISMOS.md §2, ADR-011
     """
     __tablename__ = 'organismos_expediente'
     __table_args__ = (
         db.UniqueConstraint('expediente_id', 'organismo_id', name='uq_org_exp_expediente_organismo'),
-        db.UniqueConstraint('tramite_id', name='uq_org_exp_tramite'),
         db.CheckConstraint("via IN ('consulta', 'declaracion_responsable')", name='ck_org_exp_via'),
         db.CheckConstraint(
             "estado IN ('pendiente','separata_enviada','en_tramitacion',"
@@ -76,18 +78,11 @@ class OrganismoExpediente(db.Model):
         comment='Estado del ciclo de vida del organismo en el expediente',
     )
 
-    num_iteraciones_organismo = db.Column(
+    condicionados_doc_id = db.Column(
         db.Integer,
-        nullable=False,
-        default=0,
-        comment='Contador de trámites CONSULTA_TRASLADO_ORGANISMO creados. Motor usa este valor para advertir o bloquear si supera 1',
-    )
-
-    tramite_id = db.Column(
-        db.Integer,
-        db.ForeignKey('public.tramites.id'),
+        db.ForeignKey('public.documentos.id'),
         nullable=True,
-        comment='FK al trámite CONSULTA_SEPARATA asociado a este organismo. NULL hasta que se crea el trámite',
+        comment='FK documento CONDICIONADO_OFICIO. Solo cuando titular sin_respuesta en AAC tras condicionado (ADR-011 §2)',
     )
 
     plazo_legal_dias = db.Column(
@@ -100,10 +95,23 @@ class OrganismoExpediente(db.Model):
     expediente = db.relationship('Expediente', backref='organismos')
     organismo = db.relationship('Entidad', foreign_keys=[organismo_id])
     documento = db.relationship('Documento', foreign_keys=[documento_id])
-    tramite = db.relationship('Tramite', foreign_keys=[tramite_id])
+    condicionados_doc = db.relationship('Documento', foreign_keys=[condicionados_doc_id])
 
     def __repr__(self):
         return f'<OrganismoExpediente exp={self.expediente_id} org={self.organismo_id} estado={self.estado}>'
+
+    @property
+    def consulta_completa(self) -> bool:
+        """True cuando la consulta está completamente resuelta (ADR-011 §6).
+
+        Para declaracion_responsable: completa cuando estado es exonerado.
+        Para consulta ordinaria: completa cuando el ciclo alcanzó un estado de cierre.
+        La evaluación detallada por resultado de cada trámite (casos A-D del ADR)
+        se implementará cuando TramiteOrganismo.resultado esté disponible (#460).
+        """
+        if self.via == 'declaracion_responsable':
+            return self.estado == 'exonerado'
+        return self.estado in ('cerrado_favorable', 'cerrado_con_condicionados')
 
     def as_contexto_cb(self) -> dict:
         """Fragmento de contexto para plantillas de CONSULTA_SEPARATA."""

--- a/app/models/tramites_organismos.py
+++ b/app/models/tramites_organismos.py
@@ -1,0 +1,53 @@
+from app import db
+
+
+class TramiteOrganismo(db.Model):
+    """
+    Vínculo entre un trámite de consulta y el organismo al que pertenece.
+
+    Permite que CONSULTA_SEPARATA, CONSULTA_TRASLADO_ORGANISMO y
+    CONSULTA_TRASLADO_TITULAR identifiquen unívocamente su organismo_expediente
+    en expedientes con múltiples organismos consultados.
+
+    El UNIQUE en tramite_id garantiza que cada trámite pertenece a un solo
+    organismo. Un organismo puede tener N trámites (SEPARATA + 0-2 TRASLADOs).
+
+    Diseño de referencia: ADR-011 §1
+    """
+    __tablename__ = 'tramites_organismos'
+    __table_args__ = (
+        db.UniqueConstraint('tramite_id', name='uq_tramorg_tramite'),
+        {'schema': 'public'},
+    )
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    tramite_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tramites.id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,
+        comment='FK tramites (UNIQUE — un trámite pertenece a un solo organismo)',
+    )
+
+    organismo_expediente_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.organismos_expediente.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+        comment='FK organismos_expediente. Organismo al que pertenece el trámite',
+    )
+
+    # Relaciones
+    tramite = db.relationship('Tramite', foreign_keys=[tramite_id])
+    organismo_expediente = db.relationship(
+        'OrganismoExpediente',
+        foreign_keys=[organismo_expediente_id],
+        backref=db.backref('tramites_organismo', lazy='dynamic'),
+    )
+
+    def __repr__(self):
+        return (
+            f'<TramiteOrganismo tramite={self.tramite_id} '
+            f'org_exp={self.organismo_expediente_id}>'
+        )

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -25,6 +25,7 @@ from app.models.tipos_tareas import TipoTarea
 from app.models.documentos_tarea import DocumentoTarea
 from app.models.entidad import Entidad
 from app.models.organismos_expediente import OrganismoExpediente, ESTADOS_ORGANISMO, VIAS_ORGANISMO
+from app.models.tramites_organismos import TramiteOrganismo
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
 from app.services.invariantes_esftt import check_invariante, _check_cierre_fase
@@ -452,9 +453,8 @@ def _serializar_org_exp(oe):
         'nif': oe.organismo.nif if oe.organismo else None,
         'via': oe.via,
         'estado': oe.estado,
-        'num_iteraciones_organismo': oe.num_iteraciones_organismo,
         'plazo_legal_dias': oe.plazo_legal_dias,
-        'tramite_id': oe.tramite_id,
+        'condicionados_doc_id': oe.condicionados_doc_id,
     }
 
 
@@ -463,13 +463,18 @@ def _hook_458_analizar_separata(tarea, id_producido):
     if (id_producido is not None
             and tarea.tipo_tarea.codigo == 'ANALIZAR'
             and tarea.tramite.tipo_tramite.codigo == 'CONSULTA_SEPARATA'):
-        org = OrganismoExpediente.query.filter_by(tramite_id=tarea.tramite_id).first()
-        if org:
-            org.estado = 'en_tramitacion'
+        vinculo = TramiteOrganismo.query.filter_by(tramite_id=tarea.tramite_id).first()
+        if vinculo:
+            vinculo.organismo_expediente.estado = 'en_tramitacion'
 
 
 def _hook_459_traslado_organismo(tipo_tramite, fase):
-    """Hook #459: al crear CONSULTA_TRASLADO_ORGANISMO incrementa num_iteraciones si hay exactamente 1 organismo."""
+    """Hook #459: al crear CONSULTA_TRASLADO_ORGANISMO navega al organismo vía tramites_organismos.
+
+    La lógica de incrementar un contador ya no aplica (#456 elimina num_iteraciones_organismo).
+    El conteo de iteraciones se obtiene con COUNT de filas CONSULTA_TRASLADO_ORGANISMO
+    en tramites_organismos (#460).
+    """
     if tipo_tramite.codigo != 'CONSULTA_TRASLADO_ORGANISMO':
         return
     cod_separata = TipoTramite.query.filter_by(codigo='CONSULTA_SEPARATA').first()
@@ -482,11 +487,10 @@ def _hook_459_traslado_organismo(tipo_tramite, fase):
     ids_sep = [t.id for t in tram_separatas]
     if not ids_sep:
         return
-    orgs = OrganismoExpediente.query.filter(
-        OrganismoExpediente.tramite_id.in_(ids_sep)
+    vinculos = TramiteOrganismo.query.filter(
+        TramiteOrganismo.tramite_id.in_(ids_sep)
     ).all()
-    if len(orgs) == 1:
-        orgs[0].num_iteraciones_organismo += 1
+    _ = vinculos  # reservado para #460: COUNT de TRASLADO_ORGANISMO por organismo
 
 
 # ============================================

--- a/app/services/context_builders/consulta_separata.py
+++ b/app/services/context_builders/consulta_separata.py
@@ -1,4 +1,4 @@
-from app.models.organismos_expediente import OrganismoExpediente
+from app.models.tramites_organismos import TramiteOrganismo
 
 
 class ContextoConsultaSeparata:
@@ -6,8 +6,8 @@ class ContextoConsultaSeparata:
     Context Builder para escritos del trámite CONSULTA_SEPARATA.
 
     Enriquece el contexto base con datos del organismo consultado y las
-    fechas del ciclo de consulta. Requiere que el trámite tenga un registro
-    en organismos_expediente (campo tramite_id enlazado).
+    fechas del ciclo de consulta. Navega al organismo vía tramites_organismos
+    (ADR-011 §1).
 
     Campos adicionales aportados:
     - organismo_nombre       str   Nombre oficial del organismo
@@ -27,9 +27,10 @@ class ContextoConsultaSeparata:
         if not self._tarea:
             return {}
 
-        org_exp = (OrganismoExpediente.query
+        vinculo = (TramiteOrganismo.query
                    .filter_by(tramite_id=self._tarea.tramite_id)
                    .first())
+        org_exp = vinculo.organismo_expediente if vinculo else None
 
         if not org_exp:
             return {}

--- a/app/services/context_builders/contexto_notificacion_organismo.py
+++ b/app/services/context_builders/contexto_notificacion_organismo.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from app.models.organismos_expediente import OrganismoExpediente
+from app.models.tramites_organismos import TramiteOrganismo
 
 
 class ContextoNotificacionOrganismo:
@@ -9,6 +9,7 @@ class ContextoNotificacionOrganismo:
 
     Enriquece el contexto base con datos del organismo consultado, la fecha
     de su última respuesta y la fecha límite calculada para la siguiente.
+    Navega al organismo vía tramites_organismos (ADR-011 §1).
 
     Campos adicionales aportados:
     - organismo_nombre          str   Nombre oficial del organismo
@@ -28,9 +29,10 @@ class ContextoNotificacionOrganismo:
         if not self._tarea:
             return {}
 
-        org_exp = (OrganismoExpediente.query
+        vinculo = (TramiteOrganismo.query
                    .filter_by(tramite_id=self._tarea.tramite_id)
                    .first())
+        org_exp = vinculo.organismo_expediente if vinculo else None
 
         if not org_exp:
             return {}

--- a/migrations/versions/456_tramites_organismos.py
+++ b/migrations/versions/456_tramites_organismos.py
@@ -1,0 +1,190 @@
+"""456_tramites_organismos
+
+Revision ID: 456_tramites_organismos
+Revises: 448_seed_plazos_resolucion
+Create Date: 2026-05-24
+
+Issue #456 — ADR-011: vinculación trámites↔organismos y criterios de completitud CONSULTAS.
+
+Cambios de esquema:
+  1. Nueva tabla `tramites_organismos` (id, tramite_id UNIQUE FK→tramites, organismo_expediente_id FK→organismos_expediente).
+  2. Drop columna `tramite_id` (+ FK fk_org_exp_tramite + UC uq_org_exp_tramite) de `organismos_expediente`.
+  3. Drop columna `num_iteraciones_organismo` de `organismos_expediente`.
+  4. Añadir columna `condicionados_doc_id` (nullable FK→documentos) a `organismos_expediente`.
+  5. Seed tipo_documento `CONDICIONADO_OFICIO`.
+  6. GRANT SELECT en `tramites_organismos` al rol claude_desktop.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '456_tramites_organismos'
+down_revision = '448_seed_plazos_resolucion'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Nueva tabla tramites_organismos
+    op.create_table(
+        'tramites_organismos',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('tramite_id', sa.Integer(), nullable=False,
+                  comment='FK tramites (UNIQUE — un trámite pertenece a un solo organismo)'),
+        sa.Column('organismo_expediente_id', sa.Integer(), nullable=False,
+                  comment='FK organismos_expediente. Organismo al que pertenece el trámite'),
+        sa.PrimaryKeyConstraint('id', name='pk_tramites_organismos'),
+        sa.ForeignKeyConstraint(['tramite_id'], ['public.tramites.id'],
+                                name='fk_tramorg_tramite', ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['organismo_expediente_id'], ['public.organismos_expediente.id'],
+                                name='fk_tramorg_organismo_expediente', ondelete='CASCADE'),
+        sa.UniqueConstraint('tramite_id', name='uq_tramorg_tramite'),
+        schema='public',
+    )
+    op.create_index('idx_tramorg_organismo', 'tramites_organismos',
+                    ['organismo_expediente_id'], schema='public')
+
+    # 2. Drop tramite_id de organismos_expediente
+    op.drop_constraint('uq_org_exp_tramite', 'organismos_expediente', schema='public', type_='unique')
+    op.drop_constraint('fk_org_exp_tramite', 'organismos_expediente', schema='public', type_='foreignkey')
+    op.drop_column('organismos_expediente', 'tramite_id', schema='public')
+
+    # 3. Drop num_iteraciones_organismo de organismos_expediente
+    op.drop_column('organismos_expediente', 'num_iteraciones_organismo', schema='public')
+
+    # 4. Añadir condicionados_doc_id a organismos_expediente
+    op.add_column(
+        'organismos_expediente',
+        sa.Column('condicionados_doc_id', sa.Integer(), nullable=True,
+                  comment='FK documentos (CONDICIONADO_OFICIO). Solo cuando titular sin_respuesta en AAC tras condicionado'),
+        schema='public',
+    )
+    op.create_foreign_key(
+        'fk_org_exp_condicionados_doc',
+        'organismos_expediente', 'documentos',
+        ['condicionados_doc_id'], ['id'],
+        source_schema='public', referent_schema='public',
+    )
+
+    # 5. Seed CONDICIONADO_OFICIO
+    conn = op.get_bind()
+    conn.execute(sa.text("""
+        INSERT INTO public.tipos_documentos (codigo, nombre, origen)
+        VALUES ('CONDICIONADO_OFICIO',
+                'Condicionados incorporados de oficio por falta de respuesta del titular',
+                'INTERNO')
+        ON CONFLICT (codigo) DO NOTHING
+    """))
+
+    # 6. Grant SELECT al rol claude_desktop
+    op.execute("GRANT SELECT ON public.tramites_organismos TO claude_desktop")
+
+    # 7. Actualizar consulta nombrada organismos_consulta (#395) para usar tramites_organismos
+    _SQL_NUEVO = (
+        "SELECT\n"
+        "    e.nombre_completo                                        AS organismo_nombre,\n"
+        "    e.nif                                                    AS organismo_nif,\n"
+        "    oe.plazo_legal_dias                                      AS organismo_plazo_legal,\n"
+        "    oe.estado                                                AS organismo_resultado,\n"
+        "    TO_CHAR(d_notif.fecha_administrativa, 'DD/MM/YYYY')      AS organismo_fecha_envio,\n"
+        "    TO_CHAR(d_resp.fecha_administrativa,  'DD/MM/YYYY')      AS organismo_fecha_respuesta\n"
+        "FROM public.organismos_expediente oe\n"
+        "JOIN public.entidades e\n"
+        "    ON e.id = oe.organismo_id\n"
+        "LEFT JOIN public.tramites_organismos torg\n"
+        "    ON torg.organismo_expediente_id = oe.id\n"
+        "LEFT JOIN public.tramites tr\n"
+        "    ON tr.id = torg.tramite_id\n"
+        "LEFT JOIN public.tareas t_n\n"
+        "    ON t_n.tramite_id = tr.id\n"
+        "    AND t_n.tipo_tarea_id = (SELECT id FROM public.tipos_tareas WHERE codigo = 'NOTIFICAR')\n"
+        "LEFT JOIN public.documentos_tarea dt_n\n"
+        "    ON dt_n.tarea_id = t_n.id AND dt_n.rol = 'PRODUCIDO'\n"
+        "LEFT JOIN public.documentos d_notif\n"
+        "    ON d_notif.id = dt_n.documento_id\n"
+        "LEFT JOIN public.tareas t_a\n"
+        "    ON t_a.tramite_id = tr.id\n"
+        "    AND t_a.tipo_tarea_id = (SELECT id FROM public.tipos_tareas WHERE codigo = 'ANALIZAR')\n"
+        "LEFT JOIN public.documentos_tarea dt_a\n"
+        "    ON dt_a.tarea_id = t_a.id AND dt_a.rol = 'CONSUMIDO'\n"
+        "LEFT JOIN public.documentos d_resp\n"
+        "    ON d_resp.id = dt_a.documento_id\n"
+        "WHERE oe.expediente_id = :expediente_id\n"
+        "ORDER BY e.nombre_completo"
+    )
+    conn.execute(sa.text(
+        "UPDATE public.consultas_nombradas SET sql = :sql WHERE nombre = 'organismos_consulta'"
+    ), {"sql": _SQL_NUEVO})
+
+
+def downgrade():
+    op.execute("REVOKE SELECT ON public.tramites_organismos FROM claude_desktop")
+
+    conn = op.get_bind()
+
+    # Restaurar SQL de organismos_consulta a la versión anterior a #456
+    _SQL_ANTERIOR = (
+        "SELECT\n"
+        "    e.nombre_completo                                        AS organismo_nombre,\n"
+        "    e.nif                                                    AS organismo_nif,\n"
+        "    oe.plazo_legal_dias                                      AS organismo_plazo_legal,\n"
+        "    oe.estado                                                AS organismo_resultado,\n"
+        "    TO_CHAR(d_notif.fecha_administrativa, 'DD/MM/YYYY')      AS organismo_fecha_envio,\n"
+        "    TO_CHAR(d_resp.fecha_administrativa,  'DD/MM/YYYY')      AS organismo_fecha_respuesta\n"
+        "FROM public.organismos_expediente oe\n"
+        "JOIN public.entidades e\n"
+        "    ON e.id = oe.organismo_id\n"
+        "LEFT JOIN public.tramites tr\n"
+        "    ON tr.id = oe.tramite_id\n"
+        "LEFT JOIN public.tareas t_n\n"
+        "    ON t_n.tramite_id = tr.id\n"
+        "    AND t_n.tipo_tarea_id = (SELECT id FROM public.tipos_tareas WHERE codigo = 'NOTIFICAR')\n"
+        "LEFT JOIN public.documentos_tarea dt_n\n"
+        "    ON dt_n.tarea_id = t_n.id AND dt_n.rol = 'PRODUCIDO'\n"
+        "LEFT JOIN public.documentos d_notif\n"
+        "    ON d_notif.id = dt_n.documento_id\n"
+        "LEFT JOIN public.tareas t_a\n"
+        "    ON t_a.tramite_id = tr.id\n"
+        "    AND t_a.tipo_tarea_id = (SELECT id FROM public.tipos_tareas WHERE codigo = 'ANALIZAR')\n"
+        "LEFT JOIN public.documentos_tarea dt_a\n"
+        "    ON dt_a.tarea_id = t_a.id AND dt_a.rol = 'CONSUMIDO'\n"
+        "LEFT JOIN public.documentos d_resp\n"
+        "    ON d_resp.id = dt_a.documento_id\n"
+        "WHERE oe.expediente_id = :expediente_id\n"
+        "ORDER BY e.nombre_completo"
+    )
+    conn.execute(sa.text(
+        "UPDATE public.consultas_nombradas SET sql = :sql WHERE nombre = 'organismos_consulta'"
+    ), {"sql": _SQL_ANTERIOR})
+
+    conn.execute(sa.text(
+        "DELETE FROM public.tipos_documentos WHERE codigo = 'CONDICIONADO_OFICIO'"
+    ))
+
+    op.drop_constraint('fk_org_exp_condicionados_doc', 'organismos_expediente',
+                       schema='public', type_='foreignkey')
+    op.drop_column('organismos_expediente', 'condicionados_doc_id', schema='public')
+
+    op.add_column(
+        'organismos_expediente',
+        sa.Column('num_iteraciones_organismo', sa.Integer(), nullable=False, server_default='0',
+                  comment='Contador de trámites CONSULTA_TRASLADO_ORGANISMO creados'),
+        schema='public',
+    )
+    op.add_column(
+        'organismos_expediente',
+        sa.Column('tramite_id', sa.Integer(), nullable=True,
+                  comment='FK al trámite CONSULTA_SEPARATA asociado. NULL hasta que se crea'),
+        schema='public',
+    )
+    op.create_foreign_key(
+        'fk_org_exp_tramite',
+        'organismos_expediente', 'tramites',
+        ['tramite_id'], ['id'],
+        source_schema='public', referent_schema='public',
+    )
+    op.create_unique_constraint('uq_org_exp_tramite', 'organismos_expediente',
+                                ['tramite_id'], schema='public')
+
+    op.drop_index('idx_tramorg_organismo', table_name='tramites_organismos', schema='public')
+    op.drop_table('tramites_organismos', schema='public')

--- a/tests/test_247_organismos_crud.py
+++ b/tests/test_247_organismos_crud.py
@@ -7,16 +7,15 @@ from unittest.mock import MagicMock
 
 
 def _oe_stub(id=1, organismo_id=5, via='consulta', estado='pendiente',
-             num_iteraciones=0, plazo_legal_dias=30, tramite_id=12):
+             plazo_legal_dias=30, condicionados_doc_id=None):
     oe = MagicMock()
     oe.id = id
     oe.organismo_id = organismo_id
     oe.organismo = MagicMock(nombre_completo='Red Eléctrica de España, S.A.', nif='A78003662')
     oe.via = via
     oe.estado = estado
-    oe.num_iteraciones_organismo = num_iteraciones
     oe.plazo_legal_dias = plazo_legal_dias
-    oe.tramite_id = tramite_id
+    oe.condicionados_doc_id = condicionados_doc_id
     return oe
 
 
@@ -32,9 +31,8 @@ class TestSerializarOrgExp:
         assert result['nif'] == 'A78003662'
         assert result['via'] == 'consulta'
         assert result['estado'] == 'pendiente'
-        assert result['num_iteraciones_organismo'] == 0
         assert result['plazo_legal_dias'] == 30
-        assert result['tramite_id'] == 12
+        assert result['condicionados_doc_id'] is None
 
     def test_get_expediente_no_existe(self):
         # get_or_404 gestiona la respuesta 404; sin organismo los campos vienen None
@@ -48,7 +46,7 @@ class TestSerializarOrgExp:
     def test_post_organismo_ok(self):
         # Verifica que los campos del POST se serializan correctamente al crearse el registro
         from app.routes.api_bc import _serializar_org_exp
-        oe = _oe_stub(id=7, organismo_id=5, via='consulta', plazo_legal_dias=None, tramite_id=None)
+        oe = _oe_stub(id=7, organismo_id=5, via='consulta', plazo_legal_dias=None)
         oe.organismo = MagicMock(nombre_completo='Endesa, S.A.', nif='A81947556')
         result = _serializar_org_exp(oe)
         assert result['id'] == 7

--- a/tests/test_391_organismo_expediente.py
+++ b/tests/test_391_organismo_expediente.py
@@ -20,16 +20,22 @@ def _organismo(nombre='Red Eléctrica de España', nif='A78003662'):
     return org
 
 
-def _org_exp(organismo=None, plazo_legal_dias=30, estado='pendiente', tramite_id=1):
+def _org_exp(organismo=None, plazo_legal_dias=30, estado='pendiente'):
     """Stub de OrganismoExpediente con as_contexto_cb() delegando al método real."""
     from app.models.organismos_expediente import OrganismoExpediente
     oe = MagicMock()
     oe.organismo = organismo or _organismo()
     oe.plazo_legal_dias = plazo_legal_dias
     oe.estado = estado
-    oe.tramite_id = tramite_id
     oe.as_contexto_cb = lambda: OrganismoExpediente.as_contexto_cb(oe)
     return oe
+
+
+def _vinculo_stub(oe):
+    """Stub de TramiteOrganismo apuntando a un OrganismoExpediente."""
+    v = MagicMock()
+    v.organismo_expediente = oe
+    return v
 
 
 def _tarea_stub(codigo, doc_producido=None, doc_usado=None, tramite_id=1):
@@ -113,7 +119,7 @@ class TestContextoConsultaSeparata:
         from app.services.context_builders.consulta_separata import ContextoConsultaSeparata
         tarea = _tarea_stub('ELABORAR', tramite_id=99)
         cb = ContextoConsultaSeparata(MagicMock(), MagicMock(), tarea=tarea)
-        with patch('app.services.context_builders.consulta_separata.OrganismoExpediente') as mock_cls:
+        with patch('app.services.context_builders.consulta_separata.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = None
             result = cb.get_contexto()
         assert result == {}
@@ -125,8 +131,8 @@ class TestContextoConsultaSeparata:
 
         oe = _org_exp(estado='pendiente')
         cb = ContextoConsultaSeparata(MagicMock(), MagicMock(), tarea=tarea_elab)
-        with patch('app.services.context_builders.consulta_separata.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.consulta_separata.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_envio'] is None
@@ -142,8 +148,8 @@ class TestContextoConsultaSeparata:
 
         oe = _org_exp(estado='separata_enviada')
         cb = ContextoConsultaSeparata(MagicMock(), MagicMock(), tarea=tarea_elab)
-        with patch('app.services.context_builders.consulta_separata.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.consulta_separata.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_envio'] == '15/05/2026'
@@ -160,8 +166,8 @@ class TestContextoConsultaSeparata:
 
         oe = _org_exp(estado='cerrado_con_condicionados', plazo_legal_dias=30)
         cb = ContextoConsultaSeparata(MagicMock(), MagicMock(), tarea=tarea_elab)
-        with patch('app.services.context_builders.consulta_separata.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.consulta_separata.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_envio'] == '15/05/2026'
@@ -177,8 +183,8 @@ class TestContextoConsultaSeparata:
 
         oe = _org_exp()
         cb = ContextoConsultaSeparata(MagicMock(), MagicMock(), tarea=tarea_elab)
-        with patch('app.services.context_builders.consulta_separata.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.consulta_separata.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_envio'] is None

--- a/tests/test_395_organismos_consulta.py
+++ b/tests/test_395_organismos_consulta.py
@@ -86,11 +86,15 @@ def organismos_data(app_ctx):
             "VALUES (:t,:d,'CONSUMIDO')"
         ), {"t": t_anal1, "d": doc_resp1})
 
-        conn.execute(text(
+        oe1 = conn.execute(text(
             "INSERT INTO public.organismos_expediente "
-            "(expediente_id, organismo_id, via, estado, plazo_legal_dias, tramite_id) "
-            "VALUES (:e,:o,'consulta','cerrado_favorable',30,:tr)"
-        ), {"e": _EXP_ID, "o": _ORG1_ID, "tr": tr1})
+            "(expediente_id, organismo_id, via, estado, plazo_legal_dias) "
+            "VALUES (:e,:o,'consulta','cerrado_favorable',30) RETURNING id"
+        ), {"e": _EXP_ID, "o": _ORG1_ID}).scalar()
+        conn.execute(text(
+            "INSERT INTO public.tramites_organismos (tramite_id, organismo_expediente_id) "
+            "VALUES (:tr,:oe)"
+        ), {"tr": tr1, "oe": oe1})
 
         # ── Organismo 2: sin respuesta ───────────────────────────────────
         tr2 = conn.execute(text(
@@ -113,11 +117,15 @@ def organismos_data(app_ctx):
             "VALUES (:t,:d,'PRODUCIDO')"
         ), {"t": t_notif2, "d": doc_notif2})
 
-        conn.execute(text(
+        oe2 = conn.execute(text(
             "INSERT INTO public.organismos_expediente "
-            "(expediente_id, organismo_id, via, estado, plazo_legal_dias, tramite_id) "
-            "VALUES (:e,:o,'consulta','separata_enviada',30,:tr)"
-        ), {"e": _EXP_ID, "o": _ORG2_ID, "tr": tr2})
+            "(expediente_id, organismo_id, via, estado, plazo_legal_dias) "
+            "VALUES (:e,:o,'consulta','separata_enviada',30) RETURNING id"
+        ), {"e": _EXP_ID, "o": _ORG2_ID}).scalar()
+        conn.execute(text(
+            "INSERT INTO public.tramites_organismos (tramite_id, organismo_expediente_id) "
+            "VALUES (:tr,:oe)"
+        ), {"tr": tr2, "oe": oe2})
 
         yield _EXP_ID, conn
 

--- a/tests/test_402_notificacion_organismo.py
+++ b/tests/test_402_notificacion_organismo.py
@@ -18,16 +18,22 @@ def _organismo(nombre='Confederación Hidrográfica del Guadalquivir', nif='Q415
     return org
 
 
-def _org_exp(organismo=None, plazo_legal_dias=30, estado='en_tramitacion', tramite_id=1):
+def _org_exp(organismo=None, plazo_legal_dias=30, estado='en_tramitacion'):
     """Stub de OrganismoExpediente con as_contexto_cb() delegando al método real."""
     from app.models.organismos_expediente import OrganismoExpediente
     oe = MagicMock()
     oe.organismo = organismo or _organismo()
     oe.plazo_legal_dias = plazo_legal_dias
     oe.estado = estado
-    oe.tramite_id = tramite_id
     oe.as_contexto_cb = lambda: OrganismoExpediente.as_contexto_cb(oe)
     return oe
+
+
+def _vinculo_stub(oe):
+    """Stub de TramiteOrganismo apuntando a un OrganismoExpediente."""
+    v = MagicMock()
+    v.organismo_expediente = oe
+    return v
 
 
 def _tarea_stub(codigo, doc_usado=None, tramite_id=1):
@@ -69,7 +75,7 @@ class TestContextoNotificacionOrganismo:
     def test_sin_organismo_expediente_devuelve_vacio(self):
         tarea = _tarea_stub('ELABORAR', tramite_id=99)
         cb = _cb(tarea)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = None
             result = cb.get_contexto()
         assert result == {}
@@ -80,8 +86,8 @@ class TestContextoNotificacionOrganismo:
 
         oe = _org_exp(estado='en_tramitacion', plazo_legal_dias=30)
         cb = _cb(tarea_elab)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_respuesta'] is None
@@ -96,8 +102,8 @@ class TestContextoNotificacionOrganismo:
 
         oe = _org_exp(estado='cerrado_con_condicionados', plazo_legal_dias=30)
         cb = _cb(tarea_elab)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_respuesta'] == '10/04/2026'
@@ -113,8 +119,8 @@ class TestContextoNotificacionOrganismo:
 
         oe = _org_exp(plazo_legal_dias=15)
         cb = _cb(tarea_elab)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_limite'] == '16/05/2026'  # +15 días
@@ -127,8 +133,8 @@ class TestContextoNotificacionOrganismo:
 
         oe = _org_exp(plazo_legal_dias=None)
         cb = _cb(tarea_elab)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_respuesta'] == '01/05/2026'
@@ -141,8 +147,8 @@ class TestContextoNotificacionOrganismo:
 
         oe = _org_exp(plazo_legal_dias=30)
         cb = _cb(tarea_elab)
-        with patch('app.services.context_builders.contexto_notificacion_organismo.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = oe
+        with patch('app.services.context_builders.contexto_notificacion_organismo.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(oe)
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_respuesta'] is None

--- a/tests/test_456_tramites_organismos.py
+++ b/tests/test_456_tramites_organismos.py
@@ -1,0 +1,119 @@
+"""
+Tests issue #456 — TramiteOrganismo y OrganismoExpediente.consulta_completa.
+
+Bloques:
+  A) Modelo TramiteOrganismo — atributos y constraints declarados.
+  B) OrganismoExpediente.consulta_completa — casos ADR-011 §6.
+  C) OrganismoExpediente — campo condicionados_doc_id presente.
+
+Patrón: objetos Python puros y reflexión de modelo, sin BD real.
+"""
+from unittest.mock import MagicMock
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A) Modelo TramiteOrganismo
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestModeloTramiteOrganismo:
+
+    def test_tabla_correcta(self):
+        from app.models.tramites_organismos import TramiteOrganismo
+        assert TramiteOrganismo.__tablename__ == 'tramites_organismos'
+
+    def test_columnas_requeridas(self):
+        from app.models.tramites_organismos import TramiteOrganismo
+        cols = {c.name for c in TramiteOrganismo.__table__.columns}
+        assert 'id' in cols
+        assert 'tramite_id' in cols
+        assert 'organismo_expediente_id' in cols
+
+    def test_tramite_id_unique(self):
+        from app.models.tramites_organismos import TramiteOrganismo
+        col = TramiteOrganismo.__table__.c['tramite_id']
+        assert col.unique or any(
+            'tramite_id' in [c.name for c in uc.columns]
+            for uc in TramiteOrganismo.__table__.constraints
+            if hasattr(uc, 'columns')
+        )
+
+    def test_uq_tramorg_tramite_constraint(self):
+        from app.models.tramites_organismos import TramiteOrganismo
+        nombres = [c.name for c in TramiteOrganismo.__table__.constraints]
+        assert 'uq_tramorg_tramite' in nombres
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B) OrganismoExpediente.consulta_completa
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _oe_stub(via='consulta', estado='pendiente'):
+    from app.models.organismos_expediente import OrganismoExpediente
+    oe = MagicMock()
+    oe.via = via
+    oe.estado = estado
+    oe.consulta_completa = property(lambda s: OrganismoExpediente.consulta_completa.fget(s))
+    # Instanciar delegando al método real
+    oe.consulta_completa = OrganismoExpediente.consulta_completa.fget(oe)
+    return oe
+
+
+class TestConsultaCompleta:
+
+    def _eval(self, via, estado):
+        from app.models.organismos_expediente import OrganismoExpediente
+        oe = MagicMock()
+        oe.via = via
+        oe.estado = estado
+        return OrganismoExpediente.consulta_completa.fget(oe)
+
+    def test_pendiente_incompleta(self):
+        assert not self._eval('consulta', 'pendiente')
+
+    def test_separata_enviada_incompleta(self):
+        assert not self._eval('consulta', 'separata_enviada')
+
+    def test_en_tramitacion_incompleta(self):
+        assert not self._eval('consulta', 'en_tramitacion')
+
+    def test_cerrado_favorable_completa(self):
+        assert self._eval('consulta', 'cerrado_favorable')
+
+    def test_cerrado_con_condicionados_completa(self):
+        assert self._eval('consulta', 'cerrado_con_condicionados')
+
+    def test_audiencia_previa_incompleta(self):
+        assert not self._eval('consulta', 'audiencia_previa')
+
+    def test_declaracion_responsable_exonerado_completa(self):
+        assert self._eval('declaracion_responsable', 'exonerado')
+
+    def test_declaracion_responsable_pendiente_incompleta(self):
+        assert not self._eval('declaracion_responsable', 'pendiente')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C) condicionados_doc_id en OrganismoExpediente
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCondicionadosDocId:
+
+    def test_columna_presente(self):
+        from app.models.organismos_expediente import OrganismoExpediente
+        cols = {c.name for c in OrganismoExpediente.__table__.columns}
+        assert 'condicionados_doc_id' in cols
+
+    def test_columna_nullable(self):
+        from app.models.organismos_expediente import OrganismoExpediente
+        col = OrganismoExpediente.__table__.c['condicionados_doc_id']
+        assert col.nullable
+
+    def test_tramite_id_eliminado(self):
+        from app.models.organismos_expediente import OrganismoExpediente
+        cols = {c.name for c in OrganismoExpediente.__table__.columns}
+        assert 'tramite_id' not in cols
+
+    def test_num_iteraciones_eliminado(self):
+        from app.models.organismos_expediente import OrganismoExpediente
+        cols = {c.name for c in OrganismoExpediente.__table__.columns}
+        assert 'num_iteraciones_organismo' not in cols

--- a/tests/test_458_estado_organismo.py
+++ b/tests/test_458_estado_organismo.py
@@ -15,6 +15,13 @@ def _tarea_stub(codigo_tarea, codigo_tramite, tramite_id=5):
     return tarea
 
 
+def _vinculo_stub(org):
+    """Stub de TramiteOrganismo apuntando a un OrganismoExpediente."""
+    v = MagicMock()
+    v.organismo_expediente = org
+    return v
+
+
 class TestHook458EstadoOrganismo:
 
     def test_analizar_separata_pone_en_tramitacion(self):
@@ -23,8 +30,8 @@ class TestHook458EstadoOrganismo:
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = org
+        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=10)
 
         assert org.estado == 'en_tramitacion'
@@ -36,8 +43,8 @@ class TestHook458EstadoOrganismo:
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = org
+        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=10)
 
         assert org.estado == 'separata_enviada'
@@ -47,7 +54,7 @@ class TestHook458EstadoOrganismo:
         from app.routes.api_bc import _hook_458_analizar_separata
         tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=99)
 
-        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
+        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = None
             # No debe lanzar excepción
             _hook_458_analizar_separata(tarea, id_producido=10)
@@ -58,8 +65,8 @@ class TestHook458EstadoOrganismo:
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.OrganismoExpediente') as mock_cls:
-            mock_cls.query.filter_by.return_value.first.return_value = org
+        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=None)
 
         assert org.estado == 'separata_enviada'

--- a/tests/test_459_iteraciones_organismo.py
+++ b/tests/test_459_iteraciones_organismo.py
@@ -1,9 +1,13 @@
 """
 Tests #459 — hook _hook_459_traslado_organismo en crear_tramite.
 
+Tras #456: el hook ya no incrementa num_iteraciones_organismo (campo eliminado).
+Navega al organismo vía TramiteOrganismo.query.filter(tramite_id.in_()).
+El conteo de iteraciones es un COUNT derivado que implementa #460.
+
 Patrón: objetos Python puros (MagicMock), sin BD real ni cliente Flask.
 """
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 
 def _tipo_tramite_stub(codigo):
@@ -19,55 +23,41 @@ def _fase_stub(fase_id=1):
     return fase
 
 
-def _org_stub(tramite_id, num_iteraciones=0):
-    org = MagicMock()
-    org.tramite_id = tramite_id
-    org.num_iteraciones_organismo = num_iteraciones
-    return org
+class TestHook459TrasladoOrganismo:
 
+    def test_otro_tramite_no_consulta_bd(self):
+        from app.routes.api_bc import _hook_459_traslado_organismo
+        tipo = _tipo_tramite_stub('CONSULTA_SEPARATA')
+        fase = _fase_stub(1)
 
-class TestHook459IteracionesOrganismo:
+        with patch('app.routes.api_bc.TipoTramite') as mock_tt:
+            _hook_459_traslado_organismo(tipo, fase)
+            mock_tt.query.filter_by.assert_not_called()
 
-    def test_crear_traslado_organismo_incrementa(self):
+    def test_traslado_organismo_navega_via_tramite_organismo(self):
         from app.routes.api_bc import _hook_459_traslado_organismo
         tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
         fase = _fase_stub(1)
-        org = _org_stub(tramite_id=10, num_iteraciones=0)
 
         cod_sep = MagicMock()
         cod_sep.id = 7
-
         tram_sep = MagicMock()
         tram_sep.id = 10
 
         with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
              patch('app.routes.api_bc.Tramite') as mock_tram, \
-             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+             patch('app.routes.api_bc.TramiteOrganismo') as mock_org:
 
             mock_tt.query.filter_by.return_value.first.return_value = cod_sep
             mock_tram.query.filter_by.return_value.all.return_value = [tram_sep]
-            mock_org.query.filter.return_value.all.return_value = [org]
+            mock_org.query.filter.return_value.all.return_value = []
 
+            # No debe lanzar excepción aunque no haya vínculos
             _hook_459_traslado_organismo(tipo, fase)
 
-        assert org.num_iteraciones_organismo == 1
+        mock_org.query.filter.assert_called_once()
 
-    def test_crear_otro_tramite_no_incrementa(self):
-        from app.routes.api_bc import _hook_459_traslado_organismo
-        tipo = _tipo_tramite_stub('CONSULTA_SEPARATA')
-        fase = _fase_stub(1)
-        org = _org_stub(tramite_id=10, num_iteraciones=0)
-
-        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
-             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
-
-            _hook_459_traslado_organismo(tipo, fase)
-
-            mock_tt.query.filter_by.assert_not_called()
-
-        assert org.num_iteraciones_organismo == 0
-
-    def test_sin_organismo_no_falla(self):
+    def test_sin_separatas_no_consulta_tramite_organismo(self):
         from app.routes.api_bc import _hook_459_traslado_organismo
         tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
         fase = _fase_stub(1)
@@ -77,38 +67,11 @@ class TestHook459IteracionesOrganismo:
 
         with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
              patch('app.routes.api_bc.Tramite') as mock_tram, \
-             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
+             patch('app.routes.api_bc.TramiteOrganismo') as mock_org:
 
             mock_tt.query.filter_by.return_value.first.return_value = cod_sep
             mock_tram.query.filter_by.return_value.all.return_value = []
-            mock_org.query.filter.return_value.all.return_value = []
-
-            # No debe lanzar excepción
-            _hook_459_traslado_organismo(tipo, fase)
-
-    def test_multiples_organismos_no_incrementa(self):
-        from app.routes.api_bc import _hook_459_traslado_organismo
-        tipo = _tipo_tramite_stub('CONSULTA_TRASLADO_ORGANISMO')
-        fase = _fase_stub(1)
-        org1 = _org_stub(tramite_id=10, num_iteraciones=0)
-        org2 = _org_stub(tramite_id=11, num_iteraciones=0)
-
-        cod_sep = MagicMock()
-        cod_sep.id = 7
-        tram1 = MagicMock()
-        tram1.id = 10
-        tram2 = MagicMock()
-        tram2.id = 11
-
-        with patch('app.routes.api_bc.TipoTramite') as mock_tt, \
-             patch('app.routes.api_bc.Tramite') as mock_tram, \
-             patch('app.routes.api_bc.OrganismoExpediente') as mock_org:
-
-            mock_tt.query.filter_by.return_value.first.return_value = cod_sep
-            mock_tram.query.filter_by.return_value.all.return_value = [tram1, tram2]
-            mock_org.query.filter.return_value.all.return_value = [org1, org2]
 
             _hook_459_traslado_organismo(tipo, fase)
 
-        assert org1.num_iteraciones_organismo == 0
-        assert org2.num_iteraciones_organismo == 0
+        mock_org.query.filter.assert_not_called()


### PR DESCRIPTION
## Cambios

Implementa ADR-011: vinculación trámites↔organismos y criterios de completitud de la fase CONSULTAS.

### Esquema (commit MIGRA)
- Nueva tabla `tramites_organismos` (id, tramite_id UNIQUE FK→tramites, organismo_expediente_id FK→organismos_expediente).
- Drop `tramite_id` y `num_iteraciones_organismo` de `organismos_expediente` (constraint `uq_org_exp_tramite` eliminada).
- Nuevo campo `condicionados_doc_id` en `organismos_expediente` (FK nullable → documentos).
- Seed del tipo de documento `CONDICIONADO_OFICIO`.
- `UPDATE` del SQL de la consulta nombrada `organismos_consulta` (#395) para navegar vía `tramites_organismos`.
- `GRANT SELECT` en `tramites_organismos` al rol claude_desktop.

### Modelos (commit MODEL)
- Nuevo `TramiteOrganismo` con backref `tramites_organismo` en `OrganismoExpediente`.
- `OrganismoExpediente.consulta_completa` (property) — criterios de completitud por estado; pendiente afinar con `TramiteOrganismo.resultado` (#460).
- `condicionados_doc` relationship.

### Rutas y CBs (commit RUTA)
- `ContextoConsultaSeparata` y `ContextoNotificacionOrganismo` navegan al organismo vía `TramiteOrganismo.query.filter_by(tramite_id=...)`.
- `_hook_458_analizar_separata` y `_hook_459_traslado_organismo` siguen el mismo patrón. `_hook_459` ya no incrementa contador (campo eliminado); el conteo se hará en #460 como COUNT.
- `_serializar_org_exp` deja de devolver `tramite_id` y `num_iteraciones_organismo`; añade `condicionados_doc_id`.

### Tests (commit TEST)
- Nuevo `test_456_tramites_organismos.py` (16 tests: modelo TramiteOrganismo, `consulta_completa` por estado y vía, presencia/ausencia de columnas en `organismos_expediente`).
- Actualizados 6 tests existentes (stubs sin `tramite_id`/`num_iteraciones_organismo`, patches a `TramiteOrganismo`, INSERTs SQL adaptados a la nueva tabla).

### Resultado
- Suite: 438 passed, 7 failed pre-existentes (sin relación con #456, verificado con `git stash`).
- Migración aplicada/revertida limpiamente en local.

Closes #456
