### PR TITLE
Añadir CBs ContextoConsultaTrasladoTitular y ContextoConsultaTrasladoOrganismo

### DIFF
--- a/app/services/context_builders/contexto_consulta_traslado_organismo.py
+++ b/app/services/context_builders/contexto_consulta_traslado_organismo.py
@@ -1,0 +1,104 @@
+from app.models.tramites import Tramite
+from app.models.tramites_organismos import TramiteOrganismo
+from app.models.tipos_tramites import TipoTramite
+
+
+class ContextoConsultaTrasladoOrganismo:
+    """
+    Context Builder para escritos del trámite CONSULTA_TRASLADO_ORGANISMO.
+
+    Enriquece el contexto base con datos del organismo al que se trasladan
+    los reparos del titular y las fechas del ciclo. Navega al organismo vía
+    tramites_organismos (ADR-011 §1).
+
+    Campos adicionales aportados:
+    - organismo_nombre          str   Nombre oficial del organismo
+    - organismo_nif             str   NIF del organismo (puede ser None)
+    - organismo_plazo_legal     int   Plazo legal en días capturado al crear la separata
+    - organismo_resultado       str   Estado del ciclo del organismo
+    - organismo_fecha_respuesta str   Fecha del doc producido por ESPERAR_PLAZO del trámite
+                                      anterior del organismo (separata o traslado previo).
+                                      DD/MM/AAAA o None si no está disponible
+    - titular_fecha_respuesta   str   Fecha del doc producido por ESPERAR_PLAZO del
+                                      CONSULTA_TRASLADO_TITULAR más reciente del organismo.
+                                      DD/MM/AAAA o None si aún no se ha recibido respuesta
+    - organismo_num_iteraciones int   Número de trámites CONSULTA_TRASLADO_ORGANISMO del
+                                      organismo (incluye el actual). Derivado de ADR-011 §2
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        vinculo = (TramiteOrganismo.query
+                   .filter_by(tramite_id=self._tarea.tramite_id)
+                   .first())
+        org_exp = vinculo.organismo_expediente if vinculo else None
+
+        if not org_exp:
+            return {}
+
+        ctx = org_exp.as_contexto_cb()
+
+        # Respuesta del organismo: ESPERAR_PLAZO del trámite anterior del organismo
+        # (CONSULTA_SEPARATA o CONSULTA_TRASLADO_ORGANISMO previo, excluyendo el actual)
+        tramite_ant = (TramiteOrganismo.query
+                       .join(Tramite, TramiteOrganismo.tramite_id == Tramite.id)
+                       .join(TipoTramite, Tramite.tipo_tramite_id == TipoTramite.id)
+                       .filter(TramiteOrganismo.organismo_expediente_id == org_exp.id)
+                       .filter(TipoTramite.codigo.in_(
+                           ['CONSULTA_SEPARATA', 'CONSULTA_TRASLADO_ORGANISMO']
+                       ))
+                       .filter(TramiteOrganismo.tramite_id != self._tarea.tramite_id)
+                       .order_by(TramiteOrganismo.id.desc())
+                       .first())
+        doc_org = _doc_esperar_plazo(tramite_ant)
+        ctx['organismo_fecha_respuesta'] = _formato_fecha(doc_org)
+
+        # Respuesta del titular: ESPERAR_PLAZO del CONSULTA_TRASLADO_TITULAR más reciente
+        traslado_tit = (TramiteOrganismo.query
+                        .join(Tramite, TramiteOrganismo.tramite_id == Tramite.id)
+                        .join(TipoTramite, Tramite.tipo_tramite_id == TipoTramite.id)
+                        .filter(TramiteOrganismo.organismo_expediente_id == org_exp.id)
+                        .filter(TipoTramite.codigo == 'CONSULTA_TRASLADO_TITULAR')
+                        .order_by(TramiteOrganismo.id.desc())
+                        .first())
+        doc_tit = _doc_esperar_plazo(traslado_tit)
+        ctx['titular_fecha_respuesta'] = _formato_fecha(doc_tit)
+
+        # Número de iteraciones: COUNT de CONSULTA_TRASLADO_ORGANISMO del organismo
+        ctx['organismo_num_iteraciones'] = (
+            TramiteOrganismo.query
+            .join(Tramite, TramiteOrganismo.tramite_id == Tramite.id)
+            .join(TipoTramite, Tramite.tipo_tramite_id == TipoTramite.id)
+            .filter(TramiteOrganismo.organismo_expediente_id == org_exp.id)
+            .filter(TipoTramite.codigo == 'CONSULTA_TRASLADO_ORGANISMO')
+            .count()
+        )
+
+        return ctx
+
+
+def _doc_esperar_plazo(vinculo_tramite):
+    """Devuelve el doc producido por la tarea ESPERAR_PLAZO del trámite vinculado, o None."""
+    if not vinculo_tramite:
+        return None
+    tareas = {
+        t.tipo_tarea.codigo: t
+        for t in vinculo_tramite.tramite.tareas
+        if t.tipo_tarea
+    }
+    tarea_esp = tareas.get('ESPERAR_PLAZO')
+    return tarea_esp.documento_producido if tarea_esp else None
+
+
+def _formato_fecha(doc):
+    """Formatea fecha_administrativa de un documento como DD/MM/AAAA, o None."""
+    if doc and doc.fecha_administrativa:
+        return doc.fecha_administrativa.strftime('%d/%m/%Y')
+    return None

--- a/app/services/context_builders/contexto_consulta_traslado_titular.py
+++ b/app/services/context_builders/contexto_consulta_traslado_titular.py
@@ -1,0 +1,67 @@
+from app.models.tramites_organismos import TramiteOrganismo
+
+
+class ContextoConsultaTrasladoTitular:
+    """
+    Context Builder para escritos del trámite CONSULTA_TRASLADO_TITULAR.
+
+    Enriquece el contexto base con datos del organismo cuya respuesta se traslada
+    al titular y las fechas del ciclo. Navega al organismo vía tramites_organismos
+    (ADR-011 §1).
+
+    Campos adicionales aportados:
+    - organismo_nombre         str   Nombre oficial del organismo
+    - organismo_nif            str   NIF del organismo (puede ser None)
+    - organismo_plazo_legal    int   Plazo legal en días capturado al crear la separata
+    - organismo_resultado      str   Estado del ciclo del organismo
+    - organismo_fecha_respuesta str  Fecha del doc que consume ELABORAR (respuesta del
+                                     organismo: de la separata o del traslado anterior).
+                                     DD/MM/AAAA o None si el doc no tiene fecha
+    - titular_fecha_respuesta  str   Fecha del doc producido por ESPERAR_PLAZO del trámite
+                                     (respuesta del titular). DD/MM/AAAA o None si aún
+                                     no se ha recibido respuesta
+    """
+
+    def __init__(self, expediente, db_session, tarea=None):
+        self._expediente = expediente
+        self._db = db_session
+        self._tarea = tarea
+
+    def get_contexto(self) -> dict:
+        if not self._tarea:
+            return {}
+
+        vinculo = (TramiteOrganismo.query
+                   .filter_by(tramite_id=self._tarea.tramite_id)
+                   .first())
+        org_exp = vinculo.organismo_expediente if vinculo else None
+
+        if not org_exp:
+            return {}
+
+        ctx = org_exp.as_contexto_cb()
+
+        tareas_por_codigo = {
+            t.tipo_tarea.codigo: t
+            for t in self._tarea.tramite.tareas
+            if t.tipo_tarea
+        }
+
+        # Respuesta del organismo: primer doc consumido por ELABORAR (obligatorio en migración 346)
+        tarea_elab = tareas_por_codigo.get('ELABORAR')
+        _consumidos_elab = tarea_elab.documentos_consumidos if tarea_elab else []
+        doc_org = _consumidos_elab[0] if _consumidos_elab else None
+        ctx['organismo_fecha_respuesta'] = (
+            doc_org.fecha_administrativa.strftime('%d/%m/%Y')
+            if doc_org and doc_org.fecha_administrativa else None
+        )
+
+        # Respuesta del titular: doc producido por ESPERAR_PLAZO del trámite actual
+        tarea_esp = tareas_por_codigo.get('ESPERAR_PLAZO')
+        doc_tit = tarea_esp.documento_producido if tarea_esp else None
+        ctx['titular_fecha_respuesta'] = (
+            doc_tit.fecha_administrativa.strftime('%d/%m/%Y')
+            if doc_tit and doc_tit.fecha_administrativa else None
+        )
+
+        return ctx

--- a/docs/referencia/DISEÑO_CONSULTAS_ORGANISMOS.md
+++ b/docs/referencia/DISEÑO_CONSULTAS_ORGANISMOS.md
@@ -341,5 +341,5 @@ El motor comprueba sobre los trámites de la fase:
 - **Acción en bloque** de creación de separatas desde `organismos_expediente` — issue #462.
 - ~~**Mover los diagramas PNG** de `docs_prueba/mockups/` a una ubicación permanente dentro de `docs/`.~~ **HECHO** — SVGs en `docs/diagramas_flujo/`.
 - **Tabla `tramites_organismos` + `condicionados_doc_id` + tipo `CONDICIONADO_OFICIO`:** implementar en #456 (ADR-011).
-- **CBs de traslado** (`ContextoConsultaTrasladoTitular`, `ContextoConsultaTrasladoOrganismo`): implementar en #457, tras #456.
+- ~~**CBs de traslado** (`ContextoConsultaTrasladoTitular`, `ContextoConsultaTrasladoOrganismo`): implementar en #457, tras #456.~~ **HECHO** — #457.
 - **Certificado de consultas:** el cierre favorable de la fase requiere `CERT_FIN_IP_CONSULTAS` con `favorable=True` validado por el motor — issue pendiente de crear (alcance a definir junto con #462).

--- a/docs/referencia/GUIA_CONTEXT_BUILDERS.md
+++ b/docs/referencia/GUIA_CONTEXT_BUILDERS.md
@@ -148,6 +148,8 @@ que son accedidos directamente por `ContextoBaseExpediente`.
 | `ContextoAnalisisAlegaciones` | `analisis_alegaciones.py` | `ANALISIS_ALEGACIONES` | Implementado | #394 |
 | `ContextoNotificacionOrganismo` | `notificacion_organismo.py` | `CONSULTA_TRASLADO_ORGANISMO` | Implementado | #402 |
 | `ContextoResolucion` | `resolucion.py` | `ELABORACION` (fase `RESOLUCION`) | Implementado | #403 |
+| `ContextoConsultaTrasladoTitular` | `contexto_consulta_traslado_titular.py` | `CONSULTA_TRASLADO_TITULAR` | Implementado | #457 |
+| `ContextoConsultaTrasladoOrganismo` | `contexto_consulta_traslado_organismo.py` | `CONSULTA_TRASLADO_ORGANISMO` | Implementado | #457 |
 
 ---
 

--- a/tests/test_457_cbs_traslado.py
+++ b/tests/test_457_cbs_traslado.py
@@ -1,0 +1,276 @@
+"""
+Tests issue #457 — ContextoConsultaTrasladoTitular y ContextoConsultaTrasladoOrganismo.
+
+Bloques:
+  A) ContextoConsultaTrasladoTitular.get_contexto()
+  B) ContextoConsultaTrasladoOrganismo.get_contexto()
+
+Patrón: stubs + mock de queries, sin BD ni app context.
+Los helpers de construcción se adaptan del patrón de test_391.
+"""
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Helpers compartidos
+# ───────────────────────────────────────────────────────────────────────────────
+
+def _organismo(nombre='Red Eléctrica de España', nif='A78003662'):
+    org = MagicMock()
+    org.nombre_completo = nombre
+    org.nif = nif
+    return org
+
+
+def _org_exp(organismo=None, plazo_legal_dias=30, estado='en_tramitacion'):
+    from app.models.organismos_expediente import OrganismoExpediente
+    oe = MagicMock()
+    oe.organismo = organismo or _organismo()
+    oe.plazo_legal_dias = plazo_legal_dias
+    oe.estado = estado
+    oe.as_contexto_cb = lambda: OrganismoExpediente.as_contexto_cb(oe)
+    return oe
+
+
+def _vinculo(oe):
+    v = MagicMock()
+    v.organismo_expediente = oe
+    return v
+
+
+def _doc(fecha=None):
+    d = MagicMock()
+    d.fecha_administrativa = fecha
+    return d
+
+
+def _tarea_stub(codigo, doc_producido=None, consumidos=None, tramite_id=1):
+    t = MagicMock()
+    t.tramite_id = tramite_id
+    t.tipo_tarea = MagicMock(codigo=codigo)
+    t.documento_producido = doc_producido
+    t.documentos_consumidos = consumidos if consumidos is not None else []
+    return t
+
+
+def _tramite_con_tareas(tareas):
+    tr = MagicMock()
+    tr.tareas = tareas
+    return tr
+
+
+def _vinculo_tramite(tareas):
+    """Stub de TramiteOrganismo con tramite que tiene las tareas dadas."""
+    vt = MagicMock()
+    vt.tramite = _tramite_con_tareas(tareas)
+    return vt
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# A) ContextoConsultaTrasladoTitular
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestContextoConsultaTrasladoTitular:
+
+    _MODULE = 'app.services.context_builders.contexto_consulta_traslado_titular.TramiteOrganismo'
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.contexto_consulta_traslado_titular import (
+            ContextoConsultaTrasladoTitular,
+        )
+        cb = ContextoConsultaTrasladoTitular(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_sin_organismo_expediente_devuelve_vacio(self):
+        from app.services.context_builders.contexto_consulta_traslado_titular import (
+            ContextoConsultaTrasladoTitular,
+        )
+        tarea = _tarea_stub('ELABORAR', tramite_id=5)
+        tarea.tramite = _tramite_con_tareas([tarea])
+        cb = ContextoConsultaTrasladoTitular(MagicMock(), MagicMock(), tarea=tarea)
+        with patch(self._MODULE) as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = None
+            assert cb.get_contexto() == {}
+
+    def test_elaborar_sin_documentos_fechas_none(self):
+        from app.services.context_builders.contexto_consulta_traslado_titular import (
+            ContextoConsultaTrasladoTitular,
+        )
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp(estado='en_tramitacion')
+        cb = ContextoConsultaTrasladoTitular(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo(oe)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] is None
+        assert ctx['titular_fecha_respuesta'] is None
+        assert ctx['organismo_nombre'] == 'Red Eléctrica de España'
+
+    def test_con_doc_elaborar_organismo_fecha(self):
+        from app.services.context_builders.contexto_consulta_traslado_titular import (
+            ContextoConsultaTrasladoTitular,
+        )
+        doc_respuesta = _doc(fecha=date(2026, 4, 10))
+        tarea_elab = _tarea_stub('ELABORAR', consumidos=[doc_respuesta], tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp(estado='en_tramitacion')
+        cb = ContextoConsultaTrasladoTitular(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo(oe)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] == '10/04/2026'
+        assert ctx['titular_fecha_respuesta'] is None
+
+    def test_con_esperar_plazo_ejecutado_titular_fecha(self):
+        from app.services.context_builders.contexto_consulta_traslado_titular import (
+            ContextoConsultaTrasladoTitular,
+        )
+        doc_org = _doc(fecha=date(2026, 4, 10))
+        doc_tit = _doc(fecha=date(2026, 5, 2))
+        tarea_elab = _tarea_stub('ELABORAR', consumidos=[doc_org], tramite_id=1)
+        tarea_notif = _tarea_stub('NOTIFICAR', tramite_id=1)
+        tarea_esp = _tarea_stub('ESPERAR_PLAZO', doc_producido=doc_tit, tramite_id=1)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab, tarea_notif, tarea_esp])
+
+        oe = _org_exp(estado='en_tramitacion', plazo_legal_dias=15)
+        cb = ContextoConsultaTrasladoTitular(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = _vinculo(oe)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] == '10/04/2026'
+        assert ctx['titular_fecha_respuesta'] == '02/05/2026'
+        assert ctx['organismo_resultado'] == 'en_tramitacion'
+        assert ctx['organismo_plazo_legal'] == 15
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# B) ContextoConsultaTrasladoOrganismo
+# ───────────────────────────────────────────────────────────────────────────────
+
+class TestContextoConsultaTrasladoOrganismo:
+
+    _MODULE = 'app.services.context_builders.contexto_consulta_traslado_organismo.TramiteOrganismo'
+
+    def _mock_queries(self, mock_cls, vinculo_ppal, tramite_ant=None,
+                      traslado_tit=None, num_iter=0):
+        """Configura el mock de TramiteOrganismo para el CB de traslado organismo.
+
+        Las tres queries de join se distinguen por la profundidad de la cadena
+        filter: tramite_ant usa 3 filtros, las otras dos usan 2 filtros.
+        """
+        mock_cls.query.filter_by.return_value.first.return_value = vinculo_ppal
+        q2 = (mock_cls.query.join.return_value.join.return_value
+              .filter.return_value.filter.return_value)
+        q3 = q2.filter.return_value
+        q3.order_by.return_value.first.return_value = tramite_ant
+        q2.order_by.return_value.first.return_value = traslado_tit
+        q2.count.return_value = num_iter
+
+    def test_sin_tarea_devuelve_vacio(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=None)
+        assert cb.get_contexto() == {}
+
+    def test_sin_organismo_expediente_devuelve_vacio(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        tarea = _tarea_stub('ELABORAR', tramite_id=7)
+        tarea.tramite = _tramite_con_tareas([tarea])
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=tarea)
+        with patch(self._MODULE) as mock_cls:
+            mock_cls.query.filter_by.return_value.first.return_value = None
+            assert cb.get_contexto() == {}
+
+    def test_primera_iteracion_sin_tramites_previos_fechas_none(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=10)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp(estado='en_tramitacion')
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            self._mock_queries(mock_cls, _vinculo(oe),
+                               tramite_ant=None, traslado_tit=None, num_iter=1)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] is None
+        assert ctx['titular_fecha_respuesta'] is None
+        assert ctx['organismo_num_iteraciones'] == 1
+        assert ctx['organismo_nombre'] == 'Red Eléctrica de España'
+
+    def test_con_tramite_anterior_organismo_fecha(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        doc_org = _doc(fecha=date(2026, 3, 15))
+        tramite_ant = _vinculo_tramite([
+            _tarea_stub('ESPERAR_PLAZO', doc_producido=doc_org),
+        ])
+
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=10)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp(estado='en_tramitacion')
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            self._mock_queries(mock_cls, _vinculo(oe),
+                               tramite_ant=tramite_ant, traslado_tit=None, num_iter=1)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] == '15/03/2026'
+        assert ctx['titular_fecha_respuesta'] is None
+
+    def test_con_traslado_titular_y_organismo_anterior_ambas_fechas(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        doc_org = _doc(fecha=date(2026, 3, 15))
+        doc_tit = _doc(fecha=date(2026, 4, 20))
+        tramite_ant = _vinculo_tramite([_tarea_stub('ESPERAR_PLAZO', doc_producido=doc_org)])
+        traslado_tit = _vinculo_tramite([_tarea_stub('ESPERAR_PLAZO', doc_producido=doc_tit)])
+
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=10)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp(estado='en_tramitacion', plazo_legal_dias=15)
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            self._mock_queries(mock_cls, _vinculo(oe),
+                               tramite_ant=tramite_ant, traslado_tit=traslado_tit, num_iter=2)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] == '15/03/2026'
+        assert ctx['titular_fecha_respuesta'] == '20/04/2026'
+        assert ctx['organismo_num_iteraciones'] == 2
+        assert ctx['organismo_resultado'] == 'en_tramitacion'
+        assert ctx['organismo_plazo_legal'] == 15
+
+    def test_esperar_plazo_sin_doc_producido_fecha_none(self):
+        from app.services.context_builders.contexto_consulta_traslado_organismo import (
+            ContextoConsultaTrasladoOrganismo,
+        )
+        tramite_ant = _vinculo_tramite([_tarea_stub('ESPERAR_PLAZO', doc_producido=None)])
+
+        tarea_elab = _tarea_stub('ELABORAR', tramite_id=10)
+        tarea_elab.tramite = _tramite_con_tareas([tarea_elab])
+
+        oe = _org_exp()
+        cb = ContextoConsultaTrasladoOrganismo(MagicMock(), MagicMock(), tarea=tarea_elab)
+        with patch(self._MODULE) as mock_cls:
+            self._mock_queries(mock_cls, _vinculo(oe),
+                               tramite_ant=tramite_ant, traslado_tit=None, num_iter=1)
+            ctx = cb.get_contexto()
+
+        assert ctx['organismo_fecha_respuesta'] is None


### PR DESCRIPTION
## Cambios

- Implementa `ContextoConsultaTrasladoTitular`: navega al organismo vía `TramiteOrganismo` (ADR-011) y expone `organismo_fecha_respuesta` (doc consumido por ELABORAR), `titular_fecha_respuesta` (doc producido por ESPERAR_PLAZO) y campos base del organismo
- Implementa `ContextoConsultaTrasladoOrganismo`: añade `organismo_fecha_respuesta` (ESPERAR_PLAZO del trámite anterior del organismo), `titular_fecha_respuesta` (ESPERAR_PLAZO del TRASLADO_TITULAR más reciente) y `organismo_num_iteraciones` (COUNT derivado de ADR-011 §2)
- Ambos CBs devuelven las dos fechas como `None` si el documento aún no existe, para que el diseñador de plantillas las tenga disponibles sin condicionar la generación
- 11 tests unitarios con stubs (sin BD ni app context), patrón de `test_391`
- Actualiza catálogo de CBs en `GUIA_CONTEXT_BUILDERS.md` y tacha pendiente en `DISEÑO_CONSULTAS_ORGANISMOS.md §8`

Closes #457
