### PR TITLE
Añadir smoke tests pytest Fase 1 (ADR-019, #503)

### DIFF
--- a/docs/guias/REGLAS_DESARROLLO.md
+++ b/docs/guias/REGLAS_DESARROLLO.md
@@ -62,6 +62,22 @@ No hay excepciones por "es pequeño" o "es evidente".
 
 ---
 
+## Tests
+
+### Smoke tests pytest (ADR-019 Fase 1)
+
+**Convención: cada PR que introduce una nueva vista debe añadir su smoke test en el mismo PR.**
+
+- Ubicación: `tests/smoke/test_smoke_<vista>.py`
+- Un fichero por vista (o dominio relacionado).
+- Contenido mínimo: `GET <ruta>` → `assert status_code == 200` + `assert b'class="app-main"' in r.data`.
+- Login via fixture de rol: `usuario_admin`, `usuario_supervisor`, `usuario_tramitador`, `usuario_administrativo` (definidos en `tests/conftest.py`).
+- Si la vista necesita datos (expediente, entidad…): usar `expediente_seed` o consultar `Model.query.first()` + `pytest.skip` si no hay datos.
+- Vistas sin login: usar `client` directamente.
+- Los smoke tests se ejecutan con el resto de la suite pytest (`pytest tests/`). No hay configuración separada.
+
+---
+
 ## Commits
 
 Formato: `[CATEGORÍA] #N descripción en imperativo`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,107 @@ def client(app):
     """Flask test client — sin contexto de BD gestionado."""
     with app.test_client() as c:
         yield c
+
+
+# ---------------------------------------------------------------------------
+# Fixtures de autenticación por rol (#503 — smoke tests ADR-019)
+# ---------------------------------------------------------------------------
+
+def _login_as(client, app, rol_nombre):
+    """
+    Autentica el cliente de test usando session_transaction: fija _user_id
+    y rol_activo_nombre directamente en la sesión sin simular el formulario.
+    Devuelve True si el rol existe en la BD para el usuario CLG, False si no.
+    """
+    with app.app_context():
+        from app.models.usuarios import Usuario
+        u = Usuario.query.filter_by(siglas='CLG').first()
+        if u is None:
+            return False
+        rol = next((r for r in u.roles if r.nombre == rol_nombre), None)
+        if rol is None:
+            return False
+        uid, rol_id, rol_nombre_db = str(u.id), rol.id, rol.nombre
+
+    with client.session_transaction() as sess:
+        sess['_user_id'] = uid
+        sess['_fresh'] = True
+        sess['rol_activo_id'] = rol_id
+        sess['rol_activo_nombre'] = rol_nombre_db
+    return True
+
+
+@pytest.fixture
+def usuario_admin(client, app):
+    """Cliente autenticado como CLG con rol ADMIN."""
+    if not _login_as(client, app, 'ADMIN'):
+        pytest.skip('CLG con rol ADMIN no disponible en esta BD')
+    return client
+
+
+@pytest.fixture
+def usuario_supervisor(client, app):
+    """Cliente autenticado como CLG con rol SUPERVISOR."""
+    if not _login_as(client, app, 'SUPERVISOR'):
+        pytest.skip('CLG con rol SUPERVISOR no disponible en esta BD')
+    return client
+
+
+@pytest.fixture
+def usuario_tramitador(client, app):
+    """Cliente autenticado como CLG con rol TRAMITADOR."""
+    if not _login_as(client, app, 'TRAMITADOR'):
+        pytest.skip('CLG con rol TRAMITADOR no disponible en esta BD')
+    return client
+
+
+@pytest.fixture
+def usuario_administrativo(client, app):
+    """Cliente autenticado como CLG con rol ADMINISTRATIVO."""
+    if not _login_as(client, app, 'ADMINISTRATIVO'):
+        pytest.skip('CLG con rol ADMINISTRATIVO no disponible en esta BD')
+    return client
+
+
+@pytest.fixture
+def expediente_seed(app):
+    """ID del primer expediente en la BD de desarrollo. Skip si no existe ninguno."""
+    with app.app_context():
+        from app.models.expedientes import Expediente
+        exp = Expediente.query.first()
+        if exp is None:
+            pytest.skip('No hay expedientes en la BD de desarrollo')
+        return exp.id
+
+
+@pytest.fixture
+def entidad_seed(app):
+    """ID de la primera entidad en la BD de desarrollo. Skip si no existe ninguna."""
+    with app.app_context():
+        from app.models.entidad import Entidad
+        e = Entidad.query.first()
+        if e is None:
+            pytest.skip('No hay entidades en la BD de desarrollo')
+        return e.id
+
+
+@pytest.fixture
+def plantilla_seed(app):
+    """ID de la primera plantilla en la BD de desarrollo. Skip si no existe ninguna."""
+    with app.app_context():
+        from app.models.plantillas import Plantilla
+        p = Plantilla.query.first()
+        if p is None:
+            pytest.skip('No hay plantillas en la BD de desarrollo')
+        return p.id
+
+
+@pytest.fixture
+def primer_usuario_id(app):
+    """ID del primer usuario en la BD de desarrollo. Skip si no existe ninguno."""
+    with app.app_context():
+        from app.models.usuarios import Usuario
+        u = Usuario.query.first()
+        if u is None:
+            pytest.skip('No hay usuarios en la BD de desarrollo')
+        return u.id

--- a/tests/smoke/test_smoke_acceso_admin_roles.py
+++ b/tests/smoke/test_smoke_acceso_admin_roles.py
@@ -1,0 +1,44 @@
+"""Smoke tests de acceso por rol a áreas admin (ADR-013 / #503).
+
+Cubre ADMINISTRATIVO específicamente, complementando los tests de TRAMITADOR
+ya existentes en tests/test_497_permisos_blandos.py.
+
+ADMINISTRATIVO tiene 'acceder_plantillas' y 'acceder_usuarios'
+pero NO 'gestionar_plantillas' ni 'gestionar_usuarios'.
+"""
+
+
+# ---------------------------------------------------------------------------
+# ADMINISTRATIVO — acceso en lectura (debe ser 200)
+# ---------------------------------------------------------------------------
+
+def test_administrativo_puede_ver_plantillas(usuario_administrativo):
+    r = usuario_administrativo.get('/admin/plantillas/', follow_redirects=True)
+    assert r.status_code == 200, f'ADMINISTRATIVO no puede leer /admin/plantillas/ (status {r.status_code})'
+
+
+def test_administrativo_puede_ver_usuarios(usuario_administrativo):
+    r = usuario_administrativo.get('/usuarios/', follow_redirects=True)
+    assert r.status_code == 200, f'ADMINISTRATIVO no puede leer /usuarios/ (status {r.status_code})'
+
+
+# ---------------------------------------------------------------------------
+# ADMINISTRATIVO — mutaciones bloqueadas (deben devolver 302 → /perfil)
+# ---------------------------------------------------------------------------
+
+def test_administrativo_no_puede_crear_plantilla(usuario_administrativo):
+    r = usuario_administrativo.get('/admin/plantillas/nueva/', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+def test_administrativo_no_puede_editar_plantilla(usuario_administrativo, plantilla_seed):
+    r = usuario_administrativo.get(f'/admin/plantillas/{plantilla_seed}/editar', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')
+
+
+def test_administrativo_no_puede_editar_usuario(usuario_administrativo, primer_usuario_id):
+    r = usuario_administrativo.get(f'/usuarios/{primer_usuario_id}/editar', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/perfil' in r.headers.get('Location', '')

--- a/tests/smoke/test_smoke_dashboard.py
+++ b/tests/smoke/test_smoke_dashboard.py
@@ -1,0 +1,18 @@
+"""Smoke test — dashboard (/) y demo React (/demo/diagrama).
+
+/demo/diagrama no requiere login y sirve como referencia de assert del shell
+React (class="app-shell", <div id="app-root"), según nota de implementación #503.
+"""
+
+
+def test_dashboard_render(usuario_supervisor):
+    r = usuario_supervisor.get('/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data
+
+
+def test_demo_diagrama_render(client):
+    """Demo React — pública, sin login. Verifica shell React básico."""
+    r = client.get('/demo/diagrama', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'app-shell' in r.data or b'app-root' in r.data

--- a/tests/smoke/test_smoke_entidades_detalle.py
+++ b/tests/smoke/test_smoke_entidades_detalle.py
@@ -1,0 +1,7 @@
+"""Smoke test — detalle de entidad (/entidades/<id>)."""
+
+
+def test_entidad_detalle_render(usuario_supervisor, entidad_seed):
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_entidades_listado.py
+++ b/tests/smoke/test_smoke_entidades_listado.py
@@ -1,0 +1,7 @@
+"""Smoke test — listado de entidades (/entidades/)."""
+
+
+def test_entidades_listado_render(usuario_supervisor):
+    r = usuario_supervisor.get('/entidades/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_errores.py
+++ b/tests/smoke/test_smoke_errores.py
@@ -1,0 +1,12 @@
+"""Smoke test — páginas de error (404).
+
+El 500 no se prueba directamente: forzarlo requiere romper la app intencionalmente,
+lo que contamina el estado de la sesión de test. El handler se cubre implícitamente
+por cualquier test que falle con una excepción no capturada.
+"""
+
+
+def test_404_render(client):
+    r = client.get('/ruta/que/no/existe/en/ninguna/parte')
+    assert r.status_code == 404
+    assert b'404' in r.data

--- a/tests/smoke/test_smoke_expedientes_detalle.py
+++ b/tests/smoke/test_smoke_expedientes_detalle.py
@@ -1,0 +1,7 @@
+"""Smoke test — detalle de expediente (/expedientes/<id>)."""
+
+
+def test_expediente_detalle_render(usuario_supervisor, expediente_seed):
+    r = usuario_supervisor.get(f'/expedientes/{expediente_seed}', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_expedientes_listado.py
+++ b/tests/smoke/test_smoke_expedientes_listado.py
@@ -1,0 +1,7 @@
+"""Smoke test — listado de expedientes (/expedientes/)."""
+
+
+def test_expedientes_listado_render(usuario_supervisor):
+    r = usuario_supervisor.get('/expedientes/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_expedientes_pool.py
+++ b/tests/smoke/test_smoke_expedientes_pool.py
@@ -1,0 +1,7 @@
+"""Smoke test — pool de documentos del expediente (/expedientes/<id>/documentos)."""
+
+
+def test_expediente_pool_render(usuario_supervisor, expediente_seed):
+    r = usuario_supervisor.get(f'/expedientes/{expediente_seed}/documentos', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_expedientes_seguimiento.py
+++ b/tests/smoke/test_smoke_expedientes_seguimiento.py
@@ -1,0 +1,11 @@
+"""Smoke test — seguimiento de expedientes (/expedientes/seguimiento/).
+
+Precursor del área "Mi trabajo" (#501, aún no implementada).
+Cuando exista /mi_trabajo/, añadir test_smoke_mi_trabajo.py en ese mismo PR.
+"""
+
+
+def test_expedientes_seguimiento_render(usuario_supervisor):
+    r = usuario_supervisor.get('/expedientes/seguimiento/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_login.py
+++ b/tests/smoke/test_smoke_login.py
@@ -1,0 +1,10 @@
+"""Smoke test — vista de login (/auth/login).
+
+Pública, no requiere autenticación.
+"""
+
+
+def test_login_render(client):
+    r = client.get('/auth/login')
+    assert r.status_code == 200
+    assert b'login' in r.data.lower()

--- a/tests/smoke/test_smoke_perfil.py
+++ b/tests/smoke/test_smoke_perfil.py
@@ -1,0 +1,7 @@
+"""Smoke test — perfil del usuario (/perfil/)."""
+
+
+def test_perfil_render(usuario_supervisor):
+    r = usuario_supervisor.get('/perfil/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_plantillas_detalle.py
+++ b/tests/smoke/test_smoke_plantillas_detalle.py
@@ -1,0 +1,7 @@
+"""Smoke test — detalle de plantilla (/admin/plantillas/<id>/)."""
+
+
+def test_plantilla_detalle_render(usuario_supervisor, plantilla_seed):
+    r = usuario_supervisor.get(f'/admin/plantillas/{plantilla_seed}/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_plantillas_listado.py
+++ b/tests/smoke/test_smoke_plantillas_listado.py
@@ -1,0 +1,7 @@
+"""Smoke test — listado de plantillas (/admin/plantillas/)."""
+
+
+def test_plantillas_listado_render(usuario_supervisor):
+    r = usuario_supervisor.get('/admin/plantillas/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_proyectos_listado.py
+++ b/tests/smoke/test_smoke_proyectos_listado.py
@@ -1,0 +1,7 @@
+"""Smoke test — listado de proyectos (/proyectos/)."""
+
+
+def test_proyectos_listado_render(usuario_supervisor):
+    r = usuario_supervisor.get('/proyectos/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data

--- a/tests/smoke/test_smoke_usuarios_listado.py
+++ b/tests/smoke/test_smoke_usuarios_listado.py
@@ -1,0 +1,7 @@
+"""Smoke test — listado de usuarios (/usuarios/)."""
+
+
+def test_usuarios_listado_render(usuario_supervisor):
+    r = usuario_supervisor.get('/usuarios/', follow_redirects=True)
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data


### PR DESCRIPTION
## Cambios

- **`tests/conftest.py`**: fixtures de autenticación por rol (`usuario_admin`, `usuario_supervisor`, `usuario_tramitador`, `usuario_administrativo`) vía `session_transaction` — fija `_user_id` y `rol_activo_nombre` directamente en sesión sin simular el formulario de login. Fixtures de datos: `expediente_seed`, `entidad_seed`, `plantilla_seed`, `primer_usuario_id`.
- **`tests/smoke/`** (15 ficheros nuevos): smoke tests para todas las vistas existentes hoy — dashboard, login, perfil, expedientes (listado/detalle/pool/seguimiento), entidades (listado/detalle), proyectos, usuarios, plantillas (listado/detalle), errores 404, acceso por rol ADMINISTRATIVO (ADR-013).
- **`docs/guias/REGLAS_DESARROLLO.md`**: sección § Tests con la convención "una vista nueva = un smoke test nuevo en el mismo PR".

20/20 smoke tests pasan (~1.6s). Rutas diferidas: `/expedientes/<id>/arbol` (#500) y `/mi_trabajo/` (#501) se añadirán en sus respectivos PRs.

Closes #503
