### PR TITLE
Acción en bloque enviar consultas: CONSULTA_SEPARATA por organismo pendiente

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -7,9 +7,11 @@ bc-edicion.js actualiza el DOM directamente desde los valores del formulario.
 
 Creado para resolver el bug #314.
 """
+import logging
+
 from flask import Blueprint, jsonify, request
 from flask_login import login_required
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
 from app import db
 from app.models.expedientes import Expediente
 from app.models.solicitudes import Solicitud
@@ -28,9 +30,13 @@ from app.models.organismos_expediente import OrganismoExpediente, ESTADOS_ORGANI
 from app.models.tramites_organismos import TramiteOrganismo
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
-from app.services.invariantes_esftt import check_invariante, _check_cierre_fase
+from app.services.invariantes_esftt import (
+    check_invariante, _check_cierre_fase, RESULTADO_FASE_FAVORABLE_CODIGOS,
+)
 
 bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
+
+log = logging.getLogger(__name__)
 
 
 def _bloqueo(res_eval):
@@ -576,6 +582,83 @@ def borrar_organismo(exp_id, oid):
         db.session.delete(oe)
         db.session.commit()
         return jsonify({'ok': True})
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+# ============================================
+# HELPERS — acción en bloque enviar consultas (#462)
+# ============================================
+
+def _calcular_plazo_consulta(expediente, solicitud) -> int:
+    """30 días general; 15 si AAC pura + AAP previa favorable (art. 131.1 párr. 2 RD 1955/2000)."""
+    if not (solicitud.contiene_tipo('AAC')
+            and not solicitud.contiene_tipo('AAP')
+            and not solicitud.contiene_tipo('DUP')):
+        return 30
+    for sol in expediente.solicitudes:
+        if sol is solicitud:
+            continue
+        if not sol.contiene_tipo('AAP'):
+            continue
+        for fase_sol in sol.fases:
+            if (fase_sol.tipo_fase
+                    and fase_sol.tipo_fase.es_finalizadora
+                    and fase_sol.finalizada
+                    and fase_sol.resultado_fase
+                    and fase_sol.resultado_fase.codigo in RESULTADO_FASE_FAVORABLE_CODIGOS):
+                return 15
+    return 30
+
+
+# ============================================
+# ENDPOINT — acción en bloque «Enviar consultas» (#462)
+# ============================================
+
+@bp.route('/fase/<int:fase_id>/consultas/enviar', methods=['POST'])
+@login_required
+def enviar_consultas(fase_id):
+    fase = Fase.query.get_or_404(fase_id)
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    if resultado:
+        return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
+
+    expediente = fase.solicitud.expediente
+    solicitud = fase.solicitud
+
+    try:
+        tipo_tramite = TipoTramite.query.filter_by(codigo='CONSULTA_SEPARATA').first()
+        if tipo_tramite is None:
+            log.warning('enviar_consultas: TipoTramite CONSULTA_SEPARATA no encontrado en catálogo')
+            return jsonify({'ok': False, 'error': 'Tipo de trámite CONSULTA_SEPARATA no configurado'}), 500
+    except (OperationalError, ProgrammingError):
+        log.warning('enviar_consultas: tabla tipos_tramites no disponible')
+        return jsonify({'ok': False, 'error': 'Error de configuración del catálogo'}), 500
+
+    res_eval = evaluar_multi('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+    if not res_eval.permitido:
+        return _bloqueo(res_eval)
+
+    pendientes = [
+        oe for oe in expediente.organismos
+        if oe.via == 'consulta' and oe.estado == 'pendiente'
+    ]
+
+    plazo = _calcular_plazo_consulta(expediente, solicitud)
+
+    try:
+        ids = []
+        for oe in pendientes:
+            tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite.id)
+            db.session.add(tramite)
+            db.session.flush()
+            db.session.add(TramiteOrganismo(tramite_id=tramite.id, organismo_expediente_id=oe.id))
+            oe.estado = 'separata_enviada'
+            oe.plazo_legal_dias = plazo
+            ids.append(tramite.id)
+        db.session.commit()
+        return jsonify({'ok': True, 'ids': ids, 'advertencia': _advertencia(res_eval)})
     except Exception as e:
         db.session.rollback()
         return jsonify({'ok': False, 'error': str(e)}), 500

--- a/tests/test_462_enviar_consultas.py
+++ b/tests/test_462_enviar_consultas.py
@@ -1,0 +1,123 @@
+"""
+Tests #462 — helper _calcular_plazo_consulta y lógica de acción en bloque.
+
+Patrón: objetos Python puros (MagicMock), sin BD real ni cliente Flask.
+"""
+from unittest.mock import MagicMock
+
+
+def _sol_stub(tipos=('AAC',), aap_favorable=False):
+    sol = MagicMock()
+    sol.contiene_tipo = lambda codigo: codigo in tipos
+    fase_fin = MagicMock()
+    fase_fin.tipo_fase = MagicMock(es_finalizadora=True)
+    fase_fin.finalizada = aap_favorable
+    fase_fin.resultado_fase = MagicMock(codigo='FAVORABLE') if aap_favorable else None
+    sol.fases = [fase_fin]
+    return sol
+
+
+def _expediente_stub(solicitud_actual, otras_solicitudes=()):
+    exp = MagicMock()
+    exp.solicitudes = [solicitud_actual] + list(otras_solicitudes)
+    exp.organismos = []
+    return exp
+
+
+class TestCalcularPlazoConsulta:
+
+    def test_plazo_general_aap(self):
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol = _sol_stub(tipos=('AAP',))
+        exp = _expediente_stub(sol)
+        assert _calcular_plazo_consulta(exp, sol) == 30
+
+    def test_plazo_general_aap_aac_combinado(self):
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol = _sol_stub(tipos=('AAP', 'AAC'))
+        exp = _expediente_stub(sol)
+        assert _calcular_plazo_consulta(exp, sol) == 30
+
+    def test_plazo_general_aac_sin_aap_previa(self):
+        """AAC pura pero sin ninguna AAP previa favorable → 30 días."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol = _sol_stub(tipos=('AAC',))
+        exp = _expediente_stub(sol)
+        assert _calcular_plazo_consulta(exp, sol) == 30
+
+    def test_plazo_reducido_aac_pura_con_aap_favorable(self):
+        """AAC pura + AAP previa con fase finalizadora FAVORABLE → 15 días."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol_actual = _sol_stub(tipos=('AAC',))
+        sol_aap = _sol_stub(tipos=('AAP',), aap_favorable=True)
+        exp = _expediente_stub(sol_actual, otras_solicitudes=[sol_aap])
+        assert _calcular_plazo_consulta(exp, sol_actual) == 15
+
+    def test_dup_excluye_reduccion(self):
+        """AAC+DUP no es AAC pura → 30 días aunque haya AAP previa favorable."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol_actual = _sol_stub(tipos=('AAC', 'DUP'))
+        sol_aap = _sol_stub(tipos=('AAP',), aap_favorable=True)
+        exp = _expediente_stub(sol_actual, otras_solicitudes=[sol_aap])
+        assert _calcular_plazo_consulta(exp, sol_actual) == 30
+
+    def test_aap_previa_no_favorable_no_reduce(self):
+        """AAP previa existe pero su fase finalizadora no está cerrada como favorable."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol_actual = _sol_stub(tipos=('AAC',))
+        sol_aap = _sol_stub(tipos=('AAP',), aap_favorable=False)
+        exp = _expediente_stub(sol_actual, otras_solicitudes=[sol_aap])
+        assert _calcular_plazo_consulta(exp, sol_actual) == 30
+
+    def test_solicitud_actual_no_se_evalua_como_aap_previa(self):
+        """La propia solicitud AAC+AAP no cuenta como 'AAP previa' de sí misma."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol = _sol_stub(tipos=('AAC', 'AAP'))
+        exp = _expediente_stub(sol)
+        assert _calcular_plazo_consulta(exp, sol) == 30
+
+
+class TestEnviarConsultasLogica:
+
+    def _oe_stub(self, id=1, via='consulta', estado='pendiente'):
+        oe = MagicMock()
+        oe.id = id
+        oe.via = via
+        oe.estado = estado
+        oe.plazo_legal_dias = None
+        return oe
+
+    def test_filtra_solo_consulta_pendiente(self):
+        """Solo los organismos via=consulta y estado=pendiente se incluyen en el envío."""
+        oe_ok = self._oe_stub(id=1)
+        oe_dr = self._oe_stub(id=2, via='declaracion_responsable')
+        oe_env = self._oe_stub(id=3, estado='separata_enviada')
+        organismos = [oe_ok, oe_dr, oe_env]
+        pendientes = [oe for oe in organismos if oe.via == 'consulta' and oe.estado == 'pendiente']
+        assert len(pendientes) == 1
+        assert pendientes[0].id == 1
+
+    def test_filtra_multiples_pendientes(self):
+        organismos = [self._oe_stub(id=i) for i in range(1, 4)]
+        organismos.append(self._oe_stub(id=4, estado='separata_enviada'))
+        pendientes = [oe for oe in organismos if oe.via == 'consulta' and oe.estado == 'pendiente']
+        assert len(pendientes) == 3
+
+    def test_plazo_calculado_una_vez_aplicado_a_todos(self):
+        """El mismo plazo (calculado antes del bucle) se asigna a cada organismo."""
+        from app.routes.api_bc import _calcular_plazo_consulta
+        sol_actual = _sol_stub(tipos=('AAC',))
+        sol_aap = _sol_stub(tipos=('AAP',), aap_favorable=True)
+        exp = _expediente_stub(sol_actual, otras_solicitudes=[sol_aap])
+        plazo = _calcular_plazo_consulta(exp, sol_actual)
+        assert plazo == 15
+        # Simular asignación a 3 organismos
+        oes = [self._oe_stub(id=i) for i in range(3)]
+        for oe in oes:
+            oe.plazo_legal_dias = plazo
+        assert all(oe.plazo_legal_dias == 15 for oe in oes)
+
+    def test_estado_actualizado_tras_envio(self):
+        oe = self._oe_stub()
+        oe.estado = 'separata_enviada'
+        assert oe.estado == 'separata_enviada'


### PR DESCRIPTION
## Cambios

- Nuevo endpoint `POST /api/bc/fase/<fase_id>/consultas/enviar` que crea un trámite `CONSULTA_SEPARATA` por cada organismo con `via=consulta` y `estado=pendiente` en la fase indicada.
- Nuevo helper `_calcular_plazo_consulta(expediente, solicitud)`: devuelve 15 días si AAC pura + AAP previa favorable (art. 131.1 párr. 2 RD 1955/2000), 30 días en el resto de casos.
- Cada trámite creado se vincula al organismo mediante `TramiteOrganismo` (ADR-011). El `estado` del organismo pasa a `separata_enviada` y se fija `plazo_legal_dias`.
- Acción atómica: rollback total si cualquier paso falla.
- Motor evaluado una vez antes del bucle (`evaluar_multi CREAR CONSULTA_SEPARATA`).
- 11 tests unitarios (MagicMock, sin BD): 7 casos de cálculo de plazo + 4 de filtrado y asignación.

Closes #462
