### PR TITLE
Corregir norma_origen CIERRE en catalogo_plazos (RD 88/2026)

### DIFF
--- a/migrations/versions/685e93a0c79e_fix_datos_test346_salida_registro_.py
+++ b/migrations/versions/685e93a0c79e_fix_datos_test346_salida_registro_.py
@@ -17,17 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    # test_346: REGISTRO_INTERESADOS (tipo_tramite_id=31) le faltaba la fila SALIDA
-    # en tramites_tareas_documentos. Mismo patrón que el resto de tareas ANALIZAR orden=1.
-    op.execute("""
-        INSERT INTO public.tramites_tareas_documentos
-            (tipo_tramite_id, orden_tarea, rol, tipo_documento_id, obligatorio)
-        VALUES (31, 1, 'SALIDA', 15, true)
-        ON CONFLICT DO NOTHING
-    """)
-
-    # test_448: norma_origen de CIERRE en catalogo_plazos desactualizada.
-    # RD 88/2026 modifica el art. 138 RD 1955/2000.
+    # RD 88/2026 modifica el art. 138 RD 1955/2000 — actualizar cita en catálogo de plazos.
     op.execute("""
         UPDATE public.catalogo_plazos
         SET norma_origen = 'Art. 138 RD 1955/2000 (mod. RD 88/2026)'
@@ -37,10 +27,6 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("""
-        DELETE FROM public.tramites_tareas_documentos
-        WHERE tipo_tramite_id = 31 AND orden_tarea = 1 AND rol = 'SALIDA'
-    """)
     op.execute("""
         UPDATE public.catalogo_plazos
         SET norma_origen = 'Art. 138 RD 1955/2000'

--- a/migrations/versions/685e93a0c79e_fix_datos_test346_salida_registro_.py
+++ b/migrations/versions/685e93a0c79e_fix_datos_test346_salida_registro_.py
@@ -1,0 +1,48 @@
+"""fix datos test346 salida registro_interesados y test448 norma cierre
+
+Revision ID: 685e93a0c79e
+Revises: 6a2e29774f16
+Create Date: 2026-05-29 19:28:57.545554
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '685e93a0c79e'
+down_revision = '6a2e29774f16'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # test_346: REGISTRO_INTERESADOS (tipo_tramite_id=31) le faltaba la fila SALIDA
+    # en tramites_tareas_documentos. Mismo patrón que el resto de tareas ANALIZAR orden=1.
+    op.execute("""
+        INSERT INTO public.tramites_tareas_documentos
+            (tipo_tramite_id, orden_tarea, rol, tipo_documento_id, obligatorio)
+        VALUES (31, 1, 'SALIDA', 15, true)
+        ON CONFLICT DO NOTHING
+    """)
+
+    # test_448: norma_origen de CIERRE en catalogo_plazos desactualizada.
+    # RD 88/2026 modifica el art. 138 RD 1955/2000.
+    op.execute("""
+        UPDATE public.catalogo_plazos
+        SET norma_origen = 'Art. 138 RD 1955/2000 (mod. RD 88/2026)'
+        WHERE id = 111
+          AND norma_origen = 'Art. 138 RD 1955/2000'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM public.tramites_tareas_documentos
+        WHERE tipo_tramite_id = 31 AND orden_tarea = 1 AND rol = 'SALIDA'
+    """)
+    op.execute("""
+        UPDATE public.catalogo_plazos
+        SET norma_origen = 'Art. 138 RD 1955/2000'
+        WHERE id = 111
+    """)


### PR DESCRIPTION
## Cambios

- **`catalogo_plazos` id=111**: actualizar `norma_origen` de `'Art. 138 RD 1955/2000'` a `'Art. 138 RD 1955/2000 (mod. RD 88/2026)'` — el RD 88/2026 modifica ese artículo; el test ya reflejaba la cita correcta pero el dato en BD no se había actualizado.

Corrige `test_448_seed_plazos_resolucion` (2 tests). El fallo de `test_346` se resolvió con INSERT directo sobre la BD de desarrollo (dato operacional, no estructural).
