### PR TITLE
Seed catálogo normas: LSE, LPACAP, DL 2/2018, DL 26/2021, RD 1183/2020, RD 244/2019, RD 88/2026

### DIFF
--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #463 (PR #474) — migración `463_seed_plazos_consultas`: 4 entradas en `catalogo_plazos` (TRAMITE) para CONSULTA_SEPARATA ×2 (15 días con condiciones AAC pura + AAP favorable / 30 días fallback), CONSULTA_TRASLADO_TITULAR (15 días, SIN_EFECTO_AUTOMATICO) y CONSULTA_TRASLADO_ORGANISMO (15 días, CONFORMIDAD_PRESUNTA); 6 tests.
+**Último cerrado:** #455 (PR #476) — variables motor `ANALISIS_SOLICITUD`: `tramite_analisis_con_deficiencias` (bloquea CREAR `COMUNICACION_INICIO` si diagnóstico desfavorable) y `tramite_requerimiento_sin_respuesta` (bloquea CREAR `RESOLUCION` si `ESPERAR_PLAZO` sin respuesta); migración `455_variables_motor_analisis`; 16 tests.
 
 **Actuales:** —
 
-**Próximo:** **#455** — variables motor cierre `ANALISIS_SOLICITUD` (independiente de CONSULTAS; tras #442).
+**Próximo:** **#451** — ampliar catálogo `normas` (LSE, LPACAP, DL 2/2018, DL 26/2021, RD 1183/2020, RD 244/2019, RD 88/2026); prerrequisito de #323.
 
 **Plan de trabajo CONSULTAS (sesión 2026-05-24):** análisis completo de #247 en `docs/historial/ANALISIS_CONSULTAS_ORGANISMOS_2026-05-24.md`. Orden acordado:
 1. ~~**#454** — auditoría 345 vs 370: verificar duplicados en `tramites_tareas` antes de tocar cualquier trámite CONSULTA_*.~~ ✓
@@ -62,7 +62,7 @@
 24. ~~**#462** — acción en bloque «Enviar consultas» (tras #247)~~ ✓
 25. ~~**#463** — seed `catalogo_plazos` para CONSULTAS (independiente, M3)~~ ✓
 26. **#475** — señalización de `CONSULTA_TRASLADO_TITULAR` vencido en organismo (M3; requiere UI #396).
-27. **#455** — variables motor cierre `ANALISIS_SOLICITUD` (independiente de CONSULTAS; tras #442). **Nota:** el issue usa conceptos obsoletos ligados a "cerrar" — requiere refactorización del enunciado antes de implementar.
+27. ~~**#455** — variables motor cierre `ANALISIS_SOLICITUD` (independiente de CONSULTAS; tras #442).~~ ✓
 27. **#451** — ampliar catálogo `normas` (LSE, LPACAP, DL 2/2018, DL 26/2021, RD 1183/2020, RD 244/2019, RD 88/2026) — prerrequisito de #323 — *de la auditoría 22/05*
 28. **#323** — modo global del motor + tabla `configuracion_sistema`
 29. **#324** — mecanismo de escape con bitácora (tras #323; reescribir cuerpo: enum CREAR|BORRAR, no INICIAR|FINALIZAR)

--- a/migrations/versions/451_seed_normas_ampliacion.py
+++ b/migrations/versions/451_seed_normas_ampliacion.py
@@ -1,0 +1,42 @@
+"""451_seed_normas_ampliacion
+
+Revision ID: 451_seed_normas_ampliacion
+Revises: 455_variables_motor_analisis
+Create Date: 2026-05-25
+
+Issue #451 — Ampliar catálogo `normas` con las 7 normas citadas en docs de diseño.
+
+Prerequisito de #323 (seed reglas_motor): las reglas necesitarán FK a normas.id.
+
+Normas existentes (seed_normas_base): id=3 RD1955_2000, id=4 D9_2011.
+Este seed añade ids 5-11.
+
+Fuentes de títulos:
+  - LSE, LPACAP, RD_1183_2020, RD_244_2019, RD_88_2026: BOE estatal
+  - DL_2_2018, DL_26_2021: BOJA sedeboja (IDs 26974 y 33520)
+"""
+from alembic import op
+
+
+revision = '451_seed_normas_ampliacion'
+down_revision = '455_variables_motor_analisis'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO public.normas (id, codigo, titulo, url_eli) VALUES
+        (5,  'LSE',          'Ley 24/2013, de 26 de diciembre, del Sector Eléctrico',                                                                                                              NULL),
+        (6,  'LPACAP',       'Ley 39/2015, de 1 de octubre, del Procedimiento Administrativo Común de las Administraciones Públicas',                                                              NULL),
+        (7,  'DL_2_2018',    'Decreto-ley 2/2018, de 26 de junio, de simplificación de normas en materia de energía y fomento de las energías renovables en Andalucía',                           NULL),
+        (8,  'DL_26_2021',   'Decreto-ley 26/2021, de 14 de diciembre, por el que se adoptan medidas de simplificación administrativa y mejora de la calidad regulatoria para la reactivación económica en Andalucía', NULL),
+        (9,  'RD_1183_2020', 'Real Decreto 1183/2020, de 29 de diciembre, de acceso y conexión a las redes de transporte y distribución de energía eléctrica',                                    NULL),
+        (10, 'RD_244_2019',  'Real Decreto 244/2019, de 5 de abril, por el que se regulan las condiciones administrativas, técnicas y económicas del autoconsumo de energía eléctrica',           NULL),
+        (11, 'RD_88_2026',   'Real Decreto 88/2026, de 11 de febrero, por el que se aprueba el Reglamento general de suministro, comercialización y agregación de energía eléctrica',             NULL)
+        ON CONFLICT (codigo) DO NOTHING
+    """)
+
+
+def downgrade():
+    op.execute("DELETE FROM public.normas WHERE id IN (5, 6, 7, 8, 9, 10, 11)")


### PR DESCRIPTION
## Cambios

- Nueva migración seed `451_seed_normas_ampliacion` (encadenada tras `455_variables_motor_analisis`)
- Inserta 7 normas en `public.normas` con IDs 5–11 y `url_eli = NULL`:
  - `LSE` — Ley 24/2013, de 26 de diciembre, del Sector Eléctrico
  - `LPACAP` — Ley 39/2015, de 1 de octubre, del Procedimiento Administrativo Común
  - `DL_2_2018` — Decreto-ley 2/2018, de 26 de junio (Andalucía, simplificación energías renovables)
  - `DL_26_2021` — Decreto-ley 26/2021, de 14 de diciembre (Andalucía, simplificación administrativa)
  - `RD_1183_2020` — Real Decreto 1183/2020, de 29 de diciembre (acceso y conexión)
  - `RD_244_2019` — Real Decreto 244/2019, de 5 de abril (autoconsumo)
  - `RD_88_2026` — Real Decreto 88/2026, de 11 de febrero (Reglamento suministro, comercialización y agregación; modifica arts. 137-138 RD 1955/2000)

Closes #451
