### PR TITLE
Añadir endpoints /api/search/* para Command Palette (#531)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -77,7 +77,7 @@ def create_app(config_name='development'):
     app.register_blueprint(wizard_expediente.bp)  # Issue #67
 
     # Registrar blueprints - APIs
-    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento, api_bc, api_bitacora
+    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento, api_bc, api_bitacora, api_search
 
     app.register_blueprint(api_expedientes.api_bp)                  # usa 'api_bp'
     app.register_blueprint(api_municipios.bp)                       # usa 'bp'
@@ -87,6 +87,7 @@ def create_app(config_name='development'):
     app.register_blueprint(api_seguimiento.api_seguimiento_bp)      # usa 'api_seguimiento_bp' — Issue #262
     app.register_blueprint(api_bc.bp)                               # usa 'bp' — fix #314
     app.register_blueprint(api_bitacora.bp)                         # usa 'bp' — Issue #506
+    app.register_blueprint(api_search.api_search_bp)                # usa 'api_search_bp' — Issue #531
 
     # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry

--- a/app/routes/api_search.py
+++ b/app/routes/api_search.py
@@ -1,0 +1,154 @@
+"""API de búsqueda para Command Palette (ADR-018 / #531).
+
+ENDPOINTS:
+    GET /api/search/expedientes?q=...&limit=10
+    GET /api/search/entidades?q=...&limit=10
+"""
+
+from flask import Blueprint, request, jsonify, url_for
+from flask_login import login_required
+from sqlalchemy import or_, case
+from sqlalchemy.orm import joinedload
+
+from app import db
+from app.models.expedientes import Expediente
+from app.models.entidad import Entidad
+from app.models.proyectos import Proyecto
+from app.models.municipios_proyecto import MunicipioProyecto
+from app.models.municipios import Municipio
+
+api_search_bp = Blueprint('api_search', __name__, url_prefix='/api/search')
+
+
+def _parse_numero_at(q: str):
+    """Devuelve el entero AT si q es '123' o 'AT-123'; None en caso contrario."""
+    stripped = q.strip().upper()
+    if stripped.startswith('AT-'):
+        stripped = stripped[3:]
+    try:
+        return int(stripped)
+    except ValueError:
+        return None
+
+
+@api_search_bp.route('/expedientes', methods=['GET'])
+@login_required
+def buscar_expedientes():
+    q = request.args.get('q', '').strip()
+    if len(q) < 2:
+        return jsonify({'results': []}), 200
+
+    try:
+        limit = min(int(request.args.get('limit', 10)), 20)
+    except ValueError:
+        limit = 10
+
+    num = _parse_numero_at(q)
+
+    conditions = []
+    if num is not None:
+        conditions.append(Expediente.numero_at == num)
+    conditions.append(
+        Expediente.titular.has(Entidad.nombre_completo.ilike(f'%{q}%'))
+    )
+    conditions.append(
+        Expediente.proyecto.has(Proyecto.titulo.ilike(f'%{q}%'))
+    )
+    conditions.append(
+        Expediente.proyecto.has(
+            Proyecto.municipios_afectados.any(
+                MunicipioProyecto.municipio.has(
+                    Municipio.nombre.ilike(f'%{q}%')
+                )
+            )
+        )
+    )
+
+    sort_key = (
+        case((Expediente.numero_at == num, 0), else_=1)
+        if num is not None
+        else Expediente.id
+    )
+
+    expedientes = (
+        db.session.query(Expediente)
+        .options(
+            joinedload(Expediente.proyecto)
+            .joinedload(Proyecto.municipios_afectados)
+            .joinedload(MunicipioProyecto.municipio)
+        )
+        .filter(or_(*conditions))
+        .order_by(sort_key, Expediente.id.asc())
+        .limit(limit)
+        .all()
+    )
+
+    results = []
+    for exp in expedientes:
+        label = (
+            f'AT-{exp.numero_at} — {exp.proyecto.titulo}'
+            if exp.proyecto
+            else f'AT-{exp.numero_at}'
+        )
+
+        titular_nombre = exp.titular.nombre_completo if exp.titular else ''
+        primer_mun = (
+            exp.proyecto.municipios_afectados[0].municipio
+            if exp.proyecto and exp.proyecto.municipios_afectados
+            else None
+        )
+        breadcrumb = (
+            f'{titular_nombre} · {primer_mun.nombre}'
+            if titular_nombre and primer_mun
+            else titular_nombre
+        )
+
+        results.append({
+            'tipo': 'expediente',
+            'id': exp.id,
+            'label': label,
+            'breadcrumb': breadcrumb,
+            'url': url_for('expedientes.arbol', id=exp.id),
+        })
+
+    return jsonify({'results': results}), 200
+
+
+@api_search_bp.route('/entidades', methods=['GET'])
+@login_required
+def buscar_entidades():
+    q = request.args.get('q', '').strip()
+    if len(q) < 2:
+        return jsonify({'results': []}), 200
+
+    try:
+        limit = min(int(request.args.get('limit', 10)), 20)
+    except ValueError:
+        limit = 10
+
+    entidades = (
+        Entidad.query
+        .filter(
+            Entidad.activo == True,
+            or_(
+                Entidad.nombre_completo.ilike(f'%{q}%'),
+                Entidad.nif.ilike(f'%{q}%'),
+            ),
+        )
+        .order_by(Entidad.nombre_completo.asc())
+        .limit(limit)
+        .all()
+    )
+
+    results = [
+        {
+            'tipo': 'entidad',
+            'id': e.id,
+            'label': e.nombre_completo,
+            'breadcrumb': e.nif or '',
+            'url': url_for('entidades.detalle', entidad_id=e.id),
+        }
+        for e in entidades
+    ]
+
+    return jsonify({'results': results}), 200

--- a/tests/smoke/test_smoke_search.py
+++ b/tests/smoke/test_smoke_search.py
@@ -1,0 +1,75 @@
+"""Smoke tests — endpoints de búsqueda del Command Palette (#531).
+
+Cubre:
+    GET /api/search/expedientes?q=...
+    GET /api/search/entidades?q=...
+"""
+import pytest
+
+
+def test_search_expedientes_ok(usuario_supervisor, expediente_seed, app):
+    """GET /api/search/expedientes con q válida → 200, clave 'results'."""
+    with app.app_context():
+        from app.models.expedientes import Expediente
+        exp = Expediente.query.get(expediente_seed)
+        q = str(exp.numero_at)
+
+    r = usuario_supervisor.get(f'/api/search/expedientes?q={q}')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert 'results' in data
+    assert isinstance(data['results'], list)
+
+
+def test_search_entidades_ok(usuario_supervisor, entidad_seed, app):
+    """GET /api/search/entidades con q válida → 200, clave 'results'."""
+    with app.app_context():
+        from app.models.entidad import Entidad
+        e = Entidad.query.get(entidad_seed)
+        q = e.nombre_completo[:4]
+
+    r = usuario_supervisor.get(f'/api/search/entidades?q={q}')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert 'results' in data
+    assert isinstance(data['results'], list)
+
+
+def test_search_expedientes_q_corto(usuario_supervisor):
+    """q de 1 char → 200, results vacío."""
+    r = usuario_supervisor.get('/api/search/expedientes?q=x')
+    assert r.status_code == 200
+    assert r.get_json()['results'] == []
+
+
+def test_search_entidades_q_corto(usuario_supervisor):
+    """q de 1 char → 200, results vacío."""
+    r = usuario_supervisor.get('/api/search/entidades?q=x')
+    assert r.status_code == 200
+    assert r.get_json()['results'] == []
+
+
+def test_search_sin_auth_redirige(client):
+    """Sin sesión → redirige al login (no 200)."""
+    r = client.get('/api/search/expedientes?q=test')
+    assert r.status_code != 200
+
+
+def test_search_expedientes_formato(usuario_supervisor, expediente_seed, app):
+    """Cada ítem del resultado tiene tipo, id, label, breadcrumb y url."""
+    with app.app_context():
+        from app.models.expedientes import Expediente
+        exp = Expediente.query.get(expediente_seed)
+        q = str(exp.numero_at)
+
+    r = usuario_supervisor.get(f'/api/search/expedientes?q={q}')
+    assert r.status_code == 200
+    results = r.get_json()['results']
+    if not results:
+        pytest.skip('La búsqueda no devolvió resultados para el expediente seed')
+    item = results[0]
+    assert item.get('tipo') == 'expediente'
+    assert 'id' in item
+    assert 'label' in item
+    assert 'breadcrumb' in item
+    assert 'url' in item


### PR DESCRIPTION
## Cambios

- Nuevo fichero `app/routes/api_search.py` con blueprint `api_search_bp` (prefijo `/api/search`) y dos endpoints:
  - `GET /api/search/expedientes?q=...&limit=10` — búsqueda en número AT, titular, título de proyecto y municipio; exact-match primero; respuesta `{results: [...]}` con campos `tipo/id/label/breadcrumb/url`
  - `GET /api/search/entidades?q=...&limit=10` — búsqueda en nombre y NIF, solo activas; ordenado por nombre; misma estructura de respuesta
- Registrado `api_search_bp` en `app/__init__.py` junto al resto de blueprints de API
- `tests/smoke/test_smoke_search.py` con los 6 casos del issue (ok, q corto, sin auth, formato)

Closes #531
