### PR TITLE
Crear cuaderno de bitácora agnóstico (tabla, modelo, servicio)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -35,6 +35,9 @@ from app.models.tabla_metadata import TablaMetadata
 # Configuración global del sistema (#323 — sin FKs)
 from app.models.configuracion_sistema import ConfiguracionSistema
 
+# Cuaderno de bitácora agnóstico (#1 — FK a usuarios)
+from app.models.bitacora import Bitacora
+
 # Arquitectura Entidades Simplificada (refactorizada en issue #103)
 # Elimina jerarquía polimórfica, usa roles booleanos
 from app.models.entidad import Entidad
@@ -130,6 +133,8 @@ __all__ = [
     'TablaMetadata',
     # Configuración global del sistema
     'ConfiguracionSistema',
+    # Cuaderno de bitácora
+    'Bitacora',
     # Arquitectura Entidades (simplificada en issue #103)
     'Entidad',
     'DireccionNotificacion',

--- a/app/models/bitacora.py
+++ b/app/models/bitacora.py
@@ -1,0 +1,18 @@
+"""Cuaderno de bitácora agnóstico de operaciones (issue #1)."""
+from __future__ import annotations
+
+from app import db
+
+
+class Bitacora(db.Model):
+    __tablename__ = 'bitacora'
+    __table_args__ = {'schema': 'public'}
+
+    id          = db.Column(db.Integer, primary_key=True)
+    usuario_id  = db.Column(db.Integer, db.ForeignKey('public.usuarios.id'), nullable=False)
+    operacion   = db.Column(db.String(10), nullable=False)
+    tabla       = db.Column(db.String(60), nullable=False)
+    registro_id = db.Column(db.Integer, nullable=False)
+    columna     = db.Column(db.String(60), nullable=True)
+    created_at  = db.Column(db.DateTime(timezone=True), server_default=db.text('now()'), nullable=False)
+    detalle     = db.Column(db.JSON, nullable=True)

--- a/app/services/bitacora.py
+++ b/app/services/bitacora.py
@@ -1,0 +1,22 @@
+"""Servicio de escritura en el cuaderno de bitácora (issue #1)."""
+from app import db
+from app.models.bitacora import Bitacora
+
+
+def registrar(usuario_id, operacion, tabla, registro_id, *, columna=None, detalle=None):
+    """
+    Añade una entrada al cuaderno de bitácora.
+
+    No valida dominio. No filtra. No decide si registrar — eso es responsabilidad
+    del consumidor. El commit es responsabilidad del consumidor.
+    """
+    entrada = Bitacora(
+        usuario_id=usuario_id,
+        operacion=operacion,
+        tabla=tabla,
+        registro_id=registro_id,
+        columna=columna,
+        detalle=detalle,
+    )
+    db.session.add(entrada)
+    return entrada

--- a/migrations/versions/001_bitacora.py
+++ b/migrations/versions/001_bitacora.py
@@ -1,0 +1,43 @@
+"""001_bitacora
+
+Revision ID: 001_bitacora
+Revises: 323_configuracion_sistema
+Create Date: 2026-05-25
+
+Issue #1 — Tabla bitacora: cuaderno de bitácora agnóstico de operaciones.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '001_bitacora'
+down_revision = '323_configuracion_sistema'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'bitacora',
+        sa.Column('id',          sa.Integer(),     primary_key=True),
+        sa.Column('usuario_id',  sa.Integer(),     sa.ForeignKey('public.usuarios.id'), nullable=False),
+        sa.Column('operacion',   sa.String(10),    nullable=False),
+        sa.Column('tabla',       sa.String(60),    nullable=False),
+        sa.Column('registro_id', sa.Integer(),     nullable=False),
+        sa.Column('columna',     sa.String(60),    nullable=True),
+        sa.Column('created_at',  sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('detalle',     sa.JSON(),        nullable=True),
+        sa.CheckConstraint("operacion IN ('CREAR','BORRAR','ALTERAR')", name='ck_bitacora_operacion'),
+        schema='public',
+    )
+
+    op.create_index('ix_bitacora_usuario_fecha', 'bitacora', ['usuario_id', 'created_at'], schema='public')
+    op.create_index('ix_bitacora_tabla_registro', 'bitacora', ['tabla', 'registro_id'], schema='public')
+
+    op.execute("GRANT SELECT ON public.bitacora TO claude_desktop")
+
+
+def downgrade():
+    op.drop_index('ix_bitacora_tabla_registro', table_name='bitacora', schema='public')
+    op.drop_index('ix_bitacora_usuario_fecha', table_name='bitacora', schema='public')
+    op.drop_table('bitacora', schema='public')

--- a/tests/test_001_bitacora.py
+++ b/tests/test_001_bitacora.py
@@ -1,0 +1,89 @@
+"""Tests issue #1 — Cuaderno de bitácora agnóstico.
+
+Bloques:
+  A) registrar() — escritura correcta en BD.
+  B) CHECK constraint — operación inválida rechazada por BD.
+  C) detalle libre — JSON arbitrario admitido y recuperado íntegro.
+  D) entradas independientes — cada operación produce su propia fila.
+  E) columna nullable — solo obligatoria semánticamente en ALTERAR.
+"""
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app import db
+from app.models.bitacora import Bitacora
+from app.services.bitacora import registrar
+
+# ID de usuario existente en el seed de desarrollo
+_UID = 1
+
+
+# ---------------------------------------------------------------------------
+# A) Escritura correcta
+# ---------------------------------------------------------------------------
+
+def test_registrar_persiste_campos_basicos(app_ctx):
+    entrada = registrar(_UID, 'CREAR', 'expedientes', 42)
+    db.session.flush()
+
+    assert entrada.id is not None
+    assert entrada.usuario_id == _UID
+    assert entrada.operacion == 'CREAR'
+    assert entrada.tabla == 'expedientes'
+    assert entrada.registro_id == 42
+    assert entrada.columna is None
+    assert entrada.detalle is None
+    assert entrada.created_at is not None
+
+
+# ---------------------------------------------------------------------------
+# B) CHECK constraint — operación inválida
+# ---------------------------------------------------------------------------
+
+def test_operacion_invalida_viola_constraint(app_ctx):
+    registrar(_UID, 'LEER', 'expedientes', 1)
+    with pytest.raises(IntegrityError):
+        db.session.flush()
+    db.session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# C) Detalle libre
+# ---------------------------------------------------------------------------
+
+def test_detalle_libre_json_arbitrario(app_ctx):
+    payload = {'escape': True, 'regla_id': 5, 'justificacion': 'texto libre', 'ids': [3, 7]}
+    entrada = registrar(_UID, 'ALTERAR', 'tramites', 10, columna='estado', detalle=payload)
+    db.session.flush()
+
+    recuperado = Bitacora.query.get(entrada.id)
+    assert recuperado.detalle == payload
+
+
+# ---------------------------------------------------------------------------
+# D) Entradas independientes por operación
+# ---------------------------------------------------------------------------
+
+def test_tres_operaciones_generan_tres_entradas(app_ctx):
+    registrar(_UID, 'CREAR',  'fases', 1)
+    registrar(_UID, 'ALTERAR', 'fases', 1, columna='resultado')
+    registrar(_UID, 'BORRAR', 'fases', 1, detalle={'nombre': 'INSTRUCCION'})
+    db.session.flush()
+
+    filas = Bitacora.query.filter_by(tabla='fases', registro_id=1).all()
+    assert len(filas) == 3
+    operaciones = {f.operacion for f in filas}
+    assert operaciones == {'CREAR', 'ALTERAR', 'BORRAR'}
+
+
+# ---------------------------------------------------------------------------
+# E) columna nullable fuera de ALTERAR
+# ---------------------------------------------------------------------------
+
+def test_columna_nullable_en_crear_y_borrar(app_ctx):
+    e1 = registrar(_UID, 'CREAR',  'tareas', 99)
+    e2 = registrar(_UID, 'BORRAR', 'tareas', 99)
+    db.session.flush()
+
+    assert e1.columna is None
+    assert e2.columna is None


### PR DESCRIPTION
## Cambios

- Migración `001_bitacora`: tabla `public.bitacora` con CHECK constraint en `operacion`, FK a `usuarios`, dos índices y GRANT al usuario MCP
- Modelo `Bitacora` en `app/models/bitacora.py`; registrado en `app/models/__init__.py`
- Servicio `app/services/bitacora.py` con función `registrar()` — agnóstica, sin commit propio
- 5 tests: escritura básica, CHECK constraint inválido, detalle JSON libre, entradas independientes por operación, columna nullable

Closes #1
