### PR TITLE
Seed catalogo_plazos para CONSULTAS (#463)

### DIFF
--- a/migrations/versions/463_seed_plazos_consultas.py
+++ b/migrations/versions/463_seed_plazos_consultas.py
@@ -1,0 +1,170 @@
+"""463_seed_plazos_consultas
+
+Revision ID: 463_seed_plazos_consultas
+Revises: 460_variables_motor_consultas
+Create Date: 2026-05-25
+
+Issue #463 — Seed `catalogo_plazos` para los tres tipos de trámite de
+la fase CONSULTAS: CONSULTA_SEPARATA (dos entradas con condiciones de
+prioridad), CONSULTA_TRASLADO_TITULAR y CONSULTA_TRASLADO_ORGANISMO.
+
+DISEÑO
+======
+
+Las 4 entradas utilizan:
+  - tipo_elemento = 'TRAMITE'
+  - campo_fecha = {"via_tarea_tipo": "NOTIFICAR", "rol": "PRODUCIDO"}
+    El plazo arranca cuando la tarea NOTIFICAR produce el oficio.
+    Patrón ya manejado por _resolver_campo_fecha en plazos.py.
+
+CONSULTA_SEPARATA tiene dos entradas ordenadas por prioridad (orden):
+  1. 15 días — condiciones: es_solicitud_aac_pura EQ true
+                             + tiene_solicitud_aap_favorable EQ true
+     Fundamento: art. 131.1 párr. 2 RD 1955/2000 (plazo reducido para AAC
+     pura cuando ya existe AAP favorable previa).
+  2. 30 días — sin condiciones (fallback general)
+     Fundamento: arts. 127.2 / 131.1 RD 1955/2000.
+
+CONSULTA_TRASLADO_TITULAR — 15 días, efecto SIN_EFECTO_AUTOMATICO.
+  El efecto real depende del resultado del organismo precedente (caso D
+  ADR-011); el tramitador lo gestiona manualmente.
+  Fundamento: arts. 127.3 / 131.3 RD 1955/2000.
+
+CONSULTA_TRASLADO_ORGANISMO — 15 días, efecto CONFORMIDAD_PRESUNTA.
+  Silencio del organismo ante los reparos del titular = conformidad tácita.
+  Fundamento: arts. 127.4 / 131.4 RD 1955/2000.
+
+Normas: NORMATIVA_PLAZOS.md §2.2; DIAS sin calificar = hábiles (LPACAP art. 30.2).
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '463_seed_plazos_consultas'
+down_revision = '460_variables_motor_consultas'
+branch_labels = None
+depends_on = None
+
+
+_CAMPO_FECHA = json.dumps({"via_tarea_tipo": "NOTIFICAR", "rol": "PRODUCIDO"})
+
+# Cada entrada: (tipo_elemento_codigo, plazo_valor, plazo_unidad, efecto_codigo,
+#                norma_origen, orden, condiciones)
+# condiciones: lista de (nombre_variable, operador, valor) — puede ser []
+_PLAZOS_CONSULTAS = [
+    (
+        'CONSULTA_SEPARATA', 15, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA',
+        'Art. 131.1 párr. 2 RD 1955/2000', 10,
+        [
+            ('es_solicitud_aac_pura', 'EQ', True),
+            ('tiene_solicitud_aap_favorable', 'EQ', True),
+        ],
+    ),
+    (
+        'CONSULTA_SEPARATA', 30, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA',
+        'Arts. 127.2 / 131.1 RD 1955/2000', 20,
+        [],
+    ),
+    (
+        'CONSULTA_TRASLADO_TITULAR', 15, 'DIAS_HABILES', 'SIN_EFECTO_AUTOMATICO',
+        'Arts. 127.3 / 131.3 RD 1955/2000', 10,
+        [],
+    ),
+    (
+        'CONSULTA_TRASLADO_ORGANISMO', 15, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA',
+        'Arts. 127.4 / 131.4 RD 1955/2000', 10,
+        [],
+    ),
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for codigo, valor, unidad, efecto_codigo, norma, orden, condiciones in _PLAZOS_CONSULTAS:
+        plazo_id = conn.execute(sa.text("""
+            INSERT INTO public.catalogo_plazos
+                (tipo_elemento, tipo_elemento_id, tipo_elemento_codigo, campo_fecha,
+                 plazo_valor, plazo_unidad,
+                 efecto_vencimiento_id, norma_origen, orden, activo)
+            SELECT
+                'TRAMITE',
+                tt.id,
+                :codigo,
+                CAST(:campo_fecha AS jsonb),
+                :valor,
+                :unidad,
+                ep.id,
+                :norma,
+                :orden,
+                TRUE
+            FROM public.tipos_tramites tt
+            CROSS JOIN public.efectos_plazo ep
+            WHERE tt.codigo = :codigo
+              AND ep.codigo = :efecto_codigo
+            RETURNING id
+        """), {
+            'codigo': codigo,
+            'campo_fecha': _CAMPO_FECHA,
+            'valor': valor,
+            'unidad': unidad,
+            'efecto_codigo': efecto_codigo,
+            'norma': norma,
+            'orden': orden,
+        }).scalar()
+
+        if plazo_id is None:
+            raise RuntimeError(
+                f"No se pudo insertar plazo {codigo} orden={orden}; "
+                f"verificar existencia de tipos_tramites.{codigo} y "
+                f"efectos_plazo.{efecto_codigo}"
+            )
+
+        for i, (nombre_var, operador, valor_cond) in enumerate(condiciones, start=1):
+            conn.execute(sa.text("""
+                INSERT INTO public.condiciones_plazo
+                    (catalogo_plazo_id, variable_id, operador, valor, orden)
+                SELECT
+                    :plazo_id,
+                    cv.id,
+                    :operador,
+                    CAST(:valor AS jsonb),
+                    :orden_cond
+                FROM public.catalogo_variables cv
+                WHERE cv.nombre = :nombre_var
+            """), {
+                'plazo_id': plazo_id,
+                'operador': operador,
+                'valor': json.dumps(valor_cond),
+                'orden_cond': i,
+                'nombre_var': nombre_var,
+            })
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_plazo
+        WHERE catalogo_plazo_id IN (
+            SELECT id FROM public.catalogo_plazos
+            WHERE tipo_elemento = 'TRAMITE'
+              AND tipo_elemento_codigo IN (
+                  'CONSULTA_SEPARATA',
+                  'CONSULTA_TRASLADO_TITULAR',
+                  'CONSULTA_TRASLADO_ORGANISMO'
+              )
+        )
+    """))
+
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_plazos
+        WHERE tipo_elemento = 'TRAMITE'
+          AND tipo_elemento_codigo IN (
+              'CONSULTA_SEPARATA',
+              'CONSULTA_TRASLADO_TITULAR',
+              'CONSULTA_TRASLADO_ORGANISMO'
+          )
+    """))

--- a/tests/test_463_seed_plazos_consultas.py
+++ b/tests/test_463_seed_plazos_consultas.py
@@ -1,0 +1,129 @@
+"""Tests #463 — seed catalogo_plazos para CONSULTAS.
+
+Patrón: fakes SimpleNamespace que replican las 4 entradas del seed.
+Se ejercita _evaluar_condiciones_plazo directamente (lógica pura) y
+se simula la selección por orden para verificar prioridad 15 vs 30 días.
+Sin BD real ni SQLAlchemy.
+"""
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# Helpers: fakes que replican el seed
+# ---------------------------------------------------------------------------
+
+def _var(nombre):
+    return SimpleNamespace(nombre=nombre)
+
+
+def _cond(nombre_var, operador, valor, orden):
+    return SimpleNamespace(variable=_var(nombre_var), operador=operador,
+                           valor=valor, orden=orden)
+
+
+def _plazo(plazo_valor, plazo_unidad, efecto_codigo, orden, condiciones):
+    return SimpleNamespace(
+        plazo_valor=plazo_valor,
+        plazo_unidad=plazo_unidad,
+        efecto_codigo=efecto_codigo,
+        orden=orden,
+        condiciones=condiciones,
+        activo=True,
+    )
+
+
+# Réplica exacta del seed de la migración 463
+_SEPARATA_PRIO = _plazo(
+    15, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA', 10,
+    [
+        _cond('es_solicitud_aac_pura', 'EQ', True, 1),
+        _cond('tiene_solicitud_aap_favorable', 'EQ', True, 2),
+    ],
+)
+_SEPARATA_FALLBACK = _plazo(
+    30, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA', 20, [],
+)
+_TRASLADO_TITULAR = _plazo(
+    15, 'DIAS_HABILES', 'SIN_EFECTO_AUTOMATICO', 10, [],
+)
+_TRASLADO_ORGANISMO = _plazo(
+    15, 'DIAS_HABILES', 'CONFORMIDAD_PRESUNTA', 10, [],
+)
+
+
+def _seleccionar(entradas, variables):
+    """Replica la lógica de _seleccionar_catalogo sobre una lista en memoria."""
+    from app.services.plazos import _evaluar_condiciones_plazo
+    for entrada in sorted(entradas, key=lambda e: e.orden):
+        if not entrada.condiciones:
+            return entrada
+        if _evaluar_condiciones_plazo(entrada.condiciones, variables):
+            return entrada
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSeedPlazosConsultas:
+
+    # --- CONSULTA_SEPARATA ---
+
+    def test_separata_15_dias_aac_pura_con_aap_favorable(self):
+        """Ambas condiciones cumplidas → plazo reducido de 15 días."""
+        entrada = _seleccionar(
+            [_SEPARATA_PRIO, _SEPARATA_FALLBACK],
+            {'es_solicitud_aac_pura': True, 'tiene_solicitud_aap_favorable': True},
+        )
+        assert entrada is not None
+        assert entrada.plazo_valor == 15
+        assert entrada.plazo_unidad == 'DIAS_HABILES'
+        assert entrada.efecto_codigo == 'CONFORMIDAD_PRESUNTA'
+
+    def test_separata_30_dias_fallback_sin_aac_pura(self):
+        """Sin AAC pura → condición prioritaria no cumplida → fallback 30 días."""
+        entrada = _seleccionar(
+            [_SEPARATA_PRIO, _SEPARATA_FALLBACK],
+            {'es_solicitud_aac_pura': False, 'tiene_solicitud_aap_favorable': True},
+        )
+        assert entrada is not None
+        assert entrada.plazo_valor == 30
+
+    def test_separata_30_dias_fallback_sin_aap_favorable(self):
+        """AAC pura pero sin AAP favorable → AND incompleto → fallback 30 días."""
+        entrada = _seleccionar(
+            [_SEPARATA_PRIO, _SEPARATA_FALLBACK],
+            {'es_solicitud_aac_pura': True, 'tiene_solicitud_aap_favorable': False},
+        )
+        assert entrada is not None
+        assert entrada.plazo_valor == 30
+
+    def test_separata_30_dias_fallback_ninguna_variable(self):
+        """Sin ninguna de las variables → fallback 30 días."""
+        entrada = _seleccionar(
+            [_SEPARATA_PRIO, _SEPARATA_FALLBACK],
+            {'es_solicitud_aac_pura': False, 'tiene_solicitud_aap_favorable': False},
+        )
+        assert entrada is not None
+        assert entrada.plazo_valor == 30
+
+    # --- CONSULTA_TRASLADO_TITULAR ---
+
+    def test_traslado_titular_15_dias_sin_efecto_automatico(self):
+        """Traslado al titular → 15 días hábiles, efecto SIN_EFECTO_AUTOMATICO."""
+        entrada = _seleccionar([_TRASLADO_TITULAR], {})
+        assert entrada is not None
+        assert entrada.plazo_valor == 15
+        assert entrada.plazo_unidad == 'DIAS_HABILES'
+        assert entrada.efecto_codigo == 'SIN_EFECTO_AUTOMATICO'
+
+    # --- CONSULTA_TRASLADO_ORGANISMO ---
+
+    def test_traslado_organismo_15_dias_conformidad_presunta(self):
+        """Traslado al organismo → 15 días hábiles, efecto CONFORMIDAD_PRESUNTA."""
+        entrada = _seleccionar([_TRASLADO_ORGANISMO], {})
+        assert entrada is not None
+        assert entrada.plazo_valor == 15
+        assert entrada.plazo_unidad == 'DIAS_HABILES'
+        assert entrada.efecto_codigo == 'CONFORMIDAD_PRESUNTA'


### PR DESCRIPTION
## Cambios

- Migración `463_seed_plazos_consultas.py`: inserta 4 entradas en `catalogo_plazos` (tipo TRAMITE) para la fase CONSULTAS
  - `CONSULTA_SEPARATA` × 2: entrada prioritaria 15 días (condiciones `es_solicitud_aac_pura` + `tiene_solicitud_aap_favorable`) y fallback 30 días; efecto `CONFORMIDAD_PRESUNTA`
  - `CONSULTA_TRASLADO_TITULAR`: 15 días, efecto `SIN_EFECTO_AUTOMATICO` (arts. 127.3/131.3 RD 1955/2000)
  - `CONSULTA_TRASLADO_ORGANISMO`: 15 días, efecto `CONFORMIDAD_PRESUNTA` (arts. 127.4/131.4 RD 1955/2000)
- `campo_fecha = {"via_tarea_tipo": "NOTIFICAR", "rol": "PRODUCIDO"}` en las 4 entradas; patrón ya manejado por `_resolver_campo_fecha`
- 6 tests en `test_463_seed_plazos_consultas.py` (fakes SimpleNamespace + `_evaluar_condiciones_plazo` directo; sin BD real)

Closes #463
