### PR TITLE
Árbol del expediente: endpoints de mutación + modo edición (S3b-0/1)

### DIFF
--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -36,6 +36,7 @@ from app.models.configuracion_sistema import ConfiguracionSistema
 from app.services.invariantes_esftt import (
     check_invariante, _check_cierre_fase, RESULTADO_FASE_FAVORABLE_CODIGOS,
 )
+from app.services import mutaciones_arbol as svc
 
 bp = Blueprint('api_bc', __name__, url_prefix='/api/bc')
 
@@ -97,6 +98,11 @@ def _evaluar(accion: str, expediente, *, objeto) -> EvaluacionResult:
     return _aplicar_modo_global(evaluar_multi(accion, expediente, objeto=objeto))
 
 
+def _res_error(res):
+    """Traduce ResultadoMutacion de error a respuesta HTTP 422."""
+    return jsonify({'ok': False, 'error': res.error}), 422
+
+
 # ============================================
 # ENDPOINTS POST — CREAR entidades
 # ============================================
@@ -123,8 +129,6 @@ def crear_solicitud(exp_id):
     if err:
         return err
 
-    # Fase 1: validar tipos y evaluar motor antes de crear ninguna solicitud.
-    # Si cualquiera está bloqueada, se rechaza todo sin modificar la BD.
     tipos_a_crear = []
     for tid in tipo_ids:
         try:
@@ -134,44 +138,14 @@ def crear_solicitud(exp_id):
         tipo = TipoSolicitud.query.get(tid_int)
         if not tipo:
             return jsonify({'ok': False, 'error': f'Tipo de solicitud {tid_int} no encontrado'}), 404
-
-        if justificacion is None:
-            # stub transiente: precarga tipo_solicitud para que el assembler
-            # compile el sujeto sin necesitar flush
-            sol_stub = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
-                                 tipo_solicitud_id=tid_int)
-            sol_stub.tipo_solicitud = tipo
-            res_eval = _evaluar('CREAR', expediente, objeto=sol_stub)
-            if not res_eval.permitido:
-                return _bloqueo(res_eval)
-
         tipos_a_crear.append(tipo)
 
-    # Fase 2: crear y persistir
-    creadas = []
-    try:
-        for tipo in tipos_a_crear:
-            sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
-                            tipo_solicitud_id=tipo.id)
-            db.session.add(sol)
-            db.session.flush()  # obtener sol.id para la bitácora
-
-            if justificacion:
-                sujeto = build_sujeto(expediente, sol)
-                bitacora_svc.registrar(
-                    current_user.id, 'CREAR', 'solicitudes', sol.id,
-                    detalle={'escape': True, 'justificacion': justificacion,
-                             'sujeto': sujeto},
-                )
-            creadas.append(sol)
-
-        db.session.commit()
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': str(e)}), 500
-
-    ids = [s.id for s in creadas]
-    return jsonify({'ok': True, 'ids': ids})
+    res = svc.crear_solicitud(expediente, tipos_a_crear, entidad_id, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True, 'ids': res.ids})
 
 
 @bp.route('/solicitud/<int:sol_id>/fases/nueva', methods=['POST'])
@@ -193,30 +167,12 @@ def crear_fase(sol_id):
     if err:
         return err
 
-    if justificacion is None:
-        res_eval = _evaluar('CREAR', sol.expediente, objeto={'solicitud': sol, 'tipo_fase': tipo_fase})
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-    else:
-        res_eval = PERMITIDO
-
-    fase = Fase(solicitud_id=sol_id, tipo_fase_id=tipo_fase_id)
-    db.session.add(fase)
-    db.session.flush()
-
-    if tipo_fase.codigo in _FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS:
-        from app.services.cert_fin_ip_consultas import crear_cert_fin_ip_consultas
-        crear_cert_fin_ip_consultas(sol.expediente, sol)
-
-    if justificacion:
-        sujeto = build_sujeto(sol.expediente, {'solicitud': sol, 'tipo_fase': tipo_fase})
-        bitacora_svc.registrar(
-            current_user.id, 'CREAR', 'fases', fase.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    db.session.commit()
-    return jsonify({'ok': True, 'id': fase.id, 'advertencia': _advertencia(res_eval)})
+    res = svc.crear_fase(sol, tipo_fase, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True, 'id': res.ids[0], 'advertencia': res.advertencia})
 
 
 _CODIGOS_TRASLADO = frozenset({'CONSULTA_TRASLADO_ORGANISMO', 'CONSULTA_TRASLADO_TITULAR'})
@@ -238,37 +194,16 @@ def crear_tramite(fase_id):
     if not tipo_tramite:
         return jsonify({'ok': False, 'error': 'Tipo de trámite no encontrado'}), 404
 
-    if tipo_tramite.codigo in _CODIGOS_TRASLADO:
-        return jsonify({
-            'ok': False,
-            'error': 'Los trámites de traslado se crean desde la acción específica de organismo',
-        }), 400
-
     justificacion, err = _leer_bypass(request.form)
     if err:
         return err
 
-    expediente = fase.solicitud.expediente
-    if justificacion is None:
-        res_eval = _evaluar('CREAR', expediente, objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-    else:
-        res_eval = PERMITIDO
-
-    tramite = Tramite(fase_id=fase_id, tipo_tramite_id=tipo_tramite_id)
-    db.session.add(tramite)
-    db.session.flush()
-
-    if justificacion:
-        sujeto = build_sujeto(expediente, {'fase': fase, 'tipo_tramite': tipo_tramite})
-        bitacora_svc.registrar(
-            current_user.id, 'CREAR', 'tramites', tramite.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    db.session.commit()
-    return jsonify({'ok': True, 'id': tramite.id, 'advertencia': _advertencia(res_eval)})
+    res = svc.crear_tramite(fase, tipo_tramite, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True, 'id': res.ids[0], 'advertencia': res.advertencia})
 
 
 @bp.route('/tramite/<int:tram_id>/tareas/nueva', methods=['POST'])
@@ -290,27 +225,12 @@ def crear_tarea(tram_id):
     if err:
         return err
 
-    expediente = tramite.fase.solicitud.expediente
-    if justificacion is None:
-        res_eval = _evaluar('CREAR', expediente, objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea})
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-    else:
-        res_eval = PERMITIDO
-
-    tarea = Tarea(tramite_id=tram_id, tipo_tarea_id=tipo_tarea_id)
-    db.session.add(tarea)
-    db.session.flush()
-
-    if justificacion:
-        sujeto = build_sujeto(expediente, tramite)
-        bitacora_svc.registrar(
-            current_user.id, 'CREAR', 'tareas', tarea.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    db.session.commit()
-    return jsonify({'ok': True, 'id': tarea.id, 'advertencia': _advertencia(res_eval)})
+    res = svc.crear_tarea(tramite, tipo_tarea, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True, 'id': res.ids[0], 'advertencia': res.advertencia})
 
 
 # ============================================
@@ -326,13 +246,10 @@ def editar_solicitud(sol_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    try:
-        sol.observaciones = request.form.get('observaciones') or None
-        db.session.commit()
-        return jsonify({'ok': True})
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    res = svc.editar_solicitud(sol, observaciones=request.form.get('observaciones'))
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True})
 
 
 @bp.route('/fase/<int:fase_id>/editar', methods=['POST'])
@@ -345,30 +262,17 @@ def editar_fase(fase_id):
 
     doc_resultado_raw = request.form.get('documento_resultado_id')
     nuevo_doc_resultado_id = int(doc_resultado_raw) if doc_resultado_raw else None
+    resultado_id = request.form.get('resultado_fase_id')
+    resultado_fase_id = int(resultado_id) if resultado_id else None
 
-    if nuevo_doc_resultado_id and fase.documento_resultado_id is None:
-        doc = Documento.query.get(nuevo_doc_resultado_id)
-        if not doc or doc.expediente_id != fase.solicitud.expediente_id:
-            return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
-
-        resultado_id_raw = request.form.get('resultado_fase_id')
-        if resultado_id_raw:
-            tipo_res = TipoResultadoFase.query.get(int(resultado_id_raw))
-            if tipo_res:
-                res_inv = _check_cierre_fase(fase_id, tipo_res.codigo)
-                if res_inv:
-                    return _bloqueo(res_inv)
-
-    try:
-        resultado_id = request.form.get('resultado_fase_id')
-        fase.resultado_fase_id = int(resultado_id) if resultado_id else None
-        fase.documento_resultado_id = nuevo_doc_resultado_id
-        fase.observaciones = request.form.get('observaciones') or None
-        db.session.commit()
-        return jsonify({'ok': True})
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    res = svc.editar_fase(fase, resultado_fase_id=resultado_fase_id,
+                          documento_resultado_id=nuevo_doc_resultado_id,
+                          observaciones=request.form.get('observaciones'))
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True})
 
 
 @bp.route('/tramite/<int:tram_id>/editar', methods=['POST'])
@@ -379,13 +283,10 @@ def editar_tramite(tram_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    try:
-        tramite.observaciones = request.form.get('observaciones') or None
-        db.session.commit()
-        return jsonify({'ok': True})
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    res = svc.editar_tramite(tramite, observaciones=request.form.get('observaciones'))
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True})
 
 
 @bp.route('/tarea/<int:tarea_id>/editar', methods=['POST'])
@@ -396,46 +297,20 @@ def editar_tarea(tarea_id):
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
-    expediente = tarea.tramite.fase.solicitud.expediente
+    consumidos_raw = request.form.getlist('documentos_consumidos_ids')
+    if len(consumidos_raw) == 1 and ',' in consumidos_raw[0]:
+        consumidos_raw = consumidos_raw[0].split(',')
+    ids_consumidos = [int(x) for x in consumidos_raw if x.strip()]
 
-    try:
-        # Documentos consumidos: lista de ids (campo repetido o CSV). Documento
-        # producido: id único. Vínculos vía documentos_tarea con rol (ADR-010).
-        consumidos_raw = request.form.getlist('documentos_consumidos_ids')
-        if len(consumidos_raw) == 1 and ',' in consumidos_raw[0]:
-            consumidos_raw = consumidos_raw[0].split(',')
-        ids_consumidos = [int(x) for x in consumidos_raw if x.strip()]
+    doc_producido_raw = request.form.get('documento_producido_id') or None
+    id_producido = int(doc_producido_raw) if doc_producido_raw else None
 
-        doc_producido_raw = request.form.get('documento_producido_id') or None
-        id_producido = int(doc_producido_raw) if doc_producido_raw else None
-
-        ids_todos = list(ids_consumidos) + ([id_producido] if id_producido else [])
-        for doc_id in ids_todos:
-            doc = Documento.query.get(doc_id)
-            if not doc or doc.expediente_id != expediente.id:
-                return jsonify({'ok': False, 'error': 'Documento no válido para este expediente'}), 422
-
-        # Reconstruir los vínculos de la tarea
-        tarea.vinculos_documento.clear()
-        db.session.flush()
-        for doc_id in dict.fromkeys(ids_consumidos):   # sin duplicados, orden estable
-            tarea.vinculos_documento.append(
-                DocumentoTarea(documento_id=doc_id, rol='CONSUMIDO'))
-        if id_producido:
-            tarea.vinculos_documento.append(
-                DocumentoTarea(documento_id=id_producido, rol='PRODUCIDO'))
-
-        tarea.notas = request.form.get('notas') or None
-        _hook_458_analizar_separata(tarea, id_producido)
-        db.session.commit()
-
-        return jsonify({'ok': True})
-    except IntegrityError:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': 'Este documento ya está asignado como producido a otra tarea'}), 422
-    except Exception as e:
-        db.session.rollback()
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    res = svc.editar_tarea(tarea, documentos_consumidos_ids=ids_consumidos,
+                           documento_producido_id=id_producido,
+                           notas=request.form.get('notas'))
+    if not res.ok:
+        return _res_error(res)
+    return jsonify({'ok': True})
 
 
 # ============================================
@@ -454,27 +329,11 @@ def borrar_solicitud(sol_id):
     if err:
         return err
 
-    if justificacion is None:
-        res_eval = _evaluar('BORRAR', sol.expediente, objeto=sol)
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-
-    if justificacion:
-        sujeto = build_sujeto(sol.expediente, sol)
-        bitacora_svc.registrar(
-            current_user.id, 'BORRAR', 'solicitudes', sol.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol_id).all()]
-    if fase_ids:
-        tram_ids = [t.id for t in Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).all()]
-        if tram_ids:
-            Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
-        Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).delete()
-    Fase.query.filter_by(solicitud_id=sol_id).delete()
-    db.session.delete(sol)
-    db.session.commit()
+    res = svc.borrar_solicitud(sol, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
     return jsonify({'ok': True})
 
 
@@ -490,25 +349,11 @@ def borrar_fase(fase_id):
     if err:
         return err
 
-    expediente = fase.solicitud.expediente
-    if justificacion is None:
-        res_eval = _evaluar('BORRAR', expediente, objeto=fase)
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-
-    if justificacion:
-        sujeto = build_sujeto(expediente, fase)
-        bitacora_svc.registrar(
-            current_user.id, 'BORRAR', 'fases', fase.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase_id).all()]
-    if tram_ids:
-        Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
-    Tramite.query.filter_by(fase_id=fase_id).delete()
-    db.session.delete(fase)
-    db.session.commit()
+    res = svc.borrar_fase(fase, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
     return jsonify({'ok': True})
 
 
@@ -524,22 +369,11 @@ def borrar_tramite(tram_id):
     if err:
         return err
 
-    expediente = tramite.fase.solicitud.expediente
-    if justificacion is None:
-        res_eval = _evaluar('BORRAR', expediente, objeto=tramite)
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-
-    if justificacion:
-        sujeto = build_sujeto(expediente, tramite)
-        bitacora_svc.registrar(
-            current_user.id, 'BORRAR', 'tramites', tramite.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    Tarea.query.filter_by(tramite_id=tram_id).delete()
-    db.session.delete(tramite)
-    db.session.commit()
+    res = svc.borrar_tramite(tramite, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
     return jsonify({'ok': True})
 
 
@@ -555,21 +389,11 @@ def borrar_tarea(tarea_id):
     if err:
         return err
 
-    expediente = tarea.tramite.fase.solicitud.expediente
-    if justificacion is None:
-        res_eval = _evaluar('BORRAR', expediente, objeto=tarea)
-        if not res_eval.permitido:
-            return _bloqueo(res_eval)
-
-    if justificacion:
-        sujeto = build_sujeto(expediente, tarea.tramite)
-        bitacora_svc.registrar(
-            current_user.id, 'BORRAR', 'tareas', tarea.id,
-            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
-        )
-
-    db.session.delete(tarea)
-    db.session.commit()
+    res = svc.borrar_tarea(tarea, justificacion=justificacion)
+    if res.bloqueo:
+        return _bloqueo(res.bloqueo)
+    if not res.ok:
+        return _res_error(res)
     return jsonify({'ok': True})
 
 
@@ -674,16 +498,6 @@ def _traslado_titular_vencido(oe) -> bool:
         return False
     ep = plazos.obtener_estado_plazo(vinculo.tramite, 'TRAMITE', variables={})
     return ep.estado == 'VENCIDO'
-
-
-def _hook_458_analizar_separata(tarea, id_producido):
-    """Hook #458: al producir diagnóstico en CONSULTA_SEPARATA pasa el organismo a en_tramitacion."""
-    if (id_producido is not None
-            and tarea.tipo_tarea.codigo == 'ANALIZAR'
-            and tarea.tramite.tipo_tramite.codigo == 'CONSULTA_SEPARATA'):
-        vinculo = TramiteOrganismo.query.filter_by(tramite_id=tarea.tramite_id).first()
-        if vinculo:
-            vinculo.organismo_expediente.estado = 'en_tramitacion'
 
 
 # ============================================

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -20,11 +20,14 @@ from app.models.entidad import Entidad
 from app.models.tipos_expedientes import TipoExpediente
 from app.models import (
     Solicitud, Fase, TipoSolicitud, TipoFase,
-    Proyecto, TipoIA, Usuario
+    Proyecto, TipoIA, Usuario,
+    Tramite, Tarea, TipoTramite, TipoTarea, Documento,
 )
 from app.services.arbol_expediente import construir_arbol
 from app.services.tipos_creables import tipos_creables_de_nodo
 from app.services.detalle_nodo import detalle_de_nodo
+from app.services.esquema_editable import esquema_de_nodo
+from app.services import mutaciones_arbol as svc
 from app.utils.permisos import verificar_acceso_expediente
 
 # Blueprint para API
@@ -530,6 +533,257 @@ def get_detalle_nodo(expediente_id, tipo, nodo_id):
 
     try:
         data = detalle_de_nodo(expediente, tipo, nodo_id)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 404
+    return jsonify(data), 200
+
+
+# =============================================================================
+# Helper privado de resolución de nodo
+# =============================================================================
+
+def _resolver_nodo(expediente, tipo: str, nodo_id: int):
+    """(tipo, nodo_id) → objeto del modelo validando pertenencia. ValueError si no."""
+    if tipo == 'expediente':
+        if nodo_id != expediente.id:
+            raise ValueError(
+                f'Nodo expediente {nodo_id} no coincide con el expediente {expediente.id}')
+        return expediente
+    if tipo == 'solicitud':
+        obj = Solicitud.query.get(nodo_id)
+        if obj is None or obj.expediente_id != expediente.id:
+            raise ValueError(f'Solicitud {nodo_id} no encontrada en expediente {expediente.id}')
+        return obj
+    if tipo == 'fase':
+        obj = Fase.query.get(nodo_id)
+        if obj is None or obj.solicitud.expediente_id != expediente.id:
+            raise ValueError(f'Fase {nodo_id} no encontrada en expediente {expediente.id}')
+        return obj
+    if tipo == 'tramite':
+        obj = Tramite.query.get(nodo_id)
+        if obj is None or obj.fase.solicitud.expediente_id != expediente.id:
+            raise ValueError(f'Trámite {nodo_id} no encontrado en expediente {expediente.id}')
+        return obj
+    if tipo == 'tarea':
+        obj = Tarea.query.get(nodo_id)
+        if obj is None or obj.tramite.fase.solicitud.expediente_id != expediente.id:
+            raise ValueError(f'Tarea {nodo_id} no encontrada en expediente {expediente.id}')
+        return obj
+    raise ValueError(f'Tipo de nodo desconocido: {tipo!r}')
+
+
+def _bloqueo_422(res):
+    """Respuesta uniforme árbol para bloqueo del motor."""
+    return jsonify({
+        'error': 'Bloqueado por el motor',
+        'motivo': res.bloqueo.motivo,
+        'url_norma': res.bloqueo.url_norma,
+    }), 422
+
+
+# =============================================================================
+# ENDPOINT 6: Crear hijo bajo un nodo (ADR-016 S3b)
+# =============================================================================
+
+@api_bp.route('/expedientes/<int:expediente_id>/nodo/<padre_tipo>/<int:padre_id>/hijos',
+              methods=['POST'])
+@login_required
+def crear_hijo_nodo(expediente_id, padre_tipo, padre_id):
+    """
+    POST .../nodo/<padre_tipo>/<padre_id>/hijos — crear hijo bajo un nodo (ADR-016 §S3b).
+
+    Body JSON: {tipo_id} o {tipo_ids:[...]} cuando padre_tipo=='expediente'.
+    Respuesta éxito: {ok:true, ids:[...]} 201.
+    Bloqueo motor: {error, motivo, url_norma} 422.
+    """
+    expediente = Expediente.query.get_or_404(expediente_id)
+    denegado = verificar_acceso_expediente(expediente, 'editar')
+    if denegado:
+        return denegado
+
+    try:
+        padre = _resolver_nodo(expediente, padre_tipo, padre_id)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 404
+
+    data = request.get_json(silent=True) or {}
+
+    if padre_tipo == 'expediente':
+        tipo_ids = data.get('tipo_ids') or (
+            [data['tipo_id']] if 'tipo_id' in data else None)
+        if not tipo_ids:
+            return jsonify({'error': 'Se requiere tipo_id o tipo_ids'}), 422
+        tipos = []
+        for tid in tipo_ids:
+            t = TipoSolicitud.query.get(tid)
+            if not t:
+                return jsonify({'error': f'TipoSolicitud {tid} no encontrado'}), 404
+            tipos.append(t)
+        res = svc.crear_solicitud(expediente, tipos, expediente.titular_id)
+
+    elif padre_tipo == 'solicitud':
+        tipo_id = data.get('tipo_id')
+        if not tipo_id:
+            return jsonify({'error': 'Se requiere tipo_id'}), 422
+        tipo = TipoFase.query.get(tipo_id)
+        if not tipo:
+            return jsonify({'error': f'TipoFase {tipo_id} no encontrado'}), 404
+        res = svc.crear_fase(padre, tipo)
+
+    elif padre_tipo == 'fase':
+        tipo_id = data.get('tipo_id')
+        if not tipo_id:
+            return jsonify({'error': 'Se requiere tipo_id'}), 422
+        tipo = TipoTramite.query.get(tipo_id)
+        if not tipo:
+            return jsonify({'error': f'TipoTramite {tipo_id} no encontrado'}), 404
+        res = svc.crear_tramite(padre, tipo)
+
+    elif padre_tipo == 'tramite':
+        tipo_id = data.get('tipo_id')
+        if not tipo_id:
+            return jsonify({'error': 'Se requiere tipo_id'}), 422
+        tipo = TipoTarea.query.get(tipo_id)
+        if not tipo:
+            return jsonify({'error': f'TipoTarea {tipo_id} no encontrado'}), 404
+        res = svc.crear_tarea(padre, tipo)
+
+    else:
+        return jsonify({'error': f'Tipo de nodo no admite hijos: {padre_tipo!r}'}), 422
+
+    if res.bloqueo:
+        return _bloqueo_422(res)
+    if not res.ok:
+        return jsonify({'error': res.error}), 422
+
+    payload = {'ok': True, 'ids': res.ids}
+    if res.advertencia:
+        payload['advertencia'] = res.advertencia
+    return jsonify(payload), 201
+
+
+# =============================================================================
+# ENDPOINT 7: Editar un nodo (ADR-016 S3b)
+# =============================================================================
+
+@api_bp.route('/expedientes/<int:expediente_id>/nodo/<tipo>/<int:nodo_id>',
+              methods=['PATCH'])
+@login_required
+def editar_nodo(expediente_id, tipo, nodo_id):
+    """
+    PATCH .../nodo/<tipo>/<nodo_id> — editar campos de un nodo (ADR-016 §S3b).
+
+    Body JSON varía por nivel:
+      solicitud: {observaciones}
+      fase:      {resultado_fase_id, documento_resultado_id, observaciones}
+      tramite:   {observaciones}
+      tarea:     {documentos_consumidos_ids, documento_producido_id, notas}
+    Respuesta éxito: {ok:true} 200. Bloqueo motor: {error, motivo, url_norma} 422.
+    """
+    expediente = Expediente.query.get_or_404(expediente_id)
+    denegado = verificar_acceso_expediente(expediente, 'editar')
+    if denegado:
+        return denegado
+
+    try:
+        nodo = _resolver_nodo(expediente, tipo, nodo_id)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 404
+
+    data = request.get_json(silent=True) or {}
+
+    if tipo == 'solicitud':
+        res = svc.editar_solicitud(nodo, observaciones=data.get('observaciones'))
+    elif tipo == 'fase':
+        res = svc.editar_fase(
+            nodo,
+            resultado_fase_id=data.get('resultado_fase_id'),
+            documento_resultado_id=data.get('documento_resultado_id'),
+            observaciones=data.get('observaciones'),
+        )
+    elif tipo == 'tramite':
+        res = svc.editar_tramite(nodo, observaciones=data.get('observaciones'))
+    elif tipo == 'tarea':
+        res = svc.editar_tarea(
+            nodo,
+            documentos_consumidos_ids=data.get('documentos_consumidos_ids') or [],
+            documento_producido_id=data.get('documento_producido_id'),
+            notas=data.get('notas'),
+        )
+    else:
+        return jsonify({'error': f'Tipo de nodo no editable: {tipo!r}'}), 422
+
+    if res.bloqueo:
+        return _bloqueo_422(res)
+    if not res.ok:
+        return jsonify({'error': res.error}), 422
+    return jsonify({'ok': True}), 200
+
+
+# =============================================================================
+# ENDPOINT 8: Borrar un nodo (ADR-016 S3b)
+# =============================================================================
+
+@api_bp.route('/expedientes/<int:expediente_id>/nodo/<tipo>/<int:nodo_id>',
+              methods=['DELETE'])
+@login_required
+def borrar_nodo(expediente_id, tipo, nodo_id):
+    """
+    DELETE .../nodo/<tipo>/<nodo_id> — borrar un nodo (ADR-016 §S3b).
+
+    Sin body. Respuesta éxito: {ok:true} 200. Bloqueo motor: {error, motivo, url_norma} 422.
+    """
+    expediente = Expediente.query.get_or_404(expediente_id)
+    denegado = verificar_acceso_expediente(expediente, 'editar')
+    if denegado:
+        return denegado
+
+    try:
+        nodo = _resolver_nodo(expediente, tipo, nodo_id)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 404
+
+    if tipo == 'solicitud':
+        res = svc.borrar_solicitud(nodo)
+    elif tipo == 'fase':
+        res = svc.borrar_fase(nodo)
+    elif tipo == 'tramite':
+        res = svc.borrar_tramite(nodo)
+    elif tipo == 'tarea':
+        res = svc.borrar_tarea(nodo)
+    else:
+        return jsonify({'error': f'Tipo de nodo no borrable: {tipo!r}'}), 422
+
+    if res.bloqueo:
+        return _bloqueo_422(res)
+    if not res.ok:
+        return jsonify({'error': res.error}), 422
+    return jsonify({'ok': True}), 200
+
+
+# =============================================================================
+# ENDPOINT 9: Esquema editable de un nodo (ADR-016 S3b)
+# =============================================================================
+
+@api_bp.route('/expedientes/<int:expediente_id>/nodo/<tipo>/<int:nodo_id>/editable',
+              methods=['GET'])
+@login_required
+def get_esquema_editable(expediente_id, tipo, nodo_id):
+    """
+    GET .../nodo/<tipo>/<nodo_id>/editable — esquema de campos editables (ADR-016 §S3b).
+
+    Devuelve el contrato genérico que el inspector usa para pintar el formulario editor:
+    {nodo:{tipo,id}, campos:[{campo, etiqueta, control, valor, opciones?}]}.
+    El expediente devuelve campos:[] (no editable en v1).
+    """
+    expediente = Expediente.query.get_or_404(expediente_id)
+
+    denegado = verificar_acceso_expediente(expediente)
+    if denegado:
+        return denegado
+
+    try:
+        data = esquema_de_nodo(expediente, tipo, nodo_id)
     except ValueError as e:
         return jsonify({'error': str(e)}), 404
     return jsonify(data), 200

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -573,11 +573,20 @@ def _resolver_nodo(expediente, tipo: str, nodo_id: int):
 
 
 def _bloqueo_422(res):
-    """Respuesta uniforme árbol para bloqueo del motor."""
+    """Respuesta uniforme árbol para bloqueo del motor o de un invariante ESFTT.
+
+    El mensaje legible del bloqueo puede venir de DOS fuentes (ver EvaluacionResult):
+      · motor de reglas    → `motivo` (descripción editorial de la regla)
+      · invariantes ESFTT  → `norma_compilada` (su `_bloquear` deja `motivo=''`)
+    Por eso se surfacea `motivo or norma_compilada` (mismo criterio que
+    api_bc._res_error). Omitir el fallback dejaba los bloqueos de invariante con
+    `motivo` vacío y el front solo mostraba el genérico "Bloqueado por el motor".
+    """
+    b = res.bloqueo
     return jsonify({
         'error': 'Bloqueado por el motor',
-        'motivo': res.bloqueo.motivo,
-        'url_norma': res.bloqueo.url_norma,
+        'motivo': b.motivo or b.norma_compilada,
+        'url_norma': b.url_norma,
     }), 422
 
 

--- a/app/services/esquema_editable.py
+++ b/app/services/esquema_editable.py
@@ -1,0 +1,161 @@
+"""
+esquema_editable.py — Esquema de campos editables de un nodo del árbol (ADR-016, S3b-0).
+
+Devuelve el contrato genérico que el inspector usa para pintar el formulario editor:
+    {
+      "nodo": {"tipo": str, "id": int},
+      "campos": [{"campo", "etiqueta", "control", "valor", "opciones"?}, ...]
+    }
+
+`control` ∈ {text, textarea, select}.
+`campo` mapea 1:1 a la clave que espera el PATCH editar de ese nivel.
+
+Defensivo ante catálogo no disponible: degrada a campos:[] (igual que detalle_nodo).
+ValueError si el nodo no pertenece al expediente (la ruta lo traduce a 404).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.exc import OperationalError, ProgrammingError
+
+from app.models.solicitudes import Solicitud
+from app.models.fases import Fase
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.models.tipos_resultados_fases import TipoResultadoFase
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# API pública
+# ---------------------------------------------------------------------------
+
+def esquema_de_nodo(expediente, tipo_nodo: str, nodo_id: int) -> dict:
+    """
+    Esquema editable del nodo (tipo_nodo, nodo_id) del expediente.
+
+    Lanza ValueError si el nodo no existe o no pertenece al expediente.
+    Degrada a campos:[] si el catálogo no está disponible.
+    """
+    try:
+        if tipo_nodo == 'expediente':
+            return _esquema_expediente(expediente, nodo_id)
+        if tipo_nodo == 'solicitud':
+            return _esquema_solicitud(expediente, nodo_id)
+        if tipo_nodo == 'fase':
+            return _esquema_fase(expediente, nodo_id)
+        if tipo_nodo == 'tramite':
+            return _esquema_tramite(expediente, nodo_id)
+        if tipo_nodo == 'tarea':
+            return _esquema_tarea(expediente, nodo_id)
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('esquema_editable: catálogo no disponible — %s', exc)
+        return {'nodo': {'tipo': tipo_nodo, 'id': nodo_id}, 'campos': []}
+
+    raise ValueError(f'Tipo de nodo desconocido: {tipo_nodo!r}')
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _nombre_doc(doc) -> str:
+    """Nombre legible: último segmento de la URL, o 'Documento <id>'."""
+    filename = (doc.url or '').replace('\\', '/').rsplit('/', 1)[-1]
+    filename = filename.split('?')[0].split('#')[0]
+    return filename or f'Documento {doc.id}'
+
+
+def _pool_docs(expediente) -> list[dict]:
+    """Pool completo de documentos del expediente como opciones de select."""
+    docs = Documento.query.filter_by(expediente_id=expediente.id).all()
+    return [{'valor': d.id, 'texto': _nombre_doc(d)} for d in docs]
+
+
+def _campo_textarea(campo: str, etiqueta: str, valor) -> dict:
+    return {'campo': campo, 'etiqueta': etiqueta, 'control': 'textarea',
+            'valor': valor}
+
+
+def _campo_select(campo: str, etiqueta: str, valor,
+                  opciones: list[dict]) -> dict:
+    return {'campo': campo, 'etiqueta': etiqueta, 'control': 'select',
+            'valor': valor, 'opciones': opciones}
+
+
+# ---------------------------------------------------------------------------
+# Serializadores por nivel
+# ---------------------------------------------------------------------------
+
+def _esquema_expediente(exp, exp_id: int) -> dict:
+    if exp_id != exp.id:
+        raise ValueError('El nodo expediente no coincide con el expediente de la ruta')
+    # No editable en v1
+    return {'nodo': {'tipo': 'expediente', 'id': exp.id}, 'campos': []}
+
+
+def _esquema_solicitud(exp, sol_id: int) -> dict:
+    sol = Solicitud.query.get(sol_id)
+    if sol is None or sol.expediente_id != exp.id:
+        raise ValueError(f'Solicitud {sol_id} no encontrada en el expediente {exp.id}')
+
+    return {
+        'nodo': {'tipo': 'solicitud', 'id': sol.id},
+        'campos': [
+            _campo_textarea('observaciones', 'Observaciones', sol.observaciones),
+        ],
+    }
+
+
+def _esquema_fase(exp, fase_id: int) -> dict:
+    fase = Fase.query.get(fase_id)
+    if fase is None or fase.solicitud.expediente_id != exp.id:
+        raise ValueError(f'Fase {fase_id} no encontrada en el expediente {exp.id}')
+
+    opciones_resultado = [
+        {'valor': t.id, 'texto': t.nombre}
+        for t in TipoResultadoFase.query.order_by(TipoResultadoFase.nombre).all()
+    ]
+    opciones_doc = _pool_docs(exp)
+
+    return {
+        'nodo': {'tipo': 'fase', 'id': fase.id},
+        'campos': [
+            _campo_select('resultado_fase_id', 'Resultado',
+                          fase.resultado_fase_id, opciones_resultado),
+            _campo_select('documento_resultado_id', 'Documento resultado',
+                          fase.documento_resultado_id, opciones_doc),
+            _campo_textarea('observaciones', 'Observaciones', fase.observaciones),
+        ],
+    }
+
+
+def _esquema_tramite(exp, tramite_id: int) -> dict:
+    tr = Tramite.query.get(tramite_id)
+    if tr is None or tr.fase.solicitud.expediente_id != exp.id:
+        raise ValueError(f'Trámite {tramite_id} no encontrado en el expediente {exp.id}')
+
+    return {
+        'nodo': {'tipo': 'tramite', 'id': tr.id},
+        'campos': [
+            _campo_textarea('observaciones', 'Observaciones', tr.observaciones),
+        ],
+    }
+
+
+def _esquema_tarea(exp, tarea_id: int) -> dict:
+    ta = Tarea.query.get(tarea_id)
+    if ta is None or ta.tramite.fase.solicitud.expediente_id != exp.id:
+        raise ValueError(f'Tarea {tarea_id} no encontrada en el expediente {exp.id}')
+
+    # `resultado` (NOTIFICAR) es @property de Notificacion — no editable aquí (hallazgos S3b-0)
+    return {
+        'nodo': {'tipo': 'tarea', 'id': ta.id},
+        'campos': [
+            _campo_textarea('notas', 'Notas', ta.notas),
+        ],
+    }

--- a/app/services/invariantes_esftt.py
+++ b/app/services/invariantes_esftt.py
@@ -29,6 +29,12 @@ RESULTADO_FASE_FAVORABLE_CODIGOS = frozenset({'FAVORABLE', 'FAVORABLE_CONDICIONA
 
 
 def _bloquear(mensaje: str) -> EvaluacionResult:
+    # CONVENIO de mensajería de bloqueos (invariantes vs motor):
+    # el mensaje humano del invariante va en `norma_compilada` (no hay norma
+    # compilada que mostrar) y `motivo` queda ''. El motor, en cambio, rellena
+    # `motivo`. Por eso TODO consumidor que muestre un bloqueo debe leer
+    # `motivo or norma_compilada` (ver api_expedientes._bloqueo_422 y
+    # api_bc._res_error). No basta con leer solo `motivo`.
     return EvaluacionResult(
         permitido=False, nivel='BLOQUEAR',
         variables_trigger={}, norma_compilada=mensaje, url_norma=''

--- a/app/services/motor_reglas.py
+++ b/app/services/motor_reglas.py
@@ -59,8 +59,11 @@ class EvaluacionResult:
     permitido:         bool
     nivel:             str   # 'BLOQUEAR' | 'ADVERTIR' | ''
     variables_trigger: dict  # subconjunto del dict que disparó la regla
-    norma_compilada:   str   # referencia normativa compilada
+    norma_compilada:   str   # referencia normativa compilada (motor); en invariantes ESFTT, el mensaje del bloqueo
     url_norma:         str   # URL BOE/BOJA; '' si no existe
+    # Mensaje editorial del bloqueo. OJO: solo lo rellena el MOTOR. Los invariantes
+    # ESFTT (_bloquear) dejan motivo='' y ponen su mensaje en norma_compilada. Para
+    # mostrar un bloqueo, leer SIEMPRE `motivo or norma_compilada` (no solo motivo).
     motivo:            str = ''   # descripción editorial de la regla; '' si no configurada
     puede_escapar:     bool = False  # True solo cuando el bloqueo viene del motor (no de invariantes)
 

--- a/app/services/mutaciones_arbol.py
+++ b/app/services/mutaciones_arbol.py
@@ -1,0 +1,411 @@
+"""
+mutaciones_arbol.py — Servicio de mutaciones ESFTT para el árbol (ADR-016, S3b-0).
+
+Funciones puras de dominio (sin request/jsonify) para Crear / Editar / Borrar
+los cuatro niveles del árbol (solicitud, fase, trámite, tarea).
+
+Extraídas literalmente de app/routes/api_bc.py (camino B, #500):
+- api_bc delega aquí y mantiene su contrato HTTP intacto.
+- Los endpoints JSON del árbol también llaman a estas funciones.
+
+Nota: `resultado` en tareas NOTIFICAR es una @property computada desde Notificacion
+y no es editable por este servicio — ver hallazgos S3b-0.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from flask_login import current_user
+from sqlalchemy.exc import IntegrityError
+
+from app import db
+from app.models.solicitudes import Solicitud
+from app.models.fases import Fase
+from app.models.tramites import Tramite
+from app.models.tareas import Tarea
+from app.models.documentos import Documento
+from app.models.tipos_solicitudes import TipoSolicitud
+from app.models.documentos_tarea import DocumentoTarea
+from app.models.tramites_organismos import TramiteOrganismo
+from app.models.configuracion_sistema import ConfiguracionSistema
+from app.services.assembler import evaluar_multi, build_sujeto
+from app.services import bitacora as bitacora_svc
+from app.services.motor_reglas import EvaluacionResult, PERMITIDO
+from app.services.invariantes_esftt import _check_cierre_fase
+
+log = logging.getLogger(__name__)
+
+# Espejo de api_bc — mantener sincronizados hasta unificar (deuda conocida)
+_CODIGOS_TRASLADO = frozenset({'CONSULTA_TRASLADO_ORGANISMO', 'CONSULTA_TRASLADO_TITULAR'})
+_FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS = frozenset({'RESOLUCION', 'AAU_AAUS_INTEGRADA'})
+
+
+@dataclass
+class ResultadoMutacion:
+    """Retorno unificado de todas las funciones de mutación."""
+    ok: bool
+    ids: list[int] = field(default_factory=list)
+    bloqueo: Optional[EvaluacionResult] = None
+    advertencia: Optional[dict] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers internos
+# ---------------------------------------------------------------------------
+
+def _aplicar_modo_global(res_eval: EvaluacionResult) -> EvaluacionResult:
+    # DEUDA: duplicado de api_bc._aplicar_modo_global — unificar cuando se toque api_bc
+    modo = ConfiguracionSistema.get('motor.modo_operacion', 'BLOQUEAR')
+    if modo == 'INACTIVO':
+        return PERMITIDO
+    if modo == 'SOLO_ADVERTIR' and res_eval.nivel == 'BLOQUEAR':
+        return EvaluacionResult(
+            permitido=True, nivel='ADVERTIR',
+            variables_trigger=res_eval.variables_trigger,
+            norma_compilada=res_eval.norma_compilada,
+            url_norma=res_eval.url_norma,
+            motivo=res_eval.motivo,
+        )
+    return res_eval
+
+
+def _evaluar(accion: str, expediente, *, objeto) -> EvaluacionResult:
+    return _aplicar_modo_global(evaluar_multi(accion, expediente, objeto=objeto))
+
+
+def _advertencia_dict(res_eval: EvaluacionResult) -> Optional[dict]:
+    if res_eval and res_eval.nivel == 'ADVERTIR':
+        return {
+            'motivo': res_eval.motivo,
+            'norma_compilada': res_eval.norma_compilada,
+            'url_norma': res_eval.url_norma,
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook #458 (movido desde api_bc; test_458 actualizado para importar de aquí)
+# ---------------------------------------------------------------------------
+
+def _hook_458_analizar_separata(tarea, id_producido):
+    """Hook #458: al producir diagnóstico en CONSULTA_SEPARATA pasa el organismo a en_tramitacion."""
+    if (id_producido is not None
+            and tarea.tipo_tarea.codigo == 'ANALIZAR'
+            and tarea.tramite.tipo_tramite.codigo == 'CONSULTA_SEPARATA'):
+        vinculo = TramiteOrganismo.query.filter_by(tramite_id=tarea.tramite_id).first()
+        if vinculo:
+            vinculo.organismo_expediente.estado = 'en_tramitacion'
+
+
+# ===========================================================================
+# CREAR
+# ===========================================================================
+
+def crear_solicitud(expediente, tipos: list[TipoSolicitud], entidad_id: int,
+                    *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    """Crea una o varias solicitudes (multi-tipo). Valida motor para todos antes de persistir."""
+    exp_id = expediente.id
+
+    if not entidad_id:
+        return ResultadoMutacion(ok=False, error='El expediente no tiene titular asignado.')
+
+    # Fase 1: evaluar motor para todos los tipos; si alguno bloquea, rechazar todo
+    if justificacion is None:
+        for tipo in tipos:
+            sol_stub = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
+                                 tipo_solicitud_id=tipo.id)
+            sol_stub.tipo_solicitud = tipo  # stub transiente — assembler compila sin flush
+            res_eval = _evaluar('CREAR', expediente, objeto=sol_stub)
+            if not res_eval.permitido:
+                return ResultadoMutacion(ok=False, bloqueo=res_eval)
+
+    # Fase 2: persistir
+    creadas = []
+    try:
+        for tipo in tipos:
+            sol = Solicitud(expediente_id=exp_id, entidad_id=entidad_id,
+                            tipo_solicitud_id=tipo.id)
+            db.session.add(sol)
+            db.session.flush()
+            if justificacion:
+                sujeto = build_sujeto(expediente, sol)
+                bitacora_svc.registrar(
+                    current_user.id, 'CREAR', 'solicitudes', sol.id,
+                    detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+                )
+            creadas.append(sol)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return ResultadoMutacion(ok=False, error=str(e))
+
+    return ResultadoMutacion(ok=True, ids=[s.id for s in creadas])
+
+
+def crear_fase(solicitud, tipo_fase, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente,
+                            objeto={'solicitud': solicitud, 'tipo_fase': tipo_fase})
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+    else:
+        res_eval = PERMITIDO
+
+    fase = Fase(solicitud_id=solicitud.id, tipo_fase_id=tipo_fase.id)
+    db.session.add(fase)
+    db.session.flush()
+
+    if tipo_fase.codigo in _FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS:
+        from app.services.cert_fin_ip_consultas import crear_cert_fin_ip_consultas
+        crear_cert_fin_ip_consultas(expediente, solicitud)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, {'solicitud': solicitud, 'tipo_fase': tipo_fase})
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'fases', fase.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
+    return ResultadoMutacion(ok=True, ids=[fase.id], advertencia=_advertencia_dict(res_eval))
+
+
+def crear_tramite(fase, tipo_tramite, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    if tipo_tramite.codigo in _CODIGOS_TRASLADO:
+        return ResultadoMutacion(
+            ok=False,
+            error='Los trámites de traslado se crean desde la acción específica de organismo',
+        )
+
+    expediente = fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente,
+                            objeto={'fase': fase, 'tipo_tramite': tipo_tramite})
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+    else:
+        res_eval = PERMITIDO
+
+    tramite = Tramite(fase_id=fase.id, tipo_tramite_id=tipo_tramite.id)
+    db.session.add(tramite)
+    db.session.flush()
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, {'fase': fase, 'tipo_tramite': tipo_tramite})
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'tramites', tramite.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
+    return ResultadoMutacion(ok=True, ids=[tramite.id], advertencia=_advertencia_dict(res_eval))
+
+
+def crear_tarea(tramite, tipo_tarea, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = tramite.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('CREAR', expediente,
+                            objeto={'tramite': tramite, 'tipo_tarea': tipo_tarea})
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+    else:
+        res_eval = PERMITIDO
+
+    tarea = Tarea(tramite_id=tramite.id, tipo_tarea_id=tipo_tarea.id)
+    db.session.add(tarea)
+    db.session.flush()
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, tramite)
+        bitacora_svc.registrar(
+            current_user.id, 'CREAR', 'tareas', tarea.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.commit()
+    return ResultadoMutacion(ok=True, ids=[tarea.id], advertencia=_advertencia_dict(res_eval))
+
+
+# ===========================================================================
+# EDITAR
+# ===========================================================================
+
+def editar_solicitud(sol, *, observaciones: Optional[str]) -> ResultadoMutacion:
+    try:
+        sol.observaciones = observaciones or None
+        db.session.commit()
+        return ResultadoMutacion(ok=True)
+    except Exception as e:
+        db.session.rollback()
+        return ResultadoMutacion(ok=False, error=str(e))
+
+
+def editar_fase(fase, *, resultado_fase_id: Optional[int],
+                documento_resultado_id: Optional[int],
+                observaciones: Optional[str]) -> ResultadoMutacion:
+    if documento_resultado_id and fase.documento_resultado_id is None:
+        doc = Documento.query.get(documento_resultado_id)
+        if not doc or doc.expediente_id != fase.solicitud.expediente_id:
+            return ResultadoMutacion(ok=False, error='Documento no válido para este expediente')
+
+        if resultado_fase_id:
+            from app.models.tipos_resultados_fases import TipoResultadoFase
+            tipo_res = TipoResultadoFase.query.get(resultado_fase_id)
+            if tipo_res:
+                res_inv = _check_cierre_fase(fase.id, tipo_res.codigo)
+                if res_inv:
+                    return ResultadoMutacion(ok=False, bloqueo=res_inv)
+
+    try:
+        fase.resultado_fase_id = resultado_fase_id
+        fase.documento_resultado_id = documento_resultado_id
+        fase.observaciones = observaciones or None
+        db.session.commit()
+        return ResultadoMutacion(ok=True)
+    except Exception as e:
+        db.session.rollback()
+        return ResultadoMutacion(ok=False, error=str(e))
+
+
+def editar_tramite(tr, *, observaciones: Optional[str]) -> ResultadoMutacion:
+    try:
+        tr.observaciones = observaciones or None
+        db.session.commit()
+        return ResultadoMutacion(ok=True)
+    except Exception as e:
+        db.session.rollback()
+        return ResultadoMutacion(ok=False, error=str(e))
+
+
+def editar_tarea(ta, *, documentos_consumidos_ids: list[int],
+                 documento_producido_id: Optional[int],
+                 notas: Optional[str]) -> ResultadoMutacion:
+    """Actualiza vínculos documentales + notas de la tarea.
+
+    `resultado` (NOTIFICAR) es una @property de Notificacion — no editable aquí.
+    """
+    expediente = ta.tramite.fase.solicitud.expediente
+
+    ids_todos = list(documentos_consumidos_ids) + (
+        [documento_producido_id] if documento_producido_id else [])
+    for doc_id in ids_todos:
+        doc = Documento.query.get(doc_id)
+        if not doc or doc.expediente_id != expediente.id:
+            return ResultadoMutacion(ok=False, error='Documento no válido para este expediente')
+
+    try:
+        ta.vinculos_documento.clear()
+        db.session.flush()
+        for doc_id in dict.fromkeys(documentos_consumidos_ids):   # sin duplicados, orden estable
+            ta.vinculos_documento.append(DocumentoTarea(documento_id=doc_id, rol='CONSUMIDO'))
+        if documento_producido_id:
+            ta.vinculos_documento.append(
+                DocumentoTarea(documento_id=documento_producido_id, rol='PRODUCIDO'))
+
+        ta.notas = notas or None
+        _hook_458_analizar_separata(ta, documento_producido_id)
+        db.session.commit()
+        return ResultadoMutacion(ok=True)
+    except IntegrityError:
+        db.session.rollback()
+        return ResultadoMutacion(
+            ok=False, error='Este documento ya está asignado como producido a otra tarea')
+    except Exception as e:
+        db.session.rollback()
+        return ResultadoMutacion(ok=False, error=str(e))
+
+
+# ===========================================================================
+# BORRAR (cascada manual — idéntica a api_bc)
+# ===========================================================================
+
+def borrar_solicitud(sol, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = sol.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=sol)
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, sol)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'solicitudes', sol.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    fase_ids = [f.id for f in Fase.query.filter_by(solicitud_id=sol.id).all()]
+    if fase_ids:
+        tram_ids = [t.id for t in Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).all()]
+        if tram_ids:
+            Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+        Tramite.query.filter(Tramite.fase_id.in_(fase_ids)).delete()
+    Fase.query.filter_by(solicitud_id=sol.id).delete()
+    db.session.delete(sol)
+    db.session.commit()
+    return ResultadoMutacion(ok=True)
+
+
+def borrar_fase(fase, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=fase)
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, fase)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'fases', fase.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    tram_ids = [t.id for t in Tramite.query.filter_by(fase_id=fase.id).all()]
+    if tram_ids:
+        Tarea.query.filter(Tarea.tramite_id.in_(tram_ids)).delete()
+    Tramite.query.filter_by(fase_id=fase.id).delete()
+    db.session.delete(fase)
+    db.session.commit()
+    return ResultadoMutacion(ok=True)
+
+
+def borrar_tramite(tr, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = tr.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=tr)
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, tr)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'tramites', tr.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    Tarea.query.filter_by(tramite_id=tr.id).delete()
+    db.session.delete(tr)
+    db.session.commit()
+    return ResultadoMutacion(ok=True)
+
+
+def borrar_tarea(ta, *, justificacion: Optional[str] = None) -> ResultadoMutacion:
+    expediente = ta.tramite.fase.solicitud.expediente
+    if justificacion is None:
+        res_eval = _evaluar('BORRAR', expediente, objeto=ta)
+        if not res_eval.permitido:
+            return ResultadoMutacion(ok=False, bloqueo=res_eval)
+
+    if justificacion:
+        sujeto = build_sujeto(expediente, ta.tramite)
+        bitacora_svc.registrar(
+            current_user.id, 'BORRAR', 'tareas', ta.id,
+            detalle={'escape': True, 'justificacion': justificacion, 'sujeto': sujeto},
+        )
+
+    db.session.delete(ta)
+    db.session.commit()
+    return ResultadoMutacion(ok=True)

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.THmUfNRP.js",
+    "file": "bundle.expediente-arbol.BHnw6TdD.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,
@@ -31,7 +31,7 @@
       "_chunk.index.BLcVfAtS.js"
     ],
     "css": [
-      "asset.expediente-arbol.n6gVI8cw.css"
+      "asset.expediente-arbol.CBfnaAn4.css"
     ]
   }
 }

--- a/react-src/src/expediente-arbol/App.jsx
+++ b/react-src/src/expediente-arbol/App.jsx
@@ -5,7 +5,8 @@
 // El Inspector real es S3 (aquí solo Viewbar + Arbol).
 import React, { useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import { useArbolStore } from './store.js'
+import { useArbolStore, selectHayCambios } from './store.js'
+import { showToast } from '../shared/ui/toast.js'
 import Viewbar from './components/Viewbar.jsx'
 import Arbol from './components/Arbol.jsx'
 import Inspector from './components/Inspector.jsx'
@@ -46,6 +47,8 @@ export default function App() {
   const cargando = useArbolStore((s) => s.cargando)
   const error = useArbolStore((s) => s.error)
   const arbol = useArbolStore((s) => s.arbol)
+  const enEdicion = useArbolStore((s) => s.modoEdicion)
+  const hayCambios = useArbolStore(selectHayCambios)
 
   // Carga inicial + restaurar selección desde la URL. (En dev standalone no hay
   // data-expediente-id: el mock se preinyecta en el store desde main.jsx.)
@@ -60,6 +63,24 @@ export default function App() {
   useEffect(() => {
     escribirSeleccionURL(seleccion)
   }, [seleccion])
+
+  // Lock de la UI: al ENTRAR en edición se atenúa el chrome Jinja vía body.arbol-lock
+  // (CSS) y se monta el overlay (más abajo). Idempotente (add/remove simétricos) →
+  // resiste el doble-invoke de StrictMode en dev.
+  useEffect(() => {
+    if (!enEdicion) return
+    document.body.classList.add('arbol-lock')
+    return () => document.body.classList.remove('arbol-lock')
+  }, [enEdicion])
+
+  // beforeunload (diálogo nativo "cambios sin guardar"): solo si hay cambios reales que
+  // perder. El overlay ya impide navegar dentro de la app durante la edición.
+  useEffect(() => {
+    if (!(enEdicion && hayCambios)) return
+    const handler = (e) => { e.preventDefault(); e.returnValue = '' }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [enEdicion, hayCambios])
 
   if (cargando) return <div className="p-4 text-muted">Cargando árbol…</div>
   if (error) {
@@ -80,6 +101,11 @@ export default function App() {
         <Arbol />
       </div>
       {slot && createPortal(<Inspector />, slot)}
+      {enEdicion && createPortal(
+        <div aria-hidden="true"
+             onClick={() => showToast('Estás editando este elemento — Guarda o cancela primero.', 'warning')}
+             style={{ position: 'fixed', inset: 0, zIndex: 1040, background: 'transparent', cursor: 'not-allowed' }} />,
+        document.body)}
     </div>
   )
 }

--- a/react-src/src/expediente-arbol/api.js
+++ b/react-src/src/expediente-arbol/api.js
@@ -21,3 +21,13 @@ export function getNodo(expedienteId, tipo, nodoId, opts) {
 export function getTiposCreables(expedienteId, tipo, nodoId) {
   return api.get(`/api/expedientes/${expedienteId}/nodo/${tipo}/${nodoId}/tipos-creables`)
 }
+
+// Esquema editable del nodo (editor del inspector, S3b-1).
+export function getEditable(expedienteId, tipo, nodoId) {
+  return api.get(`/api/expedientes/${expedienteId}/nodo/${tipo}/${nodoId}/editable`)
+}
+
+// Editar campos de un nodo (PATCH, S3b-1).
+export function patchNodo(expedienteId, tipo, nodoId, body) {
+  return api.patch(`/api/expedientes/${expedienteId}/nodo/${tipo}/${nodoId}`, body)
+}

--- a/react-src/src/expediente-arbol/components/Arbol.jsx
+++ b/react-src/src/expediente-arbol/components/Arbol.jsx
@@ -32,6 +32,8 @@ export default function Arbol() {
   const colapsarFinalizados = useArbolStore((s) => s.colapsarFinalizados)
   const seleccion = useArbolStore((s) => s.seleccion)
   const seleccionar = useArbolStore((s) => s.seleccionar)
+  const modoEdicion = useArbolStore((s) => s.modoEdicion)
+  const entrarEdicion = useArbolStore((s) => s.entrarEdicion)
 
   const { nodes, edges } = useMemo(
     () => construirGrafo(arbol, { colapsarFinalizados, seleccion }),
@@ -46,14 +48,25 @@ export default function Arbol() {
     },
     [seleccionar],
   )
+  // Doble-clic = atajo para editar ese nodo (en lectura). En edición el overlay
+  // intercepta los clics del lienzo, así que no permite cambiar de nodo objetivo.
+  const onNodeDoubleClick = useCallback(
+    (_, node) => {
+      if (node.data.tipo === 'tareas') return
+      entrarEdicion({ tipo: node.data.tipo, id: node.data.id })
+    },
+    [entrarEdicion],
+  )
   const onPaneClick = useCallback(() => seleccionar(null), [seleccionar])
 
   return (
     <ReactFlow
+      className={modoEdicion ? 'arbol-lienzo--edicion' : undefined}
       nodes={nodes}
       edges={edges}
       nodeTypes={nodeTypes}
       onNodeClick={onNodeClick}
+      onNodeDoubleClick={onNodeDoubleClick}
       onPaneClick={onPaneClick}
       defaultEdgeOptions={defaultEdgeOptions}
       nodesDraggable={false}

--- a/react-src/src/expediente-arbol/components/Despensa.jsx
+++ b/react-src/src/expediente-arbol/components/Despensa.jsx
@@ -1,7 +1,11 @@
-// Despensa.jsx — ESQUELETO S3 (ADR-016 §5/§10).
-// Despensa adaptativa (tipos creables / documentos del pool) con drag-drop. S3.
+// Despensa.jsx — zona inferior del split del inspector en edición (ADR-016 §5/§10).
+// S3b-1: placeholder visible (la llena de tipos creables / documentos del pool S3b-2/3).
 import React from 'react'
 
 export default function Despensa() {
-  return null
+  return (
+    <div className="h-100 d-flex align-items-center justify-content-center text-muted small fst-italic">
+      Despensa — próximamente
+    </div>
+  )
 }

--- a/react-src/src/expediente-arbol/components/Inspector.jsx
+++ b/react-src/src/expediente-arbol/components/Inspector.jsx
@@ -5,10 +5,12 @@
 // + acciones rápidas no destructivas (abrir doc, abrir carpeta, copiar referencia).
 // Edición / despensa → S3b.
 import React from 'react'
-import { useArbolStore } from '../store.js'
+import { useArbolStore, selectHayCambios } from '../store.js'
 import { api } from '../../shared/api.js'
 import { showToast } from '../../shared/ui/toast.js'
+import { tienePermiso } from '../../shared/auth.js'
 import Semaforo from './nodos/Semaforo.jsx'
+import Despensa from './Despensa.jsx'
 
 const ETIQUETA_TIPO = {
   expediente: 'Expediente',
@@ -198,6 +200,80 @@ function Acciones({ referencia, expedienteId }) {
   )
 }
 
+// --- Edición (S3b-1): editor genérico + split editor/despensa ------------------
+
+// Editor genérico: pinta un control por campo del esquema editable, autofocus en
+// el primero, botonera Guardar/Cancelar. value/onChange contra borrador/setCampo.
+function Editor() {
+  const campos    = useArbolStore((s) => s.editableCampos)
+  const cargando  = useArbolStore((s) => s.edicionCargando)
+  const borrador  = useArbolStore((s) => s.borrador)
+  const setCampo  = useArbolStore((s) => s.setCampo)
+  const guardando = useArbolStore((s) => s.guardando)
+  const guardar   = useArbolStore((s) => s.guardar)
+  const cancelar  = useArbolStore((s) => s.cancelar)
+  const hayCambios = useArbolStore(selectHayCambios)
+  const firstRef = React.useRef(null)
+  React.useEffect(() => { if (firstRef.current) firstRef.current.focus() }, [campos])
+
+  if (cargando) return <div className="text-muted small">Cargando editor…</div>
+  if (!campos.length)
+    return <div className="text-muted small">Este elemento no tiene campos editables.</div>
+
+  const ctrl = (c, ref) => {
+    const val = borrador[c.campo] ?? ''
+    if (c.control === 'textarea')
+      return <textarea ref={ref} className="form-control form-control-sm" rows={3}
+               value={val} onChange={(e) => setCampo(c.campo, e.target.value)} />
+    if (c.control === 'select')
+      return (
+        <select ref={ref} className="form-select form-select-sm" value={val}
+          onChange={(e) => setCampo(c.campo, e.target.value === '' ? null : Number(e.target.value))}>
+          <option value="">—</option>
+          {(c.opciones || []).map((o) => <option key={o.valor} value={o.valor}>{o.texto}</option>)}
+        </select>
+      )
+    return <input ref={ref} type="text" className="form-control form-control-sm"
+             value={val} onChange={(e) => setCampo(c.campo, e.target.value)} />
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); if (hayCambios && !guardando) guardar() }}>
+      {campos.map((c, i) => (
+        <div className="mb-2" key={c.campo}>
+          <label className="form-label small text-muted mb-1">{c.etiqueta}</label>
+          {ctrl(c, i === 0 ? firstRef : null)}
+        </div>
+      ))}
+      <div className="d-flex gap-2 mt-3">
+        <button type="button" className="btn btn-sm btn-primary"
+                disabled={guardando || !hayCambios} onClick={guardar}>Guardar</button>
+        <button type="button" className="btn btn-sm btn-outline-secondary"
+                onClick={cancelar}>Cancelar</button>
+      </div>
+    </form>
+  )
+}
+
+// Split vertical en edición: editor arriba (flex:1, scroll) + despensa abajo (120px
+// fija). En lectura NO hay split (igual que S3a). El inspector lleva siempre el
+// borde+sombra de edición (arbol-inspector--lock, CSS) porque editar bloquea el resto
+// de la UI desde que se entra; el inspector NUNCA se atenúa (es la zona interactiva).
+function InspectorEdicion({ nodo }) {
+  const seleccion = useArbolStore((s) => s.seleccion)
+  return (
+    <div className="d-flex flex-column h-100 arbol-inspector--lock">
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }} className="p-3">
+        <Cabecera tipo={seleccion.tipo} nodo={nodo} />
+        <Editor />
+      </div>
+      <div style={{ flex: '0 0 120px' }} className="border-top">
+        <Despensa />
+      </div>
+    </div>
+  )
+}
+
 // --- Componente principal -------------------------------------------------------
 
 export default function Inspector() {
@@ -207,6 +283,8 @@ export default function Inspector() {
   const cargando = useArbolStore((s) => s.detalleCargando)
   const error = useArbolStore((s) => s.detalleError)
   const expedienteId = useArbolStore((s) => s.expedienteId)
+  const modoEdicion = useArbolStore((s) => s.modoEdicion)
+  const entrarEdicion = useArbolStore((s) => s.entrarEdicion)
 
   if (!seleccion) {
     return (
@@ -217,11 +295,23 @@ export default function Inspector() {
   }
 
   const nodo = buscarNodo(arbol, seleccion)
+  if (modoEdicion) return <InspectorEdicion nodo={nodo} />
   const esHoja = seleccion.tipo === 'tarea'
+  const puedeEditar = tienePermiso('editar_expediente')
 
   return (
     <div className="p-3 d-flex flex-column h-100">
       <Cabecera tipo={seleccion.tipo} nodo={nodo} />
+
+      {puedeEditar && (
+        <div className="mb-3">
+          {/* Editar vive en el inspector: edita el nodo inspeccionado (no "toda la vista"). */}
+          <button type="button" className="btn btn-sm btn-outline-primary"
+                  onClick={() => entrarEdicion(seleccion)}>
+            ✏️ Editar
+          </button>
+        </div>
+      )}
 
       {cargando && <div className="text-muted small">Cargando detalle…</div>}
       {error && (

--- a/react-src/src/expediente-arbol/components/Viewbar.jsx
+++ b/react-src/src/expediente-arbol/components/Viewbar.jsx
@@ -3,7 +3,12 @@
 // Vive DENTRO de la isla (no en el slot viewbar de Jinja) para no cruzar estado
 // React↔Jinja con el toggle. El slot viewbar de base_app conserva su default
 // (código AT + bombilla de acceso).
-// Botón "Editar" y resumen-mini de pistas → S3.
+// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11).
+//
+// Vive DENTRO de la isla (no en el slot viewbar de Jinja) para no cruzar estado
+// React↔Jinja con el toggle. Muestra info del expediente + toggle "Colapsar
+// finalizados". Los botones de modo (Editar/Guardar/Cancelar) viven en el INSPECTOR
+// (decisión S3b-1): editar es "editar este nodo", no "editar toda la vista".
 import React from 'react'
 import { useArbolStore } from '../store.js'
 

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -4,9 +4,11 @@
 // (selección única, toggle "Colapsar finalizados").
 // S3a (inspector lectura): detalle lazy del nodo seleccionado (§5/§16) con caché
 // por nodo + AbortController (cancela la petición anterior al cambiar de selección).
-// S3b añadirá: modoEdicion, lock, despensa, colapsos manuales por nivel.
+// S3b-1: modoEdicion + lock + editor genérico (entrar/guardar/cancelar + refresco).
+// S3b añadirá: despensa, colapsos manuales por nivel.
 import { create } from 'zustand'
-import { getArbol, getNodo } from './api.js'
+import { getArbol, getNodo, getEditable, patchNodo } from './api.js'
+import { showToast } from '../shared/ui/toast.js'
 
 // AbortController de la petición de detalle en curso (fuera del estado: no re-render).
 let _detalleAbort = null
@@ -21,6 +23,14 @@ export const useArbolStore = create((set, get) => ({
   // --- estado UI ---
   seleccion: null,            // { tipo, id } | null  (ADR §3, selección única)
   colapsarFinalizados: false, // toggle de viewbar (ADR §11)
+
+  // --- edición (S3b-1, ADR §4/§5/§6) ---
+  modoEdicion: false,
+  editableCampos: [],         // [{campo, etiqueta, control, valor, opciones?}] del esquema editable
+  borrador: {},               // { campo: valor } en edición
+  borradorInicial: {},        // snapshot al entrar (detección de cambios → lock)
+  edicionCargando: false,
+  guardando: false,
 
   // --- detalle del inspector (S3a) ---
   detalle: null,              // payload del endpoint lazy del nodo seleccionado
@@ -88,4 +98,81 @@ export const useArbolStore = create((set, get) => ({
 
   toggleColapsarFinalizados: () =>
     set((s) => ({ colapsarFinalizados: !s.colapsarFinalizados })),
+
+  // --- acciones de edición (S3b-1) ---
+
+  // Entra en edición del nodo `sel`: fija selección, pide el esquema editable y
+  // siembra borrador/borradorInicial con el mismo objeto (hayCambios=false al entrar).
+  entrarEdicion: async (sel) => {
+    if (!sel) return
+    set({ seleccion: sel, modoEdicion: true, edicionCargando: true,
+          editableCampos: [], borrador: {}, borradorInicial: {} })
+    const expedienteId = get().expedienteId
+    if (!expedienteId) { set({ edicionCargando: false }); return }  // mock standalone: editor vacío
+    try {
+      const data = await getEditable(expedienteId, sel.tipo, sel.id)
+      const campos = data.campos || []
+      const borrador = Object.fromEntries(campos.map((c) => [c.campo, c.valor ?? null]))
+      set({ editableCampos: campos, borrador, borradorInicial: borrador, edicionCargando: false })
+    } catch (e) {
+      set({ edicionCargando: false })
+      if (e.status !== 401 && e.status !== 403) showToast(e.message || 'No se pudo cargar el editor', 'danger')
+    }
+  },
+
+  setCampo: (campo, valor) => set((s) => ({ borrador: { ...s.borrador, [campo]: valor } })),
+
+  cancelar: () => {
+    set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false })
+    showToast('Cambios descartados', 'info')
+  },
+
+  guardar: async () => {
+    const { expedienteId, seleccion, borrador } = get()
+    if (!seleccion) return
+    set({ guardando: true })
+    try {
+      const data = await patchNodo(expedienteId, seleccion.tipo, seleccion.id, borrador)
+      showToast('Cambios guardados', 'success')
+      if (data && data.advertencia) {                 // defensivo (PATCH editar no lo emite hoy)
+        const a = data.advertencia
+        showToast(typeof a === 'string' ? a : (a.mensaje || a.texto || 'Revisa la advertencia'), 'warning')
+      }
+      set({ guardando: false, modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {} })
+      await get().refrescarArbol()
+    } catch (e) {
+      set({ guardando: false })
+      if (e.status === 401 || e.status === 403) return // shared/api.js ya mostró su toast
+      if (e.status === 422 && e.payload && e.payload.motivo) {
+        showToast(e.payload.motivo, 'danger')          // bloqueo motor: PERMANECE en edición
+      } else {
+        showToast(e.message || 'No se pudo guardar', 'danger')
+      }
+    }
+  },
+
+  // Re-pide /arbol e invalida TODA la caché de detalle (una mutación puede recomputar
+  // agregados/plazos de los ancestros → decisión F). Tras refrescar, re-dispara el
+  // detalle de lectura del nodo seleccionado.
+  refrescarArbol: async () => {
+    const { expedienteId, seleccion } = get()
+    if (!expedienteId) return
+    try {
+      const arbol = await getArbol(expedienteId)
+      set({ arbol, _detalleCache: {} })
+    } catch (e) {
+      showToast('No se pudo refrescar el árbol', 'danger')
+    }
+    get().cargarDetalle(seleccion)
+  },
 }))
+
+// --- selectores derivados de edición (S3b-1) ----------------------------------
+// hayCambios = el borrador difiere del snapshot inicial.
+//   · habilita/inhabilita Guardar
+//   · arma el aviso beforeunload (solo si hay datos reales que perder)
+// El LOCK de la UI (atenuar el chrome + overlay + inspector elevado) NO depende de
+// hayCambios: se activa al ENTRAR en edición (lock-on-enter), porque editar es "editar
+// este nodo" y debe ser inequívoco desde el primer momento. Lo gobierna `modoEdicion`.
+export const selectHayCambios = (s) =>
+  JSON.stringify(s.borrador) !== JSON.stringify(s.borradorInicial)

--- a/react-src/src/expediente-arbol/styles/arbol.css
+++ b/react-src/src/expediente-arbol/styles/arbol.css
@@ -200,3 +200,29 @@
 .arbol-tarea__fill[data-color="rojo"]    { background: var(--sem-rojo); }
 .arbol-tarea__fill[data-color="verde"]   { background: var(--sem-verde); }
 .arbol-tarea__fill[data-color="gris"]    { background: var(--sem-gris); }
+
+/* ── Modo edición / lock (S3b-1) ─────────────────────────────────────────────── */
+/* Tono del lienzo en modo edición (señal inequívoca, ADR §4). */
+.react-flow.arbol-lienzo--edicion { background-color: #fff8ef; }
+
+/* Lock activo: atenúa el chrome fuera del inspector. El inspector queda nítido y se
+   eleva por encima del overlay transparente que captura los clics (App.jsx). */
+body.arbol-lock .app-topbar,
+body.arbol-lock .app-sidebar,
+body.arbol-lock .app-viewbar,
+body.arbol-lock .app-main,
+body.arbol-lock .app-footer,
+body.arbol-lock .app-dock {            /* .app-dock no existe en esta vista; inocuo */
+  opacity: .5;
+  transition: opacity .15s ease;
+}
+body.arbol-lock .app-inspector {
+  position: relative;
+  z-index: 1050;                       /* > overlay (1040), < toasts de Bootstrap (1090) */
+}
+
+/* Inspector destacado mientras el lock está activo (zona interactiva). */
+.arbol-inspector--lock {
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, .35);
+  border-radius: 8px;
+}

--- a/react-src/src/shared/api.js
+++ b/react-src/src/shared/api.js
@@ -74,5 +74,6 @@ export const api = {
   get:    (url, opts)       => request(url, { ...opts, method: 'GET' }),
   post:   (url, body, opts) => request(url, { ...opts, method: 'POST', body }),
   put:    (url, body, opts) => request(url, { ...opts, method: 'PUT', body }),
+  patch:  (url, body, opts) => request(url, { ...opts, method: 'PATCH', body }),
   delete: (url, opts)       => request(url, { ...opts, method: 'DELETE' }),
 }

--- a/tests/smoke/test_smoke_mutaciones_arbol.py
+++ b/tests/smoke/test_smoke_mutaciones_arbol.py
@@ -43,3 +43,36 @@ def test_borrar_solicitud_inexistente_404(usuario_supervisor, expediente_seed):
     r = usuario_supervisor.delete(
         f'/api/expedientes/{expediente_seed}/nodo/solicitud/99999999')
     assert r.status_code == 404
+
+
+def test_bloqueo_422_surfacea_mensaje_invariante_y_motor(app):
+    """El 422 de bloqueo debe surfacear el mensaje legible venga de donde venga (#500).
+
+    La mensajería de bloqueos tiene DOS fuentes (ver EvaluacionResult):
+      · motor de reglas   → `motivo`
+      · invariantes ESFTT → `norma_compilada` (motivo queda '')
+    `_bloqueo_422` surfacea `motivo or norma_compilada`. Sin el fallback, los
+    bloqueos de invariante llegaban con motivo='' (regresión histórica).
+    """
+    from app.routes.api_expedientes import _bloqueo_422
+    from app.services.motor_reglas import EvaluacionResult
+    from app.services.mutaciones_arbol import ResultadoMutacion
+
+    invariante = EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR', variables_trigger={},
+        norma_compilada='Mensaje del invariante', url_norma='')          # motivo='' por defecto
+    motor = EvaluacionResult(
+        permitido=False, nivel='BLOQUEAR', variables_trigger={},
+        norma_compilada='norma compilada X', url_norma='', motivo='Motivo del motor')
+
+    with app.app_context():
+        resp_inv, status_inv = _bloqueo_422(ResultadoMutacion(ok=False, bloqueo=invariante))
+        resp_mot, status_mot = _bloqueo_422(ResultadoMutacion(ok=False, bloqueo=motor))
+        body_inv = resp_inv.get_json()
+        body_mot = resp_mot.get_json()
+
+    assert status_inv == 422 and status_mot == 422
+    # invariante: el mensaje (en norma_compilada) NO debe perderse
+    assert body_inv['motivo'] == 'Mensaje del invariante'
+    # motor: el `motivo` editorial tiene prioridad sobre norma_compilada
+    assert body_mot['motivo'] == 'Motivo del motor'

--- a/tests/smoke/test_smoke_mutaciones_arbol.py
+++ b/tests/smoke/test_smoke_mutaciones_arbol.py
@@ -1,0 +1,45 @@
+"""Smoke tests — endpoints mutaciones árbol POST/PATCH/DELETE + GET editable (#500, S3b-0)."""
+import pytest
+
+
+def test_editable_expediente_campos_vacios(usuario_supervisor, expediente_seed):
+    """GET /nodo/expediente/<id>/editable → 200, campos==[] (expediente no editable en v1)."""
+    r = usuario_supervisor.get(
+        f'/api/expedientes/{expediente_seed}/nodo/expediente/{expediente_seed}/editable')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['nodo'] == {'tipo': 'expediente', 'id': expediente_seed}
+    assert data['campos'] == []
+
+
+def test_crear_hijo_tipo_inexistente_404(usuario_supervisor, expediente_seed):
+    """POST /nodo/expediente/<id>/hijos con tipo_id inexistente → 404."""
+    r = usuario_supervisor.post(
+        f'/api/expedientes/{expediente_seed}/nodo/expediente/{expediente_seed}/hijos',
+        json={'tipo_id': 99999999})
+    assert r.status_code == 404
+
+
+def test_editar_solicitud_idempotente_200(usuario_supervisor, app):
+    """PATCH /nodo/solicitud/<id> con observaciones=None → 200, ok==True."""
+    with app.app_context():
+        from app.models.solicitudes import Solicitud
+        sol = Solicitud.query.first()
+        if sol is None:
+            pytest.skip('No hay solicitudes en la BD de desarrollo')
+        exp_id = sol.expediente_id
+        sol_id = sol.id
+
+    r = usuario_supervisor.patch(
+        f'/api/expedientes/{exp_id}/nodo/solicitud/{sol_id}',
+        json={'observaciones': None})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data.get('ok') is True
+
+
+def test_borrar_solicitud_inexistente_404(usuario_supervisor, expediente_seed):
+    """DELETE /nodo/solicitud/99999999 → 404 (solicitud no pertenece al expediente)."""
+    r = usuario_supervisor.delete(
+        f'/api/expedientes/{expediente_seed}/nodo/solicitud/99999999')
+    assert r.status_code == 404

--- a/tests/test_458_estado_organismo.py
+++ b/tests/test_458_estado_organismo.py
@@ -25,12 +25,12 @@ def _vinculo_stub(org):
 class TestHook458EstadoOrganismo:
 
     def test_analizar_separata_pone_en_tramitacion(self):
-        from app.routes.api_bc import _hook_458_analizar_separata
+        from app.services.mutaciones_arbol import _hook_458_analizar_separata
         tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=5)
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+        with patch('app.services.mutaciones_arbol.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=10)
 
@@ -38,12 +38,12 @@ class TestHook458EstadoOrganismo:
         mock_cls.query.filter_by.assert_called_once_with(tramite_id=5)
 
     def test_analizar_otro_tramite_no_cambia_estado(self):
-        from app.routes.api_bc import _hook_458_analizar_separata
+        from app.services.mutaciones_arbol import _hook_458_analizar_separata
         tarea = _tarea_stub('ANALIZAR', 'REQUERIMIENTO_DE_MEJORA', tramite_id=5)
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+        with patch('app.services.mutaciones_arbol.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=10)
 
@@ -51,21 +51,21 @@ class TestHook458EstadoOrganismo:
         mock_cls.query.filter_by.assert_not_called()
 
     def test_sin_organismo_no_falla(self):
-        from app.routes.api_bc import _hook_458_analizar_separata
+        from app.services.mutaciones_arbol import _hook_458_analizar_separata
         tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=99)
 
-        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+        with patch('app.services.mutaciones_arbol.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = None
             # No debe lanzar excepción
             _hook_458_analizar_separata(tarea, id_producido=10)
 
     def test_sin_doc_producido_no_activa_hook(self):
-        from app.routes.api_bc import _hook_458_analizar_separata
+        from app.services.mutaciones_arbol import _hook_458_analizar_separata
         tarea = _tarea_stub('ANALIZAR', 'CONSULTA_SEPARATA', tramite_id=5)
         org = MagicMock()
         org.estado = 'separata_enviada'
 
-        with patch('app.routes.api_bc.TramiteOrganismo') as mock_cls:
+        with patch('app.services.mutaciones_arbol.TramiteOrganismo') as mock_cls:
             mock_cls.query.filter_by.return_value.first.return_value = _vinculo_stub(org)
             _hook_458_analizar_separata(tarea, id_producido=None)
 


### PR DESCRIPTION
Trabajo de árbol del expediente (ADR-016): capa de mutación en backend (S3b-0) y modo edición en el front (S3b-1), más un fix de mensajería de bloqueos.

## Cambios

**Backend — endpoints de mutación del árbol (S3b-0)**
- `services/mutaciones_arbol.py`: crear/editar/borrar nodos + `ResultadoMutacion`; delegación desde `api_bc.py`.
- `api_expedientes.py`: endpoints JSON `POST .../hijos`, `PATCH .../nodo/<tipo>/<id>`, `DELETE`, y `GET .../editable`.
- `services/esquema_editable.py`: esquema del editor por tipo de nodo.
- Smokes `test_smoke_mutaciones_arbol.py`; fix de imports/patch en `test_458_estado_organismo.py`.

**Front — modo edición del árbol (S3b-1, isla `expediente-arbol`)**
- `shared/api.js`: `patch`. `api.js`: `getEditable`/`patchNodo`.
- Store: estado de edición + `entrarEdicion/setCampo/guardar/cancelar/refrescarArbol` + `selectHayCambios`.
- Inspector: split editor genérico (text/textarea/select, autofocus) + despensa placeholder; **botón Editar en el inspector**; Guardar/Cancelar solo aquí.
- **Lock-on-enter**: al entrar en edición se atenúa el chrome (`body.arbol-lock`), se monta un overlay que captura clics (toast) y el inspector queda elevado/destacado; `beforeunload` solo si hay cambios reales.
- Arbol: tono de fondo en edición + doble-clic para editar.

**Fix — mensajería de bloqueos (motor + invariantes)**
- `api_expedientes._bloqueo_422` surfacea `motivo or norma_compilada`, así el mensaje de los invariantes ESFTT (que va en `norma_compilada`) llega al toast en vez del genérico. Convenio documentado en `_bloquear`, `EvaluacionResult.motivo` y `_bloqueo_422`; guard unitario en los smokes.

## Verificación
- Smokes de `mutaciones_arbol`: verde (incl. guard de `_bloqueo_422`).
- Navegador (AT-2009, rol SUPERVISOR): editar simple (PATCH + refresco + persistencia), lock-on-enter, clic bloqueado por overlay, y bloqueo de cierre de fase (422 con motivo real, permanece en edición).

Parte de #500 (ADR-016). **No cierra el issue**: quedan pendientes S3b-2 (crear/despensa), S3b-3 (docs consumido/producido) y S3b-4.
