### PR TITLE
Añadir direccion_notificacion_id a organismos_expediente

### DIFF
--- a/app/models/organismos_expediente.py
+++ b/app/models/organismos_expediente.py
@@ -1,4 +1,5 @@
 from app import db
+from app.models.direccion_notificacion import DireccionNotificacion
 
 
 ESTADOS_ORGANISMO = (
@@ -85,6 +86,14 @@ class OrganismoExpediente(db.Model):
         comment='FK documento CONDICIONADO_OFICIO. Solo cuando titular sin_respuesta en AAC tras condicionado (ADR-011 §2)',
     )
 
+    direccion_notificacion_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.direcciones_notificacion.id', name='fk_org_exp_direccion_notif'),
+        nullable=True,
+        index=True,
+        comment='FK direcciones_notificacion. Dirección elegida al añadir el organismo; NULL = usar la más reciente activa con rol CONSULTADO',
+    )
+
     plazo_legal_dias = db.Column(
         db.Integer,
         nullable=True,
@@ -96,6 +105,7 @@ class OrganismoExpediente(db.Model):
     organismo = db.relationship('Entidad', foreign_keys=[organismo_id])
     documento = db.relationship('Documento', foreign_keys=[documento_id])
     condicionados_doc = db.relationship('Documento', foreign_keys=[condicionados_doc_id])
+    direccion_notificacion = db.relationship('DireccionNotificacion', foreign_keys=[direccion_notificacion_id])
 
     def __repr__(self):
         return f'<OrganismoExpediente exp={self.expediente_id} org={self.organismo_id} estado={self.estado}>'
@@ -115,9 +125,39 @@ class OrganismoExpediente(db.Model):
 
     def as_contexto_cb(self) -> dict:
         """Fragmento de contexto para plantillas de CONSULTA_SEPARATA."""
-        return {
+        ctx = {
             'organismo_nombre': self.organismo.nombre_completo if self.organismo else None,
             'organismo_nif': self.organismo.nif if self.organismo else None,
             'organismo_plazo_legal': self.plazo_legal_dias,
             'organismo_resultado': self.estado,  # estado interno del motor; no usar en plantillas de escritos
         }
+        dir_notif = (
+            self.direccion_notificacion
+            or (
+                DireccionNotificacion.obtener_direccion_notificacion(
+                    self.organismo_id, es_consultado=True
+                )
+                if self.organismo_id
+                else None
+            )
+        )
+        if dir_notif:
+            df = dir_notif.direccion_formateada()
+            ctx.update({
+                'organismo_email': dir_notif.email,
+                'organismo_dir3': dir_notif.codigo_dir3,
+                'organismo_sir': dir_notif.codigo_sir,
+                'organismo_direccion_linea1': df['linea1'],
+                'organismo_direccion_linea2': df['linea2'],
+                'organismo_provincia': df['provincia'],
+            })
+        else:
+            ctx.update({
+                'organismo_email': None,
+                'organismo_dir3': None,
+                'organismo_sir': None,
+                'organismo_direccion_linea1': None,
+                'organismo_direccion_linea2': None,
+                'organismo_provincia': None,
+            })
+        return ctx

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #488 (PR #490) — migración seed `tramites_tareas` para `REGISTRO_INTERESADOS` (patrón A: `ANALIZAR`); corrige `test_todos_tramites_tienen_tarea` que fallaba `assert 30 == 31`.
+**Último cerrado:** #470 (PR #491) — certificado de cierre de fase CONSULTAS (`CERT_FIN_IP_CONSULTAS`): plantilla PDF on-demand, servicio `crear_cert_fin_ip_consultas`, ruta `crear_fase` emite el certificado al crear RESOLUCIÓN o AAU_AAUS_INTEGRADA, reglas del motor en BD y tests.
 
 **Actuales:** —
 
-**Próximo:** **#470** — certificado de cierre de fase CONSULTAS (`CERT_FIN_IP_CONSULTAS`) y reglas del motor; cierra el bloque CONSULTAS de extremo a extremo.
+**Próximo:** **#466** — `direccion_notificacion_id` en `organismos_expediente`: cambio de schema antes de que la UI (#396) construya sobre el modelo actual.
 
 
 ## Hoja de ruta — orden propuesto para próximas sesiones
@@ -23,7 +23,7 @@ Estos cuatro issues deben cerrarse antes de arrancar la UI porque condicionan
 el diseño del frontend o tienen código activo con huecos conocidos.
 
 1. ~~**#488**~~ — ✓ cerrado (PR #490)
-2. **#470** — certificado de cierre de fase CONSULTAS (`CERT_FIN_IP_CONSULTAS`) y reglas del motor: cierra el bloque CONSULTAS de extremo a extremo
+2. ~~**#470**~~ — ✓ cerrado (PR #491)
 3. **#466** — `direccion_notificacion_id` en `organismos_expediente`: cambio de schema antes de que la UI (#396) construya sobre el modelo actual
 4. **#174** — permisos granulares con traza en bitácora (rediseño: permiso blando + bitácora): afecta todos los endpoints que el frontend va a consumir
 

--- a/migrations/versions/342a6f032b38_466_direccion_notificacion_id_.py
+++ b/migrations/versions/342a6f032b38_466_direccion_notificacion_id_.py
@@ -1,0 +1,45 @@
+"""466_direccion_notificacion_id_organismos_expediente
+
+Revision ID: 342a6f032b38
+Revises: 470_cert_fin_ip_consultas
+Create Date: 2026-05-26 19:20:17.862386
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '342a6f032b38'
+down_revision = '470_cert_fin_ip_consultas'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'organismos_expediente',
+        sa.Column(
+            'direccion_notificacion_id',
+            sa.Integer(),
+            sa.ForeignKey('public.direcciones_notificacion.id', name='fk_org_exp_direccion_notif'),
+            nullable=True,
+            comment='FK direcciones_notificacion. Dirección elegida al añadir el organismo; NULL = usar la más reciente activa con rol CONSULTADO',
+        ),
+        schema='public',
+    )
+    op.create_index(
+        'ix_organismos_expediente_direccion_notificacion_id',
+        'organismos_expediente',
+        ['direccion_notificacion_id'],
+        schema='public',
+    )
+
+
+def downgrade():
+    op.drop_index(
+        'ix_organismos_expediente_direccion_notificacion_id',
+        table_name='organismos_expediente',
+        schema='public',
+    )
+    op.drop_column('organismos_expediente', 'direccion_notificacion_id', schema='public')

--- a/tests/test_391_organismo_expediente.py
+++ b/tests/test_391_organismo_expediente.py
@@ -1,9 +1,11 @@
 """
 Tests issue #391 — OrganismoExpediente.as_contexto_cb() y ContextoConsultaSeparata.
+Tests issue #466 — direccion_notificacion_id en as_contexto_cb() con fallback.
 
 Bloques:
   A) OrganismoExpediente.as_contexto_cb()  — stubs, sin BD ni app context.
   B) ContextoConsultaSeparata.get_contexto() — stubs + mock de query.
+  C) #466 — as_contexto_cb() con direccion_notificacion_id y fallback.
 """
 from datetime import date
 from unittest.mock import MagicMock, patch
@@ -20,13 +22,16 @@ def _organismo(nombre='Red Eléctrica de España', nif='A78003662'):
     return org
 
 
-def _org_exp(organismo=None, plazo_legal_dias=30, estado='pendiente'):
+def _org_exp(organismo=None, plazo_legal_dias=30, estado='pendiente',
+             organismo_id=None, direccion_notificacion=None):
     """Stub de OrganismoExpediente con as_contexto_cb() delegando al método real."""
     from app.models.organismos_expediente import OrganismoExpediente
     oe = MagicMock()
     oe.organismo = organismo or _organismo()
     oe.plazo_legal_dias = plazo_legal_dias
     oe.estado = estado
+    oe.organismo_id = organismo_id
+    oe.direccion_notificacion = direccion_notificacion
     oe.as_contexto_cb = lambda: OrganismoExpediente.as_contexto_cb(oe)
     return oe
 
@@ -188,3 +193,75 @@ class TestContextoConsultaSeparata:
             ctx = cb.get_contexto()
 
         assert ctx['organismo_fecha_envio'] is None
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# C) #466 — direccion_notificacion_id: campos de contacto y fallback
+# ───────────────────────────────────────────────────────────────────────────────
+
+def _dir_notif_stub(email=None, dir3=None, sir=None,
+                    linea1='C/ Ejemplo 1', linea2='41001 Sevilla', provincia='SEVILLA'):
+    """Stub de DireccionNotificacion."""
+    d = MagicMock()
+    d.email = email
+    d.codigo_dir3 = dir3
+    d.codigo_sir = sir
+    d.direccion_formateada.return_value = {
+        'linea1': linea1,
+        'linea2': linea2,
+        'provincia': provincia,
+    }
+    return d
+
+
+class TestAsContextoCbDireccion:
+
+    def test_sin_direccion_campos_son_none(self):
+        """Sin direccion_notificacion ni organismo_id → campos de dirección None."""
+        oe = _org_exp(organismo_id=None, direccion_notificacion=None)
+        ctx = oe.as_contexto_cb()
+        assert ctx['organismo_email'] is None
+        assert ctx['organismo_dir3'] is None
+        assert ctx['organismo_sir'] is None
+        assert ctx['organismo_direccion_linea1'] is None
+        assert ctx['organismo_direccion_linea2'] is None
+        assert ctx['organismo_provincia'] is None
+
+    def test_direccion_notificacion_guardada_se_usa_directamente(self):
+        """Cuando hay direccion_notificacion en el registro, se usa sin fallback."""
+        dir_stub = _dir_notif_stub(email='org@ejemplo.es', dir3='A12345678', linea1='Av. Test 5')
+        oe = _org_exp(organismo_id=99, direccion_notificacion=dir_stub)
+        ctx = oe.as_contexto_cb()
+        assert ctx['organismo_email'] == 'org@ejemplo.es'
+        assert ctx['organismo_dir3'] == 'A12345678'
+        assert ctx['organismo_direccion_linea1'] == 'Av. Test 5'
+
+    def test_fallback_a_obtener_direccion_cuando_fk_es_none(self):
+        """Sin direccion_notificacion pero con organismo_id → se llama al fallback."""
+        dir_stub = _dir_notif_stub(email='fallback@org.es', sir='SIR001')
+        oe = _org_exp(organismo_id=42, direccion_notificacion=None)
+        with patch('app.models.organismos_expediente.DireccionNotificacion') as mock_dn:
+            mock_dn.obtener_direccion_notificacion.return_value = dir_stub
+            ctx = oe.as_contexto_cb()
+        mock_dn.obtener_direccion_notificacion.assert_called_once_with(42, es_consultado=True)
+        assert ctx['organismo_email'] == 'fallback@org.es'
+        assert ctx['organismo_sir'] == 'SIR001'
+
+    def test_fallback_sin_resultado_campos_none(self):
+        """Fallback devuelve None (organismo sin dirección en BD) → campos None."""
+        oe = _org_exp(organismo_id=42, direccion_notificacion=None)
+        with patch('app.models.organismos_expediente.DireccionNotificacion') as mock_dn:
+            mock_dn.obtener_direccion_notificacion.return_value = None
+            ctx = oe.as_contexto_cb()
+        assert ctx['organismo_email'] is None
+        assert ctx['organismo_provincia'] is None
+
+    def test_campos_basicos_no_se_ven_afectados(self):
+        """Los campos existentes (nombre, nif, plazo, resultado) siguen funcionando."""
+        oe = _org_exp(plazo_legal_dias=15, estado='cerrado_favorable',
+                      organismo_id=None, direccion_notificacion=None)
+        ctx = oe.as_contexto_cb()
+        assert ctx['organismo_nombre'] == 'Red Eléctrica de España'
+        assert ctx['organismo_nif'] == 'A78003662'
+        assert ctx['organismo_plazo_legal'] == 15
+        assert ctx['organismo_resultado'] == 'cerrado_favorable'


### PR DESCRIPTION
## Cambios

- Migración: columna `direccion_notificacion_id` nullable (FK → `direcciones_notificacion`) con índice en `organismos_expediente`
- Modelo `OrganismoExpediente`: nueva columna, relación `direccion_notificacion` y enriquecimiento de `as_contexto_cb()` con campos de contacto (`email`, `dir3`, `sir`, dirección postal)
- `as_contexto_cb()`: lógica de fallback — usa la dirección guardada en FK si existe; si no, llama a `obtener_direccion_notificacion(es_consultado=True)`; si tampoco, devuelve los campos a `None`
- Tests: bloque C en `test_391` cubre los tres caminos (FK presente, fallback, sin dirección)

Closes #466
