### PR TITLE
Viewbar árbol: mover a app-viewbar via portal, elimina doble cabecera

### DIFF
--- a/app/modules/expedientes/templates/expedientes/arbol.html
+++ b/app/modules/expedientes/templates/expedientes/arbol.html
@@ -9,6 +9,13 @@
 
 {% block title %}AT-{{ expediente.numero_at }} · Árbol{% endblock %}
 
+{# Slot para la isla React de la viewbar (#523).
+   data-indicador codifica indicador_asignacion: 'ajeno'|'propio' o ausente si no aplica. #}
+{% block viewbar %}
+  <div id="arbol-viewbar-slot"
+       {% if indicador_asignacion is not none %}data-indicador="{{ 'ajeno' if indicador_asignacion else 'propio' }}"{% endif %}></div>
+{% endblock %}
+
 {% block content %}
   <div id="app-root"
        class="h-100"

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.CQba3Np_.js",
+    "file": "bundle.expediente-arbol.DhzwERmo.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/react-src/src/expediente-arbol/App.jsx
+++ b/react-src/src/expediente-arbol/App.jsx
@@ -11,9 +11,9 @@ import Viewbar from './components/Viewbar.jsx'
 import Arbol from './components/Arbol.jsx'
 import Inspector from './components/Inspector.jsx'
 
-// Slot del inspector en el shell base_app (lo define arbol.html como block inspector).
-// El Inspector se renderiza ahí vía portal: un único árbol React / un único store.
+// Slots del shell declarados en arbol.html. Portales: un único árbol React / store.
 const inspectorSlot = () => document.getElementById('arbol-inspector-slot')
+const viewbarSlot   = () => document.getElementById('arbol-viewbar-slot')
 
 function expedienteIdDesdeDOM() {
   const el = document.querySelector('[data-react-island="expediente-arbol"]')
@@ -92,15 +92,11 @@ export default function App() {
   }
   if (!arbol) return null
 
-  const slot = inspectorSlot()
-
   return (
-    <div className="d-flex flex-column" style={{ height: '100%' }}>
-      <Viewbar />
-      <div style={{ flex: 1, minHeight: 0 }}>
-        <Arbol />
-      </div>
-      {slot && createPortal(<Inspector />, slot)}
+    <div style={{ height: '100%' }}>
+      <Arbol />
+      {inspectorSlot() && createPortal(<Inspector />, inspectorSlot())}
+      {viewbarSlot()   && createPortal(<Viewbar />,   viewbarSlot())}
       {enEdicion && createPortal(
         <div aria-hidden="true"
              onClick={() => showToast('Estás editando este elemento — Guarda o cancela primero.', 'warning')}

--- a/react-src/src/expediente-arbol/components/Viewbar.jsx
+++ b/react-src/src/expediente-arbol/components/Viewbar.jsx
@@ -1,32 +1,44 @@
-// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11).
+// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11 / #523).
 //
-// Vive DENTRO de la isla (no en el slot viewbar de Jinja) para no cruzar estado
-// React↔Jinja con el toggle. El slot viewbar de base_app conserva su default
-// (código AT + bombilla de acceso).
-// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11).
+// Montada vía createPortal en #arbol-viewbar-slot (declarado en arbol.html
+// {% block viewbar %}), igual que el Inspector. Usa clases app-viewbar__* del
+// shell; el <header class="app-viewbar"> del shell ya aporta flex + padding + borde.
 //
-// Vive DENTRO de la isla (no en el slot viewbar de Jinja) para no cruzar estado
-// React↔Jinja con el toggle. Muestra info del expediente + toggle "Colapsar
-// finalizados". Los botones de modo (Editar/Guardar/Cancelar) viven en el INSPECTOR
-// (decisión S3b-1): editar es "editar este nodo", no "editar toda la vista".
+// indicador_asignacion se pasa como data-indicador='ajeno'|'propio' en el slot
+// desde Jinja (context processor inject_indicador_asignacion).
 import React from 'react'
 import { useArbolStore } from '../store.js'
+
+function leerIndicador() {
+  const slot = document.getElementById('arbol-viewbar-slot')
+  return slot ? slot.dataset.indicador : undefined  // 'ajeno' | 'propio' | undefined
+}
 
 export default function Viewbar() {
   const arbol = useArbolStore((s) => s.arbol)
   const colapsarFinalizados = useArbolStore((s) => s.colapsarFinalizados)
   const toggle = useArbolStore((s) => s.toggleColapsarFinalizados)
   const exp = arbol && arbol.expediente
+  const indicador = leerIndicador()
 
   return (
-    <div className="d-flex align-items-center justify-content-between border-bottom px-3 py-2 bg-body-tertiary">
-      <div className="text-truncate">
-        <strong>{exp && exp.codigo}</strong>
+    <>
+      {indicador !== undefined && (
+        <i className={`bi bi-lightbulb-fill app-viewbar__indicador ${indicador === 'ajeno' ? 'text-danger' : 'text-success'}`}
+           title={indicador === 'ajeno'
+             ? 'Expediente no asignado a ti — actuación registrada en bitácora'
+             : 'Tu expediente'} />
+      )}
+      <div className="app-viewbar__title" style={{ minWidth: 0, overflow: 'hidden' }}>
+        <strong className="text-truncate">{exp && exp.codigo}</strong>
         {exp && exp.tipo_expediente && (
-          <span className="text-muted ms-2">{exp.tipo_expediente}</span>
+          <span className="text-muted ms-2 text-truncate">{exp.tipo_expediente}</span>
         )}
-        {exp && exp.titular && <span className="text-muted ms-2">· {exp.titular}</span>}
+        {exp && exp.titular && (
+          <span className="text-muted ms-2 text-truncate">· {exp.titular}</span>
+        )}
       </div>
+      <div className="app-viewbar__spacer" />
       <div className="form-check form-switch m-0 flex-shrink-0">
         <input
           className="form-check-input"
@@ -40,6 +52,6 @@ export default function Viewbar() {
           Colapsar finalizados
         </label>
       </div>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Cambios

- **`arbol.html`** — añade `{% block viewbar %}` con `#arbol-viewbar-slot`; pasa `indicador_asignacion` como `data-indicador='ajeno'|'propio'` para que React lo consuma sin cruzar estado Jinja↔React
- **`Viewbar.jsx`** — convertido a Fragment con clases `app-viewbar__*` del shell; bombilla React cuando `data-indicador` está presente; eliminados estilos de contenedor propios (`border-bottom`, `bg-body-tertiary`) que ya aporta el shell
- **`App.jsx`** — `Viewbar` montado vía `createPortal` en `#arbol-viewbar-slot` (igual que el Inspector); eliminado `<Viewbar />` del árbol JSX directo; wrapper simplificado a `div style={{ height: '100%' }}`
- **`manifest.json`** — hash de bundle actualizado tras rebuild

Closes #523
