### PR TITLE
Requisitos documentales por solicitud (#192)

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -107,6 +107,13 @@ from app.models.informacion_publica import InformacionPublica
 # Requerimientos de tarea ANALIZAR (#405 — depende de Tarea y CatalogoRequerimiento)
 from app.models.requerimientos_tarea import RequerimientoTarea
 
+# Requisitos documentales por solicitud (#192 — depende de Solicitud, Documento, TipoDocumento)
+from app.models.requisitos_documentales import (
+    RequisitoDocumental,
+    CondicionRequisito,
+    DocumentoRequisito,
+)
+
 # Mapa semántico de documentos por tarea (#346 — sin FK operacional propia)
 from app.models.tramites_tareas_documentos import TramiteTareaDocumento
 
@@ -185,4 +192,8 @@ __all__ = [
     'InformacionPublica',
     # Requerimientos de tarea ANALIZAR
     'RequerimientoTarea',
+    # Requisitos documentales por solicitud
+    'RequisitoDocumental',
+    'CondicionRequisito',
+    'DocumentoRequisito',
 ]

--- a/app/models/requisitos_documentales.py
+++ b/app/models/requisitos_documentales.py
@@ -1,0 +1,247 @@
+from app import db
+
+
+class RequisitoDocumental(db.Model):
+    """
+    Catálogo de requisitos documentales que el administrado debe aportar.
+
+    Cada fila representa un tipo de documento exigido por ley como condición
+    necesaria para que la solicitud pueda tramitarse. El técnico verifica su
+    presencia durante la tarea ANALIZAR de ANALISIS_DOCUMENTAL.
+
+    CONDICIONES DE APLICACIÓN:
+        Un requisito es aplicable a una solicitud concreta si se cumplen TODAS
+        sus condiciones (tabla condiciones_requisito, AND implícito). Un requisito
+        sin condiciones es universal — aplica a cualquier solicitud.
+
+        Para expresar OR (mismo tipo de documento requerido bajo dos conjuntos
+        de condiciones mutuamente excluyentes), se crean dos filas con el mismo
+        tipo_documento_id y condiciones distintas.
+
+    CAMPO ORDEN:
+        Valor informativo para ordenar el checklist en la UI. Gestionado por el
+        Supervisor mediante drag-drop; no tiene unicidad impuesta en BD.
+
+    RELACIONES:
+        condiciones  → CONDICIONES_REQUISITO (todas las condiciones de este requisito)
+        usos         → DOCUMENTOS_REQUISITO (vinculaciones de documentos del pool)
+        tipo_documento → TIPOS_DOCUMENTOS
+        norma          → NORMAS
+
+    INTEGRACIÓN:
+        Ver app/services/requisitos.py::evaluar_requisitos para la lógica de
+        evaluación de condiciones e integración con ContextoAnalisisDocumental (#495).
+    """
+    __tablename__ = 'requisitos_documentales'
+    __table_args__ = (
+        db.Index('idx_requisitos_documentales_tipo_doc', 'tipo_documento_id'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    tipo_documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.tipos_documentos.id'),
+        nullable=False,
+        comment='FK a tipos_documentos — tipo semántico del documento requerido'
+    )
+
+    descripcion_legal = db.Column(
+        db.Text,
+        nullable=True,
+        comment='Descripción del requisito en lenguaje natural para el técnico'
+    )
+
+    norma_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.normas.id'),
+        nullable=True,
+        comment='FK a normas — norma que establece este requisito'
+    )
+
+    articulo = db.Column(
+        db.String(20),
+        nullable=True,
+        comment='Artículo concreto de la norma: "4.1" | "DA2" | "DF1"'
+    )
+
+    orden = db.Column(
+        db.Integer,
+        nullable=False,
+        default=1,
+        comment='Orden de presentación en el checklist de la UI (informativo, sin unicidad)'
+    )
+
+    # Relaciones
+    tipo_documento = db.relationship('TipoDocumento')
+    norma          = db.relationship('Norma')
+    condiciones    = db.relationship(
+        'CondicionRequisito',
+        backref='requisito',
+        cascade='all, delete-orphan',
+        order_by='CondicionRequisito.orden',
+    )
+    usos = db.relationship(
+        'DocumentoRequisito',
+        backref='requisito',
+        cascade='all, delete-orphan',
+    )
+
+    def __repr__(self):
+        return f'<RequisitoDocumental id={self.id} tipo_doc={self.tipo_documento_id}>'
+
+
+class CondicionRequisito(db.Model):
+    """
+    Condición individual de un RequisitoDocumental.
+
+    Misma semántica que CondicionRegla: evalúa una variable del dict de contexto
+    contra un valor de referencia con un operador. Todas las condiciones del mismo
+    requisito se combinan con AND implícito. Para expresar OR, crear dos requisitos
+    separados con el mismo tipo_documento_id.
+
+    La variable referenciada debe estar activa en catalogo_variables y tener
+    función registrada en el Variable Registry para que el evaluador pueda
+    obtener su valor.
+
+    OPERADORES SOPORTADOS:
+        EQ / NEQ           igual / distinto
+        IN / NOT_IN        en el conjunto / fuera del conjunto
+        IS_NULL / NOT_NULL ausente / presente
+    """
+    __tablename__ = 'condiciones_requisito'
+    __table_args__ = (
+        db.CheckConstraint(
+            "operador IN ('EQ','NEQ','IN','NOT_IN','IS_NULL','NOT_NULL')",
+            name='ck_condiciones_requisito_operador'
+        ),
+        db.Index('idx_condiciones_requisito_requisito', 'requisito_id'),
+        db.Index('idx_condiciones_requisito_variable',  'variable_id'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    requisito_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.requisitos_documentales.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a requisitos_documentales'
+    )
+
+    variable_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.catalogo_variables.id'),
+        nullable=False,
+        comment='FK a catalogo_variables — variable evaluada'
+    )
+
+    operador = db.Column(
+        db.String(20),
+        nullable=False,
+        comment='Operador de comparación: EQ|NEQ|IN|NOT_IN|IS_NULL|NOT_NULL'
+    )
+
+    valor = db.Column(
+        db.JSON,
+        nullable=True,
+        comment='Valor de referencia. Lista para IN/NOT_IN, None para IS_NULL/NOT_NULL'
+    )
+
+    orden = db.Column(
+        db.Integer,
+        nullable=False,
+        default=1,
+        comment='Orden informativo dentro del requisito (presentación en UI)'
+    )
+
+    variable = db.relationship('CatalogoVariable')
+
+    def __repr__(self):
+        nombre = self.variable.nombre if self.variable else f'var_id={self.variable_id}'
+        return (
+            f'<CondicionRequisito id={self.id} req={self.requisito_id} '
+            f'{nombre} {self.operador} {self.valor!r}>'
+        )
+
+
+class DocumentoRequisito(db.Model):
+    """
+    Vinculación entre un requisito documental y el documento del pool que lo satisface.
+
+    El técnico, durante la tarea ANALIZAR de ANALISIS_DOCUMENTAL, asocia cada
+    requisito aplicable a la solicitud con un documento concreto del pool del
+    expediente. Esta tabla registra esa decisión.
+
+    Un mismo documento del pool puede cubrir el mismo requisito en solicitudes
+    distintas del expediente (reutilización). Por ejemplo, el CIF aportado en la
+    solicitud 1 puede cubrir el mismo requisito en la solicitud 2.
+
+    UNICIDAD:
+        (requisito_id, solicitud_id) — un requisito queda cubierto exactamente
+        una vez por solicitud. El técnico puede reasignar el documento cambiando
+        la fila existente.
+
+    EVALUACIÓN:
+        Ver app/services/requisitos.py::evaluar_requisitos.
+    """
+    __tablename__ = 'documentos_requisito'
+    __table_args__ = (
+        db.UniqueConstraint(
+            'requisito_id', 'solicitud_id',
+            name='uq_documentos_requisito_req_sol'
+        ),
+        db.Index('idx_documentos_requisito_requisito',  'requisito_id'),
+        db.Index('idx_documentos_requisito_solicitud',  'solicitud_id'),
+        db.Index('idx_documentos_requisito_documento',  'documento_id'),
+        {'schema': 'public'}
+    )
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True,
+        autoincrement=True,
+        comment='Identificador único autogenerado'
+    )
+
+    requisito_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.requisitos_documentales.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a requisitos_documentales'
+    )
+
+    solicitud_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.solicitudes.id', ondelete='CASCADE'),
+        nullable=False,
+        comment='FK a solicitudes — solicitud en la que se cubre el requisito'
+    )
+
+    documento_id = db.Column(
+        db.Integer,
+        db.ForeignKey('public.documentos.id'),
+        nullable=False,
+        comment='FK a documentos — documento del pool que satisface el requisito'
+    )
+
+    # Relaciones
+    solicitud = db.relationship('Solicitud')
+    documento = db.relationship('Documento')
+
+    def __repr__(self):
+        return (
+            f'<DocumentoRequisito id={self.id} '
+            f'req={self.requisito_id} sol={self.solicitud_id} doc={self.documento_id}>'
+        )

--- a/app/services/requisitos.py
+++ b/app/services/requisitos.py
@@ -1,0 +1,141 @@
+"""
+Evaluador de requisitos documentales por solicitud (#192).
+
+Dado una solicitud y el dict de variables del expediente, determina qué
+requisitos del catálogo son aplicables y cuáles tienen ya un documento del
+pool asignado.
+
+Uso típico (dentro de ContextoAnalisisDocumental — ver #495):
+
+    from app.services.requisitos import evaluar_requisitos
+    from app.services.assembler import build
+
+    _, variables = build(expediente, objeto=fase)
+    resultado = evaluar_requisitos(solicitud, variables)
+    todos_cubiertos = resultado['todos_cubiertos']
+    checklist = resultado['items']
+
+Semántica de condiciones:
+    Cada RequisitoDocumental puede tener cero o más CondicionRequisito.
+    Todas se evalúan en AND. Un requisito sin condiciones es universal
+    (aplica siempre). Los operadores soportados son los mismos que
+    CondicionRegla: EQ, NEQ, IN, NOT_IN, IS_NULL, NOT_NULL.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+from app.models.requisitos_documentales import RequisitoDocumental, DocumentoRequisito
+
+log = logging.getLogger(__name__)
+
+# Valor devuelto en caso de error de BD o tabla inexistente
+_RESULTADO_DEGRADADO: dict = {
+    'items': [],
+    'todos_cubiertos': True,
+    'error': True,
+}
+
+
+def _evaluar_condicion(operador: str, valor_var: Any, valor_ref: Any) -> bool:
+    """Evalúa una condición individual. Devuelve True si se cumple."""
+    if operador == 'EQ':
+        return valor_var == valor_ref
+    if operador == 'NEQ':
+        return valor_var != valor_ref
+    if operador == 'IN':
+        return valor_var in (valor_ref or [])
+    if operador == 'NOT_IN':
+        return valor_var not in (valor_ref or [])
+    if operador == 'IS_NULL':
+        return valor_var is None
+    if operador == 'NOT_NULL':
+        return valor_var is not None
+    log.warning('requisitos: operador desconocido "%s" — condición ignorada', operador)
+    return True
+
+
+def _requisito_aplica(requisito: Any, variables: dict) -> bool:
+    """
+    Devuelve True si todas las condiciones del requisito se cumplen.
+    Un requisito sin condiciones es universal — siempre aplica.
+    """
+    for cond in requisito.condiciones:
+        nombre_var = cond.variable.nombre if cond.variable else None
+        if nombre_var is None:
+            log.warning(
+                'requisitos: condicion_id=%s sin variable — ignorada', cond.id
+            )
+            continue
+        valor_var = variables.get(nombre_var)
+        if not _evaluar_condicion(cond.operador, valor_var, cond.valor):
+            return False
+    return True
+
+
+def evaluar_requisitos(solicitud: Any, variables: dict) -> dict:
+    """
+    Evalúa los requisitos documentales aplicables a una solicitud concreta.
+
+    Args:
+        solicitud:  Instancia de Solicitud con relaciones accesibles.
+        variables:  Dict de variables del motor (producido por assembler.build).
+
+    Returns:
+        {
+            'items': [
+                {
+                    'requisito':  RequisitoDocumental,
+                    'cubierto':   bool,
+                    'documento':  Documento | None,
+                },
+                ...
+            ],
+            'todos_cubiertos': bool,
+            'error': bool,   # True solo si hubo fallo de BD
+        }
+
+    El resultado es siempre permisivo en caso de error (todos_cubiertos=True)
+    para no bloquear la tramitación por un fallo técnico (#347).
+    """
+    try:
+        todos_requisitos = (
+            RequisitoDocumental.query
+            .order_by(RequisitoDocumental.orden)
+            .all()
+        )
+    except (OperationalError, ProgrammingError):
+        log.warning('requisitos: tabla requisitos_documentales no disponible')
+        return _RESULTADO_DEGRADADO
+
+    # Índice de vinculaciones ya hechas para esta solicitud: requisito_id → DocumentoRequisito
+    try:
+        vinculaciones = {
+            dr.requisito_id: dr
+            for dr in DocumentoRequisito.query.filter_by(solicitud_id=solicitud.id).all()
+        }
+    except (OperationalError, ProgrammingError):
+        log.warning('requisitos: tabla documentos_requisito no disponible')
+        return _RESULTADO_DEGRADADO
+
+    items = []
+    for req in todos_requisitos:
+        if not _requisito_aplica(req, variables):
+            continue
+        vinculo = vinculaciones.get(req.id)
+        items.append({
+            'requisito': req,
+            'cubierto':  vinculo is not None,
+            'documento': vinculo.documento if vinculo else None,
+        })
+
+    todos_cubiertos = all(item['cubierto'] for item in items)
+
+    return {
+        'items':          items,
+        'todos_cubiertos': todos_cubiertos,
+        'error':          False,
+    }

--- a/app/services/variables/calculado.py
+++ b/app/services/variables/calculado.py
@@ -246,6 +246,24 @@ def _(ctx) -> bool:
 # Variables compatibilidad de tipos de solicitud (#410)
 # ---------------------------------------------------------------------------
 
+@variable('tipo_expediente')
+def _(ctx) -> str | None:
+    """
+    Tipo de expediente como string: 'Distribucion', 'Transporte', 'Renovable', 'Convencional'.
+
+    Devuelve el valor del campo TipoExpediente.tipo del expediente en contexto,
+    o None si no está definido. Se usa en condiciones de requisitos documentales
+    y en condiciones del motor que dependen del tipo de instalación.
+
+    Nota: los valores son los de la tabla tipos_expedientes.tipo — no cambiar
+    sin actualizar las condiciones_requisito que los referencian.
+    """
+    tipo_exp = ctx.expediente.tipo_expediente if ctx.expediente else None
+    if tipo_exp is None:
+        return None
+    return tipo_exp.tipo
+
+
 @variable('es_expediente_produccion')
 def _(ctx) -> bool:
     """

--- a/migrations/versions/6a2e29774f16_192_requisitos_documentales.py
+++ b/migrations/versions/6a2e29774f16_192_requisitos_documentales.py
@@ -1,0 +1,164 @@
+"""192_requisitos_documentales
+
+Revision ID: 6a2e29774f16
+Revises: 410_compatibilidad_tipos_solicitud
+Create Date: 2026-05-27 15:32:38.816419
+
+Crea las tablas del modelo de requisitos documentales (#192):
+  - requisitos_documentales
+  - condiciones_requisito
+  - documentos_requisito
+
+Añade la variable 'tipo_expediente' al catálogo de variables del motor.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '6a2e29774f16'
+down_revision = '410_compatibilidad_tipos_solicitud'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ------------------------------------------------------------------
+    # Tabla requisitos_documentales
+    # ------------------------------------------------------------------
+    op.create_table(
+        'requisitos_documentales',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('tipo_documento_id', sa.Integer(), nullable=False,
+                  comment='FK a tipos_documentos — tipo semántico del documento requerido'),
+        sa.Column('descripcion_legal', sa.Text(), nullable=True,
+                  comment='Descripción del requisito en lenguaje natural para el técnico'),
+        sa.Column('norma_id', sa.Integer(), nullable=True,
+                  comment='FK a normas — norma que establece este requisito'),
+        sa.Column('articulo', sa.String(20), nullable=True,
+                  comment='Artículo concreto de la norma: "4.1" | "DA2" | "DF1"'),
+        sa.Column('orden', sa.Integer(), nullable=False, server_default='1',
+                  comment='Orden de presentación en el checklist de la UI'),
+        sa.ForeignKeyConstraint(['tipo_documento_id'], ['public.tipos_documentos.id']),
+        sa.ForeignKeyConstraint(['norma_id'], ['public.normas.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='public',
+    )
+    op.create_index(
+        'idx_requisitos_documentales_tipo_doc',
+        'requisitos_documentales', ['tipo_documento_id'], schema='public'
+    )
+
+    # ------------------------------------------------------------------
+    # Tabla condiciones_requisito
+    # ------------------------------------------------------------------
+    op.create_table(
+        'condiciones_requisito',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('requisito_id', sa.Integer(), nullable=False,
+                  comment='FK a requisitos_documentales'),
+        sa.Column('variable_id', sa.Integer(), nullable=False,
+                  comment='FK a catalogo_variables — variable evaluada'),
+        sa.Column('operador', sa.String(20), nullable=False,
+                  comment='Operador de comparación: EQ|NEQ|IN|NOT_IN|IS_NULL|NOT_NULL'),
+        sa.Column('valor', sa.JSON(), nullable=True,
+                  comment='Valor de referencia. Lista para IN/NOT_IN, None para IS_NULL/NOT_NULL'),
+        sa.Column('orden', sa.Integer(), nullable=False, server_default='1',
+                  comment='Orden informativo dentro del requisito'),
+        sa.CheckConstraint(
+            "operador IN ('EQ','NEQ','IN','NOT_IN','IS_NULL','NOT_NULL')",
+            name='ck_condiciones_requisito_operador'
+        ),
+        sa.ForeignKeyConstraint(
+            ['requisito_id'], ['public.requisitos_documentales.id'],
+            ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(['variable_id'], ['public.catalogo_variables.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='public',
+    )
+    op.create_index(
+        'idx_condiciones_requisito_requisito',
+        'condiciones_requisito', ['requisito_id'], schema='public'
+    )
+    op.create_index(
+        'idx_condiciones_requisito_variable',
+        'condiciones_requisito', ['variable_id'], schema='public'
+    )
+
+    # ------------------------------------------------------------------
+    # Tabla documentos_requisito
+    # ------------------------------------------------------------------
+    op.create_table(
+        'documentos_requisito',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False,
+                  comment='Identificador único autogenerado'),
+        sa.Column('requisito_id', sa.Integer(), nullable=False,
+                  comment='FK a requisitos_documentales'),
+        sa.Column('solicitud_id', sa.Integer(), nullable=False,
+                  comment='FK a solicitudes — solicitud en la que se cubre el requisito'),
+        sa.Column('documento_id', sa.Integer(), nullable=False,
+                  comment='FK a documentos — documento del pool que satisface el requisito'),
+        sa.ForeignKeyConstraint(
+            ['requisito_id'], ['public.requisitos_documentales.id'],
+            ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(
+            ['solicitud_id'], ['public.solicitudes.id'],
+            ondelete='CASCADE'
+        ),
+        sa.ForeignKeyConstraint(['documento_id'], ['public.documentos.id']),
+        sa.UniqueConstraint(
+            'requisito_id', 'solicitud_id',
+            name='uq_documentos_requisito_req_sol'
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        schema='public',
+    )
+    op.create_index(
+        'idx_documentos_requisito_requisito',
+        'documentos_requisito', ['requisito_id'], schema='public'
+    )
+    op.create_index(
+        'idx_documentos_requisito_solicitud',
+        'documentos_requisito', ['solicitud_id'], schema='public'
+    )
+    op.create_index(
+        'idx_documentos_requisito_documento',
+        'documentos_requisito', ['documento_id'], schema='public'
+    )
+
+    # ------------------------------------------------------------------
+    # GRANTs para el usuario MCP de desarrollo
+    # ------------------------------------------------------------------
+    op.execute("GRANT SELECT ON public.requisitos_documentales TO claude_desktop")
+    op.execute("GRANT SELECT ON public.condiciones_requisito TO claude_desktop")
+    op.execute("GRANT SELECT ON public.documentos_requisito TO claude_desktop")
+
+    # ------------------------------------------------------------------
+    # Seed: variable 'tipo_expediente' en catalogo_variables
+    # ------------------------------------------------------------------
+    op.execute("""
+        INSERT INTO public.catalogo_variables (nombre, etiqueta, tipo_dato, norma_id, activa)
+        VALUES (
+            'tipo_expediente',
+            'Tipo de expediente (Distribucion / Transporte / Renovable / Convencional)',
+            'texto',
+            NULL,
+            TRUE
+        )
+        ON CONFLICT (nombre) DO NOTHING
+    """)
+
+
+def downgrade():
+    # Eliminar seed
+    op.execute("""
+        DELETE FROM public.catalogo_variables WHERE nombre = 'tipo_expediente'
+    """)
+
+    # Eliminar tablas en orden inverso de dependencias
+    op.drop_table('documentos_requisito', schema='public')
+    op.drop_table('condiciones_requisito', schema='public')
+    op.drop_table('requisitos_documentales', schema='public')

--- a/tests/test_192_requisitos_documentales.py
+++ b/tests/test_192_requisitos_documentales.py
@@ -1,0 +1,420 @@
+"""
+Tests issue #192 — RequisitoDocumental, CondicionRequisito, DocumentoRequisito
+y el helper evaluar_requisitos.
+
+Sin BD ni app context. Valida lógica con stubs.
+"""
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+def _variable_stub(nombre, id=1):
+    v = MagicMock()
+    v.nombre = nombre
+    v.id = id
+    return v
+
+
+def _condicion(variable_nombre, operador, valor, orden=1, var_id=1):
+    c = MagicMock()
+    c.variable = _variable_stub(variable_nombre, id=var_id)
+    c.operador = operador
+    c.valor = valor
+    c.orden = orden
+    c.id = var_id
+    return c
+
+
+def _requisito(tipo_doc_id=1, condiciones=None, orden=1, req_id=None):
+    r = MagicMock()
+    r.id = req_id or tipo_doc_id
+    r.tipo_documento_id = tipo_doc_id
+    r.condiciones = condiciones or []
+    r.orden = orden
+    return r
+
+
+def _doc_requisito(requisito_id, solicitud_id, documento_id=99):
+    dr = MagicMock()
+    dr.requisito_id = requisito_id
+    dr.solicitud_id = solicitud_id
+    dr.documento_id = documento_id
+    dr.documento = MagicMock()
+    dr.documento.id = documento_id
+    return dr
+
+
+def _solicitud(sol_id=1):
+    s = MagicMock()
+    s.id = sol_id
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Helper para importar evaluar_requisitos parchando las queries
+# ---------------------------------------------------------------------------
+
+def _evaluar(requisitos, vinculaciones, sol_id=1):
+    """
+    Llama a evaluar_requisitos con las tablas parchadas por mocks.
+
+    requisitos:    lista de objetos _requisito()
+    vinculaciones: lista de objetos _doc_requisito()
+    """
+    from app.services.requisitos import evaluar_requisitos
+
+    solicitud = _solicitud(sol_id)
+
+    mock_req_query = MagicMock()
+    mock_req_query.order_by.return_value.all.return_value = requisitos
+
+    mock_dr_query = MagicMock()
+    mock_dr_query.filter_by.return_value.all.return_value = vinculaciones
+
+    with patch('app.services.requisitos.RequisitoDocumental') as MockReq, \
+         patch('app.services.requisitos.DocumentoRequisito') as MockDR:
+        MockReq.query = mock_req_query
+        MockDR.query = mock_dr_query
+        return evaluar_requisitos(solicitud, {})
+
+
+# ---------------------------------------------------------------------------
+# A) Modelos — estructura básica
+# ---------------------------------------------------------------------------
+
+class TestModelosRequisitosDocumentales:
+
+    def test_repr_requisito(self):
+        from app.models.requisitos_documentales import RequisitoDocumental
+        r = MagicMock(spec=RequisitoDocumental)
+        r.id = 1
+        r.tipo_documento_id = 3
+        assert RequisitoDocumental.__repr__(r) == '<RequisitoDocumental id=1 tipo_doc=3>'
+
+    def test_repr_condicion(self):
+        from app.models.requisitos_documentales import CondicionRequisito
+        c = MagicMock(spec=CondicionRequisito)
+        c.id = 5
+        c.requisito_id = 2
+        c.variable = _variable_stub('tipo_solicitud')
+        c.operador = 'EQ'
+        c.valor = 'AAP'
+        assert 'tipo_solicitud' in CondicionRequisito.__repr__(c)
+        assert 'EQ' in CondicionRequisito.__repr__(c)
+
+    def test_repr_documento_requisito(self):
+        from app.models.requisitos_documentales import DocumentoRequisito
+        dr = MagicMock(spec=DocumentoRequisito)
+        dr.id = 7
+        dr.requisito_id = 1
+        dr.solicitud_id = 2
+        dr.documento_id = 99
+        assert 'req=1' in DocumentoRequisito.__repr__(dr)
+        assert 'sol=2' in DocumentoRequisito.__repr__(dr)
+
+
+# ---------------------------------------------------------------------------
+# B) Variable tipo_expediente
+# ---------------------------------------------------------------------------
+
+def _get_variable(nombre):
+    import app.services.variables.calculado  # noqa: F401
+    from app.services.variables import _REGISTRY
+    fn = _REGISTRY.get(nombre)
+    assert fn is not None, f'Variable {nombre!r} no registrada'
+    return fn
+
+
+class _StubTipoExpediente:
+    def __init__(self, tipo): self.tipo = tipo
+
+
+class _StubExpediente:
+    def __init__(self, tipo_exp): self.tipo_expediente = tipo_exp
+
+
+class _StubCtx:
+    def __init__(self, tipo_exp_str=None):
+        te = _StubTipoExpediente(tipo_exp_str) if tipo_exp_str else None
+        self.expediente = _StubExpediente(te)
+
+
+class TestVariableTipoExpediente:
+
+    def test_registrada(self):
+        _get_variable('tipo_expediente')
+
+    def test_distribucion(self):
+        fn = _get_variable('tipo_expediente')
+        assert fn(_StubCtx('Distribucion')) == 'Distribucion'
+
+    def test_renovable(self):
+        fn = _get_variable('tipo_expediente')
+        assert fn(_StubCtx('Renovable')) == 'Renovable'
+
+    def test_sin_tipo_expediente(self):
+        fn = _get_variable('tipo_expediente')
+        assert fn(_StubCtx(None)) is None
+
+    def test_expediente_none(self):
+        fn = _get_variable('tipo_expediente')
+        ctx = MagicMock()
+        ctx.expediente = None
+        assert fn(ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# C) evaluar_requisitos — catálogo vacío
+# ---------------------------------------------------------------------------
+
+class TestEvaluarRequisitosVacio:
+
+    def test_sin_requisitos_todos_cubiertos(self):
+        """Sin requisitos en el catálogo → todos_cubiertos=True, items vacío."""
+        resultado = _evaluar(requisitos=[], vinculaciones=[])
+        assert resultado['todos_cubiertos'] is True
+        assert resultado['items'] == []
+        assert resultado['error'] is False
+
+
+# ---------------------------------------------------------------------------
+# D) evaluar_requisitos — requisito universal (sin condiciones)
+# ---------------------------------------------------------------------------
+
+class TestRequisitoUniversal:
+
+    def test_universal_sin_cubrir(self):
+        """Requisito sin condiciones, sin documento asignado → cubierto=False."""
+        req = _requisito(tipo_doc_id=1, condiciones=[], req_id=10)
+        resultado = _evaluar([req], [])
+        assert resultado['todos_cubiertos'] is False
+        assert len(resultado['items']) == 1
+        item = resultado['items'][0]
+        assert item['cubierto'] is False
+        assert item['documento'] is None
+
+    def test_universal_cubierto(self):
+        """Requisito universal con documento asignado → cubierto=True."""
+        req = _requisito(tipo_doc_id=1, condiciones=[], req_id=10)
+        vl = _doc_requisito(requisito_id=10, solicitud_id=1)
+        resultado = _evaluar([req], [vl])
+        assert resultado['todos_cubiertos'] is True
+        assert resultado['items'][0]['cubierto'] is True
+        assert resultado['items'][0]['documento'] is not None
+
+
+# ---------------------------------------------------------------------------
+# E) evaluar_requisitos — condición EQ
+# ---------------------------------------------------------------------------
+
+class TestCondicionEQ:
+
+    def test_condicion_eq_cumplida(self):
+        """EQ con valor correcto → requisito aplica."""
+        cond = _condicion('tipo_solicitud', 'EQ', 'AAP')
+        req = _requisito(tipo_doc_id=2, condiciones=[cond], req_id=20)
+        resultado = _evaluar([req], [], sol_id=1)
+        # El dict de variables está vacío, pero parchamos evaluar_requisitos internamente
+        # Necesitamos variables reales para que la condición evalúe
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            res = evaluar_requisitos(solicitud, {'tipo_solicitud': 'AAP'})
+
+        assert len(res['items']) == 1
+        assert res['items'][0]['cubierto'] is False
+
+    def test_condicion_eq_no_cumplida(self):
+        """EQ con valor distinto → requisito no aplica → lista vacía."""
+        cond = _condicion('tipo_solicitud', 'EQ', 'AAP')
+        req = _requisito(tipo_doc_id=2, condiciones=[cond], req_id=20)
+
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            res = evaluar_requisitos(solicitud, {'tipo_solicitud': 'AAC'})
+
+        assert res['items'] == []
+        assert res['todos_cubiertos'] is True
+
+
+# ---------------------------------------------------------------------------
+# F) evaluar_requisitos — condición IN
+# ---------------------------------------------------------------------------
+
+class TestCondicionIN:
+
+    def _run(self, valor_var):
+        cond = _condicion('tipo_solicitud', 'IN', ['AAP', 'AAC'])
+        req = _requisito(tipo_doc_id=3, condiciones=[cond], req_id=30)
+
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            return evaluar_requisitos(solicitud, {'tipo_solicitud': valor_var})
+
+    def test_in_cumplido_aap(self):
+        res = self._run('AAP')
+        assert len(res['items']) == 1
+
+    def test_in_cumplido_aac(self):
+        res = self._run('AAC')
+        assert len(res['items']) == 1
+
+    def test_in_no_cumplido_dup(self):
+        res = self._run('DUP')
+        assert res['items'] == []
+
+
+# ---------------------------------------------------------------------------
+# G) evaluar_requisitos — AND de condiciones
+# ---------------------------------------------------------------------------
+
+class TestCondicionAND:
+
+    def test_dos_condiciones_ambas_cumplidas(self):
+        """AND: tipo_solicitud=AAP Y tipo_expediente=Renovable → aplica."""
+        c1 = _condicion('tipo_solicitud', 'EQ', 'AAP', var_id=1)
+        c2 = _condicion('tipo_expediente', 'EQ', 'Renovable', var_id=2)
+        req = _requisito(tipo_doc_id=4, condiciones=[c1, c2], req_id=40)
+
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            res = evaluar_requisitos(
+                solicitud,
+                {'tipo_solicitud': 'AAP', 'tipo_expediente': 'Renovable'}
+            )
+        assert len(res['items']) == 1
+
+    def test_dos_condiciones_una_falla(self):
+        """AND: tipo_solicitud=AAP OK pero tipo_expediente=Distribucion falla → no aplica."""
+        c1 = _condicion('tipo_solicitud', 'EQ', 'AAP', var_id=1)
+        c2 = _condicion('tipo_expediente', 'EQ', 'Renovable', var_id=2)
+        req = _requisito(tipo_doc_id=4, condiciones=[c1, c2], req_id=40)
+
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            res = evaluar_requisitos(
+                solicitud,
+                {'tipo_solicitud': 'AAP', 'tipo_expediente': 'Distribucion'}
+            )
+        assert res['items'] == []
+
+
+# ---------------------------------------------------------------------------
+# H) evaluar_requisitos — OR implícito (dos requisitos, mismo tipo_doc)
+# ---------------------------------------------------------------------------
+
+class TestOR:
+
+    def test_or_solo_uno_aplica(self):
+        """
+        Dos filas para el mismo tipo_doc con condiciones distintas (OR).
+        La solicitud cumple solo la condición de la fila B.
+        El técnico ve solo 1 requisito.
+        """
+        c_a = _condicion('tipo_solicitud', 'EQ', 'AAP', var_id=1)
+        req_a = _requisito(tipo_doc_id=5, condiciones=[c_a], req_id=50)
+
+        c_b = _condicion('tipo_solicitud', 'EQ', 'AAC', var_id=1)
+        req_b = _requisito(tipo_doc_id=5, condiciones=[c_b], req_id=51)
+
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.return_value = [req_a, req_b]
+        mock_dr_q = MagicMock()
+        mock_dr_q.filter_by.return_value.all.return_value = []
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR, \
+             patch('app.services.requisitos.DocumentoRequisito') as MDR:
+            MR.query = mock_req_q
+            MDR.query = mock_dr_q
+            res = evaluar_requisitos(solicitud, {'tipo_solicitud': 'AAC'})
+
+        assert len(res['items']) == 1
+        assert res['items'][0]['requisito'] is req_b
+
+
+# ---------------------------------------------------------------------------
+# I) evaluar_requisitos — error de BD → degradado permisivo
+# ---------------------------------------------------------------------------
+
+class TestErrorBD:
+
+    def test_tabla_no_disponible_devuelve_degradado(self):
+        """OperationalError en la query → todos_cubiertos=True, error=True."""
+        from app.services.requisitos import evaluar_requisitos
+        from unittest.mock import MagicMock, patch
+        from sqlalchemy.exc import OperationalError
+
+        solicitud = _solicitud(1)
+        mock_req_q = MagicMock()
+        mock_req_q.order_by.return_value.all.side_effect = OperationalError(
+            'stmt', 'params', Exception('tabla no existe')
+        )
+
+        with patch('app.services.requisitos.RequisitoDocumental') as MR:
+            MR.query = mock_req_q
+            res = evaluar_requisitos(solicitud, {})
+
+        assert res['todos_cubiertos'] is True
+        assert res['error'] is True
+        assert res['items'] == []


### PR DESCRIPTION
## Cambios

- **Modelos** (`app/models/requisitos_documentales.py`): tres nuevos modelos — `RequisitoDocumental` (catálogo de tipos de documento requeridos con referencia normativa y orden), `CondicionRequisito` (condiciones de aplicación en AND implícito, patrón `condiciones_regla`) y `DocumentoRequisito` (puente solicitud↔documento del pool que cubre el requisito).
- **Migración** (`6a2e29774f16`): crea las tres tablas con índices y constraints; seed de la variable `tipo_expediente` en `catalogo_variables` (`activa=True`). Tablas vacías por defecto — el catálogo real es tarea de negocio.
- **Variable** (`calculado.py`): `@variable('tipo_expediente')` devuelve el string de `TipoExpediente.tipo` (`Distribucion` / `Transporte` / `Renovable` / `Convencional`).
- **Servicio** (`app/services/requisitos.py`): `evaluar_requisitos(solicitud, variables)` evalúa las condiciones de cada requisito del catálogo contra el dict de variables del assembler y devuelve checklist con flag `cubierto`/pendiente. Degradado permisivo ante errores de BD (patrón #347).
- **Tests** (`test_192_requisitos_documentales.py`): 20 casos — reprs de modelos, variable `tipo_expediente`, catálogo vacío, requisito universal, condiciones EQ/IN/AND, OR implícito (dos filas mismo tipo_doc), error de BD degradado.

Closes #192
