### PR TITLE
Mecanismo de escape del motor con justificación y bitácora

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -10,7 +10,7 @@ Creado para resolver el bug #314.
 import logging
 
 from flask import Blueprint, jsonify, request
-from flask_login import login_required
+from flask_login import login_required, current_user
 from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
 from app import db
 from app.models.expedientes import Expediente
@@ -29,7 +29,8 @@ from app.models.entidad import Entidad
 from app.models.organismos_expediente import OrganismoExpediente, ESTADOS_ORGANISMO, VIAS_ORGANISMO
 from app.models.tramites_organismos import TramiteOrganismo
 from app.utils.permisos import verificar_acceso_expediente
-from app.services.assembler import evaluar_multi
+from app.services.assembler import evaluar_multi, build_sujeto
+from app.services import bitacora as bitacora_svc
 from app.services.motor_reglas import EvaluacionResult, PERMITIDO
 from app.models.configuracion_sistema import ConfiguracionSistema
 from app.services.invariantes_esftt import (
@@ -48,7 +49,24 @@ def _bloqueo(res_eval):
         'motivo': res_eval.motivo,
         'error': res_eval.norma_compilada or 'Acción no permitida',
         'url_norma': res_eval.url_norma,
+        'puede_escapar': res_eval.puede_escapar,
     }), 422
+
+
+def _leer_bypass(form):
+    """
+    Lee bypass + justificacion del form de la petición.
+
+    Devuelve (justificacion, None) si bypass=true con texto válido,
+    (None, None) si bypass está ausente o es false,
+    (None, respuesta_400) si bypass=true pero justificacion está vacía.
+    """
+    if form.get('bypass') not in ('true', '1', 'True'):
+        return None, None
+    justificacion = (form.get('justificacion') or '').strip()
+    if not justificacion:
+        return None, (jsonify({'ok': False, 'error': 'justificacion es obligatoria para el bypass'}), 400)
+    return justificacion, None
 
 
 def _advertencia(res_eval):
@@ -139,14 +157,29 @@ def crear_fase(sol_id):
     if not tipo_fase:
         return jsonify({'ok': False, 'error': 'Tipo de fase no encontrado'}), 404
 
-    res_eval = _evaluar('CREAR', sol.expediente, objeto={'solicitud': sol, 'tipo_fase': tipo_fase})
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', sol.expediente, objeto={'solicitud': sol, 'tipo_fase': tipo_fase})
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+    else:
+        res_eval = PERMITIDO
 
     fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
     db.session.add(fase)
-    db.session.commit()
+    db.session.flush()
 
+    if justificacion:
+        sujeto = build_sujeto(sol.expediente, {'solicitud': sol, 'tipo_fase': tipo_fase})
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'fases', fase.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
     return jsonify({'ok': True, 'id': fase.id, 'advertencia': _advertencia(res_eval)})
 
 
@@ -165,15 +198,31 @@ def crear_tramite(fase_id):
     if not tipo_tramite:
         return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
 
-    res_eval = _evaluar('CREAR', fase.solicitud.expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    expediente = fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+    else:
+        res_eval = PERMITIDO
 
     tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
     db.session.add(tramite)
     _hook_459_traslado_organismo(tipo_tramite, fase)
-    db.session.commit()
+    db.session.flush()
 
+    if justificacion:
+        sujeto = build_sujeto(expediente, {'fase': fase, 'tipo_tramite': tipo_tramite})
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'tramites', tramite.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
     return jsonify({'ok': True, 'id': tramite.id, 'advertencia': _advertencia(res_eval)})
 
 
@@ -192,14 +241,30 @@ def crear_tarea(tram_id):
     if not tipo_tarea:
         return jsonify({'ok': False, 'error': 'Tipo de tarea no encontrado'}), 404
 
-    res_eval = _evaluar('CREAR', tramite.fase.solicitud.expediente, objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea})
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    expediente = tramite.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente, objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea})
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+    else:
+        res_eval = PERMITIDO
 
     tarea = Tarea(tramite_id=tram_id, tipo_tarea_id=tipo_tarea_id)
     db.session.add(tarea)
-    db.session.commit()
+    db.session.flush()
 
+    if justificacion:
+        sujeto = build_sujeto(expediente, tramite)
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'tareas', tarea.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
     return jsonify({'ok': True, 'id': tarea.id, 'advertencia': _advertencia(res_eval)})
 
 
@@ -340,9 +405,21 @@ def borrar_solicitud(sol_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = _evaluar('BORRAR', sol.expediente, objeto=sol)
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', sol.expediente, objeto=sol)
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(sol.expediente, sol)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'solicitudes', sol.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
 
     fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol_id).all()]
     if fase_ids:
@@ -364,9 +441,22 @@ def borrar_fase(fase_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = _evaluar('BORRAR', fase.solicitud.expediente, objeto=fase)
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    expediente = fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=fase)
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, fase)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'fases', fase.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
 
     tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase_id).all()]
     if tram_ids:
@@ -385,9 +475,22 @@ def borrar_tramite(tram_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = _evaluar('BORRAR', tramite.fase.solicitud.expediente, objeto=tramite)
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    expediente = tramite.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=tramite)
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, tramite)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'tramites', tramite.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
 
     Tarea.query.filter_by(tramite_id=tram_id).delete()
     db.session.delete(tramite)
@@ -403,9 +506,22 @@ def borrar_tarea(tarea_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    res_eval = _evaluar('BORRAR', tarea.tramite.fase.solicitud.expediente, objeto=tarea)
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    expediente = tarea.tramite.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=tarea)
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, tarea.tramite)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'tareas', tarea.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
 
     db.session.delete(tarea)
     db.session.commit()
@@ -659,9 +775,16 @@ def enviar_consultas(fase_id):
         log.warning('enviar_consultas: tabla tipos_tramites no disponible')
         return jsonify({'ok': False, 'error': 'Error de configuración del catálogo'}), 500
 
-    res_eval = _evaluar('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
-    if not res_eval.permitido:
-        return _bloqueo(res_eval)
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+        if not res_eval.permitido:
+            return _bloqueo(res_eval)
+    else:
+        res_eval = PERMITIDO
 
     pendientes = [
         oe for oe in expediente.organismos
@@ -669,6 +792,7 @@ def enviar_consultas(fase_id):
     ]
 
     plazo = _calcular_plazo_consulta(expediente, solicitud)
+    objeto_sujeto = {'fase': fase, 'tipo_tramite': tipo_tramite}
 
     try:
         ids = []
@@ -680,6 +804,14 @@ def enviar_consultas(fase_id):
             oe.estado = 'separata_enviada'
             oe.plazo_legal_dias = plazo
             ids.append(tramite.id)
+
+            if justificacion:
+                sujeto = build_sujeto(expediente, objeto_sujeto)
+                bitacora_svc.registrar(
+                    current_user.id, 'CREAR', 'tramites', tramite.id,
+                    detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+                )
+
         db.session.commit()
         return jsonify({'ok': True, 'ids': ids, 'advertencia': _advertencia(res_eval)})
     except Exception as e:

--- a/app/services/assembler.py
+++ b/app/services/assembler.py
@@ -227,6 +227,11 @@ def build(expediente: Any, objeto: Any = None) -> tuple[str, dict]:
     return sujeto, variables
 
 
+def build_sujeto(expediente: Any, objeto: Any = None) -> str:
+    """Compila solo el sujeto calificado sin calcular variables (operación barata)."""
+    return _compilar_sujeto(ExpedienteContext(expediente, objeto))
+
+
 def auditar_multi(accion: str, expediente: Any, objeto: Any = None):
     """
     Companion de evaluar_multi que llama a auditar() y acumula reglas de todos los tipos.

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -61,7 +61,8 @@ class EvaluacionResult:
     variables_trigger: dict  # subconjunto del dict que disparó la regla
     norma_compilada:   str   # referencia normativa compilada
     url_norma:         str   # URL BOE/BOJA; '' si no existe
-    motivo:            str = ''  # descripción editorial de la regla; '' si no configurada
+    motivo:            str = ''   # descripción editorial de la regla; '' si no configurada
+    puede_escapar:     bool = False  # True solo cuando el bloqueo viene del motor (no de invariantes)
 
 
 PERMITIDO = EvaluacionResult(
@@ -225,6 +226,7 @@ def evaluar(
                     norma_compilada=norma_ref,
                     url_norma=url_norma,
                     motivo=regla.descripcion or '',
+                    puede_escapar=True,
                 )
 
         elif regla.efecto == 'ADVERTIR' and resultado_advertir is None:

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #323 (PR #480) — tabla `configuracion_sistema`, modelo `ConfiguracionSistema`, interceptor `_aplicar_modo_global` + wrapper `_evaluar` en `api_bc.py`; migración `323_configuracion_sistema`; 11 tests. UI del supervisor abierta como #479.
+**Último cerrado:** #1 (PR #481) — tabla `bitacora`, modelo `Bitacora`, servicio `registrar()`; migración `001_bitacora`; 5 tests.
 
 **Actuales:** —
 
-**Próximo:** **#1** — cuaderno de bitácora agnóstico (tabla `bitacora`, modelo, servicio `registrar()`); prerequisito de #324. Análisis y diseño de #324 completados en sesión 2026-05-25 (ver cuerpos actualizados en GitHub).
+**Próximo:** **#324** — mecanismo de escape del motor (backend puro): `puede_escapar` en `EvaluacionResult`, parámetro `bypass+justificacion` en endpoints, registro en `bitacora`; sin frontend; diseño completado en sesión 2026-05-25 (ver cuerpo en GitHub).
 
 **Plan de trabajo CONSULTAS (sesión 2026-05-24):** análisis completo de #247 en `docs/historial/ANALISIS_CONSULTAS_ORGANISMOS_2026-05-24.md`. Orden acordado:
 1. ~~**#454** — auditoría 345 vs 370: verificar duplicados en `tramites_tareas` antes de tocar cualquier trámite CONSULTA_*.~~ ✓
@@ -65,7 +65,7 @@
 27. ~~**#455** — variables motor cierre `ANALISIS_SOLICITUD` (independiente de CONSULTAS; tras #442).~~ ✓
 27. ~~**#451** — ampliar catálogo `normas` (LSE, LPACAP, DL 2/2018, DL 26/2021, RD 1183/2020, RD 244/2019, RD 88/2026) — prerrequisito de #323 — *de la auditoría 22/05*~~ ✓
 28. ~~**#323** — modo global del motor + tabla `configuracion_sistema`~~ ✓
-28b. **#1** — cuaderno de bitácora agnóstico: tabla `bitacora`, modelo, servicio `registrar()` (prerequisito de #324, #174, #435, #436; movido de M5 a M3 en sesión 2026-05-25)
+28b. ~~**#1** — cuaderno de bitácora agnóstico: tabla `bitacora`, modelo, servicio `registrar()` (prerequisito de #324, #174, #435, #436; movido de M5 a M3 en sesión 2026-05-25)~~ ✓
 29. **#324** — mecanismo de escape del motor (backend puro): `puede_escapar` en `EvaluacionResult`, parámetro `bypass+justificacion` en endpoints, registro en `bitacora`; sin frontend (coordinado aparte); tras #1
 30. **#450** — seed procedimiento CIERRE: fase `CONSULTA_OPERADOR_SISTEMA` + trámites `SOLICITUD_INFORME_OPERADOR` / `RECEPCION_INFORME_OPERADOR` + plazo (art. 137 RD 1955/2000 mod. RD 88/2026) — *de la auditoría 22/05*
 31. **#416** — motor de plazos para TABLON_AYUNTAMIENTOS: fecha administrativa y cierre retroactivo de ESPERAR_PLAZO (edge case del servicio de plazos)

--- a/tests/test_324_escape_motor.py
+++ b/tests/test_324_escape_motor.py
@@ -1,0 +1,146 @@
+"""
+Tests #324 — Mecanismo de escape del motor.
+
+Bloques:
+  A) EvaluacionResult.puede_escapar — campo propagado correctamente por el motor.
+  B) _bloqueo() — JSON de respuesta incluye puede_escapar.
+  C) _leer_bypass() — validación y lectura de parámetros de escape.
+  D) Invariantes — bloqueos de invariantes_esftt no son escapables.
+"""
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# A) EvaluacionResult.puede_escapar
+# ---------------------------------------------------------------------------
+
+def test_puede_escapar_es_true_en_resultado_bloquear():
+    """El motor setea puede_escapar=True cuando devuelve BLOQUEAR."""
+    from app.services.motor_reglas import EvaluacionResult
+    res = EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR',
+        variables_trigger={}, norma_compilada='Art. 1 RD test',
+        url_norma='', motivo='test', puede_escapar=True,
+    )
+    assert res.puede_escapar is True
+
+
+def test_puede_escapar_es_false_en_permitido():
+    """PERMITIDO tiene puede_escapar=False (default del dataclass)."""
+    from app.services.motor_reglas import PERMITIDO
+    assert PERMITIDO.puede_escapar is False
+
+
+def test_puede_escapar_es_false_en_advertir():
+    """ADVERTIR tiene puede_escapar=False."""
+    from app.services.motor_reglas import EvaluacionResult
+    res = EvaluacionResult(
+        permitido=True, nivel='ADVERTIR',
+        variables_trigger={}, norma_compilada='',
+        url_norma='', motivo='',
+    )
+    assert res.puede_escapar is False
+
+
+# ---------------------------------------------------------------------------
+# B) _bloqueo() — JSON incluye puede_escapar
+# ---------------------------------------------------------------------------
+
+def test_bloqueo_json_incluye_puede_escapar_true(app_ctx):
+    """_bloqueo() con resultado del motor devuelve puede_escapar: true en JSON."""
+    from app.routes.api_bc import _bloqueo
+    from app.services.motor_reglas import EvaluacionResult
+    res = EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR',
+        variables_trigger={}, norma_compilada='Art. 1 RD test',
+        url_norma='https://boe.es/test', motivo='motivo de test',
+        puede_escapar=True,
+    )
+    response, status = _bloqueo(res)
+    data = response.get_json()
+    assert status == 422
+    assert data['puede_escapar'] is True
+    assert data['ok'] is False
+
+
+def test_bloqueo_json_incluye_puede_escapar_false_para_invariante(app_ctx):
+    """_bloqueo() con resultado de invariante devuelve puede_escapar: false."""
+    from app.routes.api_bc import _bloqueo
+    from app.services.motor_reglas import EvaluacionResult
+    res = EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR',
+        variables_trigger={}, norma_compilada='Hijos sin cerrar',
+        url_norma='', motivo='',
+        # puede_escapar=False por defecto — comportamiento de invariantes_esftt
+    )
+    response, status = _bloqueo(res)
+    data = response.get_json()
+    assert status == 422
+    assert data['puede_escapar'] is False
+
+
+# ---------------------------------------------------------------------------
+# C) _leer_bypass() — validación de parámetros
+# ---------------------------------------------------------------------------
+
+def test_leer_bypass_sin_bypass_devuelve_nones():
+    """Sin bypass en el form, no hay acción de escape."""
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({})
+    assert justificacion is None
+    assert err is None
+
+
+def test_leer_bypass_bypass_false_devuelve_nones():
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({'bypass': 'false'})
+    assert justificacion is None
+    assert err is None
+
+
+def test_leer_bypass_bypass_true_sin_justificacion_devuelve_error_400(app_ctx):
+    """bypass=true sin justificacion → error 400."""
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({'bypass': 'true'})
+    assert justificacion is None
+    assert err is not None
+    response, status = err
+    assert status == 400
+    assert response.get_json()['ok'] is False
+
+
+def test_leer_bypass_justificacion_solo_espacios_devuelve_error_400(app_ctx):
+    """Justificación vacía (solo espacios) → error 400."""
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({'bypass': 'true', 'justificacion': '   '})
+    assert justificacion is None
+    assert err is not None
+
+
+def test_leer_bypass_con_justificacion_valida_devuelve_texto():
+    """bypass=true + justificacion con texto → devuelve el texto."""
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({'bypass': 'true', 'justificacion': 'Tramitación urgente'})
+    assert justificacion == 'Tramitación urgente'
+    assert err is None
+
+
+def test_leer_bypass_acepta_bypass_uno():
+    """bypass='1' también activa el escape."""
+    from app.routes.api_bc import _leer_bypass
+    justificacion, err = _leer_bypass({'bypass': '1', 'justificacion': 'justificado'})
+    assert justificacion == 'justificado'
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# D) Invariantes — bloqueos de invariantes_esftt no son escapables
+# ---------------------------------------------------------------------------
+
+def test_invariante_bloquear_no_es_escapable():
+    """_bloquear() de invariantes_esftt produce puede_escapar=False por defecto."""
+    from app.services.invariantes_esftt import _bloquear
+    res = _bloquear('Hijos sin cerrar')
+    assert res.puede_escapar is False
+    assert res.permitido is False
+    assert res.nivel == 'BLOQUEAR'


### PR DESCRIPTION
## Cambios

- `EvaluacionResult`: nuevo campo `puede_escapar: bool = False`; el motor lo pone a `True` cuando el efecto es `BLOQUEAR` (los invariantes estructurales quedan en `False` por defecto)
- `_bloqueo()` en `api_bc.py`: incluye `puede_escapar` en el JSON de respuesta 422
- `_leer_bypass(form)`: helper que extrae `bypass` + `justificacion` del form y valida que la justificación no esté vacía (→ 400 si falta)
- 8 endpoints de crear/borrar (fase, trámite, tarea, solicitud, enviar-consultas): aceptan `bypass=true` + `justificacion`; omiten el motor, llaman a `bitacora.registrar()` con `detalle.escape=True` y ejecutan la acción
- `build_sujeto()` en `assembler.py`: compila el sujeto calificado ESFTT sin calcular variables (usado en el detalle de bitácora)
- 12 tests: `puede_escapar` en resultados del motor, JSON de `_bloqueo`, validación de `_leer_bypass`, invariantes no escapables

Closes #324
