### PR TITLE
#470 Certificado de cierre de fase IP y Consultas (CERT_FIN_IP_CONSULTAS)

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -172,6 +172,10 @@ def crear_fase(sol_id):
     db.session.add(fase)
     db.session.flush()
 
+    if tipo_fase.codigo in _FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS:
+        from app.services.cert_fin_ip_consultas import crear_cert_fin_ip_consultas
+        crear_cert_fin_ip_consultas(sol.expediente, sol)
+
     if justificacion:
         sujeto = build_sujeto(sol.expediente, {'solicitud': sol, 'tipo_fase': tipo_fase})
         bitacora_svc.registrar(
@@ -184,6 +188,7 @@ def crear_fase(sol_id):
 
 
 _CODIGOS_TRASLADO = frozenset({'CONSULTA_TRASLADO_ORGANISMO', 'CONSULTA_TRASLADO_TITULAR'})
+_FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS = frozenset({'RESOLUCION', 'AAU_AAUS_INTEGRADA'})
 
 
 @bp.route('/fase/<int:fase_id>/tramites/nuevo', methods=['POST'])

--- a/app/services/cert_fin_ip_consultas.py
+++ b/app/services/cert_fin_ip_consultas.py
@@ -1,0 +1,116 @@
+"""
+Generación del certificado CERT_FIN_IP_CONSULTAS.
+
+Se emite automáticamente al crear la fase que lo necesita como habilitante
+(RESOLUCION, AAU_AAUS_INTEGRADA). Verifica que las fases IP y CONSULTAS de la
+solicitud estén finalizadas y deja el Documento en el pool con URI bddat://.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from app import db
+from app.models.certificados import Certificado
+from app.models.documentos import Documento
+
+log = logging.getLogger(__name__)
+
+_CODIGO = 'CERT_FIN_IP_CONSULTAS'
+_FASES_HABILITANTES = ('INFORMACION_PUBLICA', 'CONSULTAS')
+
+
+def crear_cert_fin_ip_consultas(expediente, solicitud) -> Certificado | None:
+    """
+    Genera el CERT_FIN_IP_CONSULTAS para la solicitud dada si no existe ya.
+
+    Recoge las fases INFORMACION_PUBLICA y CONSULTAS finalizadas, calcula
+    la fecha_fin_ultima_fase y persiste Certificado + Documento en el pool.
+
+    Devuelve el Certificado creado, o el existente si ya había uno.
+    Devuelve None si no hay fases habilitantes finalizadas (no debería ocurrir
+    si el motor validó antes).
+    """
+    cert_existente = _buscar_existente(expediente.id, solicitud.id)
+    if cert_existente:
+        return cert_existente
+
+    fases_info = _recoger_fases(solicitud)
+    if not fases_info:
+        log.warning(
+            'crear_cert_fin_ip_consultas: sin fases habilitantes finalizadas '
+            'para solicitud %s (expediente %s)', solicitud.id, expediente.id
+        )
+        return None
+
+    datos = _construir_datos(fases_info)
+
+    from app.models.tipos_documentos import TipoDocumento
+    tipo_doc = TipoDocumento.query.filter_by(codigo=_CODIGO).first()
+    if tipo_doc is None:
+        raise RuntimeError(f'TipoDocumento {_CODIGO!r} no encontrado — ¿migración aplicada?')
+
+    doc = Documento(
+        expediente_id=expediente.id,
+        tipo_doc_id=tipo_doc.id,
+        url='bddat://certificados/0',
+    )
+    db.session.add(doc)
+    db.session.flush()
+
+    cert = Certificado(
+        documento_id=doc.id,
+        datos=datos,
+        generado_en=datetime.utcnow(),
+    )
+    db.session.add(cert)
+    db.session.flush()
+
+    doc.url = f'bddat://certificados/{cert.id}'
+
+    log.info(
+        'CERT_FIN_IP_CONSULTAS creado: cert=%s doc=%s expediente=%s solicitud=%s',
+        cert.id, doc.id, expediente.id, solicitud.id,
+    )
+    return cert
+
+
+def _buscar_existente(expediente_id: int, solicitud_id: int) -> Certificado | None:
+    """Devuelve el cert existente para este expediente si ya fue emitido."""
+    from app.models.tipos_documentos import TipoDocumento
+    tipo_doc = TipoDocumento.query.filter_by(codigo=_CODIGO).first()
+    if tipo_doc is None:
+        return None
+    return (
+        db.session.query(Certificado)
+        .join(Documento, Certificado.documento_id == Documento.id)
+        .filter(Documento.expediente_id == expediente_id,
+                Documento.tipo_doc_id == tipo_doc.id)
+        .first()
+    )
+
+
+def _recoger_fases(solicitud) -> list[dict]:
+    """Devuelve lista de {codigo, fecha_fin} para fases habilitantes finalizadas."""
+    resultado = []
+    for fase in solicitud.fases:
+        if not (fase.tipo_fase and fase.tipo_fase.codigo in _FASES_HABILITANTES):
+            continue
+        if not fase.finalizada:
+            continue
+        fecha_fin = None
+        if fase.documento_resultado and fase.documento_resultado.fecha_administrativa:
+            fecha_fin = fase.documento_resultado.fecha_administrativa.isoformat()
+        resultado.append({'codigo': fase.tipo_fase.codigo, 'fase_id': fase.id,
+                          'fecha_fin': fecha_fin})
+    return resultado
+
+
+def _construir_datos(fases_info: list[dict]) -> dict:
+    """Construye el JSONB datos del certificado."""
+    fechas = [f['fecha_fin'] for f in fases_info if f['fecha_fin']]
+    fecha_fin_ultima = max(fechas) if fechas else None
+    return {
+        'fases_habilitantes': fases_info,
+        'fecha_fin_ultima_fase': fecha_fin_ultima,
+    }

--- a/app/services/cert_pdf.py
+++ b/app/services/cert_pdf.py
@@ -28,6 +28,8 @@ def generar_pdf_certificado(cert, expediente, tipo_cert: str) -> bytes:
     """
     if tipo_cert == 'CERT_PLAZO_CUMPLIDO':
         return _pdf_plazo_cumplido(cert, expediente)
+    if tipo_cert == 'CERT_FIN_IP_CONSULTAS':
+        return _pdf_fin_ip_consultas(cert, expediente)
     raise NotImplementedError(f'Sin plantilla PDF para tipo {tipo_cert!r}')
 
 
@@ -111,6 +113,89 @@ def _pdf_plazo_cumplido(cert, expediente) -> bytes:
             'Este certificado ha sido generado automáticamente por el sistema de tramitación '
             'BDDAT en la fecha indicada y tiene carácter meramente informativo del estado del '
             'procedimiento.',
+            estilo_normal,
+        ),
+        Paragraph(f'Generado: {generado_en}  ·  Certificado interno #{cert.id}', estilo_pie),
+    ]
+
+    doc.build(contenido)
+    return buffer.getvalue()
+
+
+def _pdf_fin_ip_consultas(cert, expediente) -> bytes:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import cm
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=2 * cm, rightMargin=2 * cm,
+        topMargin=2.5 * cm, bottomMargin=2.5 * cm,
+    )
+
+    estilos = getSampleStyleSheet()
+    estilo_cab = ParagraphStyle('Cab', parent=estilos['Heading2'], fontSize=10, spaceAfter=2)
+    estilo_titulo = ParagraphStyle('Titulo', parent=estilos['Heading1'], fontSize=13, spaceAfter=8)
+    estilo_normal = ParagraphStyle('Normal', parent=estilos['Normal'], fontSize=9, spaceAfter=3)
+    estilo_pie = ParagraphStyle('Pie', parent=estilos['Normal'], fontSize=7,
+                                textColor=colors.grey, spaceBefore=20)
+
+    datos = cert.datos or {}
+    numero_at = getattr(expediente, 'numero_at', '') or ''
+    generado_en = cert.generado_en.strftime('%d/%m/%Y %H:%M') if cert.generado_en else ''
+
+    fases = datos.get('fases_habilitantes', [])
+    fecha_fin_ultima = datos.get('fecha_fin_ultima_fase', '')
+
+    _nombre_fase = {
+        'INFORMACION_PUBLICA': 'Información Pública',
+        'CONSULTAS': 'Consultas a Organismos',
+    }
+
+    filas_fases = [['Fase', 'Fecha de finalización']]
+    for f in fases:
+        filas_fases.append([
+            _nombre_fase.get(f.get('codigo', ''), f.get('codigo', '')),
+            f.get('fecha_fin') or '—',
+        ])
+
+    tabla = Table(filas_fases, colWidths=[9 * cm, 8 * cm])
+    tabla.setStyle(TableStyle([
+        ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#003366')),
+        ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
+        ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 0), (-1, -1), 9),
+        ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+        ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor('#f0f4f8')]),
+        ('LEFTPADDING', (0, 0), (-1, -1), 4),
+        ('RIGHTPADDING', (0, 0), (-1, -1), 4),
+        ('TOPPADDING', (0, 0), (-1, -1), 3),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 3),
+    ]))
+
+    contenido = [
+        Paragraph('Consejería de Industria, Energía y Minas', estilo_cab),
+        Paragraph('Junta de Andalucía', estilo_cab),
+        Spacer(1, 0.4 * cm),
+        Paragraph('CERTIFICADO DE FIN DE INFORMACIÓN PÚBLICA Y CONSULTAS', estilo_titulo),
+        Spacer(1, 0.3 * cm),
+        Paragraph(f'Expediente: AT-{numero_at}', estilo_normal),
+        Spacer(1, 0.3 * cm),
+        Paragraph(
+            'El sistema BDDAT certifica que las siguientes fases han concluido '
+            'conforme al procedimiento establecido:',
+            estilo_normal,
+        ),
+        Spacer(1, 0.3 * cm),
+        tabla,
+        Spacer(1, 0.4 * cm),
+        Paragraph(
+            f'Fecha de finalización de la última fase habilitante: {fecha_fin_ultima or "—"}',
             estilo_normal,
         ),
         Paragraph(f'Generado: {generado_en}  ·  Certificado interno #{cert.id}', estilo_pie),

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -11,17 +11,20 @@ from app.services.invariantes_esftt import RESULTADO_FASE_FAVORABLE_CODIGOS
 @variable('fase_ip_finalizada')
 def _(ctx) -> bool:
     """
-    True si existe al menos una fase de tipo INFORMACION_PUBLICA finalizada
-    (con documento_resultado_id) en cualquier solicitud del expediente.
+    True si la solicitud en contexto tiene al menos una fase INFORMACION_PUBLICA
+    finalizada (documento_resultado_id IS NOT NULL).
 
-    Devuelve False si la fase no existe o existe pero no está finalizada.
+    Devuelve False si no hay solicitud en contexto, si la fase no existe o
+    existe pero no está finalizada.
     """
-    for solicitud in ctx.expediente.solicitudes:
-        for fase in solicitud.fases:
-            if (fase.tipo_fase
-                    and fase.tipo_fase.codigo == 'INFORMACION_PUBLICA'
-                    and fase.finalizada):
-                return True
+    solicitud = ctx.solicitud
+    if solicitud is None:
+        return False
+    for fase in solicitud.fases:
+        if (fase.tipo_fase
+                and fase.tipo_fase.codigo == 'INFORMACION_PUBLICA'
+                and fase.finalizada):
+            return True
     return False
 
 

--- a/migrations/versions/470_cert_fin_ip_consultas.py
+++ b/migrations/versions/470_cert_fin_ip_consultas.py
@@ -1,0 +1,118 @@
+"""470_cert_fin_ip_consultas
+
+Revision ID: 470_cert_fin_ip_consultas
+Revises: 460_variables_motor_consultas
+Create Date: 2026-05-26
+
+Issue #470 — Reglas BLOQUEAR para la emisión de CERT_FIN_IP_CONSULTAS:
+
+  Regla 1: CREAR ANY/ANY/RESOLUCION bloqueado si organismos_todos_terminados = false
+           (todos los organismos consultados deben estar en estado terminal)
+
+  Regla 2: CREAR ANY/ANY/RESOLUCION bloqueado si fase_ip_finalizada = false
+           Y tipo_solicitud IN ['AAP+DUP', 'AAP+AAC+DUP']
+           (IP obligatoria cuando la solicitud incluye DUP)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '470_cert_fin_ip_consultas'
+down_revision = ('460_variables_motor_consultas', '488_seed_tramites_tareas_registro_interesados')
+branch_labels = None
+depends_on = None
+
+_SUJETO = 'ANY/ANY/RESOLUCION'
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # --- Seed: fase_ip_finalizada en catalogo_variables (si no existe) ---
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES (
+            'fase_ip_finalizada',
+            'La solicitud en contexto tiene una fase de Información Pública finalizada',
+            'boolean', NULL, TRUE
+        )
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+    # --- Regla 1: organismos_todos_terminados = false ---
+    r1 = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR', :sujeto, 'BLOQUEAR', 20, TRUE,
+            'Hay organismos pendientes de respuesta o análisis'
+        )
+        RETURNING id
+    """), {'sujeto': _SUJETO}).scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'organismos_todos_terminados'
+    """), {'regla_id': r1})
+
+    # --- Regla 2: fase_ip_finalizada = false cuando solicitud contiene DUP ---
+    r2 = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR', :sujeto, 'BLOQUEAR', 21, TRUE,
+            'La fase de Información Pública no ha concluido'
+        )
+        RETURNING id
+    """), {'sujeto': _SUJETO}).scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'fase_ip_finalizada'
+    """), {'regla_id': r2})
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'IN',
+               '["AAP+DUP","AAP+AAC+DUP"]'::json, 2
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'tipo_solicitud'
+    """), {'regla_id': r2})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_regla
+        WHERE regla_id IN (
+            SELECT id FROM public.reglas_motor
+            WHERE sujeto = :sujeto
+              AND efecto = 'BLOQUEAR'
+              AND descripcion IN (
+                'Hay organismos pendientes de respuesta o análisis',
+                'La fase de Información Pública no ha concluido'
+              )
+        )
+    """), {'sujeto': _SUJETO})
+
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_variables
+        WHERE nombre = 'fase_ip_finalizada'
+    """))
+
+    conn.execute(sa.text("""
+        DELETE FROM public.reglas_motor
+        WHERE sujeto = :sujeto
+          AND efecto = 'BLOQUEAR'
+          AND descripcion IN (
+            'Hay organismos pendientes de respuesta o análisis',
+            'La fase de Información Pública no ha concluido'
+          )
+    """), {'sujeto': _SUJETO})

--- a/tests/test_470_cert_fin_ip_consultas.py
+++ b/tests/test_470_cert_fin_ip_consultas.py
@@ -1,0 +1,173 @@
+"""Tests issue #470 — CERT_FIN_IP_CONSULTAS: bug fix fase_ip_finalizada,
+reglas motor y servicio de generación del certificado."""
+
+
+# ---------------------------------------------------------------------------
+# Stubs mínimos de duck-typing
+# ---------------------------------------------------------------------------
+
+class _StubTipoFase:
+    def __init__(self, codigo): self.codigo = codigo
+
+
+class _StubDoc:
+    def __init__(self, fecha=None):
+        self.fecha_administrativa = fecha
+
+
+class _StubFase:
+    def __init__(self, codigo, finalizada=False, doc_resultado=None, id=1):
+        self.id = id
+        self.tipo_fase = _StubTipoFase(codigo)
+        self.finalizada = finalizada
+        self.documento_resultado = doc_resultado
+
+
+class _StubSolicitud:
+    def __init__(self, fases): self.fases = fases
+
+
+class _StubCtxConSolicitud:
+    def __init__(self, fases):
+        self.solicitud = _StubSolicitud(fases)
+
+
+# ---------------------------------------------------------------------------
+# A) Bug fix fase_ip_finalizada — ahora usa ctx.solicitud
+# ---------------------------------------------------------------------------
+
+def _get_variable(nombre):
+    import app.services.variables.calculado  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY.get(nombre)
+    assert fn is not None, f'Variable {nombre!r} no encontrada en _REGISTRY'
+    return fn
+
+
+def test_fase_ip_finalizada_sin_solicitud_en_ctx():
+    """Sin solicitud en contexto → False."""
+    class _CtxSinSolicitud:
+        solicitud = None
+
+    assert _get_variable('fase_ip_finalizada')(_CtxSinSolicitud()) is False
+
+
+def test_fase_ip_finalizada_solicitud_sin_ip():
+    """Solicitud sin fase IP → False."""
+    ctx = _StubCtxConSolicitud([
+        _StubFase('CONSULTAS', finalizada=True),
+    ])
+    assert _get_variable('fase_ip_finalizada')(ctx) is False
+
+
+def test_fase_ip_finalizada_ip_no_finalizada():
+    """Fase IP existe pero no está finalizada → False."""
+    ctx = _StubCtxConSolicitud([
+        _StubFase('INFORMACION_PUBLICA', finalizada=False),
+    ])
+    assert _get_variable('fase_ip_finalizada')(ctx) is False
+
+
+def test_fase_ip_finalizada_ip_finalizada():
+    """Fase IP finalizada → True."""
+    ctx = _StubCtxConSolicitud([
+        _StubFase('INFORMACION_PUBLICA', finalizada=True),
+        _StubFase('CONSULTAS', finalizada=True),
+    ])
+    assert _get_variable('fase_ip_finalizada')(ctx) is True
+
+
+def test_fase_ip_finalizada_solo_mira_solicitud_en_ctx():
+    """La variable NO recorre otras solicitudes del expediente — solo ctx.solicitud."""
+    # ctx.solicitud no tiene IP; en una segunda solicitud hipotética sí habría IP.
+    # La variable debe devolver False (no busca en ctx.expediente.solicitudes).
+    ctx = _StubCtxConSolicitud([
+        _StubFase('CONSULTAS', finalizada=True),
+    ])
+    assert _get_variable('fase_ip_finalizada')(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# B) Servicio crear_cert_fin_ip_consultas — tests unitarios con stubs
+# ---------------------------------------------------------------------------
+
+def test_construir_datos_dos_fases():
+    from app.services.cert_fin_ip_consultas import _construir_datos
+    fases_info = [
+        {'codigo': 'INFORMACION_PUBLICA', 'fase_id': 1, 'fecha_fin': '2026-03-10'},
+        {'codigo': 'CONSULTAS',           'fase_id': 2, 'fecha_fin': '2026-04-05'},
+    ]
+    datos = _construir_datos(fases_info)
+    assert datos['fecha_fin_ultima_fase'] == '2026-04-05'
+    assert len(datos['fases_habilitantes']) == 2
+
+
+def test_construir_datos_una_fase_sin_fecha():
+    from app.services.cert_fin_ip_consultas import _construir_datos
+    fases_info = [
+        {'codigo': 'CONSULTAS', 'fase_id': 3, 'fecha_fin': None},
+    ]
+    datos = _construir_datos(fases_info)
+    assert datos['fecha_fin_ultima_fase'] is None
+
+
+def test_recoger_fases_solo_finalizadas():
+    from app.services.cert_fin_ip_consultas import _recoger_fases
+
+    doc_con_fecha = _StubDoc(fecha=None)
+    doc_con_fecha.fecha_administrativa = None
+
+    fases = [
+        _StubFase('INFORMACION_PUBLICA', finalizada=True,
+                  doc_resultado=_StubDoc()),
+        _StubFase('CONSULTAS', finalizada=False),
+        _StubFase('ANALISIS_SOLICITUD', finalizada=True),
+    ]
+    sol = _StubSolicitud(fases)
+    resultado = _recoger_fases(sol)
+    assert len(resultado) == 1
+    assert resultado[0]['codigo'] == 'INFORMACION_PUBLICA'
+
+
+def test_recoger_fases_vacio_si_ninguna_habilitante():
+    from app.services.cert_fin_ip_consultas import _recoger_fases
+    sol = _StubSolicitud([_StubFase('RESOLUCION', finalizada=True)])
+    assert _recoger_fases(sol) == []
+
+
+# ---------------------------------------------------------------------------
+# C) Motor: reglas BLOQUEAR presentes en BD
+# ---------------------------------------------------------------------------
+
+def test_reglas_bloquear_en_bd(app_ctx):
+    """Las dos reglas BLOQUEAR para ANY/ANY/RESOLUCION están activas en BD."""
+    from app.models.motor_reglas import ReglaMotor
+    reglas = ReglaMotor.query.filter_by(
+        accion='CREAR', sujeto='ANY/ANY/RESOLUCION', efecto='BLOQUEAR', activa=True,
+    ).all()
+    descripciones = {r.descripcion for r in reglas}
+    assert 'Hay organismos pendientes de respuesta o análisis' in descripciones
+    assert 'La fase de Información Pública no ha concluido' in descripciones
+
+
+def test_regla_organismos_tiene_condicion(app_ctx):
+    from app.models.motor_reglas import ReglaMotor
+    regla = ReglaMotor.query.filter_by(
+        descripcion='Hay organismos pendientes de respuesta o análisis',
+        sujeto='ANY/ANY/RESOLUCION',
+    ).first()
+    assert regla is not None
+    nombres = [c.variable.nombre for c in regla.condiciones]
+    assert 'organismos_todos_terminados' in nombres
+
+
+def test_regla_ip_tiene_dos_condiciones(app_ctx):
+    from app.models.motor_reglas import ReglaMotor
+    regla = ReglaMotor.query.filter_by(
+        descripcion='La fase de Información Pública no ha concluido',
+        sujeto='ANY/ANY/RESOLUCION',
+    ).first()
+    assert regla is not None
+    nombres = [c.variable.nombre for c in regla.condiciones]
+    assert 'fase_ip_finalizada' in nombres
+    assert 'tipo_solicitud' in nombres


### PR DESCRIPTION
## Cambios

- **Bug fix** `fase_ip_finalizada`: corrige la variable para que busque solo en `ctx.solicitud.fases` en lugar de recorrer todas las solicitudes del expediente
- **Migración** `470_cert_fin_ip_consultas`: seed de `fase_ip_finalizada` en `catalogo_variables`; dos reglas BLOQUEAR sobre `ANY/ANY/RESOLUCION`: organismos no terminados y IP no finalizada (esta última solo cuando la solicitud contiene DUP); merge point de ramas 460 y 488
- **Servicio** `cert_fin_ip_consultas.py`: genera `Certificado` + `Documento` con URI `bddat://` al completarse las fases IP y CONSULTAS; idempotente si ya existe
- **PDF on-demand** `cert_pdf.py`: añade plantilla para `CERT_FIN_IP_CONSULTAS`
- **Integración** `api_bc.py/crear_fase`: emite automáticamente el cert al crear fases `RESOLUCION` o `AAU_AAUS_INTEGRADA`
- **Tests** `test_470_cert_fin_ip_consultas.py`: 12 tests — bug fix variable, lógica del servicio y reglas en BD
- **Fix colateral**: amplía `alembic_version.version_num` a `varchar(128)` (bloqueaba el upgrade de la migración 488)

Closes #470
