### PR TITLE
Variables motor ANALISIS_SOLICITUD: análisis con deficiencias y requerimiento sin respuesta

### DIFF
--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -125,6 +125,71 @@ def _(ctx) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# Variables ANALISIS_SOLICITUD (#455)
+# ---------------------------------------------------------------------------
+
+@variable('tramite_analisis_con_deficiencias')
+def _(ctx) -> bool:
+    """
+    True si algún trámite ANALISIS_DOCUMENTAL de la solicitud en contexto
+    tiene un Diagnostico con resultado = 'desfavorable'.
+
+    Bloquea CREAR ANALISIS_SOLICITUD/COMUNICACION_INICIO: si hay defectos
+    pendientes el técnico debe emitir un requerimiento, no comunicar el inicio.
+
+    Fuente: tabla diagnosticos (implementada en #392).
+    ANALISIS_DOCUMENTAL nunca emite resultado 'condicionado'.
+    """
+    solicitud = ctx.solicitud
+    if solicitud is None:
+        return False
+    for fase in solicitud.fases:
+        for tramite in fase.tramites:
+            if (tramite.tipo_tramite
+                    and tramite.tipo_tramite.codigo == 'ANALISIS_DOCUMENTAL'):
+                for tarea in tramite.tareas:
+                    if (tarea.tipo_tarea
+                            and tarea.tipo_tarea.codigo == 'ANALIZAR'):
+                        doc = tarea.documento_producido
+                        if (doc
+                                and doc.diagnostico
+                                and doc.diagnostico.resultado == 'desfavorable'):
+                            return True
+    return False
+
+
+@variable('tramite_requerimiento_sin_respuesta')
+def _(ctx) -> bool:
+    """
+    True si algún trámite REQUERIMIENTO_SUBSANACION de la solicitud en contexto
+    tiene la tarea ESPERAR_PLAZO sin documento producido (titular no ha respondido).
+
+    Bloquea CREAR fase RESOLUCION. Las fases intermedias (p.ej. CONSULTAS) pueden
+    avanzar si los defectos no las afectan.
+
+    La vinculación documental usa la propiedad tarea.ejecutada (rol PRODUCIDO
+    en documentos_tarea — ADR-010).
+    """
+    solicitud = ctx.solicitud
+    if solicitud is None:
+        return False
+    for fase in solicitud.fases:
+        for tramite in fase.tramites:
+            if (tramite.tipo_tramite
+                    and tramite.tipo_tramite.codigo == 'REQUERIMIENTO_SUBSANACION'):
+                for tarea in tramite.tareas:
+                    if (tarea.tipo_tarea
+                            and tarea.tipo_tarea.codigo == 'ESPERAR_PLAZO'):
+                        if not tarea.ejecutada:
+                            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Variables CONSULTAS (#460)
+# ---------------------------------------------------------------------------
+
 _ESTADOS_TERMINALES_CONSULTAS = frozenset({
     'cerrado_favorable', 'cerrado_con_condicionados', 'audiencia_previa', 'exonerado'
 })

--- a/migrations/versions/455_variables_motor_analisis.py
+++ b/migrations/versions/455_variables_motor_analisis.py
@@ -1,0 +1,120 @@
+"""455_variables_motor_analisis
+
+Revision ID: 455_variables_motor_analisis
+Revises: 463_seed_plazos_consultas
+Create Date: 2026-05-25
+
+Issue #455 — Variables del motor para ANALISIS_SOLICITUD:
+
+  - tramite_analisis_con_deficiencias:
+      True si algún trámite ANALISIS_DOCUMENTAL tiene diagnóstico desfavorable.
+      Regla: BLOQUEAR CREAR ANY/ANY/ANALISIS_SOLICITUD/COMUNICACION_INICIO.
+
+  - tramite_requerimiento_sin_respuesta:
+      True si algún trámite REQUERIMIENTO_SUBSANACION tiene ESPERAR_PLAZO sin
+      documento producido (titular no ha respondido).
+      Regla: BLOQUEAR CREAR ANY/ANY/RESOLUCION.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '455_variables_motor_analisis'
+down_revision = '463_seed_plazos_consultas'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. catalogo_variables
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES
+            ('tramite_analisis_con_deficiencias',
+             'Existe trámite ANALISIS_DOCUMENTAL con diagnóstico desfavorable',
+             'boolean', NULL, TRUE),
+            ('tramite_requerimiento_sin_respuesta',
+             'Existe trámite REQUERIMIENTO_SUBSANACION con ESPERAR_PLAZO sin respuesta del titular',
+             'boolean', NULL, TRUE)
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+    # 2. Regla: BLOQUEAR CREAR COMUNICACION_INICIO si análisis con deficiencias
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/ANY/ANALISIS_SOLICITUD/COMUNICACION_INICIO',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'No se puede comunicar el inicio con deficiencias pendientes en el análisis documental'
+        )
+        RETURNING id
+    """))
+    regla_analisis_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'true'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'tramite_analisis_con_deficiencias'
+    """), {'regla_id': regla_analisis_id})
+
+    # 3. Regla: BLOQUEAR CREAR fase RESOLUCION si requerimiento sin respuesta
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/ANY/RESOLUCION',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'No se puede abrir la fase de resolución con un requerimiento de subsanación sin respuesta'
+        )
+        RETURNING id
+    """))
+    regla_req_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'true'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'tramite_requerimiento_sin_respuesta'
+    """), {'regla_id': regla_req_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_regla
+        WHERE regla_id IN (
+            SELECT id FROM public.reglas_motor
+            WHERE sujeto IN (
+                'ANY/ANY/ANALISIS_SOLICITUD/COMUNICACION_INICIO',
+                'ANY/ANY/RESOLUCION'
+            )
+              AND efecto = 'BLOQUEAR'
+        )
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.reglas_motor
+        WHERE sujeto IN (
+            'ANY/ANY/ANALISIS_SOLICITUD/COMUNICACION_INICIO',
+            'ANY/ANY/RESOLUCION'
+        )
+          AND efecto = 'BLOQUEAR'
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_variables
+        WHERE nombre IN (
+            'tramite_analisis_con_deficiencias',
+            'tramite_requerimiento_sin_respuesta'
+        )
+    """))

--- a/tests/test_455_variables_motor_analisis.py
+++ b/tests/test_455_variables_motor_analisis.py
@@ -1,0 +1,212 @@
+"""Tests issue #455 — Variables motor ANALISIS_SOLICITUD."""
+
+
+# ---------------------------------------------------------------------------
+# Stubs mínimos de duck-typing
+# ---------------------------------------------------------------------------
+
+class _StubDiagnostico:
+    def __init__(self, resultado): self.resultado = resultado
+
+
+class _StubDoc:
+    def __init__(self, diagnostico=None): self.diagnostico = diagnostico
+
+
+class _StubTipoTarea:
+    def __init__(self, codigo): self.codigo = codigo
+
+
+class _StubTarea:
+    def __init__(self, codigo_tipo, ejecutada=False, doc=None):
+        self.tipo_tarea = _StubTipoTarea(codigo_tipo)
+        self._ejecutada = ejecutada
+        self._doc = doc
+
+    @property
+    def ejecutada(self): return self._ejecutada
+
+    @property
+    def documento_producido(self): return self._doc
+
+
+class _StubTipoTramite:
+    def __init__(self, codigo): self.codigo = codigo
+
+
+class _StubTramite:
+    def __init__(self, codigo_tipo, tareas=None):
+        self.tipo_tramite = _StubTipoTramite(codigo_tipo)
+        self.tareas = tareas or []
+
+
+class _StubTipoFase:
+    def __init__(self, codigo): self.codigo = codigo
+
+
+class _StubFase:
+    def __init__(self, tramites=None):
+        self.tramites = tramites or []
+
+
+class _StubSolicitud:
+    def __init__(self, fases=None): self.fases = fases or []
+
+
+class _StubCtx:
+    def __init__(self, solicitud): self._solicitud = solicitud
+
+    @property
+    def solicitud(self): return self._solicitud
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_variable(nombre: str):
+    import app.services.variables.calculado  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY.get(nombre)
+    assert fn is not None, f'Variable {nombre!r} no encontrada en _REGISTRY'
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# A) tramite_analisis_con_deficiencias
+# ---------------------------------------------------------------------------
+
+def test_analisis_con_deficiencias_registrada():
+    _get_variable('tramite_analisis_con_deficiencias')
+
+
+def test_analisis_con_deficiencias_sin_solicitud():
+    """ctx.solicitud = None → False."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    assert fn(_StubCtx(None)) is False
+
+
+def test_analisis_con_deficiencias_sin_tramites():
+    """Solicitud sin fases ni trámites → False."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    ctx = _StubCtx(_StubSolicitud([]))
+    assert fn(ctx) is False
+
+
+def test_analisis_con_deficiencias_favorable():
+    """ANALISIS_DOCUMENTAL con diagnóstico favorable → False."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    doc = _StubDoc(_StubDiagnostico('favorable'))
+    tarea = _StubTarea('ANALIZAR', ejecutada=True, doc=doc)
+    tramite = _StubTramite('ANALISIS_DOCUMENTAL', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+def test_analisis_con_deficiencias_desfavorable():
+    """ANALISIS_DOCUMENTAL con diagnóstico desfavorable → True."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    doc = _StubDoc(_StubDiagnostico('desfavorable'))
+    tarea = _StubTarea('ANALIZAR', ejecutada=True, doc=doc)
+    tramite = _StubTramite('ANALISIS_DOCUMENTAL', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is True
+
+
+def test_analisis_con_deficiencias_sin_documento():
+    """ANALIZAR sin documento producido aún → False (no hay diagnóstico)."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    tarea = _StubTarea('ANALIZAR', ejecutada=False, doc=None)
+    tramite = _StubTramite('ANALISIS_DOCUMENTAL', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+def test_analisis_con_deficiencias_doc_sin_diagnostico():
+    """Documento producido pero sin fila en diagnosticos → False."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    doc = _StubDoc(diagnostico=None)
+    tarea = _StubTarea('ANALIZAR', ejecutada=True, doc=doc)
+    tramite = _StubTramite('ANALISIS_DOCUMENTAL', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+def test_analisis_con_deficiencias_otro_tipo_tramite():
+    """Trámite de otro tipo no influye en la variable."""
+    fn = _get_variable('tramite_analisis_con_deficiencias')
+    doc = _StubDoc(_StubDiagnostico('desfavorable'))
+    tarea = _StubTarea('ANALIZAR', ejecutada=True, doc=doc)
+    tramite = _StubTramite('OTRO_TRAMITE', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# B) tramite_requerimiento_sin_respuesta
+# ---------------------------------------------------------------------------
+
+def test_requerimiento_sin_respuesta_registrada():
+    _get_variable('tramite_requerimiento_sin_respuesta')
+
+
+def test_requerimiento_sin_respuesta_sin_solicitud():
+    """ctx.solicitud = None → False."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    assert fn(_StubCtx(None)) is False
+
+
+def test_requerimiento_sin_respuesta_sin_tramites():
+    """Solicitud sin fases → False."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    ctx = _StubCtx(_StubSolicitud([]))
+    assert fn(ctx) is False
+
+
+def test_requerimiento_sin_respuesta_esperar_plazo_sin_doc():
+    """ESPERAR_PLAZO sin documento producido → True (requerimiento pendiente)."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    tarea = _StubTarea('ESPERAR_PLAZO', ejecutada=False)
+    tramite = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is True
+
+
+def test_requerimiento_sin_respuesta_esperar_plazo_con_doc():
+    """ESPERAR_PLAZO con documento producido → False (titular respondió)."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    tarea = _StubTarea('ESPERAR_PLAZO', ejecutada=True)
+    tramite = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+def test_requerimiento_sin_respuesta_otro_tipo_tramite():
+    """Trámite de otro tipo con ESPERAR_PLAZO sin doc no activa la variable."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    tarea = _StubTarea('ESPERAR_PLAZO', ejecutada=False)
+    tramite = _StubTramite('OTRO_TRAMITE', [tarea])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite])]))
+    assert fn(ctx) is False
+
+
+def test_requerimiento_sin_respuesta_multiples_tramites_uno_pendiente():
+    """Dos REQUERIMIENTO_SUBSANACION: uno respondido, otro no → True."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    tarea_ok = _StubTarea('ESPERAR_PLAZO', ejecutada=True)
+    tarea_pen = _StubTarea('ESPERAR_PLAZO', ejecutada=False)
+    tramite_ok = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea_ok])
+    tramite_pen = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea_pen])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite_ok, tramite_pen])]))
+    assert fn(ctx) is True
+
+
+def test_requerimiento_sin_respuesta_todos_respondidos():
+    """Dos REQUERIMIENTO_SUBSANACION ambos respondidos → False."""
+    fn = _get_variable('tramite_requerimiento_sin_respuesta')
+    tarea1 = _StubTarea('ESPERAR_PLAZO', ejecutada=True)
+    tarea2 = _StubTarea('ESPERAR_PLAZO', ejecutada=True)
+    tramite1 = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea1])
+    tramite2 = _StubTramite('REQUERIMIENTO_SUBSANACION', [tarea2])
+    ctx = _StubCtx(_StubSolicitud([_StubFase([tramite1, tramite2])]))
+    assert fn(ctx) is False


### PR DESCRIPTION
## Cambios

- `app/services/variables/calculado.py` — dos nuevas variables calculadas:
  - `tramite_analisis_con_deficiencias`: True si algún trámite `ANALISIS_DOCUMENTAL` de la solicitud tiene diagnóstico `desfavorable`; bloquea CREAR `COMUNICACION_INICIO`
  - `tramite_requerimiento_sin_respuesta`: True si algún trámite `REQUERIMIENTO_SUBSANACION` tiene `ESPERAR_PLAZO` sin documento producido; bloquea CREAR fase `RESOLUCION`
- `migrations/versions/455_variables_motor_analisis.py` — seed en `catalogo_variables` y reglas BLOQUEAR en `reglas_motor`
- `tests/test_455_variables_motor_analisis.py` — 16 tests unitarios (16/16 ✓)

Closes #455
