### PR TITLE
Corregir parpadeo del dock: render server-side del estado oculto

### DIFF
--- a/app/static/js/app-shell.js
+++ b/app/static/js/app-shell.js
@@ -26,6 +26,7 @@
   };
   var SS_BANNER   = 'bddat.banner.dismissed';
   var COOKIE_SIDEBAR = 'bddat_sidebar_collapsed';
+  var COOKIE_DOCK    = 'bddat_dock_closed';
   var BREAKPOINT_COLLAPSED = 1280;
   var BREAKPOINT_MOBILE    = 768;
 
@@ -96,14 +97,20 @@
   function applyPanelStates(shell) {
     var insp = readLS(LS.inspectorOpen);
     if (insp === 'false') shell.classList.add('is-inspector-closed');
-    var dock = readLS(LS.dockOpen);
-    if (dock === 'false') shell.classList.add('is-dock-closed');
+    // Dock: localStorage es la fuente de verdad; la cookie es su espejo para que
+    // el servidor pueda renderizar is-dock-closed en el HTML inicial y no se
+    // produzca el parpadeo abrir→cerrar al cargar cada vista (#539).
+    var dockClosed = readLS(LS.dockOpen) === 'false';
+    shell.classList.toggle('is-dock-closed', dockClosed);
+    setCookie(COOKIE_DOCK, dockClosed ? '1' : '0');
   }
 
-  function togglePanel(shell, klass, storageKey) {
+  function togglePanel(shell, klass, storageKey, cookieName) {
     var closed = !shell.classList.contains(klass);
     shell.classList.toggle(klass, closed);
     writeLS(storageKey, String(!closed));
+    // Espejo en cookie para render server-side sin parpadeo (#539; solo el dock lo usa).
+    if (cookieName) setCookie(cookieName, closed ? '1' : '0');
   }
 
   // -- Listeners
@@ -121,7 +128,7 @@
     if (action === 'sidebar')        toggleSidebar(shell);
     else if (action === 'sidebar-mobile') toggleSidebarMobile(shell);
     else if (action === 'inspector') togglePanel(shell, 'is-inspector-closed', LS.inspectorOpen);
-    else if (action === 'dock')      togglePanel(shell, 'is-dock-closed', LS.dockOpen);
+    else if (action === 'dock')      togglePanel(shell, 'is-dock-closed', LS.dockOpen, COOKIE_DOCK);
   }
 
   function onKeydown(e) {

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -50,9 +50,13 @@
   {% set inspector_html %}{% block inspector %}{% endblock %}{% endset %}
 
   {% set _sidebar_collapsed = request.cookies.get('bddat_sidebar_collapsed') == '1' %}
+  {# Estado del dock en cookie (espejo de localStorage) para renderizarlo cerrado
+     ya en el HTML inicial y evitar el parpadeo abrir→cerrar al cargar (#539). #}
+  {% set _dock_closed = request.cookies.get('bddat_dock_closed') == '1' %}
 
   <div class="app-shell
               {%- if _sidebar_collapsed %} is-sidebar-collapsed{% endif -%}
+              {%- if _dock_closed %} is-dock-closed{% endif -%}
               {%- if inspector_html | trim %} has-inspector{% endif -%}">
 
     {% include 'layout/_topbar.html' %}


### PR DESCRIPTION
## Cambios

Corrige el **parpadeo del dock** al cargar cada vista cuando el usuario lo tiene oculto.

**Causa:** el estado del dock se persistía solo en `localStorage` y se aplicaba por JS tras `DOMContentLoaded`. El HTML llegaba con el dock abierto y la `transition: grid-template-rows` lo cerraba animadamente → parpadeo abrir→cerrar. El sidebar no lo sufría porque ya usaba cookie + render server-side.

**Fix** (replica el patrón anti-flash del sidebar):
- `app-shell.js`: el estado del dock se espeja en la cookie `bddat_dock_closed`. `togglePanel` acepta un `cookieName` opcional y `applyPanelStates` sincroniza la cookie con `localStorage` (que sigue siendo la fuente de verdad).
- `base_app.html`: aplica `is-dock-closed` en el `.app-shell` del HTML inicial según esa cookie.

## Verificación

- Playwright a nivel de HTML del servidor: con el dock cerrado, el HTML crudo de otra vista llega con `app-shell … is-dock-closed` **sin ejecutar JS** → no hay transición de apertura. Caso inverso (reabrir → HTML sin la clase, cookie `=0`) simétrico.
- 45 smoke tests verdes.

Closes #539
