### PR TITLE
Corregir referencias erróneas a art. 138 como modificado por RD 88/2026

### DIFF
--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -51,7 +51,7 @@
 ### Bloque 4 — Motor de reglas y plazos
 
 15. ~~**#417** — limpiar referencias a tareas obsoletas v6.0 en `seed_demo.py` y `GUIA_GENERAL.md` (deuda técnica pequeña; independiente)~~ ✓
-16. ~~**#283** — capa ES de ESFTT: `ESTRUCTURA_ESF` (.md v2.2 + .json) + renumeración RD 88/2026~~ ✓
+16. ~~**#283** — capa ES de ESFTT: `ESTRUCTURA_ESF` (.md v2.2 + .json) + arts. 137-138 RD 88/2026~~ ✓
 17. ~~**#449** — fix `GRANT SELECT` olvidado en `organismos_expediente` (deuda menor M2, ~5 min, totalmente independiente) — *de la auditoría 22/05*~~ ✓
 18. ~~**#448** — HOTFIX seed `catalogo_plazos` RESOLUCION (crítico, bloqueante para motor de plazos): rediseño con `condiciones_plazo` por `tipo_solicitud` + nueva migración + sincronizar `DISEÑO_FECHAS_PLAZOS.md §5.2` — *de la auditoría 22/05*~~ ✓
 19. ~~**#454** — auditoría migraciones 345 vs 370 en `tramites_tareas` (prerequisito crítico de #247)~~ ✓

--- a/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
+++ b/docs/referencia/DISEÑO_FECHAS_PLAZOS.md
@@ -720,13 +720,13 @@ Estos valores son el seed del `catalogo_plazos` para las fases y trámites del p
 | RESOLUCION_AAP | `['AAP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 128 RD 1955/2000 |
 | RESOLUCION_AAC | `['AAC','AAP+AAC','AAP+AAC+DUP','AAC+DUP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 131.7 RD 1955/2000 |
 | RESOLUCION_TRANSMISION | `['AAT']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 133 RD 1955/2000 |
-| RESOLUCION_CIERRE | `['CIERRE']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 138 RD 1955/2000 (mod. RD 88/2026) |
+| RESOLUCION_CIERRE | `['CIERRE']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 138 RD 1955/2000 |
 | RESOLUCION_DUP | `['DUP']` | 3 | MESES | SILENCIO_DESESTIMATORIO | Art. 145.4 RD 1955/2000 |
 | INFORMACION_PUBLICA | **[PENDIENTE REDISEÑO campo_fecha]** | 30 | DIAS_NATURALES | SIN_EFECTO_AUTOMATICO | Art. 125 RD 1955/2000 |
 
 `campo_fecha` para todas las filas RESOLUCION_*: `{"fk": "documento_solicitud_id"}`.
 
-**Diferencias respecto al seed previo (172, código muerto):** descartado `RESOLUCION_AE` (sin sufijo — no existe ese tipo_solicitud); añadido `RESOLUCION_DUP` (procedimiento DUP autónomo, ausente del 172); CIERRE corregido (art. 137 → art. 138, mod. RD 88/2026); combinadas con AAC (`AAP+AAC`, `AAP+AAC+DUP`, `AAC+DUP`) consolidadas en la fila AAC porque art. 131.7 fija el plazo conjunto; `AE_DEFINITIVA+AAT` consume el plazo de AE_DEFINITIVA.
+**Diferencias respecto al seed previo (172, código muerto):** descartado `RESOLUCION_AE` (sin sufijo — no existe ese tipo_solicitud); añadido `RESOLUCION_DUP` (procedimiento DUP autónomo, ausente del 172); CIERRE corregido (art. 137 → art. 138; el 137 corresponde al informe del operador, no a la resolución; RD 88/2026 solo modifica art. 137); combinadas con AAC (`AAP+AAC`, `AAP+AAC+DUP`, `AAC+DUP`) consolidadas en la fila AAC porque art. 131.7 fija el plazo conjunto; `AE_DEFINITIVA+AAT` consume el plazo de AE_DEFINITIVA.
 
 **Fuera de scope del hotfix (deuda de #247):** plazos de RESOLUCION para `RAIPEE_PREVIA`, `RAIPEE_DEFINITIVA`, `RADNE`, `AMPLIACION_PLAZO`, `CORRECCION_ERRORES`, `DESISTIMIENTO`, `RENUNCIA`, `RECURSO`, `INTERESADO`, `OTRO`.
 

--- a/docs/referencia/ESTRUCTURA_ESF.json
+++ b/docs/referencia/ESTRUCTURA_ESF.json
@@ -404,7 +404,7 @@
         {
           "fase": "RESOLUCION",
           "obligatoria": true,
-          "base_legal": "RD 1955/2000 art. 138 (mod. RD 88/2026)",
+          "base_legal": "RD 1955/2000 art. 138",
           "nota": "Plazo: 6 meses (LSE art. 53.5, prevalece sobre los 3 meses del art. 138.1). Publicación obligatoria en BOE y BOP de las provincias donde radique la instalación (art. 138.3). Sin posibilidad de excepción ni supresión."
         }
       ]

--- a/docs/referencia/NORMATIVA_MAPA_PROCEDIMENTAL.md
+++ b/docs/referencia/NORMATIVA_MAPA_PROCEDIMENTAL.md
@@ -147,7 +147,7 @@ El procedimiento varía según el tipo de instalación:
 |---|---|---|---|
 | 1 | Solicitud del titular | ✅ | Art. 135 |
 | 2 | Informe del operador del sistema (REE) (3 meses; silencio: se continúa sin informe) | ✅ | Art. 137 (mod. RD 88/2026) |
-| 3 | **Resolución** (3 meses; silencio desestimatorio) | ✅ | Art. 138 (mod. RD 88/2026) |
+| 3 | **Resolución** (3 meses; silencio desestimatorio) | ✅ | Art. 138 |
 | 4 | Ejecución del cierre en el plazo fijado en la resolución (si vence → caducidad) | ✅ | Art. 138 |
 
 > **Régimen especial cierre AGE (LSE art. 53):** si pasan 6 meses desde la solicitud

--- a/migrations/versions/448_seed_plazos_resolucion.py
+++ b/migrations/versions/448_seed_plazos_resolucion.py
@@ -37,8 +37,9 @@ Diferencias respecto al seed original (172):
     en BD (solo AE_PROVISIONAL y AE_DEFINITIVA).
   - Añadido DUP (3 meses, art. 145.4 RD 1955/2000): el procedimiento DUP
     autónomo no estaba en el seed 172.
-  - Corregido CIERRE: art. 137 → art. 138 RD 1955/2000 (mod. RD 88/2026).
+  - Corregido CIERRE: art. 137 → art. 138 RD 1955/2000.
     Art. 137 corresponde al informe del operador, no a la resolución.
+    RD 88/2026 modifica art. 137, no art. 138 (sin renumeración).
   - AAC consolida sus combinadas en una sola entrada (art. 131.7 fija el
     plazo conjunto): `IN ('AAC','AAP+AAC','AAP+AAC+DUP','AAC+DUP')`.
   - AE_DEFINITIVA+AAT consume el plazo del AE_DEFINITIVA (art. 132 ter).
@@ -69,7 +70,7 @@ _PLAZOS_RESOLUCION = [
      ['AAC', 'AAP+AAC', 'AAP+AAC+DUP', 'AAC+DUP']),
     (50, 3, 'MESES', 'Art. 133 RD 1955/2000',
      ['AAT']),
-    (60, 3, 'MESES', 'Art. 138 RD 1955/2000 (mod. RD 88/2026)',
+    (60, 3, 'MESES', 'Art. 138 RD 1955/2000',
      ['CIERRE']),
     (70, 3, 'MESES', 'Art. 145.4 RD 1955/2000',
      ['DUP']),

--- a/migrations/versions/477_fix_norma_origen_cierre.py
+++ b/migrations/versions/477_fix_norma_origen_cierre.py
@@ -1,0 +1,38 @@
+"""477_fix_norma_origen_cierre
+
+Revision ID: 477_fix_norma_origen_cierre
+Revises: 451_seed_normas_ampliacion
+Create Date: 2026-05-25
+
+Corrige norma_origen en catalogo_plazos para RESOLUCION_CIERRE.
+
+RD 88/2026 solo modifica art. 137 RD 1955/2000 (informe del operador del
+sistema). El art. 138 (resolución del cierre) no fue modificado por RD 88/2026
+ni renumerado. La migración 448 insertó erróneamente el calificador
+"(mod. RD 88/2026)" en la base legal de CIERRE (id=111).
+"""
+from alembic import op
+
+
+revision = '477_fix_norma_origen_cierre'
+down_revision = '451_seed_normas_ampliacion'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        UPDATE public.catalogo_plazos
+        SET norma_origen = 'Art. 138 RD 1955/2000'
+        WHERE id = 111
+          AND norma_origen = 'Art. 138 RD 1955/2000 (mod. RD 88/2026)'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE public.catalogo_plazos
+        SET norma_origen = 'Art. 138 RD 1955/2000 (mod. RD 88/2026)'
+        WHERE id = 111
+          AND norma_origen = 'Art. 138 RD 1955/2000'
+    """)


### PR DESCRIPTION
## Cambios

Corrección de referencias erróneas que atribuían a RD 88/2026 la modificación del art. 138 RD 1955/2000. RD 88/2026 solo modifica art. 137 (informe del operador del sistema); art. 138 (resolución de cierre) no fue modificado ni renumerado.

- `DISEÑO_FECHAS_PLAZOS.md` — quitar `(mod. RD 88/2026)` de la fila RESOLUCION_CIERRE; corregir nota histórica del seed 448
- `ESTRUCTURA_ESF.json` — quitar `(mod. RD 88/2026)` de `base_legal` de la fase RESOLUCION en CIERRE
- `NORMATIVA_MAPA_PROCEDIMENTAL.md` — quitar `(mod. RD 88/2026)` de la columna Base de la resolución de cierre
- `CONTEXTO_ACTUAL.md` — corregir descripción de #283 (no hubo renumeración, solo modificación de art. 137)
- `448_seed_plazos_resolucion.py` — corregir comentario histórico y string `norma_origen` en `_PLAZOS_RESOLUCION`
- Migración `477_fix_norma_origen_cierre` — UPDATE `catalogo_plazos` id=111: eliminar `(mod. RD 88/2026)` del campo `norma_origen`
