### PR TITLE
Variables motor CONSULTAS: organismos_todos_terminados y organismo_supera_iteraciones

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -469,28 +469,13 @@ def _hook_458_analizar_separata(tarea, id_producido):
 
 
 def _hook_459_traslado_organismo(tipo_tramite, fase):
-    """Hook #459: al crear CONSULTA_TRASLADO_ORGANISMO navega al organismo vía tramites_organismos.
+    """Hook #459: guard para CONSULTA_TRASLADO_ORGANISMO.
 
-    La lógica de incrementar un contador ya no aplica (#456 elimina num_iteraciones_organismo).
-    El conteo de iteraciones se obtiene con COUNT de filas CONSULTA_TRASLADO_ORGANISMO
-    en tramites_organismos (#460).
+    La vinculación del trámite a su OrganismoExpediente en tramites_organismos
+    se implementará en #471.
     """
     if tipo_tramite.codigo != 'CONSULTA_TRASLADO_ORGANISMO':
         return
-    cod_separata = TipoTramite.query.filter_by(codigo='CONSULTA_SEPARATA').first()
-    if not cod_separata:
-        return
-    tram_separatas = Tramite.query.filter_by(
-        fase_id=fase.id,
-        tipo_tramite_id=cod_separata.id,
-    ).all()
-    ids_sep = [t.id for t in tram_separatas]
-    if not ids_sep:
-        return
-    vinculos = TramiteOrganismo.query.filter(
-        TramiteOrganismo.tramite_id.in_(ids_sep)
-    ).all()
-    _ = vinculos  # reservado para #460: COUNT de TRASLADO_ORGANISMO por organismo
 
 
 # ============================================

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -123,3 +123,52 @@ def _(ctx) -> bool:
         and not solicitud.contiene_tipo('AAP')
         and not solicitud.contiene_tipo('DUP')
     )
+
+
+_ESTADOS_TERMINALES_CONSULTAS = frozenset({
+    'cerrado_favorable', 'cerrado_con_condicionados', 'audiencia_previa', 'exonerado'
+})
+
+
+@variable('organismos_todos_terminados')
+def _(ctx) -> bool:
+    """
+    True si todos los organismos del expediente han alcanzado un estado terminal.
+    Precondición del cierre de fase CONSULTAS (ver #470).
+    """
+    organismos = ctx.expediente.organismos
+    if not organismos:
+        return True
+    return all(org.estado in _ESTADOS_TERMINALES_CONSULTAS for org in organismos)
+
+
+@variable('organismo_supera_iteraciones')
+def _(ctx) -> bool:
+    """
+    True si algún organismo acumula ≥ 1 CONSULTA_TRASLADO_ORGANISMO en tramites_organismos,
+    lo que indica que se va a crear una segunda iteración.
+
+    Devuelve False mientras #471 (vincular tramites TRASLADO a tramites_organismos)
+    no esté implementado, ya que la tabla no tendrá entradas para TRASLADOs.
+
+    Evaluar al CREAR CONSULTA_TRASLADO_ORGANISMO (motor: ADVERTIR).
+    """
+    from app.models.tramites_organismos import TramiteOrganismo
+    from app.models.tramites import Tramite as _Tramite
+    from app.models.tipos_tramites import TipoTramite
+    from app import db
+
+    for org in ctx.expediente.organismos:
+        count = (
+            db.session.query(TramiteOrganismo)
+            .join(_Tramite, TramiteOrganismo.tramite_id == _Tramite.id)
+            .join(TipoTramite, _Tramite.tipo_tramite_id == TipoTramite.id)
+            .filter(
+                TramiteOrganismo.organismo_expediente_id == org.id,
+                TipoTramite.codigo == 'CONSULTA_TRASLADO_ORGANISMO',
+            )
+            .count()
+        )
+        if count >= 1:
+            return True
+    return False

--- a/migrations/versions/460_variables_motor_consultas.py
+++ b/migrations/versions/460_variables_motor_consultas.py
@@ -1,0 +1,80 @@
+"""460_variables_motor_consultas
+
+Revision ID: 460_variables_motor_consultas
+Revises: 456_tramites_organismos
+Create Date: 2026-05-24
+
+Issue #460 — Registra variables del motor para el ciclo de CONSULTAS y
+la regla ADVERTIR al crear un segundo CONSULTA_TRASLADO_ORGANISMO.
+La regla BLOQUEAR de organismos_todos_terminados va en #470.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '460_variables_motor_consultas'
+down_revision = '456_tramites_organismos'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. catalogo_variables
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES
+            ('organismos_todos_terminados',
+             'Todos los organismos del expediente han alcanzado estado terminal',
+             'boolean', NULL, TRUE),
+            ('organismo_supera_iteraciones',
+             'Algún organismo acumula más de una iteración TRASLADO_ORGANISMO',
+             'boolean', NULL, TRUE)
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+    # 2. Regla ADVERTIR al crear CONSULTA_TRASLADO_ORGANISMO con iteraciones previas
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/ANY/CONSULTAS/CONSULTA_TRASLADO_ORGANISMO',
+            'ADVERTIR',
+            10,
+            TRUE,
+            'Uno o más organismos han requerido más de un traslado de reparos'
+        )
+        RETURNING id
+    """))
+    regla_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'true'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'organismo_supera_iteraciones'
+    """), {'regla_id': regla_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_regla
+        WHERE regla_id IN (
+            SELECT id FROM public.reglas_motor
+            WHERE sujeto = 'ANY/ANY/CONSULTAS/CONSULTA_TRASLADO_ORGANISMO'
+              AND efecto = 'ADVERTIR'
+        )
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.reglas_motor
+        WHERE sujeto = 'ANY/ANY/CONSULTAS/CONSULTA_TRASLADO_ORGANISMO'
+          AND efecto = 'ADVERTIR'
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_variables
+        WHERE nombre IN ('organismos_todos_terminados', 'organismo_supera_iteraciones')
+    """))

--- a/tests/test_460_variables_motor_consultas.py
+++ b/tests/test_460_variables_motor_consultas.py
@@ -1,0 +1,114 @@
+"""Tests issue #460 — Variables motor cierre CONSULTAS."""
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Stubs mínimos de duck-typing
+# ---------------------------------------------------------------------------
+
+class _StubOrganismo:
+    def __init__(self, estado, id=1): self.estado = estado; self.id = id
+
+
+class _StubExpediente:
+    def __init__(self, organismos): self.organismos = organismos
+
+
+class _StubCtx:
+    def __init__(self, organismos):
+        self.expediente = _StubExpediente(organismos)
+
+
+# ---------------------------------------------------------------------------
+# Registro de variables
+# ---------------------------------------------------------------------------
+
+def _get_variable(nombre: str):
+    import app.services.variables.calculado  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY.get(nombre)
+    assert fn is not None, f'Variable {nombre!r} no encontrada en _REGISTRY'
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# A) organismos_todos_terminados
+# ---------------------------------------------------------------------------
+
+def test_organismos_todos_terminados_registrada():
+    _get_variable('organismos_todos_terminados')
+
+
+def test_organismos_todos_terminados_sin_organismos():
+    """Expediente sin organismos → True (vacío es condición cumplida)."""
+    ctx = _StubCtx([])
+    assert _get_variable('organismos_todos_terminados')(ctx) is True
+
+
+def test_organismos_todos_terminados_todos_cerrado_favorable():
+    """Dos organismos en cerrado_favorable → True."""
+    ctx = _StubCtx([_StubOrganismo('cerrado_favorable'), _StubOrganismo('cerrado_favorable')])
+    assert _get_variable('organismos_todos_terminados')(ctx) is True
+
+
+def test_organismos_todos_terminados_estados_mixtos_terminales():
+    """Tres organismos en estados terminales distintos → True."""
+    ctx = _StubCtx([
+        _StubOrganismo('cerrado_favorable'),
+        _StubOrganismo('exonerado'),
+        _StubOrganismo('audiencia_previa'),
+    ])
+    assert _get_variable('organismos_todos_terminados')(ctx) is True
+
+
+def test_organismos_todos_terminados_alguno_pendiente():
+    """Un organismo pendiente → False."""
+    ctx = _StubCtx([_StubOrganismo('cerrado_favorable'), _StubOrganismo('pendiente')])
+    assert _get_variable('organismos_todos_terminados')(ctx) is False
+
+
+def test_organismos_todos_terminados_en_tramitacion():
+    """Organismo en_tramitacion → False."""
+    ctx = _StubCtx([_StubOrganismo('en_tramitacion')])
+    assert _get_variable('organismos_todos_terminados')(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# B) organismo_supera_iteraciones
+# ---------------------------------------------------------------------------
+
+def test_organismo_supera_iteraciones_registrada():
+    _get_variable('organismo_supera_iteraciones')
+
+
+def test_organismo_supera_iteraciones_sin_traslados():
+    """COUNT = 0 para todos los organismos → False."""
+    with patch('app.db') as mock_db:
+        mock_db.session.query.return_value \
+            .join.return_value \
+            .join.return_value \
+            .filter.return_value \
+            .count.return_value = 0
+        fn = _get_variable('organismo_supera_iteraciones')
+        ctx = _StubCtx([_StubOrganismo('pendiente')])
+        assert fn(ctx) is False
+
+
+def test_organismo_supera_iteraciones_con_traslado():
+    """COUNT ≥ 1 en al menos un organismo → True."""
+    with patch('app.db') as mock_db:
+        mock_db.session.query.return_value \
+            .join.return_value \
+            .join.return_value \
+            .filter.return_value \
+            .count.return_value = 1
+        fn = _get_variable('organismo_supera_iteraciones')
+        ctx = _StubCtx([_StubOrganismo('en_tramitacion')])
+        assert fn(ctx) is True
+
+
+def test_organismo_supera_iteraciones_sin_organismos():
+    """Sin organismos en el expediente → False (el bucle no itera)."""
+    fn = _get_variable('organismo_supera_iteraciones')
+    ctx = _StubCtx([])
+    assert fn(ctx) is False


### PR DESCRIPTION
## Cambios

- Añade variable `organismos_todos_terminados`: True si todos los organismos del expediente están en estado terminal (`cerrado_favorable`, `cerrado_con_condicionados`, `audiencia_previa`, `exonerado`). Precondición de cierre de fase CONSULTAS (#470).
- Añade variable `organismo_supera_iteraciones`: True si algún organismo acumula ≥ 1 `CONSULTA_TRASLADO_ORGANISMO` en `tramites_organismos`; devuelve False hasta que #471 vincule los trámites TRASLADO a esa tabla.
- Migración `460_variables_motor_consultas`: inserta ambas variables en `catalogo_variables` y crea regla `ADVERTIR` al crear `CONSULTA_TRASLADO_ORGANISMO` con iteraciones previas.
- Limpia stub `_hook_459_traslado_organismo` en `api_bc.py`: elimina la lógica de navegación reservada para #460 que ya no aplica; queda como guard vacío hasta #471.
- 10 tests unitarios (duck-typing, sin BD) que cubren todos los casos de ambas variables.

Closes #460
