### PR TITLE
Fijar solapamiento del banner de calendario sobre el viewbar

### DIFF
--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -59,9 +59,10 @@
   grid-template-columns: var(--sidebar-width-expanded) 1fr 0;
 
   /* Filas:
-     topbar fijo · viewbar auto (0 si vacío) · main 1fr · dock auto (0 si vacío) · footer fijo */
+     topbar fijo · banner auto (0 si vacío) · viewbar auto (0 si vacío) · main 1fr · dock auto (0 si vacío) · footer fijo */
   grid-template-rows:
     var(--topbar-height)
+    auto
     auto
     1fr
     auto
@@ -69,6 +70,7 @@
 
   grid-template-areas:
     "topbar  topbar  topbar"
+    "banner  banner  banner"
     "sidebar viewbar inspector"
     "sidebar main    inspector"
     "sidebar dock    dock"
@@ -481,14 +483,7 @@
    ============================================================ */
 
 .app-alert-banner {
-  grid-column: 1 / -1;
-  grid-row: 1;
-  align-self: end;
-  /* posición flotante para no romper el grid */
-  position: absolute;
-  top: var(--topbar-height);
-  left: 0; right: 0;
-  z-index: 90;
+  grid-area: banner;
   margin: 0;
   border-radius: 0;
   border-left: 0;
@@ -505,6 +500,7 @@
     grid-template-columns: 0 1fr 0;
     grid-template-areas:
       "topbar  topbar  topbar"
+      "banner  banner  banner"
       "viewbar viewbar viewbar"
       "main    main    main"
       "dock    dock    dock"

--- a/app/static/js/app-shell.js
+++ b/app/static/js/app-shell.js
@@ -24,6 +24,7 @@
     inspectorOpen:    'bddat.inspector.open',
     dockOpen:         'bddat.dock.open'
   };
+  var SS_BANNER   = 'bddat.banner.dismissed';
   var COOKIE_SIDEBAR = 'bddat_sidebar_collapsed';
   var BREAKPOINT_COLLAPSED = 1280;
   var BREAKPOINT_MOBILE    = 768;
@@ -70,6 +71,24 @@
 
   function toggleSidebarMobile(shell) {
     shell.classList.toggle('is-sidebar-open');
+  }
+
+  // -- Banner admin (sessionStorage — persiste dentro de la sesión del navegador)
+
+  function applyBannerState() {
+    try {
+      if (sessionStorage.getItem(SS_BANNER) !== '1') return;
+      var banner = document.getElementById('js-alert-banner');
+      if (banner) banner.remove();
+    } catch (e) { /* ignore */ }
+  }
+
+  function initBannerDismiss() {
+    var banner = document.getElementById('js-alert-banner');
+    if (!banner) return;
+    banner.addEventListener('close.bs.alert', function () {
+      try { sessionStorage.setItem(SS_BANNER, '1'); } catch (e) { /* ignore */ }
+    });
   }
 
   // -- Inspector / Dock (estado solo en localStorage — el server no lo necesita)
@@ -124,6 +143,8 @@
     if (!shell) return;
     applySidebarState(shell);
     applyPanelStates(shell);
+    applyBannerState();
+    initBannerDismiss();
     document.addEventListener('click', onClick);
     document.addEventListener('keydown', onKeydown);
     // Re-aplicar al cambiar de tamaño (mobile ↔ desktop)

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -91,20 +91,20 @@
 
     {% include 'layout/footer.html' %}
 
+    {# Alerta admin: calendario inhábil año N+1 no cargado (#339) — área banner del grid (#512) #}
+    {% if alerta_calendario %}
+    <div class="app-alert-banner alert alert-warning alert-dismissible fade show" id="js-alert-banner" role="alert">
+      <i class="fas fa-exclamation-triangle me-2"></i>
+      <strong>Acción requerida:</strong>
+      No hay días inhábiles registrados para el año siguiente.
+      Ejecute <code>flask inhabiles importar</code> antes de que existan plazos que aterricen en ese año.
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+    </div>
+    {% endif %}
+
     {# Backdrop del sidebar en mobile (<768px) #}
     <div class="app-sidebar-backdrop" data-app-shell-backdrop></div>
   </div>
-
-  {# Alerta admin: calendario inhábil año N+1 no cargado (#339) #}
-  {% if alerta_calendario %}
-  <div class="app-alert-banner alert alert-warning alert-dismissible fade show" role="alert">
-    <i class="fas fa-exclamation-triangle me-2"></i>
-    <strong>Acción requerida:</strong>
-    No hay días inhábiles registrados para el año siguiente.
-    Ejecute <code>flask inhabiles importar</code> antes de que existan plazos que aterricen en ese año.
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
-  </div>
-  {% endif %}
 
   {# Toasts de flash messages (#44) #}
   <div class="toast-container position-fixed bottom-0 end-0 p-3">


### PR DESCRIPTION
## Cambios

- Mueve `.app-alert-banner` dentro de `.app-shell` como hijo directo del grid (antes era hermano, fuera del contenedor)
- Añade fila `banner` al `grid-template-areas` de `app-shell.css` (desktop y mobile) con su correspondiente fila `auto` en `grid-template-rows`
- Sustituye `position: absolute` por `grid-area: banner` — el banner ocupa su propia banda entre el topbar y el viewbar sin solapar ninguna área funcional
- `app-shell.js`: al cerrar el banner se guarda `bddat.banner.dismissed = '1'` en `sessionStorage`; al cargar cada página, si la clave está presente el banner se elimina del DOM antes de renderizarse — el aviso no reaparece durante la sesión

Closes #512
