### PR TITLE
Compatibilidad de tipos de solicitud como reglas CREAR del motor

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -119,20 +119,52 @@ def crear_solicitud(exp_id):
     if not entidad_id:
         return jsonify({'ok': False, 'error': 'El expediente no tiene titular asignado. Asígnelo antes de crear solicitudes.'}), 422
 
+    justificacion, err = _leer_bypass(request.form)
+    if err:
+        return err
+
+    # Fase 1: validar tipos y evaluar motor antes de crear ninguna solicitud.
+    # Si cualquiera está bloqueada, se rechaza todo sin modificar la BD.
+    tipos_a_crear = []
+    for tid in tipo_ids:
+        try:
+            tid_int = int(tid)
+        except (ValueError, TypeError):
+            return jsonify({'ok': False, 'error': f'Tipo de solicitud inválido: {tid}'}), 400
+        tipo = TipoSolicitud.query.get(tid_int)
+        if not tipo:
+            return jsonify({'ok': False, 'error': f'Tipo de solicitud {tid_int} no encontrado'}), 404
+
+        if justificacion is None:
+            # stub transiente: precarga tipo_solicitud para que el assembler
+            # compile el sujeto sin necesitar flush
+            sol_stub = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
+                                 tipo_solicitud_id=tid_int)
+            sol_stub.tipo_solicitud = tipo
+            res_eval = _evaluar('CREAR', expediente, objeto=sol_stub)
+            if not res_eval.permitido:
+                return _bloqueo(res_eval)
+
+        tipos_a_crear.append(tipo)
+
+    # Fase 2: crear y persistir
     creadas = []
     try:
-        for tid in tipo_ids:
-            try:
-                tid_int = int(tid)
-            except (ValueError, TypeError):
-                return jsonify({'ok': False, 'error': f'Tipo de solicitud inválido: {tid}'}), 400
-            tipo = TipoSolicitud.query.get(tid_int)
-            if not tipo:
-                return jsonify({'ok': False, 'error': f'Tipo de solicitud {tid_int} no encontrado'}), 404
+        for tipo in tipos_a_crear:
             sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
-                            tipo_solicitud_id=tid_int)
+                            tipo_solicitud_id=tipo.id)
             db.session.add(sol)
+            db.session.flush()  # obtener sol.id para la bitácora
+
+            if justificacion:
+                sujeto = build_sujeto(expediente, sol)
+                bitacora_svc.registrar(
+                    current_user.id, 'CREAR', 'solicitudes', sol.id,
+                    detalle={'escape': True, 'justificacion': justificacion,
+                             'sujeto': sujeto},
+                )
             creadas.append(sol)
+
         db.session.commit()
     except Exception as e:
         db.session.rollback()

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -242,6 +242,54 @@ def _(ctx) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Variables compatibilidad de tipos de solicitud (#410)
+# ---------------------------------------------------------------------------
+
+@variable('es_expediente_produccion')
+def _(ctx) -> bool:
+    """
+    True si el tipo de expediente es de producción (Renovable o Convencional).
+
+    Los registros RAIPEE y la autorización de explotación provisional (AE_PROVISIONAL)
+    solo aplican a instalaciones de generación. En distribución, transporte y demás
+    tipos carecen de base legal y se bloquean al crear la solicitud.
+    """
+    tipo_exp = ctx.expediente.tipo_expediente
+    if tipo_exp is None:
+        return False
+    return tipo_exp.tipo in ('Renovable', 'Convencional')
+
+
+@variable('tiene_aac_resuelta_favorable')
+def _(ctx) -> bool:
+    """
+    True si existe en el expediente una solicitud con tipo AAC cuya fase
+    finalizadora está cerrada con resultado favorable.
+
+    Prerequisito para AE_PROVISIONAL y AE_DEFINITIVA: la explotación requiere
+    que la construcción haya sido autorizada favorablemente. Crear una AE sin
+    AAC resuelta constituiría una infracción administrativa (RD 1955/2000).
+
+    Patrón idéntico a tiene_solicitud_aap_favorable pero evaluando AAC.
+    La solicitud en contexto (la AE que se intenta crear) se excluye del recorrido.
+    """
+    solicitud_actual = ctx.solicitud
+    for sol in ctx.expediente.solicitudes:
+        if sol is solicitud_actual:
+            continue
+        if not sol.contiene_tipo('AAC'):
+            continue
+        for fase in sol.fases:
+            if (fase.tipo_fase
+                    and fase.tipo_fase.es_finalizadora
+                    and fase.finalizada
+                    and fase.resultado_fase
+                    and fase.resultado_fase.codigo in RESULTADO_FASE_FAVORABLE_CODIGOS):
+                return True
+    return False
+
+
 @variable('traslado_organismo_titular_vencido')
 def _(ctx) -> bool:
     """

--- a/migrations/versions/410_compatibilidad_tipos_solicitud.py
+++ b/migrations/versions/410_compatibilidad_tipos_solicitud.py
@@ -1,0 +1,187 @@
+"""410_compatibilidad_tipos_solicitud
+
+Revision ID: 410_compatibilidad_tipos_solicitud
+Revises: 342a6f032b38
+Create Date: 2026-05-27
+
+Issue #410 — Compatibilidad de tipos de solicitud como reglas CREAR del motor.
+
+Variables nuevas:
+  - es_expediente_produccion:
+      True si el expediente es de tipo Renovable o Convencional.
+      RAIPEE y AE_PROVISIONAL solo tienen base legal en instalaciones de generación.
+
+  - tiene_aac_resuelta_favorable:
+      True si existe en el expediente una solicitud AAC con fase finalizadora
+      favorable. Prerequisito para AE_PROVISIONAL y AE_DEFINITIVA.
+
+Reglas nuevas (CREAR, BLOQUEAR):
+  - ANY/RAIPEE_PREVIA     → si es_expediente_produccion == False
+  - ANY/RAIPEE_DEFINITIVA → si es_expediente_produccion == False
+  - ANY/AE_PROVISIONAL    → si tiene_aac_resuelta_favorable == False
+  - ANY/AE_DEFINITIVA     → si tiene_aac_resuelta_favorable == False
+
+Los sujetos tienen 2 segmentos porque se evalúan al CREAR la solicitud
+(nivel E/S, sin fase ni trámite).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '410_compatibilidad_tipos_solicitud'
+down_revision = '342a6f032b38'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # 1. Variables nuevas en catalogo_variables
+    conn.execute(sa.text("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES
+            ('es_expediente_produccion',
+             'El expediente es de tipo producción (Renovable o Convencional)',
+             'boolean', NULL, TRUE),
+            ('tiene_aac_resuelta_favorable',
+             'Existe en el expediente una AAC resuelta favorablemente',
+             'boolean', NULL, TRUE)
+        ON CONFLICT (nombre) DO NOTHING
+    """))
+
+    # 2. Reglas RAIPEE — bloqueadas fuera de expedientes de producción
+
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/RAIPEE_PREVIA',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'La inscripción previa en RAIPEE solo aplica a instalaciones de producción '
+            '(Renovable o Convencional)'
+        )
+        RETURNING id
+    """))
+    regla_raipee_previa_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'es_expediente_produccion'
+    """), {'regla_id': regla_raipee_previa_id})
+
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/RAIPEE_DEFINITIVA',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'La inscripción definitiva en RAIPEE solo aplica a instalaciones de producción '
+            '(Renovable o Convencional)'
+        )
+        RETURNING id
+    """))
+    regla_raipee_def_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'es_expediente_produccion'
+    """), {'regla_id': regla_raipee_def_id})
+
+    # 3. Reglas AE — bloqueadas sin AAC resuelta favorable
+
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/AE_PROVISIONAL',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'No se puede solicitar autorización de explotación provisional sin AAC '
+            'resuelta favorablemente en el expediente'
+        )
+        RETURNING id
+    """))
+    regla_ae_prov_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'tiene_aac_resuelta_favorable'
+    """), {'regla_id': regla_ae_prov_id})
+
+    result = conn.execute(sa.text("""
+        INSERT INTO public.reglas_motor
+            (accion, sujeto, efecto, prioridad, activa, descripcion)
+        VALUES (
+            'CREAR',
+            'ANY/AE_DEFINITIVA',
+            'BLOQUEAR',
+            10,
+            TRUE,
+            'No se puede solicitar autorización de explotación definitiva sin AAC '
+            'resuelta favorablemente en el expediente'
+        )
+        RETURNING id
+    """))
+    regla_ae_def_id = result.scalar()
+
+    conn.execute(sa.text("""
+        INSERT INTO public.condiciones_regla
+            (regla_id, variable_id, operador, valor, orden)
+        SELECT :regla_id, cv.id, 'EQ', 'false'::json, 1
+        FROM public.catalogo_variables cv
+        WHERE cv.nombre = 'tiene_aac_resuelta_favorable'
+    """), {'regla_id': regla_ae_def_id})
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(sa.text("""
+        DELETE FROM public.condiciones_regla
+        WHERE regla_id IN (
+            SELECT id FROM public.reglas_motor
+            WHERE sujeto IN (
+                'ANY/RAIPEE_PREVIA',
+                'ANY/RAIPEE_DEFINITIVA',
+                'ANY/AE_PROVISIONAL',
+                'ANY/AE_DEFINITIVA'
+            )
+              AND efecto = 'BLOQUEAR'
+              AND accion = 'CREAR'
+        )
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.reglas_motor
+        WHERE sujeto IN (
+            'ANY/RAIPEE_PREVIA',
+            'ANY/RAIPEE_DEFINITIVA',
+            'ANY/AE_PROVISIONAL',
+            'ANY/AE_DEFINITIVA'
+        )
+          AND efecto = 'BLOQUEAR'
+          AND accion = 'CREAR'
+    """))
+    conn.execute(sa.text("""
+        DELETE FROM public.catalogo_variables
+        WHERE nombre IN (
+            'es_expediente_produccion',
+            'tiene_aac_resuelta_favorable'
+        )
+    """))


### PR DESCRIPTION
## Cambios

- **2 variables calculadas** en `calculado.py`:
  - `es_expediente_produccion`: True si el tipo de expediente es Renovable o Convencional
  - `tiene_aac_resuelta_favorable`: True si existe en el expediente una AAC con fase finalizadora favorable

- **Migración `410_compatibilidad_tipos_solicitud`**: inserta 4 reglas CREAR/BLOQUEAR en el motor:
  - `ANY/RAIPEE_PREVIA` — bloqueada si el expediente no es de producción
  - `ANY/RAIPEE_DEFINITIVA` — bloqueada si el expediente no es de producción
  - `ANY/AE_PROVISIONAL` — bloqueada sin AAC resuelta favorablemente
  - `ANY/AE_DEFINITIVA` — bloqueada sin AAC resuelta favorablemente

- **`crear_solicitud` en `api_bc.py`**: añade evaluación del motor antes de crear. Patrón en dos fases: valida y evalúa todos los tipos primero (sin tocar BD), luego crea. Incluye soporte de bypass con registro en bitácora.

Closes #410
