### PR TITLE
Seed tramites_tareas para REGISTRO_INTERESADOS

### DIFF
--- a/migrations/versions/488_seed_tramites_tareas_registro_interesados.py
+++ b/migrations/versions/488_seed_tramites_tareas_registro_interesados.py
@@ -1,0 +1,60 @@
+"""488_seed_tramites_tareas_registro_interesados
+
+Revision ID: 488_seed_tramites_tareas_registro_interesados
+Revises: 416_seed_plazos_tablon
+Create Date: 2026-05-26
+
+Issue #488 — REGISTRO_INTERESADOS se añadió a tipos_tramites en la migración
+374_interesados_expediente pero sin su fila en tramites_tareas.
+
+Fuente: ESTRUCTURA_FTT.json — patrón A → secuencia [ANALIZAR].
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '488_seed_tramites_tareas_registro_interesados'
+down_revision = '416_seed_plazos_tablon'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text("SELECT id FROM public.tipos_tramites WHERE codigo = :c"),
+        {'c': 'REGISTRO_INTERESADOS'}
+    )
+    tt_id = result.scalar()
+    if tt_id is None:
+        raise ValueError("TipoTramite 'REGISTRO_INTERESADOS' no encontrado — migración abortada")
+
+    result = conn.execute(
+        sa.text("SELECT id FROM public.tipos_tareas WHERE codigo = :c"),
+        {'c': 'ANALIZAR'}
+    )
+    ta_id = result.scalar()
+    if ta_id is None:
+        raise ValueError("TipoTarea 'ANALIZAR' no encontrado — migración abortada")
+
+    conn.execute(sa.text("""
+        INSERT INTO public.tramites_tareas (tipo_tramite_id, orden, tipo_tarea_id)
+        VALUES (:tt_id, 1, :ta_id)
+        ON CONFLICT DO NOTHING
+    """), {'tt_id': tt_id, 'ta_id': ta_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text("SELECT id FROM public.tipos_tramites WHERE codigo = :c"),
+        {'c': 'REGISTRO_INTERESADOS'}
+    )
+    tt_id = result.scalar()
+    if tt_id is not None:
+        conn.execute(
+            sa.text("DELETE FROM public.tramites_tareas WHERE tipo_tramite_id = :tt_id"),
+            {'tt_id': tt_id}
+        )

--- a/tests/test_345_tramites_tareas.py
+++ b/tests/test_345_tramites_tareas.py
@@ -44,7 +44,7 @@ def test_fk_tipo_tarea():
 # ---------------------------------------------------------------------------
 
 def test_todos_tramites_tienen_tarea(app_ctx):
-    """Los 24 tipos de trámite del catálogo tienen al menos una tarea."""
+    """Todos los tipos de trámite del catálogo tienen al menos una tarea."""
     from app import db
     from app.models.tramites_tareas import TramiteTarea
     from app.models.tipos_tramites import TipoTramite


### PR DESCRIPTION
## Cambios

- Nueva migración `488_seed_tramites_tareas_registro_interesados.py`: inserta `REGISTRO_INTERESADOS → ANALIZAR (orden 1)` en `tramites_tareas` (patrón A según `ESTRUCTURA_FTT.json`)
- Actualiza docstring de `test_todos_tramites_tienen_tarea` (eliminaba hardcode "24 tipos" ya obsoleto)

El tipo `REGISTRO_INTERESADOS` fue añadido a `tipos_tramites` en `374_interesados_expediente` pero sin su fila en `tramites_tareas`, causando que `test_todos_tramites_tienen_tarea` fallara con `assert 30 == 31`. 18/18 tests pasan.

Closes #488
