### PR TITLE
Señalizar CONSULTA_TRASLADO_TITULAR vencido: variable motor + campo API

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -600,7 +600,35 @@ def _serializar_org_exp(oe):
         'estado': oe.estado,
         'plazo_legal_dias': oe.plazo_legal_dias,
         'condicionados_doc_id': oe.condicionados_doc_id,
+        'traslado_titular_vencido': _traslado_titular_vencido(oe),
     }
+
+
+def _traslado_titular_vencido(oe) -> bool:
+    """True si el CONSULTA_TRASLADO_TITULAR más reciente del organismo tiene plazo VENCIDO.
+
+    Llamada con variables={} para evitar recursión en _compilar_variables (#475).
+    """
+    from app.models.tramites_organismos import TramiteOrganismo
+    from app.models.tramites import Tramite as _Tramite
+    from app.models.tipos_tramites import TipoTramite
+    from app.services import plazos
+
+    vinculo = (
+        TramiteOrganismo.query
+        .join(_Tramite, TramiteOrganismo.tramite_id == _Tramite.id)
+        .join(TipoTramite, _Tramite.tipo_tramite_id == TipoTramite.id)
+        .filter(
+            TramiteOrganismo.organismo_expediente_id == oe.id,
+            TipoTramite.codigo == 'CONSULTA_TRASLADO_TITULAR',
+        )
+        .order_by(TramiteOrganismo.tramite_id.desc())
+        .first()
+    )
+    if vinculo is None:
+        return False
+    ep = plazos.obtener_estado_plazo(vinculo.tramite, 'TRAMITE', variables={})
+    return ep.estado == 'VENCIDO'
 
 
 def _hook_458_analizar_separata(tarea, id_producido):

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -237,3 +237,48 @@ def _(ctx) -> bool:
         if count >= 1:
             return True
     return False
+
+
+@variable('traslado_organismo_titular_vencido')
+def _(ctx) -> bool:
+    """
+    True si algún organismo en en_tramitacion tiene su CONSULTA_TRASLADO_TITULAR
+    más reciente con plazo VENCIDO.
+
+    Permite al motor emitir una alerta diferenciada cuando el titular no ha
+    respondido al traslado dentro del plazo legal (15 días hábiles, art. 127.3 /
+    131.3 RD 1955/2000). El efecto es SIN_EFECTO_AUTOMATICO: el sistema no puede
+    inferir la acción correcta sin leer el resultado del trámite de organismo
+    precedente (ADR-011 §5).
+
+    Implementación — variables={} para evitar recursión: el seed #463 no define
+    condiciones en la entrada de CONSULTA_TRASLADO_TITULAR, por lo que pasar un
+    dict vacío produce el mismo resultado que el contexto completo. Si en el futuro
+    se añaden condiciones a ese plazo, revisar esta llamada (#475).
+    """
+    from app.models.tramites_organismos import TramiteOrganismo
+    from app.models.tramites import Tramite as _Tramite
+    from app.models.tipos_tramites import TipoTramite
+    from app.services import plazos
+    from app import db
+
+    for org in ctx.expediente.organismos:
+        if org.estado != 'en_tramitacion':
+            continue
+        vinculo = (
+            db.session.query(TramiteOrganismo)
+            .join(_Tramite, TramiteOrganismo.tramite_id == _Tramite.id)
+            .join(TipoTramite, _Tramite.tipo_tramite_id == TipoTramite.id)
+            .filter(
+                TramiteOrganismo.organismo_expediente_id == org.id,
+                TipoTramite.codigo == 'CONSULTA_TRASLADO_TITULAR',
+            )
+            .order_by(TramiteOrganismo.tramite_id.desc())
+            .first()
+        )
+        if vinculo is None:
+            continue
+        ep = plazos.obtener_estado_plazo(vinculo.tramite, 'TRAMITE', variables={})
+        if ep.estado == 'VENCIDO':
+            return True
+    return False

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #324 (PR #482) — mecanismo de escape del motor: `puede_escapar` en `EvaluacionResult`, `_leer_bypass`, bypass+bitácora en 8 endpoints ESFTT, `build_sujeto()` en assembler; 12 tests.
+**Último cerrado:** #416 (PR #484) — motor plazos `TABLON_AYUNTAMIENTOS`: seed `catalogo_plazos` con `campo_fecha = {via_tarea_tipo: ESPERAR_PLAZO, rol: PRODUCIDO}`; 30 días naturales (art. 125 RD 1955/2000); sin cambios en `plazos.py`. Cierra el Bloque 4.
 
 **Actuales:** —
 
-**Próximo:** **#416** — motor de plazos para TABLON_AYUNTAMIENTOS: fecha administrativa y cierre retroactivo de ESPERAR_PLAZO (edge case del servicio de plazos). Cierra el Bloque 4.
+**Próximo:** **#475** — señalización de `CONSULTA_TRASLADO_TITULAR` vencido en organismo: detectar vencimiento + exponer estado en API/variables (backend independiente de UI #396).
 
 **Plan de trabajo CONSULTAS (sesión 2026-05-24):** análisis completo de #247 en `docs/historial/ANALISIS_CONSULTAS_ORGANISMOS_2026-05-24.md`. Orden acordado:
 1. ~~**#454** — auditoría 345 vs 370: verificar duplicados en `tramites_tareas` antes de tocar cualquier trámite CONSULTA_*.~~ ✓
@@ -61,15 +61,15 @@
 23. ~~**#460** — variables motor cierre CONSULTAS: `organismos_todos_terminados`, `organismo_supera_iteraciones` (tras #458)~~ ✓
 24. ~~**#462** — acción en bloque «Enviar consultas» (tras #247)~~ ✓
 25. ~~**#463** — seed `catalogo_plazos` para CONSULTAS (independiente, M3)~~ ✓
-26. **#475** — señalización de `CONSULTA_TRASLADO_TITULAR` vencido en organismo (M3; requiere UI #396).
+26. **#475** — señalización de `CONSULTA_TRASLADO_TITULAR` vencido en organismo (M3; backend independiente; UI #396 necesaria solo para mostrar la alerta al tramitador).
 27. ~~**#455** — variables motor cierre `ANALISIS_SOLICITUD` (independiente de CONSULTAS; tras #442).~~ ✓
 27. ~~**#451** — ampliar catálogo `normas` (LSE, LPACAP, DL 2/2018, DL 26/2021, RD 1183/2020, RD 244/2019, RD 88/2026) — prerrequisito de #323 — *de la auditoría 22/05*~~ ✓
 28. ~~**#323** — modo global del motor + tabla `configuracion_sistema`~~ ✓
 28b. ~~**#1** — cuaderno de bitácora agnóstico: tabla `bitacora`, modelo, servicio `registrar()` (prerequisito de #324, #174, #435, #436; movido de M5 a M3 en sesión 2026-05-25)~~ ✓
 29. ~~**#324** — mecanismo de escape del motor: `puede_escapar`, `_leer_bypass`, bypass+bitácora en 8 endpoints, `build_sujeto()`; 12 tests~~ ✓
-29b. **#483** — corregir tests obsoletos `test_296` y `test_328` (commit directo en develop; independiente)
+29b. ~~**#483** — corregir tests obsoletos `test_296` y `test_328` (commit directo en develop; independiente)~~ ✓
 30. ~~**#450**~~ → movido a M5: seed CIERRE/CONSULTA_OPERADOR_SISTEMA pendiente de UI de catálogo del supervisor
-31. **#416** — motor de plazos para TABLON_AYUNTAMIENTOS: fecha administrativa y cierre retroactivo de ESPERAR_PLAZO (edge case del servicio de plazos)
+31. ~~**#416** — motor de plazos para TABLON_AYUNTAMIENTOS: fecha administrativa y cierre retroactivo de ESPERAR_PLAZO (edge case del servicio de plazos)~~ ✓
 
 ### Bloque 5 — Análisis heurístico de PDF
 

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -12,14 +12,6 @@
 
 **Próximo:** **#475** — señalización de `CONSULTA_TRASLADO_TITULAR` vencido en organismo: detectar vencimiento + exponer estado en API/variables (backend independiente de UI #396).
 
-**Plan de trabajo CONSULTAS (sesión 2026-05-24):** análisis completo de #247 en `docs/historial/ANALISIS_CONSULTAS_ORGANISMOS_2026-05-24.md`. Orden acordado:
-1. ~~**#454** — auditoría 345 vs 370: verificar duplicados en `tramites_tareas` antes de tocar cualquier trámite CONSULTA_*.~~ ✓
-2. ~~**#247** — núcleo: API CRUD `organismos_expediente` + #458 + #459 en un único PR (decisión sesión 2026-05-24: #458 y #459 absorbidos, no PRs propios).~~ ✓
-3. ~~**#461** — endpoint `GET /api/entidades/consultables`: desbloquea la UI #396.~~ ✓
-4. ~~**#456** — `tramites_organismos` + ADR-011.~~ ✓
-5. ~~**#457** — CB traslados (titular y organismo) tras #456.~~ ✓ ~~**#460** (variables motor CONSULTAS, tras #458)~~ ✓ ~~**#462** (acción en bloque «Enviar consultas»)~~ ✓ Resto: #463 (seed plazos CONSULTAS); #464 (seed demo organismos, M4). Independiente: #455 (variables motor ANALISIS_SOLICITUD, tras #442).
-
----
 
 ## Hoja de ruta — orden propuesto para próximas sesiones
 

--- a/tests/test_475_traslado_titular_vencido.py
+++ b/tests/test_475_traslado_titular_vencido.py
@@ -1,0 +1,158 @@
+"""Tests #475 — señalización de CONSULTA_TRASLADO_TITULAR vencido.
+
+Cubre:
+  A) Variable del motor `traslado_organismo_titular_vencido` (calculado.py)
+  B) Helper `_traslado_titular_vencido` de la serialización de organismos (api_bc.py)
+
+Patrón sin BD real: stubs SimpleNamespace + patch de db.session.query y
+plazos.obtener_estado_plazo. Igual que #460.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+def _ep(estado):
+    return SimpleNamespace(estado=estado)
+
+
+def _org(estado, id=1):
+    return SimpleNamespace(estado=estado, id=id)
+
+
+def _ctx(organismos):
+    exp = SimpleNamespace(organismos=organismos)
+    return SimpleNamespace(expediente=exp)
+
+
+def _get_variable(nombre):
+    import app.services.variables.calculado  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY.get(nombre)
+    assert fn is not None, f'Variable {nombre!r} no encontrada en _REGISTRY'
+    return fn
+
+
+def _mock_query(vinculo_o_none):
+    """Devuelve un mock de db.session.query(...).join(...).join(...).filter(...).order_by(...).first()"""
+    m = MagicMock()
+    m.return_value.join.return_value.join.return_value.filter.return_value \
+        .order_by.return_value.first.return_value = vinculo_o_none
+    return m
+
+
+# ---------------------------------------------------------------------------
+# A) Variable traslado_organismo_titular_vencido
+# ---------------------------------------------------------------------------
+
+class TestVariableMotor:
+
+    def test_registrada(self):
+        _get_variable('traslado_organismo_titular_vencido')
+
+    def test_sin_organismos_false(self):
+        """Expediente sin organismos → False."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        assert fn(_ctx([])) is False
+
+    def test_organismo_no_en_tramitacion_se_ignora(self):
+        """Organismo en estado cerrado_favorable → no se evalúa su plazo → False."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        ctx = _ctx([_org('cerrado_favorable')])
+        with patch('app.db') as mock_db:
+            mock_db.session.query.side_effect = AssertionError('no debería consultarse BD')
+            assert fn(ctx) is False
+
+    def test_organismo_en_tramitacion_sin_vinculo_false(self):
+        """Organismo en_tramitacion pero sin CONSULTA_TRASLADO_TITULAR vinculado → False."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        ctx = _ctx([_org('en_tramitacion')])
+        with patch('app.db') as mock_db:
+            mock_db.session.query = _mock_query(None)
+            assert fn(ctx) is False
+
+    def test_organismo_en_tramitacion_plazo_en_plazo_false(self):
+        """Organismo en_tramitacion con traslado EN_PLAZO → False."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        ctx = _ctx([_org('en_tramitacion')])
+        tramite_stub = SimpleNamespace()
+        vinculo = SimpleNamespace(tramite=tramite_stub)
+        with patch('app.db') as mock_db, \
+             patch('app.services.plazos.obtener_estado_plazo', return_value=_ep('EN_PLAZO')):
+            mock_db.session.query = _mock_query(vinculo)
+            assert fn(ctx) is False
+
+    def test_organismo_en_tramitacion_plazo_vencido_true(self):
+        """Organismo en_tramitacion con traslado VENCIDO → True."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        ctx = _ctx([_org('en_tramitacion')])
+        tramite_stub = SimpleNamespace()
+        vinculo = SimpleNamespace(tramite=tramite_stub)
+        with patch('app.db') as mock_db, \
+             patch('app.services.plazos.obtener_estado_plazo', return_value=_ep('VENCIDO')):
+            mock_db.session.query = _mock_query(vinculo)
+            assert fn(ctx) is True
+
+    def test_or_global_un_vencido_entre_varios_true(self):
+        """Un organismo vencido y otro en plazo → True (OR global)."""
+        fn = _get_variable('traslado_organismo_titular_vencido')
+        ctx = _ctx([_org('en_tramitacion', id=1), _org('en_tramitacion', id=2)])
+        tramite_stub = SimpleNamespace()
+        vinculo = SimpleNamespace(tramite=tramite_stub)
+
+        efectos = {'1': _ep('VENCIDO'), '2': _ep('EN_PLAZO')}
+        call_count = 0
+
+        def fake_plazo(tramite, tipo, variables=None):
+            nonlocal call_count
+            call_count += 1
+            return efectos[str(call_count)]
+
+        with patch('app.db') as mock_db, \
+             patch('app.services.plazos.obtener_estado_plazo', side_effect=fake_plazo):
+            mock_db.session.query = _mock_query(vinculo)
+            assert fn(ctx) is True
+
+
+# ---------------------------------------------------------------------------
+# B) Helper _traslado_titular_vencido (serialización API)
+# ---------------------------------------------------------------------------
+
+class TestHelperSerializacion:
+
+    def _fn(self):
+        from app.routes.api_bc import _traslado_titular_vencido
+        return _traslado_titular_vencido
+
+    def test_sin_vinculo_false(self):
+        """Organismo sin CONSULTA_TRASLADO_TITULAR → False."""
+        oe = SimpleNamespace(id=10)
+        with patch('app.models.tramites_organismos.TramiteOrganismo') as mock_model:
+            mock_model.query.join.return_value.join.return_value \
+                .filter.return_value.order_by.return_value.first.return_value = None
+            assert self._fn()(oe) is False
+
+    def test_tramite_vencido_true(self):
+        """Trámite vinculado con plazo VENCIDO → True."""
+        oe = SimpleNamespace(id=10)
+        tramite_stub = SimpleNamespace()
+        vinculo = SimpleNamespace(tramite=tramite_stub)
+        with patch('app.models.tramites_organismos.TramiteOrganismo') as mock_model, \
+             patch('app.services.plazos.obtener_estado_plazo', return_value=_ep('VENCIDO')):
+            mock_model.query.join.return_value.join.return_value \
+                .filter.return_value.order_by.return_value.first.return_value = vinculo
+            assert self._fn()(oe) is True
+
+    def test_tramite_en_plazo_false(self):
+        """Trámite vinculado con plazo EN_PLAZO → False."""
+        oe = SimpleNamespace(id=10)
+        tramite_stub = SimpleNamespace()
+        vinculo = SimpleNamespace(tramite=tramite_stub)
+        with patch('app.models.tramites_organismos.TramiteOrganismo') as mock_model, \
+             patch('app.services.plazos.obtener_estado_plazo', return_value=_ep('EN_PLAZO')):
+            mock_model.query.join.return_value.join.return_value \
+                .filter.return_value.order_by.return_value.first.return_value = vinculo
+            assert self._fn()(oe) is False


### PR DESCRIPTION
## Cambios

- Variable del motor `traslado_organismo_titular_vencido` en `calculado.py`: `True` si algún organismo en `en_tramitacion` tiene su `CONSULTA_TRASLADO_TITULAR` más reciente con plazo `VENCIDO`. OR global, `variables={}` para evitar recursión (ADR-011 §5, seed #463).
- Helper `_traslado_titular_vencido` en `api_bc.py`: busca el trámite más reciente del organismo vía `tramites_organismos` y calcula su estado de plazo.
- Campo `traslado_titular_vencido: bool` en `_serializar_org_exp`: el endpoint `GET /expediente/<id>/organismos` ya expone por organismo si su traslado al titular ha vencido, listo para la UI #396.
- 10 tests sin BD real (patrón #460).

Closes #475
