### PR TITLE
Añadir ADR-022 (sistema visual) y ADR-023 (list-detail)

### DIFF
--- a/docs/decisiones/ADR-016-vista-arbol-expediente.md
+++ b/docs/decisiones/ADR-016-vista-arbol-expediente.md
@@ -5,6 +5,7 @@
 **Issue:** #500
 **Enmendada:** 2026-05-30 (#500, sesión de implementación) — añadidos §16 (contrato de endpoints), agregadores en colapso (§11), tooltip-peek de hover (§2.4/§15); iteración de trámite fuera de v1 (§2).
 **Enmendada:** 2026-06-03 (#500, sesión S3b-4) — §7 y §8: Borrar eliminado del menú contextual; vive exclusivamente en inspector modo edición con flujo de dos pasos. §9: doble clic funcional (`zoomOnDoubleClick=false`, commit 71d9b5e); atajos F2 y Supr eliminados.
+**Enmendada:** 2026-06-07 (ADR-023, #534) — §14: el redimensionado del inspector pasa a ser **mecanismo de shell** (CSS Grid + JS + `localStorage`), no `react-resizable-panels`; esta librería queda solo para splitters internos de la isla (split despensa/detalle). El inspector entra en la negociación de espacio global de ADR-023.
 
 ---
 

--- a/docs/decisiones/ADR-022-sistema-visual-base.md
+++ b/docs/decisiones/ADR-022-sistema-visual-base.md
@@ -1,0 +1,83 @@
+# ADR-022 — Sistema visual base: escala tipográfica única, tokens y tabla unificada
+
+**Estado:** Adoptada
+**Fecha:** 2026-06-07
+**Issue:** #533
+**Origen:** PRE-ADR `docs/diseño/PRE-ADR-workbench-listados.md` (sesión de revisión de altura del workbench).
+**Relación:** prerrequisito de **ADR-023** (list-detail + inspector universal). Cierra parcialmente la decisión §5.5 de `ANALISIS_CRITICO.md` (sistema de diseño).
+
+---
+
+## Contexto
+
+La base visual del revamping creció por capas (v0…v3, shell ADR-014) y no quedó unificada. Síntomas verificados en código:
+
+- **Tres escalas tipográficas** conviven sin criterio único: `body` 16px (`v2-theme.css:92`), tablas 0.875rem/14px (`v2-components.css:120,137`), shell e inspector 13px hardcodeado en px (`app-shell.css:18,451`).
+- **Dos sistemas de tabla** distintos: `data-table` (DIV + CSS Grid, `v2-data-table.css`) y `expedientes-table` (HTML `<table>`, `v2-components.css:99`). La base real de listados usa el segundo; el primero quedó sin consumir.
+- **Truncados y recortes ad-hoc** por implementación: reglas `nth-child` por tabla, `plantillas-table td:nth-child(2){max-width:180px}`, media queries que ocultan columnas a mano. No hay un mecanismo general del que hereden las particularizaciones.
+- **Recorte lateral ~95%** vía `--content-padding: max(1rem, 2.5vw)` (`v2-theme.css:14`), introducido para homogeneidad con los bloques redondeados (#202). Redundante cuando el listado vive en `main`, ya acotado por sidebar e inspector.
+
+El principio de densidad ya estaba aterrizado (`ANALISIS_CRITICO §4.1`, "13-14px base") pero nunca se cerró en una decisión ni se ejecutó de forma global. Este ADR lo cierra.
+
+Es **prerrequisito de ADR-023**: el patrón list-detail mete el detalle en el inspector y comprime el `main`; sin una escala densa y una tabla única, esa compresión rompe la legibilidad.
+
+---
+
+## Decisión
+
+### 1. Escala tipográfica única y densa
+
+- **Mando maestro por `rem` global.** Se fija `html { font-size: 14-15px }` (valor exacto a calibrar en implementación con verificación visual). Al estar Bootstrap y el CDN de la Junta dimensionados en `rem`, todo lo que va en `rem` se densifica de forma coherente con un único parámetro.
+- **El shell pasa de `px` a `rem`.** Hoy el chrome (`app-shell.css`) usa px directos y queda fuera del mando. Se reexpresa en `rem` para que obedezca a la escala única.
+- **Tokens tipográficos (`--fs-*`) solo para excepciones deliberadas** (p. ej. un dato numérico destacado en la cabecera del detalle, estilo Stripe). No son el mecanismo principal de densidad: el `rem` global lo es.
+
+> Se descarta el enfoque de "solo tokens en px sin tocar el rem": perseguir cada componente uno a uno arriesga perpetuar la dualidad de escalas que este ADR elimina.
+
+### 2. Tokens de color sin fugas
+
+- Los hardcodeos del shell (`#ebebeb`, `#888`, `#666`, rgba sueltos…) se consolidan sobre las variables corporativas de `v2-theme.css` (`--primary`, `--gris-*`, `--border-color`, etc.).
+- La identidad JdA se mantiene (principio §4.7): cambia la consistencia, no la paleta.
+
+### 3. Componente de tabla único con overrides heredables
+
+- **Un solo sistema de tabla** sustituye a la dualidad `data-table` / `expedientes-table`.
+- **Mecanismo general de columnas y truncado**: ancho mínimo/máximo por columna, elipsis y **prioridad de ocultación responsive declarativa** (cada columna declara su prioridad; el sistema oculta de menor a mayor según el ancho disponible), en vez de `nth-child` ad-hoc por tabla.
+- Las particularizaciones por listado **heredan** el general y solo añaden lo propio; no lo reescriben.
+
+### 4. Retirada del recorte ~95% en `main`
+
+- El listado en `main` ocupa el ancho disponible real; el recorte lateral por `--content-padding` deja de aplicarse a los listados del workbench. El recorte tenía sentido para bloques redondeados aislados, no para un maestro ya acotado por sidebar + inspector (ADR-023).
+
+### 5. Excepciones tokenizadas — estudio de tamaños diferido
+
+Dos áreas no escalan 1:1 con el contenido y se afinan por tokens propios **después** de fijar el rem global:
+
+- **Dock**: panel tipo consola (líneas densas de bitácora/avisos), eje vertical. Su altura, densidad y el comportamiento del botón maximizar (listado completo / fetch ampliado) merecen estudio propio.
+- **Sidebar**: alto de ítem e icono+label, token propio de navegación.
+
+No bloquean este ADR; quedan como deuda acotada.
+
+---
+
+## Cómo implementar
+
+1. Calibrar `html { font-size }` (14-15px) y reexpresar el shell en `rem`. Verificación visual con Playwright MCP de que el CDN Junta aguanta el reescalado sin descuadres.
+2. Barrido de hardcodeos de color del shell → variables de `v2-theme.css`.
+3. Diseñar el componente de tabla único (mecanismo de columnas + truncado + prioridad responsive) y migrar los listados existentes; eliminar `v2-data-table.css` si queda sin uso.
+4. Retirar `--content-padding` de los listados del workbench.
+5. Smoke tests pytest (ADR-019, Fase 1) de las vistas tocadas.
+
+La migración de Plantillas y Usuarios a listado unificado (#281) se absorbe en este trabajo.
+
+---
+
+## Alternativas descartadas
+
+### A. Solo tokens en px, sin tocar el `rem`
+Control total pero exige tokenizar cada componente; lo que se escape perpetúa la dualidad de escalas. Descartada como mecanismo principal (sí se conserva para excepciones).
+
+### B. Bajar el `rem` a 14px de golpe sin calibración
+Riesgo de descuadrar componentes del CDN Junta sin red. Se prefiere calibrar el valor con verificación visual.
+
+### C. Mantener los dos sistemas de tabla
+Es el origen de los truncados ad-hoc y la deuda visual que cada listado nuevo reproduce. Descartada.

--- a/docs/decisiones/ADR-023-list-detail-inspector-universal.md
+++ b/docs/decisiones/ADR-023-list-detail-inspector-universal.md
@@ -1,0 +1,121 @@
+# ADR-023 — List-detail + inspector universal con negociación de espacio
+
+**Estado:** Adoptada
+**Fecha:** 2026-06-07
+**Issue:** #534
+**Depende de:** ADR-022 (#533) — escala densa y tabla unificada.
+**Enmienda:** ADR-016 §14 (el inspector resizable se redefine como mecanismo de shell, ver §2).
+**Origen:** PRE-ADR `docs/diseño/PRE-ADR-workbench-listados.md`.
+
+---
+
+## Contexto
+
+La app tiene **dos paradigmas de interacción conviviendo**:
+
+- **Árbol del expediente** (ADR-016): list-detail moderno. Seleccionas un nodo en `main` → el `inspector` muestra su detalle sin cerrar el árbol (ADR-016 §3/§5).
+- **Listados v2**: navegación web clásica. Botón "Ver" por fila (`v2-scroll-infinito.js:208-216`, `window.location.href = detailUrl(id)`) → carga una página de detalle → botón "volver".
+
+La coexistencia es el origen de la "maraña de accesos cruzados": cada vista de detalle necesita botones de retorno hacia su invocador. El inspector ya es, por nomenclatura (ADR-014), "el panel del elemento seleccionado en `main`" — pero solo el árbol lo explota.
+
+Este ADR **unifica los listados bajo el mismo patrón list-detail** que el árbol, y formaliza el modelo de espacio que lo hace viable en pantallas reales.
+
+---
+
+## Decisión
+
+### 1. Selección, no navegación
+
+- Click en una fila → fila **seleccionada** + el `inspector` muestra su detalle en "modo reacción". El listado **no se cierra**.
+- Desaparecen la columna "Ver"/acciones por fila y los botones de retorno.
+- **Las vistas de detalle actuales se reaprovechan**, adaptadas al layout del inspector. No se tiran.
+- Las acciones sobre el elemento (las que hoy se replican por fila) viven en el detalle del inspector.
+- Sincronización con URL (`?sel=<id>`), igual que el árbol (ADR-016 §12): compartir enlace, recargar manteniendo selección, "atrás" coherente.
+
+### 2. Inspector redimensionable a nivel de SHELL
+
+El redimensionado del inspector sube de la isla React (ADR-016 §14) al **shell**:
+
+- Implementación: CSS Grid del shell con `--inspector-width` como variable + un JS ligero y agnóstico que escucha el drag del splitter y persiste en `localStorage`.
+- Funciona en **cualquier vista**, Jinja o React. Es lo que permite que los listados (Jinja puro) tengan inspector arrastrable, no solo el árbol.
+- `react-resizable-panels` queda **solo para splitters internos de una isla** (p. ej. el split despensa/detalle del árbol en modo edición, ADR-016 §5). **Enmienda ADR-016 §14.**
+
+### 3. Negociación de espacio — contrato de cuatro números (+1)
+
+Cada vista declara sus mínimos; el shell reparte por aritmética:
+
+- **`--main-min`**: lo declara el **listado**. Es el ancho de su **maestro reducido** (ver §6).
+- **`[inspector_min, inspector_objetivo]`**: lo declara cada **tipo de detalle**.
+  - `inspector_min` = ruptura: el ancho donde "todo tiene elipsis y ya no se puede apretar más". Por debajo → el inspector colapsa.
+  - `inspector_objetivo` = lectura cómoda, sin apretar. Es el ancho al que el sistema lleva el inspector **automáticamente** al abrirlo, y el techo del crecimiento **automático** (no devora espacio que nadie pidió).
+- **La viewbar entra en la negociación.** Comparte columna con `main` (`app-shell.css` grid: `"sidebar viewbar inspector"` / `"sidebar main inspector"`), así que sus controles no comprimibles fijan un suelo:
+
+  > **`main_min = max(mínimo del contenido de main, mínimo de la viewbar)`**
+
+  En la **isla árbol manda la viewbar**: el lienzo react-flow es elástico (zoom + pan absorben cualquier ancho), así que el árbol no aporta `main_min`; lo dicta la viewbar y sus botones.
+
+### 4. Automático parco, manual libre
+
+- **Automático** (al abrir/negociar): el inspector no pasa de su `inspector_objetivo`.
+- **Manual** (drag del usuario): puede **superar el objetivo** para ganar aire (el contenido se relaja, como agrandar la ventana), hasta donde `main_min` lo permita. El objetivo es punto de partida inteligente, no jaula.
+- Modelo "fractal": el inspector es a su contenido lo que la ventana es al workbench.
+
+### 5. Regla de prioridad
+
+Cuando los mínimos no caben todos a la vez, en este orden:
+
+1. **`main_min` se respeta siempre** (calculado sobre el maestro reducido + viewbar, §3/§6).
+2. El **sidebar colapsa** automáticamente (208 → 56 → 0) antes de que el inspector ceda. El drag manual de agrandar el inspector dispara esta misma cascada.
+3. El **inspector cede** hasta su `inspector_min`.
+4. Último recurso: **overlay** (§7).
+
+### 6. Maestro reducido por tipo de listado
+
+- Al abrir el inspector, el listado muestra solo sus **columnas esenciales** (técnica Gmail/Outlook/Linear): el detalle completo está en el inspector.
+- Las columnas esenciales se **definen por tipo de listado**, no hay regla genérica "las N primeras". Expedientes/seguimiento tiene su esencial; Entidades el suyo.
+- `--main-min` se calcula sobre ese maestro reducido.
+
+### 7. Modo overlay (sustituye el corte duro de breakpoint)
+
+- Hoy el responsive es un corte fijo `@media (max-width:768px)`: sidebar → off-canvas + backdrop, inspector → `display:none` (`app-shell.css:707-742`).
+- Se generaliza: cuando push ya no respeta los mínimos (paso 4 de §5), sidebar e inspector pasan a **superponerse al `main`** (off-canvas + backdrop), accesibles por toggle. En vez de cerrarse y **perder** el detalle, el inspector se mantiene en overlay.
+- **Disparo por espacio, no por píxel fijo**, con **histéresis** (umbral de entrada en overlay distinto del de salida) para no parpadear en el borde.
+- Beneficia portátiles (≤1366) y pantallas verticales, donde el ancho es el recurso escaso.
+
+---
+
+## Reconciliación con ADR-016
+
+- **§14 enmendado**: inspector resizable = mecanismo de shell (este ADR). `react-resizable-panels` solo para splitters internos de islas.
+- **§3/§5 generalizados**: el patrón "seleccionar → inspector" del árbol se extiende a todos los listados.
+- **§16 generalizado**: el endpoint de detalle lazy del árbol es el patrón a reutilizar para "detalle de entidad en inspector".
+
+---
+
+## Validación numérica (Expedientes)
+
+Pantalla de referencia 1920×1080. Seguimiento (el listado más rico) = 53rem de columnas fijas (`custom.css:311`); sin la columna "Ver" = 48.5rem = **776px@16**.
+
+- Inspector **900px** + sidebar colapsado (56) → `main` = **964px**. El seguimiento completo cabe con **~188px de holgura, incluso sin bajar el rem**.
+- Conflicto solo en ≤1366px al combinar inspector muy grande + maestro completo: lo resuelven el maestro reducido (§6) y la regla de prioridad (§5).
+
+Detalle de la tabla de reparto en el PRE-ADR §4.
+
+---
+
+## Alternativas descartadas
+
+### A. Mantener el botón "Ver" + navegación
+Es el origen de la maraña de retornos. Descartada.
+
+### B. Split horizontal en `main` (maestro arriba / detalle abajo)
+Genera scrolls verticales apilados antipáticos. Todo el detalle va al inspector. Descartada por decisión del usuario.
+
+### C. Inspector resizable con `react-resizable-panels` a nivel de shell
+No sirve: vive dentro de islas React; los listados Jinja no lo tendrían. El redimensionado debe ser del shell. Descartada.
+
+### D. Bottom-sheet del inspector en pantallas verticales
+Un tercer patrón distinto, más código. El overlay lateral (§7) ya cubre el caso. Descartada (sobre-diseño).
+
+### E. Corte responsive por breakpoint fijo
+El paso a overlay por píxel fijo (768) es arbitrario frente a la negociación de mínimos. Sustituido por disparo por espacio con histéresis (§7).

--- a/docs/diseño/DECISIONES_UI.md
+++ b/docs/diseño/DECISIONES_UI.md
@@ -34,6 +34,8 @@ El **análisis crítico es snapshot inmutable** del estado de reflexión al 28-m
 | **ADR-018** | Command Palette (Ctrl+K) — búsqueda global de expedientes/entidades + navegación + recientes. Versión básica en M4, iteraciones extendidas en M5. Sustituye #75 | #502 (M4) | 2026-05-28 |
 | **ADR-019** | Estrategia de tests UI por 3 fases. Fase 1 (durante revamping): solo smoke tests pytest + verificación manual Playwright MCP. NO E2E ni RTL hasta que la UI estabilice | #503 | 2026-05-28 |
 | **ADR-020** | Dock global: deja de ser slot Jinja por vista y pasa a chrome global (partial del shell). Toggle vía campana del topbar. Dos tabs verticales: Bitácora (por usuario, BD) + Avisos (toasts de sesión, sessionStorage). Badge de no leídos, modal por tab, botón limpiar | #506 | 2026-05-29 |
+| **ADR-022** | Sistema visual base — escala tipográfica única (rem global 14-15px + shell a rem), tokens de color sin fugas, componente de tabla unificado con overrides heredables, retirada del recorte ~95% en `main`. Prerrequisito de ADR-023 | #533 | 2026-06-07 |
+| **ADR-023** | List-detail + inspector universal — selección de fila en lugar de botón "Ver", inspector resizable a nivel de shell con negociación de espacio (maestro reducido por listado, viewbar en `main_min`, automático parco/manual libre, overlay con histéresis). Enmienda ADR-016 §14 | #534 | 2026-06-07 |
 
 ---
 
@@ -104,6 +106,8 @@ De ANALISIS_CRITICO §6:
 - **2026-05-28** — ADR-018 cerrado (#502 M4, sustituye #75). Command Palette (Ctrl+K) versión básica.
 - **2026-05-28** — ADR-019 cerrado (#503). Estrategia de tests UI por 3 fases. Fase 1 inmediata: smoke tests pytest.
 - **2026-05-29** — ADR-020 cerrado (#506). Dock global: chrome partial + toggle campana topbar + tabs Bitácora/Avisos.
+- **2026-06-07** — ADR-022 cerrado (#533). Sistema visual base: escala tipográfica única + tokens de color + tabla unificada.
+- **2026-06-07** — ADR-023 cerrado (#534). List-detail + inspector universal con negociación de espacio. Enmienda ADR-016 §14. Deriva del PRE-ADR `PRE-ADR-workbench-listados.md`.
 
 ---
 

--- a/docs/diseño/PRE-ADR-workbench-listados.md
+++ b/docs/diseño/PRE-ADR-workbench-listados.md
@@ -1,0 +1,160 @@
+# PRE-ADR — Workbench, inspector universal y listados list-detail
+
+> **Estado:** Cerrado — convertido en **ADR-022** (#533) y **ADR-023** (#534) el 2026-06-07. Se conserva como memoria del razonamiento, la validación numérica y los cálculos de espacio.
+> **Fecha:** 2026-06-07.
+> **Deriva en:** dos ADRs previstos — **ADR-022** (sistema visual base) y **ADR-023** (patrón list-detail + inspector universal). Y sus issues.
+> **Origen:** revisión de altura de la vista workbench (sesión 2026-06-07). Confirma/matiza afirmaciones del usuario contra código, ADRs e issues.
+> **Convención:** `[VERIFICADO]` = comprobado en código/ADR/issue. `[PROPUESTO]` = decisión a confirmar. `[ABIERTO]` = pendiente de cierre en esta sesión.
+
+---
+
+## 1. Problema
+
+La app tiene **dos paradigmas de interacción conviviendo**:
+
+- **Árbol del expediente** (ADR-016): list-detail moderno. Seleccionas un nodo en `main` → el `inspector` muestra su detalle sin cerrar el árbol. Ya construido.
+- **Listados v2**: navegación web clásica. Botón "Ver" por fila → carga página de detalle → botón "volver". Legado.
+
+La coexistencia genera la "maraña de accesos cruzados" (necesidad de botones de retorno en cada vista de detalle). Además, la base visual no está unificada.
+
+### Hallazgos verificados
+
+| # | Hallazgo | Evidencia |
+|---|---|---|
+| H1 | **Tres escalas tipográficas** conviven sin unificar | `body` 16px (`v2-theme.css:92`), tablas 0.875rem/14px (`v2-components.css:120,137`), shell+inspector 13px hardcodeado (`app-shell.css:18,451`) |
+| H2 | El "bajar el rem" es **principio, no decisión cerrada** | `ANALISIS_CRITICO §4.1` ("densidad 13-14px"). No hay ADR ni implementación global; el `body` sigue a 16px |
+| H3 | **Botón "Ver" por fila** navega a página completa | `v2-scroll-infinito.js:208-216` (`window.location.href = detailUrl(id)`) |
+| H4 | **Dos sistemas de tabla** distintos | `data-table` (DIV+grid, `v2-data-table.css`) y `expedientes-table` (HTML, `v2-components.css:99`). La base real usa el segundo |
+| H5 | **Truncados/recortes ad-hoc** por implementación | `nth-child` por tabla, `plantillas-table td:nth-child(2) max-width:180px`, media queries que ocultan columnas a mano |
+| H6 | **No todos los listados** usan scroll infinito | Plantillas y Usuarios pendientes → **#281 (OPEN)** |
+| H7 | Recorte lateral **~95%** (no 90%) por homogeneidad con bloques | `--content-padding: max(1rem, 2.5vw)` (`v2-theme.css:14`); motivo #202 (`v2-components.css:39`). #94 nació "100% ancho" |
+| H8 | **Inspector resizable** atado a la isla del árbol, no al shell | `ADR-016 §14` (`react-resizable-panels`). No hay issue ni mecanismo de shell |
+
+---
+
+## 2. Decisión propuesta — dos bloques
+
+### D1 — Sistema visual base `[PROPUESTO]` → ADR-022
+
+Prerrequisito de D2. No es cosmética: sin escala densa y tabla única, el list-detail asfixia el `main`.
+
+1. **Escala tipográfica única y densa.** Un solo conjunto de tamaños (13-14px base) que mata las tres escalas de H1. `[ABIERTO]` cómo: ver §5.
+2. **Tokens de color sin fugas.** Consolidar los hardcodeos del shell (`#ebebeb`, `#888`…) sobre las variables de `v2-theme.css`.
+3. **Componente de tabla único** con overrides heredables. Un mecanismo general de columnas + truncado (mín/máx, elipsis, prioridad de ocultación responsive declarativa) y particularizaciones que **heredan** el general en vez de reescribirlo. Mata H4 y H5.
+4. **Retirar el recorte ~95% (H7)** del listado cuando va en `main`: el recorte tenía sentido para bloques redondeados aislados, no para un maestro que ya está acotado por sidebar + inspector.
+
+### D2 — List-detail con inspector universal `[PROPUESTO]` → ADR-023
+
+1. **Selección, no navegación.** Click en fila → fila seleccionada + `inspector` muestra el detalle en "modo reacción". El listado **no se cierra**. Desaparecen la columna "Acciones/Ver" (H3) y los botones de retorno. Generaliza a los listados lo que ADR-016 §3/§5 ya hace en el árbol.
+2. **Las vistas de detalle actuales se reaprovechan**, adaptadas al layout del inspector. No se tiran.
+3. **Todo el detalle vive en el inspector** `[PROPUESTO, confirmado por el usuario]`. Se descarta el split-en-main (genera scrolls verticales antipáticos). El inspector se **adapta** a lo que cada detalle necesita.
+4. **Inspector redimensionable y negociable a nivel de SHELL** (no de isla React). Sube de ADR-016 §14 a mecanismo del shell. Ver §3 y §4.
+5. **Acciones del elemento** (las que hoy se replican por fila) viven en el detalle del inspector.
+
+---
+
+## 3. Modelo de negociación de espacio `[PROPUESTO]`
+
+Modelo del usuario: *cada vista define un "mínimo aceptable"; el inspector intenta su tamaño preferido o cede si el `main` exige su propio mínimo.* Es el modelo de los IDEs (VS Code: paneles con `min-width` + colapso por prioridad). Es correcto y estandarizable.
+
+### Sobre Bootstrap (criterio técnico pedido)
+
+**Bootstrap no gobierna el layout del shell.** El shell es **CSS Grid propio** (`app-shell.css`, `grid-template-areas`); Bootstrap solo aporta componentes (botones, cards, dropdowns, toasts) y su grid `.row/.col` **no se usa** aquí. Por tanto no hay que "sobreseer" a Bootstrap en el layout: ya mandamos nosotros. La negociación se implementa con `minmax()` nativo de Grid:
+
+```
+grid-template-columns:
+   [sidebar]   auto                              /* 208 / 56 / 0 */
+   [main]      minmax(var(--main-min), 1fr)      /* mínimo lo declara la vista */
+   [inspector] minmax(0, var(--inspector-width)) /* preferido del usuario, persistido */
+```
+
+- `--main-min`: lo declara la **vista de listado** (su versión maestra-reducida).
+- `--inspector-width`: gobernado por **drag del splitter + `localStorage`**, acotado por el `--inspector-min` que declara la **vista de detalle** montada (su "mínimo aceptable").
+- Si los mínimos no caben todos, el min duro de `main` gana y el inspector cede.
+
+### Regla de prioridad propuesta `[recomendada, pend. OK]`
+
+1. El `main_min` **siempre** se respeta. Se calcula sobre el **maestro reducido** (sin las columnas que migran al detalle) — Q2.
+2. El **sidebar colapsa** automáticamente (208→56→0) **antes** de que el inspector ceda.
+3. El inspector toma el resto, acotado: nunca por debajo de su `inspector_min` (ruptura) **ni por encima de su `inspector_objetivo`** (ancho donde el detalle se ve completo y cómodo). Por encima del objetivo no crece: no devora espacio que el detalle no aprovecha — Q4.
+4. Si ni así cabe (pantalla muy pequeña), el inspector se cierra por toggle y el detalle queda accesible bajo demanda (en móvil ya se oculta, `app-shell.css:742`).
+
+> **Contrato por vista:** cada listado declara `--main-min` (su maestro reducido) y cada tipo de detalle declara `[inspector_min, inspector_objetivo]`. La negociación es aritmética sobre esos cuatro números + el ancho del sidebar.
+
+---
+
+## 4. Validación numérica — Expedientes `[VERIFICADO sobre medidas reales]`
+
+Pedida por el usuario: validar el patrón con el listado **más rico** (seguimiento, 5 pistas) a nivel de cálculos, no de implementación.
+
+**Medidas base:** sidebar 208/56px (`app-shell.css:23-26`); seguimiento = **53rem** de columnas fijas (`custom.css:311`), desglose `AT 5.5 + SOL 9 + FECHA 5.25 + 5×pista(5.75)=28.75 + ACC 4.5`. En list-detail la columna **ACC desaparece** → seguimiento = **48.5rem**.
+
+Conversión de 48.5rem (seguimiento sin columna acciones) según rem base:
+
+| rem base | Seguimiento maestro completo |
+|---|---|
+| 16px (actual) | 776px |
+| 14px | 679px |
+| 13px | 631px |
+
+Maestro **reducido** (AT+SOL+FECHA+semáforo agregado ≈ 23.75rem): 380px @16, 333px @14.
+
+### Reparto en 1920×1080 (pantalla de referencia del usuario)
+
+Sidebar colapsado (56). Disponible main+inspector = 1864px.
+
+| Inspector | Main resultante | ¿Cabe seguimiento completo @16 (776)? |
+|---|---|---|
+| 380 (actual) | 1484 | Sí, sobran 708 |
+| 600 (máx ADR-016) | 1264 | Sí, sobran 488 |
+| **900 (deseo del usuario)** | **964** | **Sí, sobran 188** |
+| 1100 | 764 | No (falta 12) → negociación |
+
+**Resultado:** en 1080p, el inspector puede tomar **900px** y el listado de seguimiento **completo** sigue cabiendo con ~188px de holgura, **incluso sin bajar el rem**. Bajar el rem da margen extra (~100px) y permite inspectores aún mayores. El deseo del usuario es viable con holgura.
+
+### Caso peor — portátil 1366×768
+
+| Configuración | Main | Veredicto |
+|---|---|---|
+| Inspector 400 (mín ficha) + sidebar 56 | 910 | Seguimiento completo cabe |
+| Inspector 900 + maestro **reducido** (333) | 977 disp. → inspector OK | El usuario tiene su inspector grande |
+| Inspector 900 + maestro **completo** exigido | 410 < 776 | Inspector **cede** a ~534px (negociación) |
+
+**Conclusión global:** el patrón es holgado en 1080p. El conflicto solo aparece en ≤1366 al combinar inspector muy grande + maestro completo, y se resuelve con (a) modo maestro reducido al abrir el inspector —técnica Gmail/Outlook— y/o (b) la regla de prioridad de mínimos. El "mínimo aceptable por vista" es exactamente el parámetro que gobierna esa negociación: el modelo del usuario es correcto.
+
+---
+
+## 5. Cuestiones
+
+### Cerradas (sesión 2026-06-07)
+
+| ID | Cuestión | Decisión |
+|---|---|---|
+| Q2 | **Maestro reducido al abrir inspector** | **Sí, reducir columnas.** Las columnas esenciales se definen **por tipo de listado** (no hay regla genérica "las N primeras"): Expedientes/seguimiento tiene su esencial, Entidades el suyo, etc. |
+| Q4 | **Rango del inspector** | Acotado por vista: **`inspector_min`** (ruptura) ≤ ancho ≤ **`inspector_objetivo`** (donde el detalle se ve completo y cómodo). No crece más allá del objetivo (no devorador). El `main_min` se mide sobre el maestro reducido (Q2) |
+
+### Recomendadas, pendientes de tu OK
+
+| ID | Cuestión | Recomendación |
+|---|---|---|
+| Q1 | **Cómo bajar el rem (D1)** | **(c) híbrido con rem global de base:** fijar `html` a 14-15px (mando maestro que unifica Bootstrap + CDN Junta + todo lo que va en rem), **pasar el shell de px a rem** para que obedezca al mando, y reservar tokens solo para excepciones tipográficas deliberadas. Descartada (b) pura: persigue cada componente y arriesga perpetuar la dualidad de escalas |
+| Q3 | **Regla de prioridad** (§3) | `main_min` (sobre maestro reducido) se respeta siempre → sidebar colapsa → inspector cede hasta su `inspector_min` → como último recurso el inspector se cierra |
+| Q5 | **Reconciliación ADR-016 §14** | **ADR-023 absorbe** el inspector resizable como mecanismo de shell (CSS Grid + JS ligero + `localStorage`); se deja **nota de enmienda en ADR-016 §14** apuntando a ADR-023. `react-resizable-panels` queda solo para splitters *internos* de una isla (p. ej. el split despensa del árbol), no para el inspector del shell |
+
+---
+
+## 6. Alternativas descartadas
+
+- **Split horizontal en `main`** (maestro arriba / detalle abajo, Patrón A de DECISIONES_UI): descartado por el usuario — los scrolls verticales apilados son antipáticos. Todo el detalle va al inspector.
+- **Mantener botón "Ver" + navegación**: es el origen de la maraña de retornos (H3).
+- **Solo estética (rem + colores) sin tocar comportamiento**: insuficiente — no cura la maraña de navegación, que es estructural. La estética es prerrequisito de D2, no su alternativa.
+- **react-resizable-panels para el inspector del shell**: no sirve — vive dentro de islas React; los listados Jinja no lo tienen. El redimensionado debe ser del shell.
+
+---
+
+## 7. Issues previstos (a crear al cierre)
+
+- **ADR-022 / Issue A — Sistema visual base:** escala tipográfica única, tokens sin fugas, componente de tabla unificado con overrides, retirada del recorte ~95%. Absorbe/cierra parte de #281.
+- **ADR-023 / Issue B — List-detail + inspector universal:** selección→inspector en listados, retirada de botones "Ver", inspector redimensionable y negociable a nivel de shell, contrato `--main-min` / `--inspector-min` por vista. Reconcilia ADR-016 §14.
+
+> Pendiente de confirmar numeración de ADR (siguientes libres tras ADR-021) y milestone de los issues.


### PR DESCRIPTION
## Cambios

Cierre de la **fase de diseño** del workbench/listados (deriva del PRE-ADR-workbench-listados). Este PR añade documentos de decisión; **no implementa** los issues.

- **ADR-022** — Sistema visual base: escala tipográfica única (rem global 14-15px + shell a rem), tokens de color sin fugas, componente de tabla unificado con overrides heredables, retirada del recorte ~95% en `main`. Prerrequisito de ADR-023.
- **ADR-023** — List-detail + inspector universal: selección de fila en lugar de botón "Ver"; inspector resizable a nivel de shell con negociación de espacio (maestro reducido por listado, viewbar en `main_min`, automático parco / manual libre, overlay con histéresis).
- **ADR-016 §14 enmendado** — el inspector resizable pasa a mecanismo de shell; `react-resizable-panels` queda solo para splitters internos de isla.
- **DECISIONES_UI** actualizado (decisiones cerradas + histórico). **PRE-ADR** conservado como memoria del razonamiento y la validación numérica.

Las contradicciones documentales que destapan estas decisiones (ADR-014 §3, anotación "Patrón A", NOMENCLATURA, guías de estilo) quedan registradas como checklist en el cuerpo de #533 y #534, para resolverlas durante la implementación.

Refs #533
Refs #534
