### PR TITLE
S3b-4: menú contextual y borrar documento desde inspector

### DIFF
--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.ChbgHjpl.js",
+    "file": "bundle.expediente-arbol.a2lt1_HC.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,
@@ -31,7 +31,7 @@
       "_chunk.index.BLcVfAtS.js"
     ],
     "css": [
-      "asset.expediente-arbol.CBfnaAn4.css"
+      "asset.expediente-arbol.Cpt8VahC.css"
     ]
   }
 }

--- a/docs/decisiones/ADR-016-vista-arbol-expediente.md
+++ b/docs/decisiones/ADR-016-vista-arbol-expediente.md
@@ -4,6 +4,7 @@
 **Fecha:** 2026-05-28
 **Issue:** #500
 **Enmendada:** 2026-05-30 (#500, sesión de implementación) — añadidos §16 (contrato de endpoints), agregadores en colapso (§11), tooltip-peek de hover (§2.4/§15); iteración de trámite fuera de v1 (§2).
+**Enmendada:** 2026-06-03 (#500, sesión S3b-4) — §7 y §8: Borrar eliminado del menú contextual; vive exclusivamente en inspector modo edición con flujo de dos pasos. §9: doble clic funcional (`zoomOnDoubleClick=false`, commit 71d9b5e); atajos F2 y Supr eliminados.
 
 ---
 
@@ -175,6 +176,15 @@ Inspector se **divide en split vertical** mediante un splitter ajustable por el 
 
 Otras "acciones" (finalizar fase, cerrar trámite, registrar resultado de notificación, marcar diagnóstico) son **resultados de edición + guardar**, no acciones independientes. Ejemplo: cerrar una fase = editar la fase + rellenar `resultado_fase_id` y `documento_resultado_id` + Guardar.
 
+**Borrar es una modificación** y vive exclusivamente en modo edición (inspector). No es accesible desde modo lectura — ni por menú contextual ni por atajo de teclado. El inspector en modo edición muestra `Cancelar | Borrar | Guardar`.
+
+**Flujo de borrado (dos pasos, inline en inspector):**
+1. Clic "Borrar" → el motor valida. Si 422 → toast con motivo, permanece en edición.
+2. Si el motor permite → el inspector muestra las consecuencias usando los `agregados` ya disponibles en el store (contadores del subárbol) con aviso de irreversibilidad y botón "Borrar definitivamente".
+3. Clic "Borrar definitivamente" → DELETE → toast success + refrescar árbol + deseleccionar + salir edición.
+
+El overlay de edición (commit 898094b) bloquea el árbol cuando hay cambios pendientes, por lo que el menú contextual (modo lectura) nunca aparece en edición — la separación es estructural.
+
 ### 8. Menú contextual (right-click)
 
 #### Sobre nodo no-tarea (Solicitud / Fase / Trámite)
@@ -182,8 +192,7 @@ Otras "acciones" (finalizar fase, cerrar trámite, registrar resultado de notifi
 ```
 ➕ Crear hijo                  ▶   (submenú con tipos creables filtrados por motor;
                                      "Mostrar todos..." expande con atenuados + tooltip norma)
-✏️ Editar                  F2
-🗑️ Borrar                  Supr
+✏️ Editar
 ─────────────────────────────────
 📂 Abrir carpeta del expediente
 📋 Copiar referencia
@@ -194,13 +203,14 @@ Otras "acciones" (finalizar fase, cerrar trámite, registrar resultado de notifi
 ```
 📄 Abrir documento producido       (solo si lo tiene)
 📄 Abrir consumido(s)           ▶   (submenú si hay >1, directo si 1)
-✏️ Editar                  F2
-🗑️ Borrar                  Supr
+✏️ Editar
 ─────────────────────────────────
 📂 Abrir carpeta del documento     (si tarea tiene doc; texto adaptativo)
 📂 Abrir carpeta del expediente    (si no tiene doc — fallback)
 📋 Copiar referencia
 ```
+
+> **Enmendado (2026-06-03):** Borrar eliminado del menú contextual. Ver §7 — vive en inspector modo edición.
 
 #### Prioridad para "Abrir carpeta del documento"
 
@@ -227,7 +237,7 @@ Copia al portapapeles algo como: `AT-1234 · AAP · Fase Información Pública �
 | **Click izquierdo** sobre nodo | Selecciona |
 | **Click izquierdo** sobre fondo | Deselecciona |
 | **Click derecho** sobre nodo | Menú contextual (§8) |
-| **Doble clic** sobre nodo | Selecciona + activa edición + enfoca primer editable |
+| **Doble clic** sobre nodo | Selecciona + activa edición + enfoca primer editable (`zoomOnDoubleClick=false`, commit 71d9b5e) |
 | **Drag-drop** desde despensa (tipos) sobre nodo padre | Crea hijo del tipo arrastrado |
 | **Drag-drop** desde despensa (documentos) sobre tarea | Vincula documento a la tarea |
 | **Scroll del ratón** sobre área del árbol | Zoom in/out de xyflow |

--- a/react-src/src/expediente-arbol/api.js
+++ b/react-src/src/expediente-arbol/api.js
@@ -41,3 +41,8 @@ export function postHijo(expedienteId, padreTipo, padreId, body) {
 export function getPool(expedienteId) {
   return api.get(`/api/expedientes/${expedienteId}/pool`)
 }
+
+// Borrar un nodo (DELETE, S3b-4). Respuesta éxito: {ok:true} 200. Motor: {motivo,url_norma} 422.
+export function deleteNodo(expedienteId, tipo, nodoId) {
+  return api.delete(`/api/expedientes/${expedienteId}/nodo/${tipo}/${nodoId}`)
+}

--- a/react-src/src/expediente-arbol/components/Arbol.jsx
+++ b/react-src/src/expediente-arbol/components/Arbol.jsx
@@ -15,6 +15,7 @@ import NodoSolicitud from './nodos/NodoSolicitud.jsx'
 import NodoFase from './nodos/NodoFase.jsx'
 import NodoTramite from './nodos/NodoTramite.jsx'
 import NodoTareas from './nodos/NodoTareas.jsx'
+import MenuContextual from './MenuContextual.jsx'
 
 const nodeTypes = {
   expediente: NodoExpediente,
@@ -34,6 +35,7 @@ export default function Arbol() {
   const seleccionar = useArbolStore((s) => s.seleccionar)
   const modoEdicion = useArbolStore((s) => s.modoEdicion)
   const entrarEdicion = useArbolStore((s) => s.entrarEdicion)
+  const abrirMenu = useArbolStore((s) => s.abrirMenu)
 
   const { nodes, edges } = useMemo(
     () => construirGrafo(arbol, { colapsarFinalizados, seleccion }),
@@ -59,7 +61,17 @@ export default function Arbol() {
   )
   const onPaneClick = useCallback(() => seleccionar(null), [seleccionar])
 
+  const onNodeContextMenu = useCallback(
+    (e, node) => {
+      if (node.data.tipo === 'tareas') return  // container-nodo; cada tarea lo gestiona internamente
+      e.preventDefault()
+      abrirMenu(e.clientX, e.clientY, { tipo: node.data.tipo, id: node.data.id })
+    },
+    [abrirMenu],
+  )
+
   return (
+    <>
     <ReactFlow
       className={modoEdicion ? 'arbol-lienzo--edicion' : undefined}
       nodes={nodes}
@@ -67,6 +79,7 @@ export default function Arbol() {
       nodeTypes={nodeTypes}
       onNodeClick={onNodeClick}
       onNodeDoubleClick={onNodeDoubleClick}
+      onNodeContextMenu={onNodeContextMenu}
       onPaneClick={onPaneClick}
       defaultEdgeOptions={defaultEdgeOptions}
       nodesDraggable={false}
@@ -81,5 +94,7 @@ export default function Arbol() {
       <Background />
       <Controls showInteractive={false} />
     </ReactFlow>
+    <MenuContextual />
+    </>
   )
 }

--- a/react-src/src/expediente-arbol/components/Inspector.jsx
+++ b/react-src/src/expediente-arbol/components/Inspector.jsx
@@ -30,7 +30,7 @@ const ETIQUETA_PLAZO = {
 
 const ROL_DOC = { CONSUMIDO: 'Consumido', PRODUCIDO: 'Producido' }
 
-// --- Búsqueda del nodo en el árbol del store (cabecera + agregados, §5) ---------
+// --- Búsqueda y conteo de subárbol (para confirmación de borrado, §7) -----------
 
 function buscarNodo(arbol, sel) {
   if (!arbol || !sel) return null
@@ -48,6 +48,28 @@ function buscarNodo(arbol, sel) {
     }
   }
   return null
+}
+
+function contarSubarbol(arbol, sel) {
+  if (!sel || !arbol) return {}
+  const nodo = buscarNodo(arbol, sel)
+  if (!nodo) return {}
+  if (sel.tipo === 'solicitud') {
+    const fases = nodo.fases || []
+    const tramites = fases.reduce((n, f) => n + (f.tramites || []).length, 0)
+    const tareas = fases.reduce((n, f) =>
+      n + (f.tramites || []).reduce((n2, tr) => n2 + (tr.tareas || []).length, 0), 0)
+    return { fases: fases.length, tramites, tareas }
+  }
+  if (sel.tipo === 'fase') {
+    const tramites = nodo.tramites || []
+    const tareas = tramites.reduce((n, tr) => n + (tr.tareas || []).length, 0)
+    return { tramites: tramites.length, tareas }
+  }
+  if (sel.tipo === 'tramite') {
+    return { tareas: (nodo.tareas || []).length }
+  }
+  return {}
 }
 
 function tituloNodo(tipo, nodo) {
@@ -200,29 +222,76 @@ function Acciones({ referencia, expedienteId }) {
   )
 }
 
+// --- Borrado (S3b-4): bloque inline de consecuencias + confirmación dos pasos ---
+
+function ConfirmacionBorrado({ nodo }) {
+  const seleccion      = useArbolStore((s) => s.seleccion)
+  const arbol          = useArbolStore((s) => s.arbol)
+  const borrando       = useArbolStore((s) => s.borrando)
+  const borrarNodo     = useArbolStore((s) => s.borrarNodo)
+  const cancelarBorrado = useArbolStore((s) => s.cancelarBorrado)
+
+  const titulo = tituloNodo(seleccion.tipo, nodo)
+  const conteo = contarSubarbol(arbol, seleccion)
+
+  const partes = []
+  if (conteo.fases)    partes.push(`${conteo.fases} fase${conteo.fases    !== 1 ? 's' : ''}`)
+  if (conteo.tramites) partes.push(`${conteo.tramites} trámite${conteo.tramites !== 1 ? 's' : ''}`)
+  if (conteo.tareas)   partes.push(`${conteo.tareas} tarea${conteo.tareas   !== 1 ? 's' : ''}`)
+
+  return (
+    <div>
+      <div className="alert alert-warning py-2 px-3 mb-3 small">
+        <div className="fw-semibold mb-1">
+          ¿Borrar {ETIQUETA_TIPO[seleccion.tipo]?.toLowerCase()} «{titulo || '—'}»?
+        </div>
+        {partes.length > 0 && (
+          <div>Contiene: {partes.join(', ')}.</div>
+        )}
+        <div className="text-danger fw-semibold mt-1">Esta acción es irreversible.</div>
+      </div>
+      <div className="d-flex gap-2">
+        <button type="button" className="btn btn-sm btn-danger"
+                disabled={borrando} onClick={borrarNodo}>
+          {borrando ? 'Borrando…' : 'Borrar definitivamente'}
+        </button>
+        <button type="button" className="btn btn-sm btn-outline-secondary"
+                disabled={borrando} onClick={cancelarBorrado}>
+          Cancelar
+        </button>
+      </div>
+    </div>
+  )
+}
+
 // --- Edición (S3b-1): editor genérico + split editor/despensa ------------------
 
 // Editor genérico: pinta un control por campo del esquema editable, autofocus en
 // el primero, botonera Guardar/Cancelar. value/onChange contra borrador/setCampo.
 function Editor() {
-  const campos    = useArbolStore((s) => s.editableCampos)
-  const cargando  = useArbolStore((s) => s.edicionCargando)
-  const borrador  = useArbolStore((s) => s.borrador)
-  const setCampo  = useArbolStore((s) => s.setCampo)
-  const guardando = useArbolStore((s) => s.guardando)
-  const guardar   = useArbolStore((s) => s.guardar)
-  const cancelar  = useArbolStore((s) => s.cancelar)
+  const seleccion  = useArbolStore((s) => s.seleccion)
+  const campos     = useArbolStore((s) => s.editableCampos)
+  const cargando   = useArbolStore((s) => s.edicionCargando)
+  const borrador   = useArbolStore((s) => s.borrador)
+  const setCampo   = useArbolStore((s) => s.setCampo)
+  const guardando  = useArbolStore((s) => s.guardando)
+  const guardar    = useArbolStore((s) => s.guardar)
+  const cancelar   = useArbolStore((s) => s.cancelar)
   const hayCambios = useArbolStore(selectHayCambios)
+  const solicitarBorrado = useArbolStore((s) => s.solicitarBorrado)
   const firstRef = React.useRef(null)
   React.useEffect(() => { if (firstRef.current) firstRef.current.focus() }, [campos])
 
+  const puedeBorrar = tienePermiso('editar_expediente') &&
+                      seleccion && seleccion.tipo !== 'expediente'
+
   if (cargando) return <div className="text-muted small">Cargando editor…</div>
   if (!campos.length)
-    // Sin campos editables (p.ej. expediente): NO atrapar al usuario en edición.
-    // Siempre debe poder salir → botón Cancelar (no hay nada que Guardar). (#511)
     return (
       <div>
-        <div className="text-muted small mb-3">Este elemento no tiene campos editables.</div>
+        <div className="text-muted small mb-3">
+          Sin campos editables. Usa la despensa inferior para añadir elementos al árbol.
+        </div>
         <button type="button" className="btn btn-sm btn-outline-secondary"
                 onClick={cancelar}>Cancelar</button>
       </div>
@@ -258,6 +327,10 @@ function Editor() {
                 disabled={guardando || !hayCambios} onClick={guardar}>Guardar</button>
         <button type="button" className="btn btn-sm btn-outline-secondary"
                 onClick={cancelar}>Cancelar</button>
+        {puedeBorrar && (
+          <button type="button" className="btn btn-sm btn-outline-danger ms-auto"
+                  onClick={solicitarBorrado}>🗑️ Borrar</button>
+        )}
       </div>
     </form>
   )
@@ -268,16 +341,22 @@ function Editor() {
 // borde+sombra de edición (arbol-inspector--lock, CSS) porque editar bloquea el resto
 // de la UI desde que se entra; el inspector NUNCA se atenúa (es la zona interactiva).
 function InspectorEdicion({ nodo }) {
-  const seleccion = useArbolStore((s) => s.seleccion)
+  const seleccion             = useArbolStore((s) => s.seleccion)
+  const borrarPendienteConfirm = useArbolStore((s) => s.borrarPendienteConfirm)
   return (
     <div className="d-flex flex-column h-100 arbol-inspector--lock">
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }} className="p-3">
         <Cabecera tipo={seleccion.tipo} nodo={nodo} />
-        <Editor />
+        {borrarPendienteConfirm
+          ? <ConfirmacionBorrado nodo={nodo} />
+          : <Editor />
+        }
       </div>
-      <div style={{ flex: '0 0 auto' }} className="border-top">
-        <Despensa />
-      </div>
+      {!borrarPendienteConfirm && (
+        <div style={{ flex: '0 0 auto' }} className="border-top">
+          <Despensa />
+        </div>
+      )}
     </div>
   )
 }
@@ -305,9 +384,7 @@ export default function Inspector() {
   const nodo = buscarNodo(arbol, seleccion)
   if (modoEdicion) return <InspectorEdicion nodo={nodo} />
   const esHoja = seleccion.tipo === 'tarea'
-  // El nodo expediente no tiene campos editables (esquema_editable → []): no ofrecer
-  // Editar para no entrar en una edición vacía (#511, alternativa "deshabilitar editar").
-  const puedeEditar = tienePermiso('editar_expediente') && seleccion.tipo !== 'expediente'
+  const puedeEditar = tienePermiso('editar_expediente')
 
   return (
     <div className="p-3 d-flex flex-column h-100">

--- a/react-src/src/expediente-arbol/components/MenuContextual.jsx
+++ b/react-src/src/expediente-arbol/components/MenuContextual.jsx
@@ -1,7 +1,216 @@
-// MenuContextual.jsx — ESQUELETO S3 (ADR-016 §8).
-// Menú right-click (crear hijo, editar, borrar, abrir carpeta, copiar referencia). S3.
-import React from 'react'
+// MenuContextual.jsx — menú right-click del árbol (ADR-016 §8, S3b-4).
+// Sin Borrar — vive en el inspector modo edición (ADR §7 enmendado 2026-06-03).
+// Estado de posición/visibilidad en el store (menuCtx) para que NodoTareas pueda abrirlo.
+import React, { useState, useEffect, useRef } from 'react'
+import { useArbolStore } from '../store.js'
+import { api } from '../../shared/api.js'
+import { showToast } from '../../shared/ui/toast.js'
+import { tienePermiso } from '../../shared/auth.js'
+
+async function copiarReferencia(ref) {
+  try {
+    await navigator.clipboard.writeText(ref)
+    showToast('Referencia copiada al portapapeles', 'success')
+  } catch {
+    showToast('No se pudo copiar la referencia', 'danger')
+  }
+}
+
+async function postAccion(url) {
+  try { await api.post(url) }
+  catch (e) { showToast((e && e.message) || 'No se pudo completar la acción', 'danger') }
+}
+
+const MENU_W = 220
+const MENU_H = 220
 
 export default function MenuContextual() {
-  return null
+  const menuCtx               = useArbolStore((s) => s.menuCtx)
+  const cerrarMenu            = useArbolStore((s) => s.cerrarMenu)
+  const tiposCreables         = useArbolStore((s) => s.tiposCreables)
+  const tiposCreablesCargando = useArbolStore((s) => s.tiposCreablesCargando)
+  const detalle               = useArbolStore((s) => s.detalle)
+  const expedienteId          = useArbolStore((s) => s.expedienteId)
+  const entrarEdicion         = useArbolStore((s) => s.entrarEdicion)
+  const seleccionarTipoCrear  = useArbolStore((s) => s.seleccionarTipoCrear)
+  const crearHijo             = useArbolStore((s) => s.crearHijo)
+
+  const menuRef = useRef(null)
+  const [submenuActivo, setSubmenuActivo] = useState(null) // 'crear-hijo' | 'consumidos' | null
+
+  // Cerrar menú al cambiar sel (reset submenu)
+  useEffect(() => { setSubmenuActivo(null) }, [menuCtx?.sel])
+
+  // Click fuera → cerrar
+  useEffect(() => {
+    if (!menuCtx) return
+    const onMouseDown = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) cerrarMenu()
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    return () => document.removeEventListener('mousedown', onMouseDown)
+  }, [menuCtx, cerrarMenu])
+
+  // Esc y scroll → cerrar
+  useEffect(() => {
+    if (!menuCtx) return
+    const onKey    = (e) => { if (e.key === 'Escape') cerrarMenu() }
+    const onScroll = () => cerrarMenu()
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('scroll', onScroll, true)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('scroll', onScroll, true)
+    }
+  }, [menuCtx, cerrarMenu])
+
+  if (!menuCtx) return null
+
+  const { x, y, sel } = menuCtx
+  const px = Math.min(x, window.innerWidth  - MENU_W - 8)
+  const py = Math.min(y, window.innerHeight - MENU_H - 8)
+
+  const esTarea    = sel.tipo === 'tarea'
+  const puedeEditar = tienePermiso('editar_expediente') && sel.tipo !== 'expediente'
+
+  const tipos        = tiposCreables?.tipos || []
+  const permitidos   = tipos.filter((t) => t.permitido)
+  const noPermitidos = tipos.filter((t) => !t.permitido)
+
+  const producido  = detalle?.documentos?.find((d) => d.rol === 'PRODUCIDO')
+  const consumidos = detalle?.documentos?.filter((d) => d.rol === 'CONSUMIDO') || []
+  // Carpeta del documento: producido con carpeta > primer consumido con carpeta > expediente
+  const docParaCarpeta = producido?.puede_abrir_carpeta
+    ? producido
+    : consumidos.find((d) => d.puede_abrir_carpeta) || null
+
+  const handleEditar = () => { entrarEdicion(sel); cerrarMenu() }
+
+  const handleCrearTipo = (tipo) => {
+    seleccionarTipoCrear({ tipo_id: tipo.tipo_id, codigo: tipo.codigo, nombre: tipo.nombre })
+    crearHijo()
+    cerrarMenu()
+  }
+
+  const handleCarpetaDoc = (doc) => {
+    postAccion(`/expedientes/${expedienteId}/documentos/${doc.id}/abrir-en-carpeta`)
+    cerrarMenu()
+  }
+
+  const handleCarpetaExp = () => {
+    postAccion(`/expedientes/${expedienteId}/abrir-carpeta`)
+    cerrarMenu()
+  }
+
+  const handleCopiarRef = () => {
+    if (detalle?.referencia) copiarReferencia(detalle.referencia)
+    cerrarMenu()
+  }
+
+  return (
+    <div ref={menuRef} className="arbol-menu"
+         style={{ position: 'fixed', top: py, left: px, zIndex: 9999 }}>
+
+      {/* ── Nodo no-tarea ── */}
+      {!esTarea && (
+        <>
+          <div className="arbol-menu__submenu-wrap"
+               onMouseEnter={() => setSubmenuActivo('crear-hijo')}
+               onMouseLeave={() => setSubmenuActivo(null)}>
+            <div className="arbol-menu__item">
+              <span>➕ Crear hijo</span>
+              <span style={{ marginLeft: 'auto', opacity: .5, fontSize: 10 }}>▶</span>
+            </div>
+            {submenuActivo === 'crear-hijo' && (
+              <div className="arbol-menu__submenu">
+                {tiposCreablesCargando && (
+                  <div className="arbol-menu__item" style={{ opacity: .6 }}>Cargando…</div>
+                )}
+                {!tiposCreablesCargando && tipos.length === 0 && (
+                  <div className="arbol-menu__item" style={{ opacity: .6 }}>Sin tipos disponibles</div>
+                )}
+                {permitidos.map((t) => (
+                  <div key={t.tipo_id} className="arbol-menu__item"
+                       onClick={() => handleCrearTipo(t)}>
+                    {t.nombre || t.codigo}
+                  </div>
+                ))}
+                {noPermitidos.length > 0 && permitidos.length > 0 && (
+                  <div className="arbol-menu__sep" />
+                )}
+                {noPermitidos.map((t) => (
+                  <div key={t.tipo_id}
+                       className="arbol-menu__item arbol-menu__item--disabled"
+                       title={[t.motivo, t.norma].filter(Boolean).join(' — ')}>
+                    {t.nombre || t.codigo}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          {puedeEditar && (
+            <div className="arbol-menu__item" onClick={handleEditar}>✏️ Editar</div>
+          )}
+        </>
+      )}
+
+      {/* ── Nodo tarea ── */}
+      {esTarea && (
+        <>
+          {producido && (
+            <a href={producido.enlace} target="_blank" rel="noreferrer"
+               className="arbol-menu__item" onClick={cerrarMenu}>
+              📄 Abrir documento producido
+            </a>
+          )}
+          {consumidos.length === 1 && (
+            <a href={consumidos[0].enlace} target="_blank" rel="noreferrer"
+               className="arbol-menu__item" onClick={cerrarMenu}>
+              📄 Abrir consumido
+            </a>
+          )}
+          {consumidos.length > 1 && (
+            <div className="arbol-menu__submenu-wrap"
+                 onMouseEnter={() => setSubmenuActivo('consumidos')}
+                 onMouseLeave={() => setSubmenuActivo(null)}>
+              <div className="arbol-menu__item">
+                <span>📄 Abrir consumido(s)</span>
+                <span style={{ marginLeft: 'auto', opacity: .5, fontSize: 10 }}>▶</span>
+              </div>
+              {submenuActivo === 'consumidos' && (
+                <div className="arbol-menu__submenu">
+                  {consumidos.map((d) => (
+                    <a key={d.id} href={d.enlace} target="_blank" rel="noreferrer"
+                       className="arbol-menu__item" onClick={cerrarMenu}>
+                      {d.nombre}
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          {puedeEditar && (
+            <div className="arbol-menu__item" onClick={handleEditar}>✏️ Editar</div>
+          )}
+        </>
+      )}
+
+      <div className="arbol-menu__sep" />
+
+      {/* ── Carpeta ── */}
+      {esTarea && docParaCarpeta ? (
+        <div className="arbol-menu__item" onClick={() => handleCarpetaDoc(docParaCarpeta)}>
+          📂 Abrir carpeta del documento
+        </div>
+      ) : (
+        <div className="arbol-menu__item" onClick={handleCarpetaExp}>
+          📂 Abrir carpeta del expediente
+        </div>
+      )}
+
+      <div className="arbol-menu__item" onClick={handleCopiarRef}>
+        📋 Copiar referencia
+      </div>
+    </div>
+  )
 }

--- a/react-src/src/expediente-arbol/components/nodos/NodoTareas.jsx
+++ b/react-src/src/expediente-arbol/components/nodos/NodoTareas.jsx
@@ -33,7 +33,7 @@ function barraPlazo(tarea) {
   }
 }
 
-function FilaTarea({ tarea, seleccionada, onSelect }) {
+function FilaTarea({ tarea, seleccionada, onSelect, onContextMenu }) {
   const titulo = tarea.abrev || tarea.nombre || tarea.tipo_codigo || ''
   const sem = tarea.semaforo || { color: 'gris' }
   const esPlazo = tarea.tipo_codigo === 'ESPERAR_PLAZO'
@@ -44,6 +44,7 @@ function FilaTarea({ tarea, seleccionada, onSelect }) {
       className={`arbol-tarea${seleccionada ? ' is-selected' : ''}`}
       title={tarea.nombre || ''}
       onClick={(e) => { e.stopPropagation(); onSelect(tarea.id) }}
+      onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); onContextMenu(e, tarea.id) }}
     >
       <div className="arbol-tarea__fila">
         <i className={`bi ${ICONO[tarea.tipo_codigo] || 'bi-dot'} arbol-tarea__icono`} />
@@ -62,7 +63,9 @@ function FilaTarea({ tarea, seleccionada, onSelect }) {
 
 export default function NodoTareas({ data }) {
   const seleccionar = useArbolStore((s) => s.seleccionar)
+  const abrirMenu   = useArbolStore((s) => s.abrirMenu)
   const onSelect = (id) => seleccionar({ tipo: 'tarea', id })
+  const onContextMenu = (e, id) => abrirMenu(e.clientX, e.clientY, { tipo: 'tarea', id })
 
   return (
     <div className="arbol-tareas">
@@ -73,6 +76,7 @@ export default function NodoTareas({ data }) {
           tarea={t}
           seleccionada={data.seleccionTarea === t.id}
           onSelect={onSelect}
+          onContextMenu={onContextMenu}
         />
       ))}
       <Handle type="source" position={Position.Bottom} className="arbol-handle" />

--- a/react-src/src/expediente-arbol/store.js
+++ b/react-src/src/expediente-arbol/store.js
@@ -7,7 +7,7 @@
 // S3b-1: modoEdicion + lock + editor genérico (entrar/guardar/cancelar + refresco).
 // S3b añadirá: despensa, colapsos manuales por nivel.
 import { create } from 'zustand'
-import { getArbol, getNodo, getEditable, patchNodo, getTiposCreables, postHijo, getPool } from './api.js'
+import { getArbol, getNodo, getEditable, patchNodo, getTiposCreables, postHijo, getPool, deleteNodo } from './api.js'
 import { showToast } from '../shared/ui/toast.js'
 
 // AbortController de la petición de detalle en curso (fuera del estado: no re-render).
@@ -46,6 +46,13 @@ export const useArbolStore = create((set, get) => ({
   docVinculandoPendiente: null,   // {id, nombre, tipo_doc, fecha} staged para vincular
   vinculando: false,
 
+  // --- borrar (S3b-4) ---
+  borrarPendienteConfirm: false, // true = inspector muestra bloque de consecuencias + "Borrar definitivamente"
+  borrando: false,
+
+  // --- menú contextual (S3b-4) ---
+  menuCtx: null,           // { x, y, sel } | null
+
   // --- detalle del inspector (S3a) ---
   detalle: null,              // payload del endpoint lazy del nodo seleccionado
   detalleCargando: false,
@@ -64,7 +71,7 @@ export const useArbolStore = create((set, get) => ({
 
   // Selección única: además dispara la carga del detalle del nodo (o lo limpia).
   seleccionar: (sel) => {
-    set({ seleccion: sel })
+    set({ seleccion: sel, borrarPendienteConfirm: false })
     get().cargarDetalle(sel)
   },
 
@@ -122,7 +129,8 @@ export const useArbolStore = create((set, get) => ({
     set({ seleccion: sel, modoEdicion: true, edicionCargando: true,
           editableCampos: [], borrador: {}, borradorInicial: {},
           tiposCreables: null, tipoCreacionPendiente: null,
-          docVinculandoPendiente: null })
+          docVinculandoPendiente: null,
+          menuCtx: null, borrarPendienteConfirm: false })
     const expedienteId = get().expedienteId
     if (!expedienteId) { set({ edicionCargando: false }); return }  // mock standalone: editor vacío
     try {
@@ -150,6 +158,7 @@ export const useArbolStore = create((set, get) => ({
     set({ modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {}, edicionCargando: false,
           tiposCreables: null, tipoCreacionPendiente: null,
           docVinculandoPendiente: null,
+          borrarPendienteConfirm: false,
           detalle: null, detalleCargando: false, detalleError: null })
     get().cargarDetalle(seleccion)
     showToast('Cambios descartados', 'info')
@@ -178,6 +187,52 @@ export const useArbolStore = create((set, get) => ({
       }
     }
   },
+
+  // --- acciones de borrado (S3b-4) ---
+
+  // Paso 1: muestra el bloque de consecuencias en el inspector (sin llamada API).
+  solicitarBorrado: () => set({ borrarPendienteConfirm: true }),
+
+  cancelarBorrado: () => set({ borrarPendienteConfirm: false }),
+
+  // Paso 2: ejecuta el DELETE real. Motor 422 → toast + vuelve al editor; éxito → limpia.
+  borrarNodo: async () => {
+    const { expedienteId, seleccion } = get()
+    if (!seleccion || !expedienteId) return
+    set({ borrando: true })
+    try {
+      await deleteNodo(expedienteId, seleccion.tipo, seleccion.id)
+      showToast('Elemento borrado', 'success')
+      set({
+        borrando: false, borrarPendienteConfirm: false,
+        seleccion: null,
+        modoEdicion: false, editableCampos: [], borrador: {}, borradorInicial: {},
+        edicionCargando: false, tiposCreables: null, tipoCreacionPendiente: null,
+        docVinculandoPendiente: null,
+        detalle: null, detalleCargando: false, detalleError: null, _detalleCache: {},
+      })
+      await get().refrescarArbol()
+    } catch (e) {
+      set({ borrando: false, borrarPendienteConfirm: false })
+      if (e.status === 401 || e.status === 403) return
+      if (e.status === 422 && e.payload && e.payload.motivo) {
+        showToast(e.payload.motivo, 'danger')
+      } else {
+        showToast(e.message || 'No se pudo borrar el elemento', 'danger')
+      }
+    }
+  },
+
+  // --- menú contextual (S3b-4) ---
+
+  // Selecciona el nodo, carga su detalle y tipos-creables, abre el menú.
+  abrirMenu: (x, y, sel) => {
+    get().seleccionar(sel)
+    if (sel.tipo !== 'tarea') get().cargarTiposCreables(sel)
+    set({ menuCtx: { x, y, sel } })
+  },
+
+  cerrarMenu: () => set({ menuCtx: null }),
 
   // --- acciones de creación (S3b-2) ---
 

--- a/react-src/src/expediente-arbol/styles/arbol.css
+++ b/react-src/src/expediente-arbol/styles/arbol.css
@@ -226,3 +226,49 @@ body.arbol-lock .app-inspector {
   box-shadow: 0 0 0 3px rgba(13, 110, 253, .35);
   border-radius: 8px;
 }
+
+/* ── Menú contextual (S3b-4) ──────────────────────────────────────────────── */
+.arbol-menu {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, .12);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, .15);
+  min-width: 200px;
+  padding: 4px 0;
+  font-size: 13px;
+  user-select: none;
+}
+.arbol-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #333;
+  text-decoration: none;
+}
+.arbol-menu__item:hover { background: #f0f4ff; }
+.arbol-menu__item--disabled {
+  opacity: .4;
+  cursor: not-allowed;
+}
+.arbol-menu__item--disabled:hover { background: transparent; }
+.arbol-menu__sep {
+  height: 1px;
+  background: #e8e8e8;
+  margin: 4px 0;
+}
+.arbol-menu__submenu-wrap { position: relative; }
+.arbol-menu__submenu {
+  position: absolute;
+  left: 100%;
+  top: -4px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, .12);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, .15);
+  min-width: 180px;
+  padding: 4px 0;
+  z-index: 10000;
+}


### PR DESCRIPTION
S3b-4: menú contextual y borrar documento desde inspector

## Cambios

- Nuevo componente `MenuContextual` con opciones contextuales sobre nodos del árbol
- Inspector ampliado con botón "Borrar" para eliminar el documento vinculado a la tarea
- Store actualizado con acción `deleteDocumento` y gestión del estado de confirmación
- API: nuevo endpoint para desvinculación/borrado desde el árbol
- `NodoTareas` actualiza el trigger para abrir el menú contextual
- ADR-016 actualizado para reflejar las decisiones de interacción del menú contextual
- CSS: estilos para el menú contextual y estados hover/activo

Refs #500
