### PR TITLE
Despensa de tipos creables + crear (S3b-2, #500)

### DIFF
--- a/app/services/estado_semaforo.py
+++ b/app/services/estado_semaforo.py
@@ -161,9 +161,13 @@ def estado_fase(fase, estados_tramites: list[str]) -> tuple[str, bool]:
     if fase.planificada:                   # sin trámites aún
         return ('PENDIENTE_TRAMITAR', True)
     if fase.pdte_cierre:                   # todos los trámites cerrados, falta formalizar
-        if fase.resultado_fase_id is None:
+        # Solo las finalizadoras requieren resultado_fase_id explícito (el técnico
+        # tiene la última palabra). Las intermedias cierran por documento_resultado_id;
+        # su resultado_fase_id debe quedar NULL.
+        es_finalizadora = getattr(fase.tipo_fase, 'es_finalizadora', False)
+        if es_finalizadora and fase.resultado_fase_id is None:
             return ('PENDIENTE_ESTUDIO', True)   # 🔴 falta decidir resultado
-        return ('PENDIENTE_CERRAR', True)        # 🟠 resultado puesto, falta documento
+        return ('PENDIENTE_CERRAR', True)        # 🟠 falta documento formalizador
     return (_mayor_prioridad(estados_tramites), False)
 
 

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.CfrJnBnR.js",
+    "file": "bundle.expediente-arbol.DebO25BR.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.DebO25BR.js",
+    "file": "bundle.expediente-arbol.DZmxq0S7.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/react-src/src/expediente-arbol/api.js
+++ b/react-src/src/expediente-arbol/api.js
@@ -31,3 +31,8 @@ export function getEditable(expedienteId, tipo, nodoId) {
 export function patchNodo(expedienteId, tipo, nodoId, body) {
   return api.patch(`/api/expedientes/${expedienteId}/nodo/${tipo}/${nodoId}`, body)
 }
+
+// Crear hijo bajo un nodo (POST, S3b-2). Respuesta: {ok, ids:[...], advertencia?}.
+export function postHijo(expedienteId, padreTipo, padreId, body) {
+  return api.post(`/api/expedientes/${expedienteId}/nodo/${padreTipo}/${padreId}/hijos`, body)
+}

--- a/react-src/src/expediente-arbol/components/Despensa.jsx
+++ b/react-src/src/expediente-arbol/components/Despensa.jsx
@@ -1,11 +1,176 @@
 // Despensa.jsx — zona inferior del split del inspector en edición (ADR-016 §5/§10).
-// S3b-1: placeholder visible (la llena de tipos creables / documentos del pool S3b-2/3).
+// S3b-2: tipos de hijo creables con dos vías de creación equivalentes:
+//   · Drag del chip → soltar en la zona de drop del inspector
+//   · Click en el chip → botón "Crear" aparece en la zona de confirmación
 import React from 'react'
+import { useArbolStore } from '../store.js'
+
+const ETIQUETA_TIPO_HIJO = {
+  solicitud: 'solicitud',
+  fase:      'fase',
+  tramite:   'trámite',
+  tarea:     'tarea',
+}
+
+function ChipTipo({ tipo, seleccionado, onClickChip, onDragStart }) {
+  const tooltip = !tipo.permitido
+    ? [tipo.motivo, tipo.norma].filter(Boolean).join(' — ')
+    : tipo.advertencia ? `Advertencia: ${tipo.advertencia}` : ''
+
+  return (
+    <span
+      className={`badge border small ${
+        seleccionado
+          ? 'text-bg-primary border-primary'
+          : tipo.permitido
+            ? 'text-bg-light border-secondary-subtle'
+            : 'text-bg-secondary opacity-50 border-0'
+      }`}
+      style={{
+        cursor: tipo.permitido ? 'grab' : 'not-allowed',
+        userSelect: 'none',
+      }}
+      draggable={tipo.permitido}
+      onDragStart={tipo.permitido ? onDragStart : undefined}
+      onClick={tipo.permitido ? onClickChip : undefined}
+      title={tooltip || undefined}
+    >
+      {tipo.advertencia && <span className="me-1">⚠</span>}
+      {tipo.codigo}
+    </span>
+  )
+}
 
 export default function Despensa() {
+  const seleccion              = useArbolStore((s) => s.seleccion)
+  const modoEdicion            = useArbolStore((s) => s.modoEdicion)
+  const tiposCreables          = useArbolStore((s) => s.tiposCreables)
+  const tiposCreablesCargando  = useArbolStore((s) => s.tiposCreablesCargando)
+  const tipoCreacionPendiente  = useArbolStore((s) => s.tipoCreacionPendiente)
+  const creando                = useArbolStore((s) => s.creando)
+  const cargarTiposCreables    = useArbolStore((s) => s.cargarTiposCreables)
+  const seleccionarTipoCrear   = useArbolStore((s) => s.seleccionarTipoCrear)
+  const cancelarCrear          = useArbolStore((s) => s.cancelarCrear)
+  const crearHijo              = useArbolStore((s) => s.crearHijo)
+
+  const [mostrarTodos, setMostrarTodos] = React.useState(false)
+  const [draggingOver, setDraggingOver] = React.useState(false)
+
+  React.useEffect(() => {
+    if (modoEdicion && seleccion && seleccion.tipo !== 'tarea') {
+      cargarTiposCreables(seleccion)
+    }
+  }, [seleccion?.tipo, seleccion?.id, modoEdicion])  // eslint-disable-line
+
+  if (!modoEdicion || !seleccion || seleccion.tipo === 'tarea') return null
+
+  if (tiposCreablesCargando) {
+    return (
+      <div className="p-2 text-muted small fst-italic">Cargando tipos…</div>
+    )
+  }
+  if (!tiposCreables) return null
+
+  const tipos     = tiposCreables.tipos || []
+  const permitidos = tipos.filter((t) => t.permitido)
+  const hayNoPermitidos = permitidos.length < tipos.length
+  const mostrados = mostrarTodos ? tipos : permitidos
+  const tipoHijo  = ETIQUETA_TIPO_HIJO[tiposCreables.tipo_hijo] || tiposCreables.tipo_hijo || 'hijo'
+
+  const onDragStart = (tipo) => (e) => {
+    e.dataTransfer.setData('application/despensa-tipo', JSON.stringify({
+      tipo_id: tipo.tipo_id,
+      codigo:  tipo.codigo,
+      nombre:  tipo.nombre,
+    }))
+    e.dataTransfer.effectAllowed = 'copy'
+  }
+
+  const onDragOver = (e) => {
+    if (e.dataTransfer.types.includes('application/despensa-tipo')) {
+      e.preventDefault()
+      setDraggingOver(true)
+    }
+  }
+  const onDragLeave = () => setDraggingOver(false)
+  const onDrop = (e) => {
+    e.preventDefault()
+    setDraggingOver(false)
+    try {
+      const tipo = JSON.parse(e.dataTransfer.getData('application/despensa-tipo'))
+      seleccionarTipoCrear(tipo)
+    } catch { /* ignorar datos malformados */ }
+  }
+
   return (
-    <div className="h-100 d-flex align-items-center justify-content-center text-muted small fst-italic">
-      Despensa — próximamente
+    <div className="p-2 d-flex flex-column gap-2">
+      {/* Cabecera */}
+      <div className="d-flex justify-content-between align-items-center">
+        <span className="text-muted small fw-semibold">Crear {tipoHijo}</span>
+        {hayNoPermitidos && (
+          <button
+            type="button"
+            className="btn btn-link btn-sm p-0 small"
+            onClick={() => setMostrarTodos((v) => !v)}
+          >
+            {mostrarTodos ? 'Solo permitidos' : 'Mostrar todos'}
+          </button>
+        )}
+      </div>
+
+      {/* Chips de tipos */}
+      {mostrados.length > 0 ? (
+        <div className="d-flex flex-wrap gap-1">
+          {mostrados.map((t) => (
+            <ChipTipo
+              key={t.tipo_id}
+              tipo={t}
+              seleccionado={tipoCreacionPendiente?.tipo_id === t.tipo_id}
+              onClickChip={() => seleccionarTipoCrear({ tipo_id: t.tipo_id, codigo: t.codigo, nombre: t.nombre })}
+              onDragStart={onDragStart(t)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-muted small fst-italic">No hay tipos disponibles</div>
+      )}
+
+      {/* Zona de drop / confirmación de creación */}
+      {tipoCreacionPendiente ? (
+        <div className="d-flex align-items-center gap-2 px-2 py-1 rounded border bg-primary-subtle border-primary-subtle">
+          <span className="small flex-grow-1 text-truncate">
+            <strong>{tipoCreacionPendiente.nombre}</strong>
+          </span>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            disabled={creando}
+            onClick={crearHijo}
+          >
+            {creando ? '…' : 'Crear'}
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-secondary"
+            disabled={creando}
+            onClick={cancelarCrear}
+          >
+            ✕
+          </button>
+        </div>
+      ) : (
+        <div
+          className={`d-flex align-items-center justify-content-center rounded border small text-muted p-2 ${
+            draggingOver ? 'bg-primary-subtle border-primary text-primary' : 'border-secondary-subtle'
+          }`}
+          style={{ borderStyle: 'dashed', minHeight: 36 }}
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+        >
+          {draggingOver ? 'Suelta aquí' : 'Arrastra o selecciona un tipo'}
+        </div>
+      )}
     </div>
   )
 }

--- a/react-src/src/expediente-arbol/components/Inspector.jsx
+++ b/react-src/src/expediente-arbol/components/Inspector.jsx
@@ -269,15 +269,18 @@ function Editor() {
 // de la UI desde que se entra; el inspector NUNCA se atenúa (es la zona interactiva).
 function InspectorEdicion({ nodo }) {
   const seleccion = useArbolStore((s) => s.seleccion)
+  const mostrarDespensa = seleccion && seleccion.tipo !== 'tarea'
   return (
     <div className="d-flex flex-column h-100 arbol-inspector--lock">
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }} className="p-3">
         <Cabecera tipo={seleccion.tipo} nodo={nodo} />
         <Editor />
       </div>
-      <div style={{ flex: '0 0 120px' }} className="border-top">
-        <Despensa />
-      </div>
+      {mostrarDespensa && (
+        <div style={{ flex: '0 0 auto' }} className="border-top">
+          <Despensa />
+        </div>
+      )}
     </div>
   )
 }

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -131,8 +131,11 @@ export const useArbolStore = create((set, get) => ({
   setCampo: (campo, valor) => set((s) => ({ borrador: { ...s.borrador, [campo]: valor } })),
 
   cancelar: () => {
+    const { seleccion } = get()
     set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false,
-          tiposCreables: null, tipoCreacionPendiente: null })
+          tiposCreables: null, tipoCreacionPendiente: null,
+          detalle: null, detalleCargando: false, detalleError: null })
+    get().cargarDetalle(seleccion)
     showToast('Cambios descartados', 'info')
   },
 

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -7,7 +7,7 @@
 // S3b-1: modoEdicion + lock + editor genérico (entrar/guardar/cancelar + refresco).
 // S3b añadirá: despensa, colapsos manuales por nivel.
 import { create } from 'zustand'
-import { getArbol, getNodo, getEditable, patchNodo } from './api.js'
+import { getArbol, getNodo, getEditable, patchNodo, getTiposCreables, postHijo } from './api.js'
 import { showToast } from '../shared/ui/toast.js'
 
 // AbortController de la petición de detalle en curso (fuera del estado: no re-render).
@@ -31,6 +31,13 @@ export const useArbolStore = create((set, get) => ({
   borradorInicial: {},        // snapshot al entrar (detección de cambios → lock)
   edicionCargando: false,
   guardando: false,
+
+  // --- creación de hijo (S3b-2) ---
+  _tiposCreablesCache: {},    // { 'tipo-id': payload } — compartida con menú contextual S3b-4
+  tiposCreables: null,        // payload de GET tipos-creables del nodo seleccionado
+  tiposCreablesCargando: false,
+  tipoCreacionPendiente: null, // { tipo_id, codigo, nombre } staged para crear
+  creando: false,
 
   // --- detalle del inspector (S3a) ---
   detalle: null,              // payload del endpoint lazy del nodo seleccionado
@@ -106,7 +113,8 @@ export const useArbolStore = create((set, get) => ({
   entrarEdicion: async (sel) => {
     if (!sel) return
     set({ seleccion: sel, modoEdicion: true, edicionCargando: true,
-          editableCampos: [], borrador: {}, borradorInicial: {} })
+          editableCampos: [], borrador: {}, borradorInicial: {},
+          tiposCreables: null, tipoCreacionPendiente: null })
     const expedienteId = get().expedienteId
     if (!expedienteId) { set({ edicionCargando: false }); return }  // mock standalone: editor vacío
     try {
@@ -123,7 +131,8 @@ export const useArbolStore = create((set, get) => ({
   setCampo: (campo, valor) => set((s) => ({ borrador: { ...s.borrador, [campo]: valor } })),
 
   cancelar: () => {
-    set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false })
+    set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false,
+          tiposCreables: null, tipoCreacionPendiente: null })
     showToast('Cambios descartados', 'info')
   },
 
@@ -147,6 +156,79 @@ export const useArbolStore = create((set, get) => ({
         showToast(e.payload.motivo, 'danger')          // bloqueo motor: PERMANECE en edición
       } else {
         showToast(e.message || 'No se pudo guardar', 'danger')
+      }
+    }
+  },
+
+  // --- acciones de creación (S3b-2) ---
+
+  // Carga tipos-creables del nodo `sel` (con caché compartida con el menú S3b-4).
+  cargarTiposCreables: async (sel) => {
+    if (!sel || sel.tipo === 'tarea') {
+      set({ tiposCreables: null, tiposCreablesCargando: false })
+      return
+    }
+    const key = `${sel.tipo}-${sel.id}`
+    const cacheado = get()._tiposCreablesCache[key]
+    if (cacheado) {
+      set({ tiposCreables: cacheado, tiposCreablesCargando: false })
+      return
+    }
+    const expedienteId = get().expedienteId
+    if (!expedienteId) { set({ tiposCreables: null, tiposCreablesCargando: false }); return }
+    set({ tiposCreablesCargando: true })
+    try {
+      const data = await getTiposCreables(expedienteId, sel.tipo, sel.id)
+      set((s) => ({
+        tiposCreables: data,
+        tiposCreablesCargando: false,
+        _tiposCreablesCache: { ...s._tiposCreablesCache, [key]: data },
+      }))
+    } catch {
+      set({ tiposCreables: null, tiposCreablesCargando: false })
+    }
+  },
+
+  seleccionarTipoCrear: (tipo) => set({ tipoCreacionPendiente: tipo }),
+
+  cancelarCrear: () => set({ tipoCreacionPendiente: null }),
+
+  crearHijo: async () => {
+    const { expedienteId, seleccion, tipoCreacionPendiente, tiposCreables } = get()
+    if (!seleccion || !tipoCreacionPendiente || !expedienteId) return
+    set({ creando: true })
+    try {
+      const esMulti = seleccion.tipo === 'expediente'
+      const body = esMulti
+        ? { tipo_ids: [tipoCreacionPendiente.tipo_id] }
+        : { tipo_id: tipoCreacionPendiente.tipo_id }
+      const data = await postHijo(expedienteId, seleccion.tipo, seleccion.id, body)
+      const nuevoTipo = tiposCreables?.tipo_hijo   // 'solicitud', 'fase', 'tramite', 'tarea'
+      const nuevoId = (data.ids || [])[0]
+
+      set({ creando: false, tipoCreacionPendiente: null })
+      showToast('Elemento creado', 'success')
+      if (data.advertencia) {
+        const a = data.advertencia
+        showToast(typeof a === 'string' ? a : (a.mensaje || a.texto || 'Revisa la advertencia'), 'warning')
+      }
+      // Invalidar caché de tipos del padre (el nuevo hijo puede cambiar lo creable).
+      set((s) => {
+        const cache = { ...s._tiposCreablesCache }
+        delete cache[`${seleccion.tipo}-${seleccion.id}`]
+        return { _tiposCreablesCache: cache }
+      })
+      await get().refrescarArbol()
+      if (nuevoId && nuevoTipo) {
+        await get().entrarEdicion({ tipo: nuevoTipo, id: nuevoId })
+      }
+    } catch (e) {
+      set({ creando: false })
+      if (e.status === 401 || e.status === 403) return
+      if (e.status === 422 && e.payload) {
+        showToast(e.payload.motivo || e.payload.error || 'Operación bloqueada', 'danger')
+      } else {
+        showToast(e.message || 'No se pudo crear el elemento', 'danger')
       }
     }
   },


### PR DESCRIPTION
## Cambios

- **Despensa de tipos creables** en el inspector (modo edición, nodos no-tarea): chips arrastrables por tipo de hijo, toggle "Mostrar todos" condicional para tipos no permitidos con tooltip de motivo/norma.
- **Dos vías de creación equivalentes:** drag del chip a zona de drop en el inspector, o click en el chip + botón "Crear". Ambas desembocan en la misma zona de confirmación (nombre completo + Crear + ✕).
- **Acción `crearHijo`** en el store: POST al backend, refresco del árbol, auto-select del nuevo nodo en modo edición. Caché de tipos-creables compartida con el futuro menú contextual (S3b-4).
- **Fix:** `cancelar()` ahora limpia el detalle y recarga el del nodo seleccionado; sin este fix el inspector mostraba datos del padre tras crear un hijo y cancelar su edición.
- **Fix semáforo:** fases intermedias en PDTE_CIERRE mostraban 🔴 (PENDIENTE_ESTUDIO) porque el semáforo exigía `resultado_fase_id` a todas las fases. Solo las finalizadoras (`es_finalizadora=True`) requieren ese campo; las intermedias cierran por `documento_resultado_id` y van directamente a 🟠 (PENDIENTE_CERRAR).

Closes #500
