### PR TITLE
Fix vincular doc: respetar ciclo borrador→Guardar/Cancelar

### DIFF
--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.dRAWX_ts.js",
+    "file": "bundle.expediente-arbol.C4CxN52S.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/react-src/src/expediente-arbol/components/Despensa.jsx
+++ b/react-src/src/expediente-arbol/components/Despensa.jsx
@@ -195,11 +195,10 @@ function FichaDoc({ doc, vinculado, seleccionada, onClick }) {
 
 function DespensaDocs() {
   const seleccion               = useArbolStore((s) => s.seleccion)
-  const detalle                 = useArbolStore((s) => s.detalle)
+  const borrador                = useArbolStore((s) => s.borrador)
   const pool                    = useArbolStore((s) => s.pool)
   const poolCargando            = useArbolStore((s) => s.poolCargando)
   const docVinculandoPendiente  = useArbolStore((s) => s.docVinculandoPendiente)
-  const vinculando              = useArbolStore((s) => s.vinculando)
   const cargarPool              = useArbolStore((s) => s.cargarPool)
   const seleccionarDocVincular  = useArbolStore((s) => s.seleccionarDocVincular)
   const cancelarVincular        = useArbolStore((s) => s.cancelarVincular)
@@ -209,11 +208,12 @@ function DespensaDocs() {
     cargarPool()
   }, [seleccion?.id])  // eslint-disable-line
 
-  // Ids de docs ya vinculados a esta tarea (para marcarlos visualmente)
+  // Ids de docs vinculados según el borrador activo (refleja cambios pendientes de guardar)
   const vinculadosIds = React.useMemo(() => {
-    const docs = (detalle && detalle.documentos) || []
-    return new Set(docs.map((d) => d.id))
-  }, [detalle])
+    const ids = new Set(borrador.documentos_consumidos_ids || [])
+    if (borrador.documento_producido_id) ids.add(borrador.documento_producido_id)
+    return ids
+  }, [borrador.documentos_consumidos_ids, borrador.documento_producido_id])
 
   if (poolCargando) {
     return <div className="p-2 text-muted small fst-italic">Cargando documentos…</div>
@@ -251,23 +251,20 @@ function DespensaDocs() {
             <button
               type="button"
               className="btn btn-sm btn-success flex-grow-1"
-              disabled={vinculando}
               onClick={() => vincularDoc('CONSUMIDO')}
             >
-              {vinculando ? '…' : '+ Consumido'}
+              + Consumido
             </button>
             <button
               type="button"
               className="btn btn-sm btn-primary flex-grow-1"
-              disabled={vinculando}
               onClick={() => vincularDoc('PRODUCIDO')}
             >
-              {vinculando ? '…' : '+ Producido'}
+              + Producido
             </button>
             <button
               type="button"
               className="btn btn-sm btn-outline-secondary"
-              disabled={vinculando}
               onClick={cancelarVincular}
             >
               ✕

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -129,7 +129,14 @@ export const useArbolStore = create((set, get) => ({
       const data = await getEditable(expedienteId, sel.tipo, sel.id)
       const campos = data.campos || []
       const borrador = Object.fromEntries(campos.map((c) => [c.campo, c.valor ?? null]))
-      set({ editableCampos: campos, borrador, borradorInicial: borrador, edicionCargando: false })
+      // Para tarea: incluir vínculos documentales actuales en el borrador para que
+      // el ciclo dirty → Guardar/Cancelar cubra también la despensa de documentos.
+      if (sel.tipo === 'tarea') {
+        const docs = (get().detalle && get().detalle.documentos) || []
+        borrador.documentos_consumidos_ids = docs.filter((d) => d.rol === 'CONSUMIDO').map((d) => d.id)
+        borrador.documento_producido_id    = (docs.find((d) => d.rol === 'PRODUCIDO') || {}).id ?? null
+      }
+      set({ editableCampos: campos, borrador, borradorInicial: { ...borrador }, edicionCargando: false })
     } catch (e) {
       set({ edicionCargando: false })
       if (e.status !== 401 && e.status !== 403) showToast(e.message || 'No se pudo cargar el editor', 'danger')
@@ -266,19 +273,18 @@ export const useArbolStore = create((set, get) => ({
 
   cancelarVincular: () => set({ docVinculandoPendiente: null }),
 
-  // Vincula `docVinculandoPendiente` a la tarea seleccionada con el rol dado.
-  // El PATCH reconstruye el conjunto COMPLETO (no incremental): toma los vínculos
-  // actuales del `detalle` + añade el nuevo. Preserva `notas` del borrador activo.
-  vincularDoc: async (rol) => {
-    const { expedienteId, seleccion, docVinculandoPendiente, detalle, borrador } = get()
-    if (!seleccion || seleccion.tipo !== 'tarea' || !docVinculandoPendiente || !expedienteId) return
+  // Añade `docVinculandoPendiente` al borrador con el rol dado.
+  // No hace PATCH directamente: sigue el ciclo borrador → hayCambios → Guardar/Cancelar.
+  // El PATCH lo ejecuta `guardar` con el borrador completo.
+  vincularDoc: (rol) => {
+    const { seleccion, docVinculandoPendiente, borrador } = get()
+    if (!seleccion || seleccion.tipo !== 'tarea' || !docVinculandoPendiente) return
 
-    const docs = (detalle && detalle.documentos) || []
-    const consumidosIds = docs.filter((d) => d.rol === 'CONSUMIDO').map((d) => d.id)
-    const producidoId = (docs.find((d) => d.rol === 'PRODUCIDO') || {}).id || null
+    const consumidosIds = borrador.documentos_consumidos_ids || []
+    const producidoId   = borrador.documento_producido_id ?? null
 
     let nuevosConsumidosIds = [...consumidosIds]
-    let nuevoProducidoId = producidoId
+    let nuevoProducidoId    = producidoId
 
     if (rol === 'CONSUMIDO') {
       if (!nuevosConsumidosIds.includes(docVinculandoPendiente.id)) {
@@ -288,25 +294,14 @@ export const useArbolStore = create((set, get) => ({
       nuevoProducidoId = docVinculandoPendiente.id
     }
 
-    set({ vinculando: true })
-    try {
-      await patchNodo(expedienteId, 'tarea', seleccion.id, {
+    set((s) => ({
+      borrador: {
+        ...s.borrador,
         documentos_consumidos_ids: nuevosConsumidosIds,
         documento_producido_id:    nuevoProducidoId,
-        notas:                     borrador['notas'] ?? null,
-      })
-      set({ vinculando: false, docVinculandoPendiente: null })
-      showToast('Documento vinculado', 'success')
-      await get().refrescarArbol()
-    } catch (e) {
-      set({ vinculando: false })
-      if (e.status === 401 || e.status === 403) return
-      if (e.status === 422 && e.payload) {
-        showToast(e.payload.motivo || e.payload.error || 'No se pudo vincular el documento', 'danger')
-      } else {
-        showToast(e.message || 'No se pudo vincular el documento', 'danger')
-      }
-    }
+      },
+      docVinculandoPendiente: null,
+    }))
   },
 
   // Re-pide /arbol e invalida TODA la caché de detalle (una mutación puede recomputar


### PR DESCRIPTION
## Cambios

- `vincularDoc` ya no hace PATCH inmediato al elegir rol: actualiza el borrador (`documentos_consumidos_ids` / `documento_producido_id`), activa `hayCambios` y habilita el botón Guardar. El ciclo **Editar → dirty → Guardar/Cancelar** se respeta como en el resto del editor.
- `entrarEdicion` inicializa el borrador con los vínculos actuales de `detalle.documentos` (para tarea) para que el marcado visual y el ciclo dirty partan del estado real de la BD.
- `DespensaDocs` computa `vinculadosIds` desde el borrador (no desde `detalle`), reflejando inmediatamente los cambios pendientes de guardar.
- Eliminado el estado `vinculando` (ya no hay operación asíncrona en `vincularDoc`).

Closes #500
