### PR TITLE
Bombilla TRAMITADOR como chrome del shell, fuera del block viewbar

### DIFF
--- a/app/modules/expedientes/templates/expedientes/arbol.html
+++ b/app/modules/expedientes/templates/expedientes/arbol.html
@@ -10,10 +10,9 @@
 {% block title %}AT-{{ expediente.numero_at }} · Árbol{% endblock %}
 
 {# Slot para la isla React de la viewbar (#523).
-   data-indicador codifica indicador_asignacion: 'ajeno'|'propio' o ausente si no aplica. #}
+   La bombilla es chrome del shell (base_app.html #525); aquí solo el contenido de la isla. #}
 {% block viewbar %}
-  <div id="arbol-viewbar-slot"
-       {% if indicador_asignacion is not none %}data-indicador="{{ 'ajeno' if indicador_asignacion else 'propio' }}"{% endif %}></div>
+  <div id="arbol-viewbar-slot"></div>
 {% endblock %}
 
 {% block content %}

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.DhzwERmo.js",
+    "file": "bundle.expediente-arbol.BveZz2AN.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -44,15 +44,8 @@
 </head>
 <body>
   {# Captura de bloques opcionales sin doble render: {% set ... %}...{% endset %} #}
-  {% set viewbar_html %}{% block viewbar %}{% if indicador_asignacion is not none %}
-    <div class="app-viewbar__title">
-      <i class="bi bi-lightbulb-fill app-viewbar__indicador {{ 'text-danger' if indicador_asignacion else 'text-success' }}"
-         data-bs-toggle="tooltip" data-bs-placement="bottom"
-         title="{{ 'Expediente no asignado a ti — actuación registrada en bitácora' if indicador_asignacion else 'Tu expediente' }}"></i>
-      {% set _exp = g.get('expediente_actual') %}
-      {% if _exp %}<span>AT-{{ _exp.numero_at }}</span>{% endif %}
-    </div>
-  {% endif %}{% endblock %}{% endset %}
+  {# Bombilla fuera del bloque: es chrome del shell, no responsabilidad de cada isla (#525). #}
+  {% set viewbar_html %}{% block viewbar %}{% endblock %}{% endset %}
 
   {% set inspector_html %}{% block inspector %}{% endblock %}{% endset %}
   {% set dock_html      %}{% block dock      %}{% endblock %}{% endset %}
@@ -67,8 +60,13 @@
     {% include 'layout/_topbar.html' %}
     {% include 'layout/_sidebar.html' %}
 
-    {% if viewbar_html | trim %}
+    {% if indicador_asignacion is not none or viewbar_html | trim %}
     <header class="app-viewbar" role="banner">
+      {% if indicador_asignacion is not none %}
+        <i class="bi bi-lightbulb-fill app-viewbar__indicador {{ 'text-danger' if indicador_asignacion else 'text-success' }}"
+           data-bs-toggle="tooltip" data-bs-placement="bottom"
+           title="{{ 'Expediente no asignado a ti — actuación registrada en bitácora' if indicador_asignacion else 'Tu expediente' }}"></i>
+      {% endif %}
       {{ viewbar_html }}
     </header>
     {% endif %}

--- a/react-src/src/expediente-arbol/components/Viewbar.jsx
+++ b/react-src/src/expediente-arbol/components/Viewbar.jsx
@@ -1,34 +1,20 @@
-// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11 / #523).
+// Viewbar.jsx — cabecera de la isla del árbol (#500, ADR-016 §11 / #523 / #525).
 //
 // Montada vía createPortal en #arbol-viewbar-slot (declarado en arbol.html
 // {% block viewbar %}), igual que el Inspector. Usa clases app-viewbar__* del
-// shell; el <header class="app-viewbar"> del shell ya aporta flex + padding + borde.
-//
-// indicador_asignacion se pasa como data-indicador='ajeno'|'propio' en el slot
-// desde Jinja (context processor inject_indicador_asignacion).
+// shell; el <header class="app-viewbar"> del shell aporta flex + padding + borde
+// y renderiza la bombilla de asignación como chrome propio (#525).
 import React from 'react'
 import { useArbolStore } from '../store.js'
-
-function leerIndicador() {
-  const slot = document.getElementById('arbol-viewbar-slot')
-  return slot ? slot.dataset.indicador : undefined  // 'ajeno' | 'propio' | undefined
-}
 
 export default function Viewbar() {
   const arbol = useArbolStore((s) => s.arbol)
   const colapsarFinalizados = useArbolStore((s) => s.colapsarFinalizados)
   const toggle = useArbolStore((s) => s.toggleColapsarFinalizados)
   const exp = arbol && arbol.expediente
-  const indicador = leerIndicador()
 
   return (
     <>
-      {indicador !== undefined && (
-        <i className={`bi bi-lightbulb-fill app-viewbar__indicador ${indicador === 'ajeno' ? 'text-danger' : 'text-success'}`}
-           title={indicador === 'ajeno'
-             ? 'Expediente no asignado a ti — actuación registrada en bitácora'
-             : 'Tu expediente'} />
-      )}
       <div className="app-viewbar__title" style={{ minWidth: 0, overflow: 'hidden' }}>
         <strong className="text-truncate">{exp && exp.codigo}</strong>
         {exp && exp.tipo_expediente && (


### PR DESCRIPTION
## Cambios

- **`base_app.html`** — bombilla de asignación sacada del `{% block viewbar %}` al `<header class="app-viewbar">` como chrome del shell; condición de render actualizada a `indicador_asignacion is not none or viewbar_html | trim`
- **`arbol.html`** — eliminado `data-indicador` del slot React (ya no hace falta pasarlo)
- **`Viewbar.jsx`** — eliminados `leerIndicador()` y el `<i>` de bombilla React; el shell la renderiza directamente
- **`manifest.json`** — hash de bundle actualizado tras rebuild

Closes #525
