### PR TITLE
Permisos centralizados, permiso blando e indicador de asignación

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,6 +95,28 @@ def create_app(config_name='development'):
     from app.cli.inhabiles import inhabiles
     app.cli.add_command(inhabiles)
 
+    # Context processor — indicador de asignación de expediente (#174)
+    @app.context_processor
+    def inject_indicador_asignacion():
+        from flask import g, session as _s
+        indicador_asignacion = None
+        indicador_exp_id = None
+        if (current_user.is_authenticated
+                and _s.get('rol_activo_nombre') == 'TRAMITADOR'
+                and hasattr(g, 'expediente_actual')
+                and g.expediente_actual is not None):
+            from app.utils.permisos import es_expediente_ajeno
+            indicador_asignacion = es_expediente_ajeno(g.expediente_actual)
+            indicador_exp_id = g.expediente_actual.id
+        return {
+            'indicador_asignacion': indicador_asignacion,
+            'indicador_exp_id':     indicador_exp_id,
+        }
+
+    # Global Jinja2 — tiene_permiso disponible en todos los templates (#174)
+    from app.utils.permisos import tiene_permiso
+    app.jinja_env.globals['tiene_permiso'] = tiene_permiso
+
     # Context processor — inyecta navegación de módulos en todos los templates
     @app.context_processor
     def inject_module_nav():

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -2,6 +2,27 @@ from functools import wraps
 from flask import flash, redirect, url_for, session
 from flask_login import current_user
 
+
+def require_permiso(nombre_permiso):
+    """
+    Decorador que verifica el permiso por nombre contra el dict PERMISOS (#174).
+    Uso: @require_permiso('gestionar_plantillas')
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.is_authenticated:
+                flash('Debe iniciar sesión para acceder', 'warning')
+                return redirect(url_for('auth.login'))
+            from app.utils.permisos import tiene_permiso
+            if not tiene_permiso(nombre_permiso):
+                flash('No tiene permisos suficientes para acceder a esta sección', 'danger')
+                return redirect(url_for('perfil.index'))
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
 def role_required(*roles):
     """
     Decorador para restringir acceso por roles.

--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -27,7 +27,7 @@ from flask import (Blueprint, abort, current_app, flash, jsonify, redirect,
 from flask_login import login_required
 
 from app import db
-from app.decorators import role_required
+from app.decorators import require_permiso
 from app.models.consultas_nombradas import ConsultaNombrada
 from app.models.plantillas import Plantilla
 from app.models.tipos_documentos import TipoDocumento
@@ -195,7 +195,7 @@ def _selects_context():
 
 @bp.route('/api/tipos-solicitud')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def api_tipos_solicitud():
     """Devuelve todos los tipos de solicitud disponibles."""
     tipos = TipoSolicitud.query.order_by(TipoSolicitud.siglas).all()
@@ -207,7 +207,7 @@ def api_tipos_solicitud():
 
 @bp.route('/api/tipos-fase')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def api_tipos_fase():
     """Devuelve todos los tipos de fase disponibles."""
     tipos = TipoFase.query.order_by(TipoFase.nombre).all()
@@ -219,7 +219,7 @@ def api_tipos_fase():
 
 @bp.route('/api/tipos-tramite')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def api_tipos_tramite():
     """Devuelve todos los tipos de trámite disponibles."""
     tipos = TipoTramite.query.order_by(TipoTramite.nombre).all()
@@ -231,7 +231,7 @@ def api_tipos_tramite():
 
 @bp.route('/api/fs')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def api_explorador_fs():
     """
     Explorador de ficheros del servidor restringido a PLANTILLAS_BASE/plantillas/.
@@ -264,7 +264,7 @@ def api_explorador_fs():
 
 @bp.route('/api/tokens')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def api_tokens():
     """
     Stub para refresco dinámico de tokens (Capa 2 — Fase 5+).
@@ -287,7 +287,7 @@ def api_tokens():
 
 @bp.route('/')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def listado():
     plantillas = Plantilla.query.order_by(Plantilla.nombre).all()
     return render_template('admin_plantillas/listado.html', plantillas=plantillas)
@@ -295,7 +295,7 @@ def listado():
 
 @bp.route('/nueva/', methods=['GET', 'POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def nueva():
     if request.method == 'POST':
         ruta_rel = request.form.get('ruta_plantilla', '').strip()
@@ -366,7 +366,7 @@ def nueva():
 
 @bp.route('/<int:id>/')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def detalle(id):
     plantilla = Plantilla.query.get_or_404(id)
     tokens = _build_tokens(plantilla)
@@ -384,7 +384,7 @@ def detalle(id):
 
 @bp.route('/<int:id>/editar', methods=['GET', 'POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def editar(id):
     plantilla = Plantilla.query.get_or_404(id)
 
@@ -448,7 +448,7 @@ def editar(id):
 
 @bp.route('/<int:id>/descargar')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def descargar(id):
     plantilla = Plantilla.query.get_or_404(id)
     d = _plantillas_dir()
@@ -462,7 +462,7 @@ def descargar(id):
 
 @bp.route('/<int:id>/activar', methods=['POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_plantillas')
 def activar(id):
     plantilla = Plantilla.query.get_or_404(id)
     plantilla.activo = not plantilla.activo

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -35,7 +35,6 @@ from app.models.tramites import Tramite
 from app.models.tareas import Tarea
 from app.models.documentos import Documento
 from app.models.tipos_documentos import TipoDocumento
-from app.decorators import role_required
 from app.services.plazos import obtener_estado_plazo
 from app.utils.permisos import (
     puede_cambiar_responsable,

--- a/app/modules/expedientes/templates/expedientes/detalle.html
+++ b/app/modules/expedientes/templates/expedientes/detalle.html
@@ -118,7 +118,7 @@
                        placeholder="Sin asignar">
                 {% else %}
                 <select class="form-select form-select-sm" id="responsable_id" name="responsable_id"
-                        {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}disabled{% endif %}>
+                        {% if not tiene_permiso('cambiar_responsable') %}disabled{% endif %}>
                     <option value="">-- Sin asignar (huérfano) --</option>
                     {% for usuario in usuarios %}
                         <option value="{{ usuario.id }}"
@@ -127,7 +127,7 @@
                         </option>
                     {% endfor %}
                 </select>
-                {% if not current_user.tiene_rol('ADMIN', 'SUPERVISOR') %}
+                {% if not tiene_permiso('cambiar_responsable') %}
                     <small>Solo ADMIN/SUPERVISOR</small>
                 {% endif %}
                 {% endif %}

--- a/app/modules/proyectos/routes.py
+++ b/app/modules/proyectos/routes.py
@@ -12,6 +12,7 @@ ISSUE: #128
 
 from flask import Blueprint, render_template, redirect, url_for, abort
 from flask_login import login_required, current_user
+from app.utils.permisos import tiene_permiso
 from app import db
 from app.models.proyectos import Proyecto
 from app.models.expedientes import Expediente
@@ -67,10 +68,6 @@ def detalle(id):
     if not proyecto:
         abort(404)
 
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        if proyecto.expediente.responsable_id != current_user.id:
-            abort(403)
-
     # La Vista V4 de expediente contiene toda la info del proyecto → redirigir
     return redirect(url_for('expedientes.detalle', id=proyecto.expediente.id))
 
@@ -97,9 +94,5 @@ def editar_proyecto(id):
 
     if not proyecto:
         abort(404)
-
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        if proyecto.expediente.responsable_id != current_user.id:
-            abort(403)
 
     return redirect(url_for('expedientes.editar', id=proyecto.expediente.id) + '#proyecto')

--- a/app/modules/usuarios/routes.py
+++ b/app/modules/usuarios/routes.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from sqlalchemy.exc import IntegrityError
 from app import db
 from app.models.usuarios import Usuario, Rol
-from app.decorators import role_required
+from app.decorators import require_permiso
 
 # Definimos el Blueprint con template_folder propio (convención app/modules/)
 bp = Blueprint('usuarios', __name__, url_prefix='/usuarios',
@@ -19,7 +19,7 @@ def current_user_es_admin():
 
 @bp.route('/', methods=['GET', 'POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_usuarios')
 def index():
     # Recuperamos todos los roles para el formulario
     todos_los_roles = Rol.query.all()
@@ -153,7 +153,7 @@ def index():
 
 @bp.route('/<int:id>')
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_usuarios')
 def detalle(id):
     usuario = Usuario.query.get_or_404(id)
     roles = Rol.query.all()
@@ -166,7 +166,7 @@ def detalle(id):
 
 @bp.route('/<int:id>/editar', methods=['GET', 'POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_usuarios')
 def editar(id):
     usuario = Usuario.query.get_or_404(id)
     todos_los_roles = Rol.query.all()
@@ -344,7 +344,7 @@ def editar(id):
 
 @bp.route('/<int:id>/toggle_estado', methods=['POST'])
 @login_required
-@role_required('ADMIN', 'SUPERVISOR')
+@require_permiso('gestionar_usuarios')
 def toggle_estado(id):
     """Toggle rápido del estado activo/inactivo"""
     usuario = Usuario.query.get_or_404(id)

--- a/app/routes/api_proyectos.py
+++ b/app/routes/api_proyectos.py
@@ -17,6 +17,7 @@ from app.models.proyectos import Proyecto
 from app.models.expedientes import Expediente
 from app.models.usuarios import Usuario
 from app.models.tipos_ia import TipoIA
+from app.utils.permisos import tiene_permiso
 
 api_proyectos_bp = Blueprint('api_proyectos', __name__, url_prefix='/api')
 
@@ -90,8 +91,8 @@ def listar_proyectos():
         .outerjoin(TipoIA, Proyecto.ia_id == TipoIA.id)
     )
 
-    # Filtro de permisos: TRAMITADOR solo ve sus expedientes
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+    # TRAMITADOR solo ve sus expedientes; ADMIN/SUPERVISOR/ADMINISTRATIVO ven todos
+    if not tiene_permiso('ver_todos_proyectos'):
         query = query.filter(Expediente.responsable_id == current_user.id)
 
     # Cursor
@@ -130,7 +131,7 @@ def listar_proyectos():
             .join(Expediente)
             .outerjoin(TipoIA, Proyecto.ia_id == TipoIA.id)
         )
-        if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+        if not tiene_permiso('ver_todos_proyectos'):
             count_query = count_query.filter(Expediente.responsable_id == current_user.id)
         if cursor > 0:
             count_query = count_query.filter(Proyecto.id > cursor)

--- a/app/routes/proyectos.py
+++ b/app/routes/proyectos.py
@@ -9,6 +9,7 @@ from app.models.usuarios import Usuario, Rol
 from app.models.tipos_ia import TipoIA
 from app.models.municipios import Municipio
 from app.models.municipios_proyecto import MunicipioProyecto
+from app.utils.permisos import tiene_permiso
 
 bp = Blueprint('proyectos', __name__, url_prefix='/proyectos')
 
@@ -36,11 +37,9 @@ def index():
         TipoIA, Proyecto.ia_id == TipoIA.id
     )
     
-    # Aplicar filtro de permisos según rol
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        # TRAMITADOR puro: solo proyectos de sus expedientes
+    # TRAMITADOR solo ve sus expedientes; ADMIN/SUPERVISOR/ADMINISTRATIVO ven todos
+    if not tiene_permiso('ver_todos_proyectos'):
         query = query.filter(Expediente.responsable_id == current_user.id)
-    # ADMIN y SUPERVISOR ven todos los proyectos (incluyendo huérfanos con responsable=NULL)
     
     # Filtro por texto libre (título, descripción, número AT, municipio)
     buscar = request.args.get('buscar', '').strip()
@@ -73,8 +72,8 @@ def index():
         
         query = query.filter(Proyecto.id.in_(subquery))
     
-    # Filtro por responsable (solo para ADMIN/SUPERVISOR)
-    if current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+    # Filtro por responsable (solo para quienes ven todos los proyectos)
+    if tiene_permiso('ver_todos_proyectos'):
         responsable_id = request.args.get('responsable', type=int)
         if responsable_id:
             query = query.filter(Expediente.responsable_id == responsable_id)
@@ -121,10 +120,9 @@ def index():
         ('41', 'Sevilla')
     ]
     
-    # Responsables (solo para ADMIN/SUPERVISOR)
-    # Obtener usuarios que son responsables de al menos un expediente
+    # Responsables (solo para quienes ven todos los proyectos)
     responsables = []
-    if current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
+    if tiene_permiso('ver_todos_proyectos'):
         responsables = db.session.query(Usuario).join(
             Expediente, Usuario.id == Expediente.responsable_id
         ).distinct().order_by(Usuario.nombre).all()
@@ -178,12 +176,6 @@ def detalle(id):
     if not proyecto:
         abort(404)
     
-    # Verificar permisos
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        # TRAMITADOR solo ve proyectos de sus expedientes
-        if proyecto.expediente.responsable_id != current_user.id:
-            abort(403)
-    
     return render_template(
         'proyectos/detalle.html',
         proyecto=proyecto
@@ -224,10 +216,4 @@ def editar_proyecto(id):
     if not proyecto:
         abort(404)
     
-    # Verificar permisos (mismo criterio que detalle)
-    if current_user.tiene_rol('TRAMITADOR') and not current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        if proyecto.expediente.responsable_id != current_user.id:
-            abort(403)
-    
-    # Redirigir a edición de expediente con anchor #proyecto
     return redirect(url_for('expedientes.editar', id=proyecto.expediente.id) + '#proyecto')

--- a/app/templates/layout/header.html
+++ b/app/templates/layout/header.html
@@ -55,6 +55,42 @@
 
     <div class="spacer"></div>
 
+    {# Indicador de asignación de expediente — solo para TRAMITADOR (#174) #}
+    {% if indicador_asignacion is not none %}
+    <span id="indicador-asignacion"
+          class="bi bi-lightbulb-fill me-2 {{ 'text-danger' if indicador_asignacion else 'text-success' }}"
+          style="font-size: 1.2rem;"
+          title="{{ 'Expediente no asignado a ti — actuación registrada en bitácora' if indicador_asignacion else 'Tu expediente' }}"
+          data-bs-toggle="tooltip" data-bs-placement="bottom">
+    </span>
+    {% if indicador_asignacion %}
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index:1100">
+        <div id="toast-asignacion" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header bg-warning text-dark">
+                <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                <strong class="me-auto">Expediente no asignado</strong>
+                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+            </div>
+            <div class="toast-body">
+                Este expediente no está asignado a ti. La actuación quedará registrada en bitácora.
+            </div>
+        </div>
+    </div>
+    <script>
+        (function () {
+            var key = 'warned_exp_{{ indicador_exp_id }}';
+            if (!sessionStorage.getItem(key)) {
+                var el = document.getElementById('toast-asignacion');
+                if (el && typeof bootstrap !== 'undefined') {
+                    new bootstrap.Toast(el, { delay: 6000 }).show();
+                    sessionStorage.setItem(key, '1');
+                }
+            }
+        }());
+    </script>
+    {% endif %}
+    {% endif %}
+
     <div class="user-menu">
         {% if current_user.is_authenticated %}
         <div class="dropdown">

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -2,15 +2,19 @@
 Módulo de utilidades de la aplicación.
 """
 from app.utils.permisos import (
+    tiene_permiso,
+    es_expediente_ajeno,
     puede_acceder_expediente,
     puede_editar_expediente,
     puede_cambiar_responsable,
-    verificar_acceso_expediente
+    verificar_acceso_expediente,
 )
 
 __all__ = [
+    'tiene_permiso',
+    'es_expediente_ajeno',
     'puede_acceder_expediente',
     'puede_editar_expediente',
     'puede_cambiar_responsable',
-    'verificar_acceso_expediente'
+    'verificar_acceso_expediente',
 ]

--- a/app/utils/permisos.py
+++ b/app/utils/permisos.py
@@ -1,74 +1,89 @@
 """
-Utilidades para control de permisos sobre expedientes.
+Control de acceso centralizado (#174).
 
-Centraliza la lógica de acceso según roles para evitar duplicación
-y facilitar el mantenimiento de las reglas de negocio.
+PERMISOS es la única fuente de verdad de qué rol puede hacer qué.
+Cambiar un permiso = una línea en este dict.
+Añadir un permiso nuevo = una entrada aquí + el check en el endpoint.
+
+La evaluación usa siempre el rol ACTIVO de sesión, no todos los roles del usuario,
+para que el cambio de rol tenga efecto real.
 """
-from flask import flash, redirect, url_for
+from flask import flash, g, redirect, session, url_for
 from flask_login import current_user
 
+from app.services import bitacora
+
+PERMISOS = {
+    'acceder_expediente':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'editar_expediente':    {'ADMIN', 'SUPERVISOR', 'TRAMITADOR'},
+    'cambiar_responsable':  {'ADMIN', 'SUPERVISOR'},
+    'ver_todos_proyectos':  {'ADMIN', 'SUPERVISOR', 'ADMINISTRATIVO'},
+    'gestionar_usuarios':   {'ADMIN', 'SUPERVISOR'},
+    'gestionar_plantillas': {'ADMIN', 'SUPERVISOR'},
+}
+
+
+def tiene_permiso(nombre):
+    """True si el rol activo de sesión tiene el permiso indicado."""
+    rol_activo = session.get('rol_activo_nombre')
+    if not rol_activo:
+        return False
+    return rol_activo in PERMISOS.get(nombre, set())
+
+
+def es_expediente_ajeno(expediente):
+    """
+    True si el rol activo es TRAMITADOR y el expediente no está asignado al usuario.
+
+    Solo aplica a TRAMITADOR: ADMIN/SUPERVISOR tienen acceso pleno por diseño,
+    ADMINISTRATIVO no es elegible como responsable de expediente.
+    """
+    return (
+        session.get('rol_activo_nombre') == 'TRAMITADOR'
+        and expediente.responsable_id != current_user.id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wrappers de compatibilidad — los call sites existentes no cambian
+# ---------------------------------------------------------------------------
 
 def puede_acceder_expediente(expediente):
-    """
-    Verifica si el usuario actual puede acceder a un expediente.
-    
-    Reglas:
-    - ADMIN/SUPERVISOR: Acceso total a todos los expedientes
-    - TRAMITADOR/ADMINISTRATIVO: Solo sus expedientes asignados
-    
-    Args:
-        expediente: Instancia del modelo Expediente
-        
-    Returns:
-        bool: True si tiene acceso, False si no
-    """
-    # ADMIN y SUPERVISOR pueden acceder a cualquier expediente
-    if current_user.tiene_rol('ADMIN', 'SUPERVISOR'):
-        return True
-    
-    # Otros roles solo a expedientes donde son responsables
-    return expediente.responsable_id == current_user.id
+    return tiene_permiso('acceder_expediente')
 
 
 def puede_editar_expediente(expediente):
-    """
-    Verifica si el usuario actual puede editar un expediente.
-    
-    Actualmente usa las mismas reglas que puede_acceder_expediente,
-    pero está separado por si en el futuro las reglas difieren
-    (por ejemplo, permitir lectura pero no escritura).
-    
-    Args:
-        expediente: Instancia del modelo Expediente
-        
-    Returns:
-        bool: True si puede editar, False si no
-    """
-    return puede_acceder_expediente(expediente)
+    return tiene_permiso('editar_expediente')
 
 
 def puede_cambiar_responsable():
-    """
-    Verifica si el usuario actual puede cambiar el responsable de un expediente.
-    
-    Returns:
-        bool: True si puede cambiar responsable, False si no
-    """
-    return current_user.tiene_rol('ADMIN', 'SUPERVISOR')
+    return tiene_permiso('cambiar_responsable')
 
 
 def verificar_acceso_expediente(expediente, accion='acceder'):
     """
-    Verifica acceso y redirige con mensaje si no tiene permisos.
-    
-    Args:
-        expediente: Instancia del modelo Expediente
-        accion: Texto descriptivo de la acción ('acceder', 'ver', 'editar', etc.)
-        
-    Returns:
-        None si tiene acceso, Response (redirect) si no tiene acceso
+    Verifica acceso al expediente y gestiona el indicador de asignación.
+
+    - Establece g.expediente_actual para que el context processor
+      pueda inyectar el indicador de bombilla en el layout.
+    - Si la acción es 'editar' y el expediente es ajeno, registra
+      en bitácora (sin commit — responsabilidad del consumidor).
+    - Devuelve None si el acceso es correcto, o un redirect si no.
     """
-    if not puede_acceder_expediente(expediente):
+    g.expediente_actual = expediente
+
+    permiso = 'editar_expediente' if accion == 'editar' else 'acceder_expediente'
+    if not tiene_permiso(permiso):
         flash(f'No tienes permisos para {accion} este expediente', 'danger')
         return redirect(url_for('expedientes.listado_v2'))
+
+    if accion == 'editar' and es_expediente_ajeno(expediente):
+        bitacora.registrar(
+            usuario_id=current_user.id,
+            operacion='ALTERAR',
+            tabla='expedientes',
+            registro_id=expediente.id,
+            detalle={'actuacion_fuera_asignacion': True, 'accion': accion},
+        )
+
     return None

--- a/docs/decisiones/ADR-012-permisos-centralizados-permiso-blando-expedientes.md
+++ b/docs/decisiones/ADR-012-permisos-centralizados-permiso-blando-expedientes.md
@@ -1,0 +1,113 @@
+# ADR-012 — Permisos centralizados en código y permiso blando de acceso a expedientes
+
+**Estado:** Adoptada
+**Fecha:** 2026-05-27
+**Issue:** #174
+
+---
+
+## Contexto
+
+El sistema de control de acceso de BDDAT tiene dos capas de protección:
+
+1. **Acceso a secciones administrativas** (`@role_required`): protege endpoints de gestión de usuarios y plantillas. Funciona correctamente.
+2. **Acceso a expedientes concretos** (`verificar_acceso_expediente`): bloqueaba a TRAMITADOR/ADMINISTRATIVO el acceso a expedientes cuyo `responsable_id` no coincidía con su `id`. Lógica de permiso duro.
+
+La lógica de permisos estaba dispersa en ~30 endpoints distribuidos en cinco ficheros, todos comprobando strings literales `'ADMIN'`, `'SUPERVISOR'`, `'TRAMITADOR'` mediante `tiene_rol()`. La tabla `roles` existe en BD y es útil para asignar roles a personas, pero no hay ninguna tabla de permisos: qué puede hacer cada rol está exclusivamente en código Python, sin punto de referencia único.
+
+Esta dispersión genera dos problemas:
+
+- **Mantenibilidad**: añadir o cambiar un permiso implica buscar y editar múltiples ficheros.
+- **Coherencia**: crear un rol nuevo en BD es inútil sin modificar código en docenas de puntos.
+
+Por otra parte, la decisión de negocio (presentación a jefatura, mayo 2026) establece que la tramitación de un expediente **no debe restringirse** al usuario responsable asignado. Cualquier técnico puede tramitar cualquier expediente; el cuaderno de bitácora (#1) registra las actuaciones realizadas fuera de la asignación nominal.
+
+El contexto organizativo es relevante: los roles de BDDAT son divisiones funcionales ad-hoc para el sistema, no equivalentes biunívocos a puestos administrativos. Un funcionario puede tener varios roles. Los cambios de permisos son decisiones de diseño del producto BDDAT, no configuraciones realizadas en producción por el administrador de turno.
+
+---
+
+## Decisión
+
+### 1. No se implementa RBAC orientado a BD
+
+No se crea tabla `permisos` ni `rol_permisos`. Los permisos son decisiones de diseño de BDDAT —equivalentes a decisiones de producto— y no requieren ser configurables en producción. Configurarlos en BD añadiría complejidad sin beneficio real para este sistema.
+
+La tabla `roles` y `usuarios_roles` **se mantienen** porque tienen uso legítimo: permiten asignar roles a personas desde la UI de administración de usuarios.
+
+### 2. Dict `PERMISOS` como única fuente de verdad
+
+Se introduce en `app/utils/permisos.py` un diccionario plano:
+
+```python
+PERMISOS = {
+    'acceder_expediente':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'editar_expediente':    {'ADMIN', 'SUPERVISOR', 'TRAMITADOR'},
+    'cambiar_responsable':  {'ADMIN', 'SUPERVISOR'},
+    'ver_todos_proyectos':  {'ADMIN', 'SUPERVISOR'},
+    'gestionar_usuarios':   {'ADMIN', 'SUPERVISOR'},
+    'gestionar_plantillas': {'ADMIN', 'SUPERVISOR'},
+}
+```
+
+Cambiar qué rol puede hacer qué = una línea en este dict. Añadir un permiso nuevo = una entrada en el dict + el check en el endpoint.
+
+La función `tiene_permiso(nombre)` evalúa el dict contra el rol activo de sesión.
+
+### 3. Permiso blando de acceso a expedientes
+
+Se elimina el bloqueo duro por `responsable_id`. Cualquier usuario con permiso `editar_expediente` puede actuar sobre cualquier expediente. Cuando un usuario actúa (acción `editar`) sobre un expediente del que no es responsable, `verificar_acceso_expediente` registra automáticamente una entrada en la bitácora (`operacion='ALTERAR'`, `detalle={'actuacion_fuera_asignacion': True}`). Las acciones de sólo lectura (`ver`) no generan traza.
+
+### 4. Decorador `require_permiso` para endpoints admin
+
+Se añade `require_permiso(nombre_permiso)` en `app/decorators.py`. Los endpoints de admin_plantillas y usuarios migran de `@role_required('ADMIN', 'SUPERVISOR')` a `@require_permiso('gestionar_plantillas')` / `@require_permiso('gestionar_usuarios')`. El decorador `role_required` se mantiene sin modificar para no romper código existente.
+
+### 5. Checks manuales de TRAMITADOR en proyectos
+
+Los checks `tiene_rol('TRAMITADOR') and not tiene_rol('ADMIN', 'SUPERVISOR')` en los módulos de proyectos se reemplazan por `not tiene_permiso('ver_todos_proyectos')`.
+
+---
+
+## Razonamiento
+
+**Por qué dict en código y no tabla en BD.**
+Los permisos de BDDAT los decide el equipo de desarrollo, no el administrador del sistema en producción. Moverlos a BD no añade agilidad: seguiría requiriendo despliegue para que el cambio tenga efecto real (la UI admin solo modifica datos, no lógica). Un dict en código es explícito, versionado en git, y revisable en una línea.
+
+**Por qué permiso blando y no eliminar los controles.**
+La trazabilidad de actuaciones fuera de asignación es un requisito de auditoría. El permiso blando satisface la necesidad de flexibilidad operativa sin sacrificar la trazabilidad.
+
+**Por qué solo registrar en editar y no en ver.**
+Las lecturas no producen efectos. Registrar cada consulta de un expediente no asignado generaría ruido en la bitácora sin valor auditorial.
+
+**Por qué mantener `role_required`.**
+Tiene 16 usos activos. No aporta valor romper su firma; `require_permiso` coexiste como mecanismo declarativo para código nuevo o migrado.
+
+### 6. Indicador visual de asignación (bombilla) + toast
+
+Para usuarios con rol activo TRAMITADOR que editan un expediente no asignado, el sistema muestra un indicador visual persistente en el layout y lanza un toast de advertencia al entrar por primera vez.
+
+**Función:**
+```python
+def es_expediente_ajeno(expediente):
+    """True si rol activo es TRAMITADOR y expediente.responsable_id != current_user.id."""
+```
+
+ADMINISTRATIVO, ADMIN y SUPERVISOR quedan excluidos: los primeros no son dueños de expedientes; los segundos tienen acceso pleno por diseño.
+
+**Mecanismo (Opción A):**
+- `verificar_acceso_expediente` asigna `g.expediente_actual = expediente` en todos los puntos de edición.
+- Un context processor en `app/__init__.py` inyecta `indicador_asignacion` (bool o None) a todos los templates.
+- El layout renderiza un icono `bi-lightbulb-fill` en posición fija: verde si es propio, rojo si es ajeno.
+- Un `<script>` inline lanza el toast Bootstrap **una sola vez por expediente** usando `sessionStorage('warned_exp_<id>')`.
+
+El toast y el indicador rojo son UI informativa, no bloqueo. La traza en bitácora se produce igualmente.
+
+---
+
+## Consecuencias
+
+- Añadir o cambiar un permiso requiere editar una sola línea en `PERMISOS`.
+- Las actuaciones de técnicos fuera de su asignación quedan registradas en bitácora automáticamente.
+- Los módulos de proyectos dejan de usar `tiene_rol()` directo; usan `tiene_permiso()`.
+- Los templates que mostraban/ocultaban controles según rol usan `tiene_permiso()` vía contexto Jinja2.
+- La tabla `roles` sigue siendo útil para la UI de usuarios; no hay cambio de esquema.
+- No hay migración de BD.


### PR DESCRIPTION
## Cambios

- Introduce `PERMISOS` dict en `app/utils/permisos.py` como única fuente de verdad para control de acceso; cambiar un permiso = una línea
- Añade `tiene_permiso(nombre)` que evalúa el rol activo de sesión (no todos los roles del usuario)
- Añade `es_expediente_ajeno()` para detectar TRAMITADOR actuando fuera de su asignación
- `verificar_acceso_expediente`: elimina la restricción dura por `responsable_id`, establece `g.expediente_actual` y registra en bitácora cuando TRAMITADOR edita un expediente no asignado
- Nuevo decorador `require_permiso(nombre)` en `decorators.py`; `admin_plantillas` y `usuarios` migran de `@role_required('ADMIN','SUPERVISOR')` a `@require_permiso`
- Checks manuales `tiene_rol('TRAMITADOR')` en proyectos (routes + api) migran a `not tiene_permiso('ver_todos_proyectos')`; se eliminan los `abort(403)` en detalle/editar de proyectos
- Indicador bombilla (`bi-lightbulb-fill`) en posición fija del header: verde cuando el expediente es del usuario, rojo cuando es ajeno
- Toast Bootstrap de advertencia al entrar por primera vez en un expediente ajeno; no se repite en recargas (sessionStorage por expediente)
- `tiene_permiso` registrado como global Jinja2; templates migran de `current_user.tiene_rol()` a `tiene_permiso()`
- ADR-012 documenta las decisiones arquitectónicas (no RBAC en BD, dict centralizado, permiso blando)

Closes #174
