### PR TITLE
Fix bitácora dock: errores visibles en consola y guard en _descripcion()

### DIFF
--- a/app/routes/api_bitacora.py
+++ b/app/routes/api_bitacora.py
@@ -1,10 +1,14 @@
 """API del cuaderno de bitácora — endpoints para el dock global (#506)."""
+import logging
+
 from flask import Blueprint, jsonify
 from flask_login import current_user, login_required
 from sqlalchemy import text
 
 from app import db
 from app.models.bitacora import Bitacora
+
+log = logging.getLogger(__name__)
 
 bp = Blueprint('api_bitacora', __name__, url_prefix='/api')
 
@@ -21,10 +25,14 @@ def _descripcion(entrada):
     op      = entrada.operacion
 
     if tabla == 'expedientes':
-        num = db.session.execute(
-            text('SELECT numero_at FROM public.expedientes WHERE id = :id'),
-            {'id': entrada.registro_id},
-        ).scalar()
+        try:
+            num = db.session.execute(
+                text('SELECT numero_at FROM public.expedientes WHERE id = :id'),
+                {'id': entrada.registro_id},
+            ).scalar()
+        except Exception:
+            log.exception('_descripcion: fallo al resolver expediente id=%s', entrada.registro_id)
+            num = None
         ref = f'AT-{num}' if num else f'#{entrada.registro_id}'
         if detalle.get('actuacion_fuera_asignacion'):
             return f'Actuó fuera de asignación en {ref}'
@@ -38,18 +46,22 @@ def _descripcion(entrada):
 @bp.route('/bitacora/reciente')
 @login_required
 def bitacora_reciente():
-    entradas = (
-        Bitacora.query
-        .filter_by(usuario_id=current_user.id)
-        .order_by(Bitacora.created_at.desc())
-        .limit(50)
-        .all()
-    )
-    return jsonify([
-        {
-            'hora':        e.created_at.strftime('%H:%M'),
-            'icono':       _ICONOS.get(e.operacion, 'bi-circle'),
-            'descripcion': _descripcion(e),
-        }
-        for e in entradas
-    ])
+    try:
+        entradas = (
+            Bitacora.query
+            .filter_by(usuario_id=current_user.id)
+            .order_by(Bitacora.created_at.desc())
+            .limit(50)
+            .all()
+        )
+        return jsonify([
+            {
+                'hora':        e.created_at.strftime('%H:%M'),
+                'icono':       _ICONOS.get(e.operacion, 'bi-circle'),
+                'descripcion': _descripcion(e),
+            }
+            for e in entradas
+        ])
+    except Exception:
+        log.exception('bitacora_reciente: error inesperado para usuario_id=%s', current_user.id)
+        return jsonify({'error': 'Error interno'}), 500

--- a/app/templates/layout/_dock.html
+++ b/app/templates/layout/_dock.html
@@ -151,13 +151,26 @@
 
   function cargarBitacora() {
     fetch('/api/bitacora/reciente', { credentials: 'same-origin' })
-      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (r) {
+        if (!r.ok) {
+          console.error('dock/bitácora: HTTP ' + r.status + ' ' + r.url);
+          return [];
+        }
+        var ct = r.headers.get('content-type') || '';
+        if (!ct.includes('application/json')) {
+          // Redirect a login seguido → respuesta HTML con r.ok=true
+          console.warn('dock/bitácora: respuesta no-JSON (¿sesión expirada o redirect a login?)');
+          return [];
+        }
+        return r.json();
+      })
       .then(function (items) {
         _bitacoraItems = items;
         renderStream('js-dock-bitacora-list', items, lineaBitacora, 'Sin actividad registrada.');
         setBadge('dock-badge-bitacora', items.length);
       })
-      .catch(function () {
+      .catch(function (err) {
+        console.error('dock/bitácora: error al parsear respuesta', err);
         renderStream('js-dock-bitacora-list', [], lineaBitacora, 'Error al cargar la bitácora.');
       });
   }


### PR DESCRIPTION
## Cambios

- **`api_bitacora.py`**: añade `try/except` en `_descripcion()` para que un fallo de BD al resolver `numero_at` no tumbe el endpoint; `try/except` global en `bitacora_reciente()` con `log.exception` y respuesta 500 explícita en lugar de error sin capturar.
- **`_dock.html`**: `cargarBitacora()` ahora loguea en consola cuando `r.ok=false` (HTTP status visible) y detecta el caso de redirect a login seguido (Content-Type no-JSON con `r.ok=true`); el `.catch()` también loguea el error concreto.

Closes #528
