### PR TITLE
Permisos blandos generalizados: acceder_X / gestionar_X (ADR-013)

### DIFF
--- a/app/modules/admin_plantillas/metadata.json
+++ b/app/modules/admin_plantillas/metadata.json
@@ -4,7 +4,7 @@
   "icon": "fa-file-word",
   "order": 80,
   "permissions": {
-    "list":   ["ADMIN", "SUPERVISOR"],
+    "list":   ["ADMIN", "SUPERVISOR", "TRAMITADOR", "ADMINISTRATIVO"],
     "create": ["ADMIN", "SUPERVISOR"],
     "edit":   ["ADMIN", "SUPERVISOR"],
     "delete": ["ADMIN"]

--- a/app/modules/admin_plantillas/routes.py
+++ b/app/modules/admin_plantillas/routes.py
@@ -287,7 +287,7 @@ def api_tokens():
 
 @bp.route('/')
 @login_required
-@require_permiso('gestionar_plantillas')
+@require_permiso('acceder_plantillas')
 def listado():
     plantillas = Plantilla.query.order_by(Plantilla.nombre).all()
     return render_template('admin_plantillas/listado.html', plantillas=plantillas)
@@ -366,7 +366,7 @@ def nueva():
 
 @bp.route('/<int:id>/')
 @login_required
-@require_permiso('gestionar_plantillas')
+@require_permiso('acceder_plantillas')
 def detalle(id):
     plantilla = Plantilla.query.get_or_404(id)
     tokens = _build_tokens(plantilla)
@@ -448,7 +448,7 @@ def editar(id):
 
 @bp.route('/<int:id>/descargar')
 @login_required
-@require_permiso('gestionar_plantillas')
+@require_permiso('acceder_plantillas')
 def descargar(id):
     plantilla = Plantilla.query.get_or_404(id)
     d = _plantillas_dir()

--- a/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/detalle.html
@@ -29,9 +29,11 @@
             <a href="{{ url_for('admin_plantillas.listado') }}" class="btn btn-outline-primary">
                 <i class="fas fa-arrow-left me-1"></i> Volver
             </a>
+            {% if tiene_permiso('gestionar_plantillas') %}
             <a href="{{ url_for('admin_plantillas.editar', id=plantilla.id) }}" class="btn btn-primary">
                 <i class="fas fa-edit me-1"></i> Editar
             </a>
+            {% endif %}
         </div>
     </div>
 </div>
@@ -160,12 +162,14 @@
             {% endif %}
 
             {# Acción desactivar/activar #}
+            {% if tiene_permiso('gestionar_plantillas') %}
             <form method="POST" action="{{ url_for('admin_plantillas.activar', id=plantilla.id) }}">
                 <button type="submit" class="btn {% if plantilla.activo %}btn-outline-danger{% else %}btn-outline-success{% endif %}">
                     <i class="fas {% if plantilla.activo %}fa-toggle-off{% else %}fa-toggle-on{% endif %} me-1"></i>
                     {% if plantilla.activo %}Desactivar plantilla{% else %}Activar plantilla{% endif %}
                 </button>
             </form>
+            {% endif %}
 
         </div>{# fin col-lg-7 #}
 
@@ -174,12 +178,14 @@
             <div class="sticky-top" style="top: 1rem">
                 {% set solo_lectura = true %}
                 {% include 'admin_plantillas/_panel_tokens.html' %}
+                {% if tiene_permiso('gestionar_plantillas') %}
                 <div class="mt-2 text-center">
                     <a href="{{ url_for('admin_plantillas.editar', id=plantilla.id) }}"
                        class="btn btn-sm btn-outline-primary">
                         <i class="fas fa-edit me-1"></i> Editar para copiar tokens
                     </a>
                 </div>
+                {% endif %}
             </div>
         </div>
 

--- a/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
@@ -12,9 +12,11 @@
 <div class="lista-cabecera">
     <div class="page-header content-constrained">
         <h1><i class="fas fa-file-word"></i> Plantillas de escritos</h1>
+        {% if tiene_permiso('gestionar_plantillas') %}
         <a href="{{ url_for('admin_plantillas.nueva') }}" class="btn btn-primary">
             <i class="fas fa-plus me-1"></i> Nueva plantilla
         </a>
+        {% endif %}
     </div>
 </div>
 
@@ -67,10 +69,12 @@
                            class="btn-accion-ver me-1">
                             <i class="fas fa-eye"></i> Ver
                         </a>
+                        {% if tiene_permiso('gestionar_plantillas') %}
                         <a href="{{ url_for('admin_plantillas.editar', id=p.id) }}"
                            class="btn btn-sm btn-outline-secondary">
                             <i class="fas fa-edit"></i>
                         </a>
+                        {% endif %}
                     </td>
                 </tr>
                 {% else %}

--- a/app/modules/usuarios/metadata.json
+++ b/app/modules/usuarios/metadata.json
@@ -4,7 +4,7 @@
   "icon": "fa-users",
   "order": 30,
   "permissions": {
-    "list":   ["ADMIN", "SUPERVISOR"],
+    "list":   ["ADMIN", "SUPERVISOR", "TRAMITADOR", "ADMINISTRATIVO"],
     "create": ["ADMIN", "SUPERVISOR"],
     "edit":   ["ADMIN", "SUPERVISOR"],
     "delete": ["ADMIN"]

--- a/app/modules/usuarios/routes.py
+++ b/app/modules/usuarios/routes.py
@@ -19,7 +19,7 @@ def current_user_es_admin():
 
 @bp.route('/', methods=['GET', 'POST'])
 @login_required
-@require_permiso('gestionar_usuarios')
+@require_permiso('acceder_usuarios')
 def index():
     # Recuperamos todos los roles para el formulario
     todos_los_roles = Rol.query.all()
@@ -31,6 +31,10 @@ def index():
     error_email = None
 
     if request.method == 'POST':
+        from flask import abort
+        from app.utils.permisos import tiene_permiso as _tp
+        if not _tp('gestionar_usuarios'):
+            abort(403)
         # Lógica para crear usuario
         try:
             siglas = request.form['siglas']
@@ -153,7 +157,7 @@ def index():
 
 @bp.route('/<int:id>')
 @login_required
-@require_permiso('gestionar_usuarios')
+@require_permiso('acceder_usuarios')
 def detalle(id):
     usuario = Usuario.query.get_or_404(id)
     roles = Rol.query.all()

--- a/app/modules/usuarios/templates/usuarios/detalle.html
+++ b/app/modules/usuarios/templates/usuarios/detalle.html
@@ -35,9 +35,11 @@
         <a href="{{ url_for('usuarios.index') }}" class="btn btn-outline-primary">
             <i class="fas fa-arrow-left me-1"></i> Volver
         </a>
+        {% if tiene_permiso('gestionar_usuarios') %}
         <a href="{{ url_for('usuarios.editar', id=usuario.id) }}" class="btn btn-primary">
             <i class="fas fa-edit me-1"></i> Editar
         </a>
+        {% endif %}
     {% else %}
         <a href="{{ url_for('usuarios.detalle', id=usuario.id) }}" class="btn btn-outline-primary">
             <i class="fas fa-times me-1"></i> Cancelar

--- a/app/modules/usuarios/templates/usuarios/index.html
+++ b/app/modules/usuarios/templates/usuarios/index.html
@@ -16,10 +16,12 @@
         <h1>
             <i class="fas fa-users"></i> Usuarios
         </h1>
+        {% if tiene_permiso('gestionar_usuarios') %}
         <button type="button" class="btn btn-primary"
                 data-bs-toggle="modal" data-bs-target="#crearUsuarioModal">
             <i class="fas fa-plus"></i> Nuevo Usuario
         </button>
+        {% endif %}
     </div>
     <div class="filters-row content-constrained">
         <div class="filters">
@@ -91,6 +93,7 @@
                             {% endfor %}
                         </td>
                         <td>
+                            {% if tiene_permiso('gestionar_usuarios') %}
                             <form action="{{ url_for('usuarios.toggle_estado', id=usuario.id) }}"
                                   method="POST" style="display: inline;"
                                   {% if usuario.id == current_user.id %}
@@ -113,6 +116,13 @@
                                     </label>
                                 </div>
                             </form>
+                            {% else %}
+                                {% if usuario.activo %}
+                                    <span class="badge bg-success">Activo</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">Inactivo</span>
+                                {% endif %}
+                            {% endif %}
                         </td>
                         <td>
                             <a href="{{ url_for('usuarios.detalle', id=usuario.id) }}"
@@ -134,6 +144,7 @@
     </div>
 </div>
 
+{% if tiene_permiso('gestionar_usuarios') %}
 <!-- Modal de Creación -->
 <div class="modal fade" id="crearUsuarioModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg">
@@ -248,6 +259,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 <script>
 // Inicializar tooltips

--- a/app/templates/layout/_sidebar.html
+++ b/app/templates/layout/_sidebar.html
@@ -1,6 +1,6 @@
-{# _sidebar.html — Navegación lateral persistente (ADR-014 §4).
-   Generado desde ModuleRegistry (mismo origen que module_nav). El filtrado
-   por rol seguirá aplicándose hasta que #497 lo neutralice (permisos blandos).
+{# _sidebar.html — Navegación lateral persistente (ADR-014 §4, ADR-013 §6).
+   Generado desde ModuleRegistry. Todos los roles ven todos los módulos;
+   los permisos restringen acciones dentro de cada pantalla, no la navegación.
 #}
 <nav class="app-sidebar" aria-label="Navegación principal">
 

--- a/app/utils/permisos.py
+++ b/app/utils/permisos.py
@@ -14,12 +14,28 @@ from flask_login import current_user
 from app.services import bitacora
 
 PERMISOS = {
-    'acceder_expediente':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
-    'editar_expediente':    {'ADMIN', 'SUPERVISOR', 'TRAMITADOR'},
-    'cambiar_responsable':  {'ADMIN', 'SUPERVISOR'},
-    'ver_todos_proyectos':  {'ADMIN', 'SUPERVISOR', 'ADMINISTRATIVO'},
-    'gestionar_usuarios':   {'ADMIN', 'SUPERVISOR'},
-    'gestionar_plantillas': {'ADMIN', 'SUPERVISOR'},
+    # Expedientes (ADR-012)
+    'acceder_expediente':        {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'editar_expediente':         {'ADMIN', 'SUPERVISOR', 'TRAMITADOR'},
+    'cambiar_responsable':       {'ADMIN', 'SUPERVISOR'},
+    'ver_todos_proyectos':       {'ADMIN', 'SUPERVISOR', 'ADMINISTRATIVO'},
+
+    # Áreas administrativas — patrón acceder/gestionar (ADR-013)
+    'acceder_plantillas':        {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_plantillas':      {'ADMIN', 'SUPERVISOR'},
+
+    'acceder_usuarios':          {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_usuarios':        {'ADMIN', 'SUPERVISOR'},
+
+    # Sin UI aún — reservados para #170/#171
+    'acceder_reglas_motor':      {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_reglas_motor':    {'ADMIN', 'SUPERVISOR'},
+
+    'acceder_catalogo_plazos':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_catalogo_plazos': {'ADMIN', 'SUPERVISOR'},
+
+    'acceder_tablas_maestras':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_tablas_maestras': {'ADMIN', 'SUPERVISOR'},
 }
 
 

--- a/tests/test_497_permisos_blandos.py
+++ b/tests/test_497_permisos_blandos.py
@@ -1,0 +1,197 @@
+"""Smoke tests de permisos blandos (ADR-013 / Issue #497).
+
+Verifica que:
+  1. TRAMITADOR puede acceder en lectura a áreas administrativas (GET 200).
+  2. TRAMITADOR no puede ejecutar mutaciones (302 a perfil o 403).
+  3. SUPERVISOR sigue teniendo acceso completo sin regresiones.
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers de login
+# ---------------------------------------------------------------------------
+
+def _login(client, siglas, password, rol_nombre):
+    """
+    Hace login con siglas/password y selecciona el rol indicado.
+    Devuelve True si el login fue exitoso, False si el rol no existe.
+    """
+    r1 = client.post(
+        '/auth/login',
+        data={'siglas': siglas, 'password': password},
+        follow_redirects=False,
+    )
+    if r1.status_code not in (200, 302):
+        return False
+
+    if r1.status_code == 200:
+        # El servidor pide selección de rol
+        from app.models.usuarios import Usuario
+        u = Usuario.query.filter_by(siglas=siglas).first()
+        if u is None:
+            return False
+        rol = next((r for r in u.roles if r.nombre == rol_nombre), None)
+        if rol is None:
+            return False
+        r2 = client.post(
+            '/auth/login',
+            data={'rol_id': str(rol.id)},
+            follow_redirects=False,
+        )
+        if r2.status_code not in (200, 302):
+            return False
+
+    return True
+
+
+@pytest.fixture
+def tramitador(client):
+    """Cliente autenticado como CLG con rol TRAMITADOR."""
+    ok = _login(client, 'CLG', '31416', 'TRAMITADOR')
+    if not ok:
+        pytest.skip('Usuario CLG con rol TRAMITADOR no disponible en esta BD')
+    return client
+
+
+@pytest.fixture
+def supervisor(client):
+    """Cliente autenticado como CLG con rol SUPERVISOR."""
+    ok = _login(client, 'CLG', '31416', 'SUPERVISOR')
+    if not ok:
+        pytest.skip('Usuario CLG con rol SUPERVISOR no disponible en esta BD')
+    return client
+
+
+# ---------------------------------------------------------------------------
+# TRAMITADOR — acceso de lectura (debe ser 200)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ruta', [
+    '/admin/plantillas/',
+    '/usuarios/',
+])
+def test_tramitador_puede_leer(tramitador, ruta):
+    """TRAMITADOR accede en lectura a áreas administrativas."""
+    r = tramitador.get(ruta, follow_redirects=True)
+    assert r.status_code == 200, f'TRAMITADOR no puede leer {ruta} (status {r.status_code})'
+
+
+def test_tramitador_puede_ver_detalle_plantilla(tramitador):
+    """TRAMITADOR puede ver el detalle de una plantilla si existe alguna."""
+    from app.models.plantillas import Plantilla
+    p = Plantilla.query.first()
+    if p is None:
+        pytest.skip('No hay plantillas en la BD')
+    r = tramitador.get(f'/admin/plantillas/{p.id}/', follow_redirects=True)
+    assert r.status_code == 200
+
+
+def test_tramitador_puede_ver_detalle_usuario(tramitador):
+    """TRAMITADOR puede ver el detalle de un usuario."""
+    from app.models.usuarios import Usuario
+    u = Usuario.query.first()
+    if u is None:
+        pytest.skip('No hay usuarios en la BD')
+    r = tramitador.get(f'/usuarios/{u.id}', follow_redirects=True)
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# TRAMITADOR — mutaciones de plantillas (debe ser 302 → perfil)
+# ---------------------------------------------------------------------------
+
+def test_tramitador_no_puede_crear_plantilla_get(tramitador):
+    """TRAMITADOR no accede al formulario de nueva plantilla."""
+    r = tramitador.get('/admin/plantillas/nueva/', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+def test_tramitador_no_puede_editar_plantilla(tramitador):
+    """TRAMITADOR no accede al formulario de edición de plantilla."""
+    from app.models.plantillas import Plantilla
+    p = Plantilla.query.first()
+    if p is None:
+        pytest.skip('No hay plantillas en la BD')
+    r = tramitador.get(f'/admin/plantillas/{p.id}/editar', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+def test_tramitador_no_puede_activar_plantilla(tramitador):
+    """TRAMITADOR no puede activar/desactivar una plantilla."""
+    from app.models.plantillas import Plantilla
+    p = Plantilla.query.first()
+    if p is None:
+        pytest.skip('No hay plantillas en la BD')
+    r = tramitador.post(f'/admin/plantillas/{p.id}/activar', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+# ---------------------------------------------------------------------------
+# TRAMITADOR — mutaciones de usuarios
+# ---------------------------------------------------------------------------
+
+def test_tramitador_no_puede_crear_usuario(tramitador):
+    """TRAMITADOR recibe 403 al intentar crear un usuario vía POST."""
+    r = tramitador.post(
+        '/usuarios/',
+        data={'siglas': 'TST', 'nombre': 'Test', 'apellido1': 'Test',
+              'password': 'x', 'confirm_password': 'x'},
+        follow_redirects=False,
+    )
+    assert r.status_code == 403
+
+
+def test_tramitador_no_puede_editar_usuario(tramitador):
+    """TRAMITADOR no accede al formulario de edición de un usuario."""
+    from app.models.usuarios import Usuario
+    u = Usuario.query.first()
+    if u is None:
+        pytest.skip('No hay usuarios en la BD')
+    r = tramitador.get(f'/usuarios/{u.id}/editar', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+def test_tramitador_no_puede_toggle_estado(tramitador):
+    """TRAMITADOR no puede cambiar el estado activo de un usuario."""
+    from app.models.usuarios import Usuario
+    u = Usuario.query.first()
+    if u is None:
+        pytest.skip('No hay usuarios en la BD')
+    r = tramitador.post(f'/usuarios/{u.id}/toggle_estado', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+# ---------------------------------------------------------------------------
+# SUPERVISOR — sin regresiones (acceso completo)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('ruta', [
+    '/admin/plantillas/',
+    '/usuarios/',
+])
+def test_supervisor_sigue_accediendo(supervisor, ruta):
+    """SUPERVISOR mantiene acceso de lectura sin regresiones."""
+    r = supervisor.get(ruta, follow_redirects=True)
+    assert r.status_code == 200, f'SUPERVISOR perdió acceso a {ruta}'
+
+
+def test_supervisor_puede_crear_plantilla_get(supervisor):
+    """SUPERVISOR accede al formulario de nueva plantilla."""
+    r = supervisor.get('/admin/plantillas/nueva/', follow_redirects=True)
+    assert r.status_code == 200
+
+
+def test_supervisor_puede_editar_usuario(supervisor):
+    """SUPERVISOR accede al formulario de edición de un usuario."""
+    from app.models.usuarios import Usuario
+    u = Usuario.query.first()
+    if u is None:
+        pytest.skip('No hay usuarios en la BD')
+    r = supervisor.get(f'/usuarios/{u.id}/editar', follow_redirects=True)
+    assert r.status_code == 200


### PR DESCRIPTION
## Cambios

- Expande `PERMISOS` con pares `acceder_X` / `gestionar_X` para plantillas, usuarios y áreas futuras (reglas_motor, catálogo_plazos, tablas_maestras)
- Rutas de lectura (`listado`, `detalle`, `descargar`) en `admin_plantillas` pasan a `acceder_plantillas`; mutaciones se mantienen en `gestionar_plantillas`
- Ruta `index` de usuarios usa `acceder_usuarios`; bloque POST añade `abort(403)` interno para defensa en profundidad
- `metadata.json` de ambos módulos: `permissions.list` abierto a los 4 roles → sidebar único para todos (ADR-013 §6)
- Templates: botones de mutación (Nueva, Editar, Activar, toggle estado, modal crear usuario) envueltos en `{% if tiene_permiso('gestionar_X') %}`
- Sidebar: comentario de compat `#497` reemplazado por referencia a ADR-013
- 14 smoke tests: TRAMITADOR lee (200), no muta (302/403); SUPERVISOR sin regresiones

Closes #497
