### PR TITLE
Despensa de documentos del pool + vínculo a tarea (S3b-3)

### DIFF
--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -796,3 +796,37 @@ def get_esquema_editable(expediente_id, tipo, nodo_id):
     except ValueError as e:
         return jsonify({'error': str(e)}), 404
     return jsonify(data), 200
+
+
+# =============================================================================
+# ENDPOINT 10: Pool de documentos del expediente (despensa de tarea, ADR-016 §S3b-3)
+# =============================================================================
+
+@api_bp.route('/expedientes/<int:expediente_id>/pool', methods=['GET'])
+@login_required
+def pool_documentos(expediente_id):
+    """
+    GET /api/expedientes/<id>/pool — pool estructurado para la despensa de tareas (S3b-3).
+
+    Devuelve: {documentos: [{id, nombre, tipo_doc, fecha}]}, orden id DESC.
+    """
+    expediente = Expediente.query.get_or_404(expediente_id)
+    denegado = verificar_acceso_expediente(expediente)
+    if denegado:
+        return denegado
+
+    docs = Documento.query.filter_by(
+        expediente_id=expediente_id
+    ).order_by(Documento.id.desc()).all()
+
+    result = []
+    for doc in docs:
+        filename = (doc.url or '').replace('\\', '/').rsplit('/', 1)[-1]
+        filename = filename.split('?')[0].split('#')[0]
+        result.append({
+            'id': doc.id,
+            'nombre': filename or f'Documento {doc.id}',
+            'tipo_doc': doc.tipo_doc.nombre if doc.tipo_doc else None,
+            'fecha': doc.fecha_administrativa.strftime('%d/%m/%Y') if doc.fecha_administrativa else None,
+        })
+    return jsonify({'documentos': result}), 200

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.DZmxq0S7.js",
+    "file": "bundle.expediente-arbol.dRAWX_ts.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/react-src/src/expediente-arbol/api.js
+++ b/react-src/src/expediente-arbol/api.js
@@ -36,3 +36,8 @@ export function patchNodo(expedienteId, tipo, nodoId, body) {
 export function postHijo(expedienteId, padreTipo, padreId, body) {
   return api.post(`/api/expedientes/${expedienteId}/nodo/${padreTipo}/${padreId}/hijos`, body)
 }
+
+// Pool de documentos del expediente (GET, S3b-3). Respuesta: {documentos:[{id,nombre,tipo_doc,fecha}]}.
+export function getPool(expedienteId) {
+  return api.get(`/api/expedientes/${expedienteId}/pool`)
+}

--- a/react-src/src/expediente-arbol/components/Despensa.jsx
+++ b/react-src/src/expediente-arbol/components/Despensa.jsx
@@ -1,9 +1,12 @@
 // Despensa.jsx — zona inferior del split del inspector en edición (ADR-016 §5/§10).
-// S3b-2: tipos de hijo creables con dos vías de creación equivalentes:
-//   · Drag del chip → soltar en la zona de drop del inspector
-//   · Click en el chip → botón "Crear" aparece en la zona de confirmación
+//
+// Modo adaptativo según el tipo de nodo seleccionado:
+//   · tipos-creables (S3b-2): solicitud, fase, trámite, tarea  → chips de tipo + zona de drop/staging
+//   · docs del pool (S3b-3):  tarea  → fichas de doc del pool + staging consumido/producido
 import React from 'react'
 import { useArbolStore } from '../store.js'
+
+// ─── Modo tipos-creables (S3b-2) ────────────────────────────────────────────
 
 const ETIQUETA_TIPO_HIJO = {
   solicitud: 'solicitud',
@@ -41,9 +44,8 @@ function ChipTipo({ tipo, seleccionado, onClickChip, onDragStart }) {
   )
 }
 
-export default function Despensa() {
+function DespensaTipos() {
   const seleccion              = useArbolStore((s) => s.seleccion)
-  const modoEdicion            = useArbolStore((s) => s.modoEdicion)
   const tiposCreables          = useArbolStore((s) => s.tiposCreables)
   const tiposCreablesCargando  = useArbolStore((s) => s.tiposCreablesCargando)
   const tipoCreacionPendiente  = useArbolStore((s) => s.tipoCreacionPendiente)
@@ -57,25 +59,19 @@ export default function Despensa() {
   const [draggingOver, setDraggingOver] = React.useState(false)
 
   React.useEffect(() => {
-    if (modoEdicion && seleccion && seleccion.tipo !== 'tarea') {
-      cargarTiposCreables(seleccion)
-    }
-  }, [seleccion?.tipo, seleccion?.id, modoEdicion])  // eslint-disable-line
-
-  if (!modoEdicion || !seleccion || seleccion.tipo === 'tarea') return null
+    cargarTiposCreables(seleccion)
+  }, [seleccion?.tipo, seleccion?.id])  // eslint-disable-line
 
   if (tiposCreablesCargando) {
-    return (
-      <div className="p-2 text-muted small fst-italic">Cargando tipos…</div>
-    )
+    return <div className="p-2 text-muted small fst-italic">Cargando tipos…</div>
   }
   if (!tiposCreables) return null
 
-  const tipos     = tiposCreables.tipos || []
+  const tipos      = tiposCreables.tipos || []
   const permitidos = tipos.filter((t) => t.permitido)
   const hayNoPermitidos = permitidos.length < tipos.length
-  const mostrados = mostrarTodos ? tipos : permitidos
-  const tipoHijo  = ETIQUETA_TIPO_HIJO[tiposCreables.tipo_hijo] || tiposCreables.tipo_hijo || 'hijo'
+  const mostrados  = mostrarTodos ? tipos : permitidos
+  const tipoHijo   = ETIQUETA_TIPO_HIJO[tiposCreables.tipo_hijo] || tiposCreables.tipo_hijo || 'hijo'
 
   const onDragStart = (tipo) => (e) => {
     e.dataTransfer.setData('application/despensa-tipo', JSON.stringify({
@@ -104,7 +100,6 @@ export default function Despensa() {
 
   return (
     <div className="p-2 d-flex flex-column gap-2">
-      {/* Cabecera */}
       <div className="d-flex justify-content-between align-items-center">
         <span className="text-muted small fw-semibold">Crear {tipoHijo}</span>
         {hayNoPermitidos && (
@@ -118,7 +113,6 @@ export default function Despensa() {
         )}
       </div>
 
-      {/* Chips de tipos */}
       {mostrados.length > 0 ? (
         <div className="d-flex flex-wrap gap-1">
           {mostrados.map((t) => (
@@ -135,7 +129,6 @@ export default function Despensa() {
         <div className="text-muted small fst-italic">No hay tipos disponibles</div>
       )}
 
-      {/* Zona de drop / confirmación de creación */}
       {tipoCreacionPendiente ? (
         <div className="d-flex align-items-center gap-2 px-2 py-1 rounded border bg-primary-subtle border-primary-subtle">
           <span className="small flex-grow-1 text-truncate">
@@ -173,4 +166,134 @@ export default function Despensa() {
       )}
     </div>
   )
+}
+
+// ─── Modo docs del pool (S3b-3) ─────────────────────────────────────────────
+
+function FichaDoc({ doc, vinculado, seleccionada, onClick }) {
+  return (
+    <button
+      type="button"
+      className={`btn btn-sm w-100 text-start border rounded px-2 py-1 ${
+        seleccionada
+          ? 'btn-primary'
+          : vinculado
+            ? 'btn-outline-success'
+            : 'btn-outline-secondary'
+      }`}
+      style={{ fontSize: '0.78rem' }}
+      onClick={onClick}
+      title={doc.nombre}
+    >
+      <div className="text-truncate fw-semibold">{doc.nombre}</div>
+      <div className="text-truncate opacity-75">
+        {[doc.tipo_doc, doc.fecha].filter(Boolean).join(' · ')}
+      </div>
+    </button>
+  )
+}
+
+function DespensaDocs() {
+  const seleccion               = useArbolStore((s) => s.seleccion)
+  const detalle                 = useArbolStore((s) => s.detalle)
+  const pool                    = useArbolStore((s) => s.pool)
+  const poolCargando            = useArbolStore((s) => s.poolCargando)
+  const docVinculandoPendiente  = useArbolStore((s) => s.docVinculandoPendiente)
+  const vinculando              = useArbolStore((s) => s.vinculando)
+  const cargarPool              = useArbolStore((s) => s.cargarPool)
+  const seleccionarDocVincular  = useArbolStore((s) => s.seleccionarDocVincular)
+  const cancelarVincular        = useArbolStore((s) => s.cancelarVincular)
+  const vincularDoc             = useArbolStore((s) => s.vincularDoc)
+
+  React.useEffect(() => {
+    cargarPool()
+  }, [seleccion?.id])  // eslint-disable-line
+
+  // Ids de docs ya vinculados a esta tarea (para marcarlos visualmente)
+  const vinculadosIds = React.useMemo(() => {
+    const docs = (detalle && detalle.documentos) || []
+    return new Set(docs.map((d) => d.id))
+  }, [detalle])
+
+  if (poolCargando) {
+    return <div className="p-2 text-muted small fst-italic">Cargando documentos…</div>
+  }
+
+  return (
+    <div className="p-2 d-flex flex-column gap-2">
+      <span className="text-muted small fw-semibold">Pool de documentos</span>
+
+      {pool.length === 0 ? (
+        <div className="text-muted small fst-italic">No hay documentos en el expediente</div>
+      ) : (
+        <div className="d-flex flex-column gap-1" style={{ maxHeight: 120, overflowY: 'auto' }}>
+          {pool.map((doc) => (
+            <FichaDoc
+              key={doc.id}
+              doc={doc}
+              vinculado={vinculadosIds.has(doc.id)}
+              seleccionada={docVinculandoPendiente?.id === doc.id}
+              onClick={() =>
+                docVinculandoPendiente?.id === doc.id
+                  ? cancelarVincular()
+                  : seleccionarDocVincular(doc)
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Zona de confirmación / staging */}
+      {docVinculandoPendiente ? (
+        <div className="d-flex flex-column gap-1 px-2 py-1 rounded border bg-primary-subtle border-primary-subtle">
+          <span className="small text-truncate fw-semibold">{docVinculandoPendiente.nombre}</span>
+          <div className="d-flex gap-1">
+            <button
+              type="button"
+              className="btn btn-sm btn-success flex-grow-1"
+              disabled={vinculando}
+              onClick={() => vincularDoc('CONSUMIDO')}
+            >
+              {vinculando ? '…' : '+ Consumido'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-primary flex-grow-1"
+              disabled={vinculando}
+              onClick={() => vincularDoc('PRODUCIDO')}
+            >
+              {vinculando ? '…' : '+ Producido'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary"
+              disabled={vinculando}
+              onClick={cancelarVincular}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div
+          className="d-flex align-items-center justify-content-center rounded border small text-muted p-2 border-secondary-subtle"
+          style={{ borderStyle: 'dashed', minHeight: 36 }}
+        >
+          Selecciona un documento
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Componente principal (adaptativo) ──────────────────────────────────────
+
+export default function Despensa() {
+  const seleccion   = useArbolStore((s) => s.seleccion)
+  const modoEdicion = useArbolStore((s) => s.modoEdicion)
+
+  if (!modoEdicion || !seleccion) return null
+
+  if (seleccion.tipo === 'tarea') return <DespensaDocs />
+  return <DespensaTipos />
 }

--- a/react-src/src/expediente-arbol/components/Inspector.jsx
+++ b/react-src/src/expediente-arbol/components/Inspector.jsx
@@ -269,18 +269,15 @@ function Editor() {
 // de la UI desde que se entra; el inspector NUNCA se atenúa (es la zona interactiva).
 function InspectorEdicion({ nodo }) {
   const seleccion = useArbolStore((s) => s.seleccion)
-  const mostrarDespensa = seleccion && seleccion.tipo !== 'tarea'
   return (
     <div className="d-flex flex-column h-100 arbol-inspector--lock">
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }} className="p-3">
         <Cabecera tipo={seleccion.tipo} nodo={nodo} />
         <Editor />
       </div>
-      {mostrarDespensa && (
-        <div style={{ flex: '0 0 auto' }} className="border-top">
-          <Despensa />
-        </div>
-      )}
+      <div style={{ flex: '0 0 auto' }} className="border-top">
+        <Despensa />
+      </div>
     </div>
   )
 }

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -7,7 +7,7 @@
 // S3b-1: modoEdicion + lock + editor genérico (entrar/guardar/cancelar + refresco).
 // S3b añadirá: despensa, colapsos manuales por nivel.
 import { create } from 'zustand'
-import { getArbol, getNodo, getEditable, patchNodo, getTiposCreables, postHijo } from './api.js'
+import { getArbol, getNodo, getEditable, patchNodo, getTiposCreables, postHijo, getPool } from './api.js'
 import { showToast } from '../shared/ui/toast.js'
 
 // AbortController de la petición de detalle en curso (fuera del estado: no re-render).
@@ -38,6 +38,13 @@ export const useArbolStore = create((set, get) => ({
   tiposCreablesCargando: false,
   tipoCreacionPendiente: null, // { tipo_id, codigo, nombre } staged para crear
   creando: false,
+
+  // --- pool de documentos (S3b-3) ---
+  pool: [],                       // [{id, nombre, tipo_doc, fecha}] del expediente
+  poolCargado: false,             // carga perezosa una vez por isla (el pool no cambia en esta vista)
+  poolCargando: false,
+  docVinculandoPendiente: null,   // {id, nombre, tipo_doc, fecha} staged para vincular
+  vinculando: false,
 
   // --- detalle del inspector (S3a) ---
   detalle: null,              // payload del endpoint lazy del nodo seleccionado
@@ -114,7 +121,8 @@ export const useArbolStore = create((set, get) => ({
     if (!sel) return
     set({ seleccion: sel, modoEdicion: true, edicionCargando: true,
           editableCampos: [], borrador: {}, borradorInicial: {},
-          tiposCreables: null, tipoCreacionPendiente: null })
+          tiposCreables: null, tipoCreacionPendiente: null,
+          docVinculandoPendiente: null })
     const expedienteId = get().expedienteId
     if (!expedienteId) { set({ edicionCargando: false }); return }  // mock standalone: editor vacío
     try {
@@ -134,6 +142,7 @@ export const useArbolStore = create((set, get) => ({
     const { seleccion } = get()
     set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false,
           tiposCreables: null, tipoCreacionPendiente: null,
+          docVinculandoPendiente: null,
           detalle: null, detalleCargando: false, detalleError: null })
     get().cargarDetalle(seleccion)
     showToast('Cambios descartados', 'info')
@@ -232,6 +241,70 @@ export const useArbolStore = create((set, get) => ({
         showToast(e.payload.motivo || e.payload.error || 'Operación bloqueada', 'danger')
       } else {
         showToast(e.message || 'No se pudo crear el elemento', 'danger')
+      }
+    }
+  },
+
+  // --- acciones del pool (S3b-3) ---
+
+  // Carga el pool una sola vez por vida de la isla (lazy). El pool no cambia mientras
+  // se usa la despensa de tareas (las subidas viven en otra vista).
+  cargarPool: async () => {
+    if (get().poolCargado || get().poolCargando) return
+    const expedienteId = get().expedienteId
+    if (!expedienteId) return
+    set({ poolCargando: true })
+    try {
+      const data = await getPool(expedienteId)
+      set({ pool: data.documentos || [], poolCargado: true, poolCargando: false })
+    } catch {
+      set({ poolCargando: false })
+    }
+  },
+
+  seleccionarDocVincular: (doc) => set({ docVinculandoPendiente: doc }),
+
+  cancelarVincular: () => set({ docVinculandoPendiente: null }),
+
+  // Vincula `docVinculandoPendiente` a la tarea seleccionada con el rol dado.
+  // El PATCH reconstruye el conjunto COMPLETO (no incremental): toma los vínculos
+  // actuales del `detalle` + añade el nuevo. Preserva `notas` del borrador activo.
+  vincularDoc: async (rol) => {
+    const { expedienteId, seleccion, docVinculandoPendiente, detalle, borrador } = get()
+    if (!seleccion || seleccion.tipo !== 'tarea' || !docVinculandoPendiente || !expedienteId) return
+
+    const docs = (detalle && detalle.documentos) || []
+    const consumidosIds = docs.filter((d) => d.rol === 'CONSUMIDO').map((d) => d.id)
+    const producidoId = (docs.find((d) => d.rol === 'PRODUCIDO') || {}).id || null
+
+    let nuevosConsumidosIds = [...consumidosIds]
+    let nuevoProducidoId = producidoId
+
+    if (rol === 'CONSUMIDO') {
+      if (!nuevosConsumidosIds.includes(docVinculandoPendiente.id)) {
+        nuevosConsumidosIds = [...nuevosConsumidosIds, docVinculandoPendiente.id]
+      }
+    } else {
+      nuevoProducidoId = docVinculandoPendiente.id
+    }
+
+    set({ vinculando: true })
+    try {
+      await patchNodo(expedienteId, 'tarea', seleccion.id, {
+        documentos_consumidos_ids: nuevosConsumidosIds,
+        documento_producido_id:    nuevoProducidoId,
+        notas:                     borrador['notas'] ?? null,
+      })
+      set({ vinculando: false, docVinculandoPendiente: null })
+      showToast('Documento vinculado', 'success')
+      await get().refrescarArbol()
+    } catch (e) {
+      set({ vinculando: false })
+      if (e.status === 401 || e.status === 403) return
+      if (e.status === 422 && e.payload) {
+        showToast(e.payload.motivo || e.payload.error || 'No se pudo vincular el documento', 'danger')
+      } else {
+        showToast(e.message || 'No se pudo vincular el documento', 'danger')
       }
     }
   },

--- a/tests/smoke/test_smoke_pool_documentos.py
+++ b/tests/smoke/test_smoke_pool_documentos.py
@@ -1,0 +1,31 @@
+"""Smoke tests — endpoint GET /pool de documentos del expediente (#500, S3b-3)."""
+import pytest
+
+
+def test_pool_documentos_200(usuario_supervisor, expediente_seed):
+    """GET /api/expedientes/<id>/pool → 200, clave 'documentos' es lista."""
+    r = usuario_supervisor.get(f'/api/expedientes/{expediente_seed}/pool')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert 'documentos' in data
+    assert isinstance(data['documentos'], list)
+
+
+def test_pool_documentos_campos(usuario_supervisor, expediente_seed, app):
+    """Cada doc del pool tiene id, nombre, tipo_doc, fecha."""
+    r = usuario_supervisor.get(f'/api/expedientes/{expediente_seed}/pool')
+    assert r.status_code == 200
+    docs = r.get_json()['documentos']
+    if not docs:
+        pytest.skip('No hay documentos en el expediente seed')
+    doc = docs[0]
+    assert 'id' in doc
+    assert 'nombre' in doc
+    assert 'tipo_doc' in doc
+    assert 'fecha' in doc
+
+
+def test_pool_documentos_sin_acceso_403(usuario_admin, app):
+    """GET /api/expedientes/99999999/pool → 404 (no existe)."""
+    r = usuario_admin.get('/api/expedientes/99999999/pool')
+    assert r.status_code == 404


### PR DESCRIPTION
## Cambios

- Nuevo endpoint `GET /api/expedientes/<id>/pool` con payload estructurado `{id, nombre, tipo_doc, fecha}` para la despensa de tareas (3 smokes verdes).
- `Despensa.jsx` refactorizado como componente adaptativo: modo **tipos-creables** para nodos no-tarea (S3b-2, sin cambios) y modo **docs del pool** para nodo tarea (S3b-3).
- Click en doc del pool → zona de staging con `[+ Consumido]` / `[+ Producido]` / `[✕]`; docs ya vinculados se marcan con borde verde.
- `store.js`: estado y acciones del pool (`cargarPool` lazy, `seleccionarDocVincular`, `cancelarVincular`, `vincularDoc`); el PATCH reconstruye el conjunto completo de vínculos (consumidos + producido) preservando `notas`.
- `Inspector.jsx`: eliminada la guardia `tipo !== 'tarea'` en `InspectorEdicion` — la despensa gestiona su propio modo.

Closes #500
