### PR TITLE
Modo global del motor + tabla configuracion_sistema

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -32,6 +32,9 @@ from app.models.catalogo_requerimientos import CatalogoRequerimiento
 # Modelo de metadata del sistema (issue #85)
 from app.models.tabla_metadata import TablaMetadata
 
+# Configuración global del sistema (#323 — sin FKs)
+from app.models.configuracion_sistema import ConfiguracionSistema
+
 # Arquitectura Entidades Simplificada (refactorizada en issue #103)
 # Elimina jerarquía polimórfica, usa roles booleanos
 from app.models.entidad import Entidad
@@ -125,6 +128,8 @@ __all__ = [
     'CatalogoRequerimiento',
     # Metadata del sistema
     'TablaMetadata',
+    # Configuración global del sistema
+    'ConfiguracionSistema',
     # Arquitectura Entidades (simplificada en issue #103)
     'Entidad',
     'DireccionNotificacion',

--- a/app/models/configuracion_sistema.py
+++ b/app/models/configuracion_sistema.py
@@ -1,0 +1,31 @@
+"""Tabla genérica de configuración del sistema (issue #323)."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+from app import db
+
+log = logging.getLogger(__name__)
+
+
+class ConfiguracionSistema(db.Model):
+    __tablename__ = 'configuracion_sistema'
+    __table_args__ = {'schema': 'public'}
+
+    clave     = db.Column(db.String(80),  primary_key=True)
+    valor     = db.Column(db.Text(),      nullable=False)
+    tipo_dato = db.Column(db.String(20),  nullable=False)
+    etiqueta  = db.Column(db.String(200), nullable=True)
+
+    @classmethod
+    def get(cls, clave: str, default: Optional[str] = None) -> Optional[str]:
+        """Devuelve el valor de la clave o `default` si no existe o BD no disponible."""
+        try:
+            row = cls.query.filter_by(clave=clave).first()
+            return row.valor if row is not None else default
+        except (OperationalError, ProgrammingError):
+            log.warning('configuracion_sistema: tabla no disponible, devolviendo default para %s', clave)
+            return default

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -30,6 +30,8 @@ from app.models.organismos_expediente import OrganismoExpediente, ESTADOS_ORGANI
 from app.models.tramites_organismos import TramiteOrganismo
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.assembler import evaluar_multi
+from app.services.motor_reglas import EvaluacionResult, PERMITIDO
+from app.models.configuracion_sistema import ConfiguracionSistema
 from app.services.invariantes_esftt import (
     check_invariante, _check_cierre_fase, RESULTADO_FASE_FAVORABLE_CODIGOS,
 )
@@ -54,6 +56,22 @@ def _advertencia(res_eval):
     if res_eval and res_eval.nivel == 'ADVERTIR':
         return {'motivo': res_eval.motivo, 'norma_compilada': res_eval.norma_compilada, 'url_norma': res_eval.url_norma}
     return None
+
+
+def _aplicar_modo_global(res_eval: EvaluacionResult) -> EvaluacionResult:
+    """Ajusta el resultado del motor según el modo global configurado en BD."""
+    modo = ConfiguracionSistema.get('motor.modo_operacion', 'BLOQUEAR')
+    if modo == 'INACTIVO':
+        return PERMITIDO
+    if modo == 'SOLO_ADVERTIR' and res_eval.nivel == 'BLOQUEAR':
+        return EvaluacionResult(
+            permitido=True, nivel='ADVERTIR',
+            variables_trigger=res_eval.variables_trigger,
+            norma_compilada=res_eval.norma_compilada,
+            url_norma=res_eval.url_norma,
+            motivo=res_eval.motivo,
+        )
+    return res_eval
 
 
 # ============================================
@@ -116,7 +134,7 @@ def crear_fase(sol_id):
     if not tipo_fase:
         return jsonify({'ok': False, 'error': 'Tipo de fase no encontrado'}), 404
 
-    res_eval = evaluar_multi('CREAR', sol.expediente, objeto={'solicitud': sol, 'tipo_fase': tipo_fase})
+    res_eval = _aplicar_modo_global(evaluar_multi('CREAR', sol.expediente, objeto={'solicitud': sol, 'tipo_fase': tipo_fase}))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -142,7 +160,7 @@ def crear_tramite(fase_id):
     if not tipo_tramite:
         return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
 
-    res_eval = evaluar_multi('CREAR', fase.solicitud.expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+    res_eval = _aplicar_modo_global(evaluar_multi('CREAR', fase.solicitud.expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite}))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -169,7 +187,7 @@ def crear_tarea(tram_id):
     if not tipo_tarea:
         return jsonify({'ok': False, 'error': 'Tipo de tarea no encontrado'}), 404
 
-    res_eval = evaluar_multi('CREAR', tramite.fase.solicitud.expediente, objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea})
+    res_eval = _aplicar_modo_global(evaluar_multi('CREAR', tramite.fase.solicitud.expediente, objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea}))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -317,7 +335,7 @@ def borrar_solicitud(sol_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar_multi('BORRAR', sol.expediente, objeto=sol)
+    res_eval = _aplicar_modo_global(evaluar_multi('BORRAR', sol.expediente, objeto=sol))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -341,7 +359,7 @@ def borrar_fase(fase_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar_multi('BORRAR', fase.solicitud.expediente, objeto=fase)
+    res_eval = _aplicar_modo_global(evaluar_multi('BORRAR', fase.solicitud.expediente, objeto=fase))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -362,7 +380,7 @@ def borrar_tramite(tram_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar_multi('BORRAR', tramite.fase.solicitud.expediente, objeto=tramite)
+    res_eval = _aplicar_modo_global(evaluar_multi('BORRAR', tramite.fase.solicitud.expediente, objeto=tramite))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -380,7 +398,7 @@ def borrar_tarea(tarea_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = evaluar_multi('BORRAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
+    res_eval = _aplicar_modo_global(evaluar_multi('BORRAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 
@@ -636,7 +654,7 @@ def enviar_consultas(fase_id):
         log.warning('enviar_consultas: tabla tipos_tramites no disponible')
         return jsonify({'ok': False, 'error': 'Error de configuración del catálogo'}), 500
 
-    res_eval = evaluar_multi('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+    res_eval = _aplicar_modo_global(evaluar_multi('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite}))
     if not res_eval.permitido:
         return _bloqueo(res_eval)
 

--- a/migrations/versions/323_configuracion_sistema.py
+++ b/migrations/versions/323_configuracion_sistema.py
@@ -1,0 +1,39 @@
+"""323_configuracion_sistema
+
+Revision ID: 323_configuracion_sistema
+Revises: 477_fix_norma_origen_cierre
+Create Date: 2026-05-25
+
+Issue #323 — Tabla genérica de configuración del sistema + seed modo global del motor.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '323_configuracion_sistema'
+down_revision = '477_fix_norma_origen_cierre'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'configuracion_sistema',
+        sa.Column('clave',     sa.String(80),  primary_key=True),
+        sa.Column('valor',     sa.Text(),       nullable=False),
+        sa.Column('tipo_dato', sa.String(20),   nullable=False),
+        sa.Column('etiqueta',  sa.String(200),  nullable=True),
+        schema='public',
+    )
+
+    op.execute("""
+        INSERT INTO public.configuracion_sistema (clave, valor, tipo_dato, etiqueta) VALUES
+        ('motor.modo_operacion', 'BLOQUEAR', 'enum',
+         'Modo global del motor de reglas: BLOQUEAR | SOLO_ADVERTIR | INACTIVO')
+    """)
+
+    op.execute("GRANT SELECT ON public.configuracion_sistema TO claude_desktop")
+
+
+def downgrade():
+    op.drop_table('configuracion_sistema', schema='public')


### PR DESCRIPTION
## Cambios

- Nueva tabla `configuracion_sistema` (PK `clave`, columnas `valor`, `tipo_dato`, `etiqueta`) con migración Alembic y seed `motor.modo_operacion = BLOQUEAR`
- Modelo `ConfiguracionSistema` con método de clase `get(clave, default)` con manejo de `OperationalError`/`ProgrammingError`
- Función `_aplicar_modo_global(res_eval)` en `api_bc.py`: transforma el `EvaluacionResult` según el modo configurado (`BLOQUEAR` / `SOLO_ADVERTIR` / `INACTIVO`) antes de actuar sobre él
- Aplicado el interceptor en los 8 call sites de `evaluar_multi` en `api_bc.py` (CREAR fase, trámite, tarea; BORRAR solicitud, fase, trámite, tarea; enviar consultas)
- `motor_reglas.py:evaluar()` y `assembler.py:evaluar_multi()` no se tocan

Closes #323
