### PR TITLE
Inspector overlay de shell + tres capas (ADR-023) — Entidades como listado de referencia

### DIFF
--- a/app/modules/entidades/metadata.json
+++ b/app/modules/entidades/metadata.json
@@ -18,8 +18,7 @@
       { "key": "nombre_completo", "label": "Nombre / Raz\u00f3n Social", "type": "text",     "truncate": true },
       { "key": "nif",             "label": "NIF",                        "type": "text"     },
       { "key": "roles",           "label": "Roles",                      "type": "text",     "hide": "lg" },
-      { "key": "activo",          "label": "Activo",                     "type": "bool",     "hide": "md" },
-      { "key": "_acciones",       "label": "Acciones",                   "type": "acciones" }
+      { "key": "activo",          "label": "Activo",                     "type": "bool",     "hide": "md" }
     ]
   }
 }

--- a/app/modules/entidades/routes.py
+++ b/app/modules/entidades/routes.py
@@ -4,16 +4,17 @@ RUTAS:
     GET  /entidades/                                   → listado (shell V2, datos vía API)
     GET  /entidades/nueva                              → formulario nueva entidad
     POST /entidades/nueva                              → crear entidad
-    GET  /entidades/<id>                               → detalle entidad V4 solo lectura (#134)
+    GET  /entidades/<id>                               → redirect a /entidades/?sel=<id> (ADR-023 #534)
+    GET  /entidades/<id>/fragmento                     → parcial lectura para el inspector (ADR-023 #534)
     GET  /entidades/<id>/editar                        → edición V4 mismo template (#135)
     POST /entidades/<id>/editar                        → guardar cambios entidad (#135)
     POST /entidades/<id>/direcciones/nueva             → añadir dirección de notificación (#136)
     POST /entidades/<id>/direcciones/<dir_id>/editar   → editar dirección (#136)
     POST /entidades/<id>/direcciones/<dir_id>/toggle   → activar/desactivar dirección (#136)
 
-VERSIÓN: 1.2
-FECHA: 2026-02-22
-ISSUE: #136
+VERSIÓN: 1.3
+FECHA: 2026-06-11
+ISSUE: #534
 """
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash
@@ -111,21 +112,24 @@ def nueva():
 @bp.route('/<int:entidad_id>')
 @login_required
 def detalle(entidad_id):
-    """Vista detalle de entidad — patrón V4 solo lectura."""
-    entidad = Entidad.query.get_or_404(entidad_id)
+    """Redirige al listado con el inspector abierto en esa entidad (ADR-023 §9)."""
+    return redirect(url_for('entidades.index', sel=entidad_id))
 
-    # Cargar historial completo de autorizaciones si es titular
+
+@bp.route('/<int:entidad_id>/fragmento')
+@login_required
+def fragmento(entidad_id):
+    """Fragmento HTML de lectura para el inspector (ADR-023 §9 / #534)."""
+    entidad = Entidad.query.get_or_404(entidad_id)
     autorizaciones = []
     if entidad.rol_titular:
         autorizaciones = AutorizadoTitular.obtener_autorizados_de_titular(
             entidad_id, solo_activos=False
         )
-
     return render_template(
-        'entidades/detalle.html',
+        'entidades/_detalle_fragmento.html',
         entidad=entidad,
         autorizaciones=autorizaciones,
-        modo='ver',
     )
 
 

--- a/app/modules/entidades/routes.py
+++ b/app/modules/entidades/routes.py
@@ -6,18 +6,19 @@ RUTAS:
     POST /entidades/nueva                              → crear entidad
     GET  /entidades/<id>                               → redirect a /entidades/?sel=<id> (ADR-023 #534)
     GET  /entidades/<id>/fragmento                     → parcial lectura para el inspector (ADR-023 #534)
-    GET  /entidades/<id>/editar                        → edición V4 mismo template (#135)
-    POST /entidades/<id>/editar                        → guardar cambios entidad (#135)
+    GET  /entidades/<id>/editar-fragmento              → parcial edición para el inspector (ADR-023 §5 #534)
+    GET  /entidades/<id>/editar                        → redirect a /entidades/?sel=<id> (ADR-023 #534)
+    POST /entidades/<id>/editar                        → guardar cambios; JSON si XHR, redirect si no (#534)
     POST /entidades/<id>/direcciones/nueva             → añadir dirección de notificación (#136)
     POST /entidades/<id>/direcciones/<dir_id>/editar   → editar dirección (#136)
     POST /entidades/<id>/direcciones/<dir_id>/toggle   → activar/desactivar dirección (#136)
 
-VERSIÓN: 1.3
+VERSIÓN: 1.4
 FECHA: 2026-06-11
 ISSUE: #534
 """
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
 from flask_login import login_required
 from app import db
 from app.models.entidad import Entidad
@@ -133,24 +134,26 @@ def fragmento(entidad_id):
     )
 
 
+@bp.route('/<int:entidad_id>/editar-fragmento')
+@login_required
+def editar_fragmento(entidad_id):
+    """Fragmento HTML de edición para el inspector (ADR-023 §5 / #534)."""
+    entidad = Entidad.query.get_or_404(entidad_id)
+    return render_template('entidades/_editar_fragmento.html', entidad=entidad)
+
+
 @bp.route('/<int:entidad_id>/editar', methods=['GET', 'POST'])
 @login_required
 def editar(entidad_id):
-    """Edición de entidad — patrón V4 mismo template con modo='editar' (#135)."""
+    """Edición de entidad (ADR-023 §5 / #534).
+
+    GET  → redirect al listado con inspector abierto (ya no es página).
+    POST → JSON si X-Requested-With:XMLHttpRequest; redirect si no (fallback).
+    """
     entidad = Entidad.query.get_or_404(entidad_id)
 
     if request.method == 'GET':
-        autorizaciones = []
-        if entidad.rol_titular:
-            autorizaciones = AutorizadoTitular.obtener_autorizados_de_titular(
-                entidad_id, solo_activos=False
-            )
-        return render_template(
-            'entidades/detalle.html',
-            entidad=entidad,
-            autorizaciones=autorizaciones,
-            modo='editar',
-        )
+        return redirect(url_for('entidades.index', sel=entidad_id))
 
     # --- POST: recoger y validar ---
     nombre_completo = request.form.get('nombre_completo', '').strip()
@@ -180,20 +183,14 @@ def editar(entidad_id):
         if duplicado and duplicado.id != entidad_id:
             errores.append(f'Ya existe otra entidad con el NIF {nif}.')
 
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+
     if errores:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': errores})
         for msg in errores:
             flash(msg, 'danger')
-        autorizaciones = []
-        if entidad.rol_titular:
-            autorizaciones = AutorizadoTitular.obtener_autorizados_de_titular(
-                entidad_id, solo_activos=False
-            )
-        return render_template(
-            'entidades/detalle.html',
-            entidad=entidad,
-            autorizaciones=autorizaciones,
-            modo='editar',
-        )
+        return redirect(url_for('entidades.index', sel=entidad_id))
 
     # --- Actualizar ---
     entidad.nombre_completo    = nombre_completo
@@ -211,8 +208,13 @@ def editar(entidad_id):
 
     db.session.commit()
 
+    if is_xhr:
+        return jsonify({
+            'ok': True,
+            'message': f'Entidad "{entidad.nombre_completo}" actualizada correctamente.',
+        })
     flash(f'Entidad "{entidad.nombre_completo}" actualizada correctamente.', 'success')
-    return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
+    return redirect(url_for('entidades.index', sel=entidad_id))
 
 
 # =============================================================================

--- a/app/modules/entidades/routes.py
+++ b/app/modules/entidades/routes.py
@@ -9,11 +9,14 @@ RUTAS:
     GET  /entidades/<id>/editar-fragmento              → parcial edición para el inspector (ADR-023 §5 #534)
     GET  /entidades/<id>/editar                        → redirect a /entidades/?sel=<id> (ADR-023 #534)
     POST /entidades/<id>/editar                        → guardar cambios; JSON si XHR, redirect si no (#534)
-    POST /entidades/<id>/direcciones/nueva             → añadir dirección de notificación (#136)
-    POST /entidades/<id>/direcciones/<dir_id>/editar   → editar dirección (#136)
-    POST /entidades/<id>/direcciones/<dir_id>/toggle   → activar/desactivar dirección (#136)
+    POST /entidades/<id>/direcciones/nueva             → añadir dirección; JSON si XHR, redirect si no (#136 #534)
+    POST /entidades/<id>/direcciones/<dir_id>/editar   → editar dirección; JSON si XHR, redirect si no (#136 #534)
+    POST /entidades/<id>/direcciones/<dir_id>/toggle   → activar/desactivar dirección; JSON si XHR (#136 #534)
+    POST /entidades/<id>/autorizados/nueva             → nueva autorización; JSON si XHR (#137 #534)
+    POST /entidades/<id>/autorizados/<aut_id>/revocar  → revocar autorización; JSON si XHR (#137 #534)
+    POST /entidades/<id>/autorizados/<aut_id>/restaurar → restaurar autorización; JSON si XHR (#137 #534)
 
-VERSIÓN: 1.4
+VERSIÓN: 1.5
 FECHA: 2026-06-11
 ISSUE: #534
 """
@@ -129,6 +132,34 @@ def fragmento(entidad_id):
         )
     return render_template(
         'entidades/_detalle_fragmento.html',
+        entidad=entidad,
+        autorizaciones=autorizaciones,
+    )
+
+
+@bp.route('/<int:entidad_id>/gestionar-direcciones')
+@login_required
+def gestionar_direcciones(entidad_id):
+    """Fragmento modal grande — gestión de direcciones de notificación (ADR-023 §6 / #534)."""
+    entidad = Entidad.query.get_or_404(entidad_id)
+    return render_template(
+        'entidades/_gestionar_direcciones_fragmento.html',
+        entidad=entidad,
+    )
+
+
+@bp.route('/<int:entidad_id>/gestionar-autorizaciones')
+@login_required
+def gestionar_autorizaciones(entidad_id):
+    """Fragmento modal grande — gestión de autorizaciones (ADR-023 §6 / #534). Solo titulares."""
+    entidad = Entidad.query.get_or_404(entidad_id)
+    if not entidad.rol_titular:
+        return '', 403
+    autorizaciones = AutorizadoTitular.obtener_autorizados_de_titular(
+        entidad_id, solo_activos=False
+    )
+    return render_template(
+        'entidades/_gestionar_autorizaciones_fragmento.html',
         entidad=entidad,
         autorizaciones=autorizaciones,
     )
@@ -265,8 +296,11 @@ def nueva_direccion(entidad_id):
     """Añade una nueva dirección de notificación a la entidad."""
     entidad = Entidad.query.get_or_404(entidad_id)
     datos, errores = _recoger_datos_direccion(request.form, entidad)
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
 
     if errores:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': errores})
         for msg in errores:
             flash(msg, 'danger')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
@@ -286,6 +320,8 @@ def nueva_direccion(entidad_id):
     db.session.add(dir_nueva)
     db.session.commit()
 
+    if is_xhr:
+        return jsonify({'ok': True, 'message': 'Dirección de notificación añadida.'})
     flash('Dirección de notificación añadida.', 'success')
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -300,8 +336,11 @@ def editar_direccion(entidad_id, dir_id):
     ).first_or_404()
 
     datos, errores = _recoger_datos_direccion(request.form, entidad)
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
 
     if errores:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': errores})
         for msg in errores:
             flash(msg, 'danger')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
@@ -316,6 +355,8 @@ def editar_direccion(entidad_id, dir_id):
     direccion.notas              = datos['notas']
 
     db.session.commit()
+    if is_xhr:
+        return jsonify({'ok': True, 'message': 'Dirección de notificación actualizada.'})
     flash('Dirección de notificación actualizada.', 'success')
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -333,6 +374,9 @@ def toggle_direccion(entidad_id, dir_id):
     db.session.commit()
 
     estado = 'activada' if direccion.activo else 'desactivada'
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    if is_xhr:
+        return jsonify({'ok': True, 'message': f'Dirección "{direccion.descripcion or dir_id}" {estado}.'})
     flash(f'Dirección "{direccion.descripcion or dir_id}" {estado}.', 'success')
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -346,18 +390,26 @@ def toggle_direccion(entidad_id, dir_id):
 def nueva_autorizacion(entidad_id):
     """Crea una nueva autorización para que otra entidad actúe en nombre del titular."""
     entidad = Entidad.query.get_or_404(entidad_id)
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+
     if not entidad.rol_titular:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': ['Esta entidad no tiene rol Titular.']})
         flash('Esta entidad no tiene rol Titular.', 'danger')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
     autorizado_id_str = request.form.get('autorizado_id', '').strip()
     if not autorizado_id_str or not autorizado_id_str.isdigit():
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': ['Debe seleccionar una entidad autorizada.']})
         flash('Debe seleccionar una entidad autorizada.', 'danger')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
     autorizado_id = int(autorizado_id_str)
 
     if autorizado_id == entidad_id:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': ['Una entidad no puede autorizarse a sí misma.']})
         flash('Una entidad no puede autorizarse a sí misma.', 'danger')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -369,11 +421,15 @@ def nueva_autorizacion(entidad_id):
 
     if existente:
         if existente.activo:
+            if is_xhr:
+                return jsonify({'ok': False, 'errors': ['Ya existe una autorización activa con esa entidad.']})
             flash('Ya existe una autorización activa con esa entidad.', 'warning')
             return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
         # Reutilizar la revocada en vez de crear un duplicado
         existente.restaurar()
         db.session.commit()
+        if is_xhr:
+            return jsonify({'ok': True, 'message': f'Autorización restaurada para "{existente.autorizado.nombre_completo}".'})
         flash(f'Autorización restaurada para "{existente.autorizado.nombre_completo}".', 'success')
         return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -381,8 +437,12 @@ def nueva_autorizacion(entidad_id):
         nueva = AutorizadoTitular.crear_autorizacion(entidad_id, autorizado_id)
         db.session.add(nueva)
         db.session.commit()
+        if is_xhr:
+            return jsonify({'ok': True, 'message': f'Autorización concedida a "{nueva.autorizado.nombre_completo}".'})
         flash(f'Autorización concedida a "{nueva.autorizado.nombre_completo}".', 'success')
     except ValueError as e:
+        if is_xhr:
+            return jsonify({'ok': False, 'errors': [str(e)]})
         flash(str(e), 'danger')
 
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
@@ -399,6 +459,9 @@ def revocar_autorizacion(entidad_id, aut_id):
 
     aut.revocar()
     db.session.commit()
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    if is_xhr:
+        return jsonify({'ok': True, 'message': f'Autorización de "{aut.autorizado.nombre_completo}" revocada.'})
     flash(f'Autorización de "{aut.autorizado.nombre_completo}" revocada.', 'success')
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))
 
@@ -414,5 +477,8 @@ def restaurar_autorizacion(entidad_id, aut_id):
 
     aut.restaurar()
     db.session.commit()
+    is_xhr = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    if is_xhr:
+        return jsonify({'ok': True, 'message': f'Autorización de "{aut.autorizado.nombre_completo}" restaurada.'})
     flash(f'Autorización de "{aut.autorizado.nombre_completo}" restaurada.', 'success')
     return redirect(url_for('entidades.detalle', entidad_id=entidad_id))

--- a/app/modules/entidades/templates/entidades/_detalle_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_detalle_fragmento.html
@@ -1,0 +1,211 @@
+{# _detalle_fragmento.html — Parcial de lectura para el inspector (ADR-023 §9 / #534).
+   No extiende base_app.html. Inyectado vía AppInspector.open({ fragmentUrl }).
+   Fase 2: solo lectura. Botón "Editar" (Fase 3), "Gestionar…" (Fase 4).
+#}
+
+<div class="p-3">
+
+<!-- CARD 1 — Identificación -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-id-card me-1"></i> Identificación
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-12">
+                <label class="form-label fw-semibold small">Nombre / Razón social</label>
+                <input type="text" class="form-control form-control-sm" value="{{ entidad.nombre_completo }}" readonly>
+            </div>
+            <div class="col-6">
+                <label class="form-label fw-semibold small">NIF</label>
+                <input type="text" class="form-control form-control-sm" value="{{ entidad.nif or '—' }}" readonly>
+            </div>
+            <div class="col-3">
+                <label class="form-label fw-semibold small">Estado</label>
+                <div class="form-control form-control-sm d-flex align-items-center gap-2"
+                     style="background:#fff; pointer-events:none;">
+                    {% if entidad.activo %}
+                        <i class="fas fa-check-circle text-success"></i> Activa
+                    {% else %}
+                        <i class="fas fa-times-circle text-danger"></i> Inactiva
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-3">
+                <label class="form-label fw-semibold small">Roles</label>
+                <div class="form-control form-control-sm d-flex align-items-center gap-1 flex-wrap"
+                     style="background:#fff; min-height:31px; pointer-events:none;">
+                    {% if entidad.rol_titular %}
+                        <span class="badge bg-success">Titular</span>
+                    {% endif %}
+                    {% if entidad.rol_consultado %}
+                        <span class="badge bg-info text-dark">Consultado</span>
+                    {% endif %}
+                    {% if entidad.rol_publicador %}
+                        <span class="badge bg-warning text-dark">Publicador</span>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- CARD 2 — Contacto -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-envelope me-1"></i> Contacto
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-6">
+                <label class="form-label fw-semibold small">Email</label>
+                {% if entidad.email %}
+                <div class="form-control form-control-sm" style="background:#fff; pointer-events:none;">
+                    <a href="mailto:{{ entidad.email }}" style="pointer-events:auto;">{{ entidad.email }}</a>
+                </div>
+                {% else %}
+                <input type="text" class="form-control form-control-sm" value="—" readonly>
+                {% endif %}
+            </div>
+            <div class="col-6">
+                <label class="form-label fw-semibold small">Teléfono</label>
+                <input type="text" class="form-control form-control-sm" value="{{ entidad.telefono or '—' }}" readonly>
+            </div>
+            {% if entidad.notas %}
+            <div class="col-12">
+                <label class="form-label fw-semibold small">Notas</label>
+                <textarea class="form-control form-control-sm" rows="3" readonly
+                          style="background:#fff; resize:none;">{{ entidad.notas }}</textarea>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<!-- CARD 3 — Dirección (solo si hay datos) -->
+{% set dir = entidad.direccion_formateada() %}
+{% if dir.linea1 or dir.linea2 %}
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-map-marker-alt me-1"></i> Dirección
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-8">
+                <label class="form-label fw-semibold small">Calle / Dirección</label>
+                <input type="text" class="form-control form-control-sm" value="{{ dir.linea1 or '—' }}" readonly>
+            </div>
+            <div class="col-4">
+                <label class="form-label fw-semibold small">CP y Municipio</label>
+                <input type="text" class="form-control form-control-sm" value="{{ dir.linea2 or '—' }}" readonly>
+            </div>
+            {% if dir.provincia %}
+            <div class="col-12">
+                <label class="form-label fw-semibold small">Provincia</label>
+                <input type="text" class="form-control form-control-sm" value="{{ dir.provincia }}" readonly>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- CARD 4 — Direcciones de notificación -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-bell me-1"></i> Direcciones de notificación
+    </div>
+    <div class="card-body p-0">
+        {% if entidad.direcciones_notificacion %}
+        <table class="table table-sm table-hover table-embedded">
+            <thead class="table-light">
+                <tr>
+                    <th>Descripción</th>
+                    <th>Roles</th>
+                    <th>Email</th>
+                    <th>Estado</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for d in entidad.direcciones_notificacion %}
+                <tr class="{% if not d.activo %}text-secondary{% endif %}">
+                    <td>{{ d.descripcion or '—' }}</td>
+                    <td>
+                        {% if d.es_titular %}
+                            <span class="badge bg-success">Titular</span>
+                        {% endif %}
+                        {% if d.es_consultado %}
+                            <span class="badge bg-info text-dark">Consultado</span>
+                        {% endif %}
+                        {% if d.es_publicador %}
+                            <span class="badge bg-warning text-dark">Publicador</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if d.email %}
+                            <a href="mailto:{{ d.email }}">{{ d.email }}</a>
+                        {% else %}—{% endif %}
+                    </td>
+                    <td>
+                        {% if d.activo %}
+                            <span class="badge bg-success">Activa</span>
+                        {% else %}
+                            <span class="badge bg-secondary">Inactiva</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="text-secondary mb-0 p-3">
+            <i class="fas fa-info-circle me-1"></i> Sin direcciones de notificación registradas.
+        </p>
+        {% endif %}
+    </div>
+</div>
+
+<!-- CARD 5 — Autorizaciones (solo si es titular) -->
+{% if entidad.rol_titular %}
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-user-check me-1"></i> Autorizaciones
+    </div>
+    <div class="card-body p-0">
+        {% if autorizaciones %}
+        <table class="table table-sm table-hover table-embedded">
+            <thead class="table-light">
+                <tr>
+                    <th>Entidad autorizada</th>
+                    <th>NIF</th>
+                    <th>Alta</th>
+                    <th>Estado</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for aut in autorizaciones %}
+                <tr class="{% if not aut.activo %}text-secondary{% endif %}">
+                    <td>{{ aut.autorizado.nombre_completo }}</td>
+                    <td>{{ aut.autorizado.nif or '—' }}</td>
+                    <td>{{ aut.created_at.strftime('%d/%m/%Y') }}</td>
+                    <td>
+                        {% if aut.activo %}
+                            <span class="badge bg-success">Activa</span>
+                        {% else %}
+                            <span class="badge bg-secondary">Revocada</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="text-secondary mb-0 p-3">
+            <i class="fas fa-info-circle me-1"></i> Sin autorizaciones registradas.
+        </p>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+
+</div>{# /p-3 #}

--- a/app/modules/entidades/templates/entidades/_detalle_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_detalle_fragmento.html
@@ -122,8 +122,13 @@
 
 <!-- CARD 4 — Direcciones de notificación -->
 <div class="card mb-3">
-    <div class="card-header card-header-accent fw-semibold">
-        <i class="fas fa-bell me-1"></i> Direcciones de notificación
+    <div class="card-header card-header-accent fw-semibold d-flex justify-content-between align-items-center">
+        <span><i class="fas fa-bell me-1"></i> Direcciones de notificación</span>
+        <button type="button" class="btn btn-outline-primary btn-sm"
+                data-modal-large-url="{{ url_for('entidades.gestionar_direcciones', entidad_id=entidad.id) }}"
+                data-modal-large-title="Direcciones de notificación">
+            <i class="fas fa-cog me-1"></i> Gestionar
+        </button>
     </div>
     <div class="card-body p-0">
         {% if entidad.direcciones_notificacion %}
@@ -178,8 +183,13 @@
 <!-- CARD 5 — Autorizaciones (solo si es titular) -->
 {% if entidad.rol_titular %}
 <div class="card mb-3">
-    <div class="card-header card-header-accent fw-semibold">
-        <i class="fas fa-user-check me-1"></i> Autorizaciones
+    <div class="card-header card-header-accent fw-semibold d-flex justify-content-between align-items-center">
+        <span><i class="fas fa-user-check me-1"></i> Autorizaciones</span>
+        <button type="button" class="btn btn-outline-primary btn-sm"
+                data-modal-large-url="{{ url_for('entidades.gestionar_autorizaciones', entidad_id=entidad.id) }}"
+                data-modal-large-title="Autorizaciones">
+            <i class="fas fa-cog me-1"></i> Gestionar
+        </button>
     </div>
     <div class="card-body p-0">
         {% if autorizaciones %}

--- a/app/modules/entidades/templates/entidades/_detalle_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_detalle_fragmento.html
@@ -5,6 +5,14 @@
 
 <div class="p-3">
 
+<div class="d-flex justify-content-end mb-3">
+    <button type="button" class="btn btn-primary btn-sm"
+            data-inspector-edit
+            data-edit-url="{{ url_for('entidades.editar_fragmento', entidad_id=entidad.id) }}">
+        <i class="fas fa-edit me-1"></i> Editar
+    </button>
+</div>
+
 <!-- CARD 1 — Identificación -->
 <div class="card mb-3">
     <div class="card-header card-header-accent fw-semibold">
@@ -71,13 +79,15 @@
                 <label class="form-label fw-semibold small">Teléfono</label>
                 <input type="text" class="form-control form-control-sm" value="{{ entidad.telefono or '—' }}" readonly>
             </div>
-            {% if entidad.notas %}
             <div class="col-12">
                 <label class="form-label fw-semibold small">Notas</label>
+                {% if entidad.notas %}
                 <textarea class="form-control form-control-sm" rows="3" readonly
                           style="background:#fff; resize:none;">{{ entidad.notas }}</textarea>
+                {% else %}
+                <input type="text" class="form-control form-control-sm" value="—" readonly>
+                {% endif %}
             </div>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/app/modules/entidades/templates/entidades/_editar_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_editar_fragmento.html
@@ -1,0 +1,140 @@
+{# _editar_fragmento.html — Parcial de edición para el inspector (ADR-023 §5 / #534).
+   No extiende base_app.html. Inyectado por inspector-overlay.js vía data-inspector-edit.
+   Submit interceptado por inspector-overlay.js: POST XHR → JSON { ok, errors, message }.
+#}
+
+<div class="p-3">
+
+<form data-inspector-form
+      data-action="{{ url_for('entidades.editar', entidad_id=entidad.id) }}">
+
+<div id="inspector-form-errors" class="alert alert-danger py-2 mb-3 small"
+     style="display:none;"></div>
+
+<div class="d-flex justify-content-end gap-2 mb-3">
+    <button type="button" class="btn btn-outline-secondary btn-sm"
+            data-inspector-cancel-edit>
+        <i class="fas fa-times me-1"></i> Cancelar
+    </button>
+    <button type="submit" class="btn btn-primary btn-sm">
+        <i class="fas fa-save me-1"></i> Guardar cambios
+    </button>
+</div>
+
+<!-- CARD 1 — Identificación -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-id-card me-1"></i> Identificación
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-12">
+                <label class="form-label fw-semibold small" for="ef_nombre">Nombre / Razón social</label>
+                <input type="text" class="form-control form-control-sm" id="ef_nombre"
+                       name="nombre_completo" value="{{ entidad.nombre_completo }}"
+                       required maxlength="200">
+            </div>
+            <div class="col-6">
+                <label class="form-label fw-semibold small" for="ef_nif">NIF</label>
+                <input type="text" class="form-control form-control-sm" id="ef_nif"
+                       name="nif" value="{{ entidad.nif or '' }}" maxlength="20"
+                       placeholder="Ej: B12345678">
+            </div>
+            <div class="col-3">
+                <label class="form-label fw-semibold small">Estado</label>
+                <div class="form-control form-control-sm d-flex align-items-center"
+                     style="background:#fff; min-height:31px;">
+                    <div class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="ef_activo"
+                               name="activo" {% if entidad.activo %}checked{% endif %}>
+                        <label class="form-check-label small" for="ef_activo">Activa</label>
+                    </div>
+                </div>
+            </div>
+            <div class="col-3">
+                <label class="form-label fw-semibold small">Roles</label>
+                <div class="form-control form-control-sm d-flex flex-column gap-1"
+                     style="background:#fff; min-height:60px;">
+                    <div class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="ef_titular"
+                               name="rol_titular" {% if entidad.rol_titular %}checked{% endif %}>
+                        <label class="form-check-label small" for="ef_titular">Titular</label>
+                    </div>
+                    <div class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="ef_consultado"
+                               name="rol_consultado" {% if entidad.rol_consultado %}checked{% endif %}>
+                        <label class="form-check-label small" for="ef_consultado">Consultado</label>
+                    </div>
+                    <div class="form-check mb-0">
+                        <input class="form-check-input" type="checkbox" id="ef_publicador"
+                               name="rol_publicador" {% if entidad.rol_publicador %}checked{% endif %}>
+                        <label class="form-check-label small" for="ef_publicador">Publicador</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- CARD 2 — Contacto -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-envelope me-1"></i> Contacto
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-6">
+                <label class="form-label fw-semibold small" for="ef_email">Email</label>
+                <input type="email" class="form-control form-control-sm" id="ef_email"
+                       name="email" value="{{ entidad.email or '' }}" maxlength="120"
+                       placeholder="correo@ejemplo.es">
+            </div>
+            <div class="col-6">
+                <label class="form-label fw-semibold small" for="ef_telefono">Teléfono</label>
+                <input type="text" class="form-control form-control-sm" id="ef_telefono"
+                       name="telefono" value="{{ entidad.telefono or '' }}" maxlength="20"
+                       placeholder="958 000 000">
+            </div>
+            <div class="col-12">
+                <label class="form-label fw-semibold small" for="ef_notas">Notas</label>
+                <textarea class="form-control form-control-sm" id="ef_notas"
+                          name="notas" rows="3">{{ entidad.notas or '' }}</textarea>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- CARD 3 — Dirección -->
+<div class="card mb-3">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-map-marker-alt me-1"></i> Dirección
+    </div>
+    <div class="card-body card-body-tinted">
+        <div class="row g-2">
+            <div class="col-8">
+                <label class="form-label fw-semibold small" for="ef_direccion">Calle / Dirección</label>
+                <input type="text" class="form-control form-control-sm" id="ef_direccion"
+                       name="direccion" value="{{ entidad.direccion or '' }}"
+                       placeholder="Calle, número, piso...">
+            </div>
+            <div class="col-4">
+                <label class="form-label fw-semibold small" for="ef_cp">Código Postal</label>
+                <input type="text" class="form-control form-control-sm" id="ef_cp"
+                       name="codigo_postal" value="{{ entidad.codigo_postal or '' }}"
+                       maxlength="10" placeholder="18001">
+            </div>
+            <div class="col-12">
+                <label class="form-label fw-semibold small" for="ef_fallback">
+                    Dirección libre
+                    <span class="text-secondary fw-normal">(extranjero / casos especiales)</span>
+                </label>
+                <input type="text" class="form-control form-control-sm" id="ef_fallback"
+                       name="direccion_fallback" value="{{ entidad.direccion_fallback or '' }}"
+                       placeholder="Dirección completa en texto libre...">
+            </div>
+        </div>
+    </div>
+</div>
+
+</form>
+</div>{# /p-3 #}

--- a/app/modules/entidades/templates/entidades/_gestionar_autorizaciones_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_gestionar_autorizaciones_fragmento.html
@@ -1,0 +1,151 @@
+{# _gestionar_autorizaciones_fragmento.html — Modal grande: gestión de autorizaciones.
+   Solo para entidades con rol_titular.
+   Cargado por AppModalLarge vía GET /entidades/<id>/gestionar-autorizaciones (ADR-023 §6 / #534).
+   Submit del form interceptado por modal-large.js (data-modal-form → XHR → JSON).
+   SelectorBusqueda inicializado en el <script> del fragmento (re-ejecutado por AppModalLarge).
+   Revocar/Restaurar via fetch directo.
+#}
+
+<div class="p-3">
+
+<p class="text-secondary small mb-3">
+    Entidades que pueden actuar en nombre de <strong>{{ entidad.nombre_completo }}</strong>.
+</p>
+
+{# Formulario: nueva autorización (siempre visible — el modal es grande) #}
+<div class="card mb-3 border-primary">
+    <div class="card-header card-header-accent fw-semibold">
+        <i class="fas fa-user-plus me-1"></i> Añadir autorizado
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="gaut-form" data-modal-form method="POST"
+              action="{{ url_for('entidades.nueva_autorizacion', entidad_id=entidad.id) }}">
+            <div data-modal-errors class="alert alert-danger py-2 mb-3 small" style="display:none;"></div>
+            <div class="row g-2 align-items-end">
+                <div class="col-md-8 col-12">
+                    <label class="form-label fw-semibold small">Entidad autorizada</label>
+                    <div id="gaut-sb"></div>
+                    <input type="hidden" name="autorizado_id" id="gaut-autorizado-id">
+                    <div id="gaut-aviso" class="text-secondary small mt-1" style="display:none;">
+                        Cargando entidades...
+                    </div>
+                </div>
+                <div class="col-md-4 col-12 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary btn-sm w-100" id="gaut-btn-guardar" disabled>
+                        <i class="fas fa-save me-1"></i> Autorizar
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+{# Tabla de autorizaciones #}
+{% if autorizaciones %}
+<table class="table table-sm table-hover table-embedded">
+    <thead class="table-light">
+        <tr>
+            <th>Entidad autorizada</th>
+            <th>NIF</th>
+            <th>Alta</th>
+            <th>Estado</th>
+            <th class="text-end">Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for aut in autorizaciones %}
+        <tr class="{% if not aut.activo %}text-secondary{% endif %}">
+            <td>{{ aut.autorizado.nombre_completo }}</td>
+            <td>{{ aut.autorizado.nif or '—' }}</td>
+            <td>{{ aut.created_at.strftime('%d/%m/%Y') }}</td>
+            <td>
+                {% if aut.activo %}
+                    <span class="badge bg-success">Activa</span>
+                {% else %}
+                    <span class="badge bg-secondary">Revocada</span>
+                {% endif %}
+            </td>
+            <td class="text-end">
+                {% if aut.activo %}
+                <button type="button"
+                        class="btn btn-sm btn-outline-warning"
+                        data-toggle-url="{{ url_for('entidades.revocar_autorizacion', entidad_id=entidad.id, aut_id=aut.id) }}"
+                        data-toggle-confirm="¿Revocar la autorización de {{ aut.autorizado.nombre_completo }}?"
+                        title="Revocar">
+                    <i class="fas fa-ban"></i>
+                </button>
+                {% else %}
+                <button type="button"
+                        class="btn btn-sm btn-outline-success"
+                        data-toggle-url="{{ url_for('entidades.restaurar_autorizacion', entidad_id=entidad.id, aut_id=aut.id) }}"
+                        data-toggle-confirm="¿Restaurar la autorización de {{ aut.autorizado.nombre_completo }}?"
+                        title="Restaurar">
+                    <i class="fas fa-redo"></i>
+                </button>
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p class="text-secondary mb-0 p-2">
+    <i class="fas fa-info-circle me-1"></i> Sin autorizaciones registradas.
+</p>
+{% endif %}
+
+</div>{# /p-3 #}
+
+<script>
+(function () {
+    var URL_CANDIDATOS = {{ url_for('api_entidades.candidatos_autorizacion', titular_id=entidad.id) | tojson }};
+
+    // SelectorBusqueda para elegir entidad autorizada
+    var selAut = new SelectorBusqueda('#gaut-sb', [], {
+        placeholder: '— Buscar entidad —',
+        name: '_gaut_sel',
+        onChange: function (v) {
+            document.getElementById('gaut-autorizado-id').value = v;
+            document.getElementById('gaut-btn-guardar').disabled = !v;
+        }
+    });
+
+    // Cargar candidatos al montar el fragmento
+    var aviso = document.getElementById('gaut-aviso');
+    aviso.style.display = 'block';
+    fetch(URL_CANDIDATOS, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then(function (r) { return r.json(); })
+        .then(function (json) {
+            aviso.style.display = 'none';
+            if (json.data && json.data.length) {
+                selAut.setOpciones(json.data);
+            } else {
+                aviso.textContent = 'No hay entidades disponibles para autorizar.';
+                aviso.style.display = 'block';
+            }
+        })
+        .catch(function () {
+            aviso.textContent = 'Error al cargar entidades.';
+            aviso.style.display = 'block';
+        });
+
+    // Toggle revocar / restaurar
+    document.querySelectorAll('[data-toggle-url]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            if (!confirm(btn.dataset.toggleConfirm || '¿Confirmar?')) return;
+            fetch(btn.dataset.toggleUrl, {
+                method:  'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            })
+            .then(function (r) { return r.json(); })
+            .then(function (json) {
+                if (json.ok && window.mostrar_toast) window.mostrar_toast('success', json.message || 'Actualizado.');
+                if (window.AppModalLarge) window.AppModalLarge.refresh();
+            })
+            .catch(function () {
+                if (window.mostrar_toast) window.mostrar_toast('danger', 'Error al actualizar.');
+            });
+        });
+    });
+})();
+</script>

--- a/app/modules/entidades/templates/entidades/_gestionar_direcciones_fragmento.html
+++ b/app/modules/entidades/templates/entidades/_gestionar_direcciones_fragmento.html
@@ -1,0 +1,260 @@
+{# _gestionar_direcciones_fragmento.html — Modal grande: gestión de direcciones de notificación.
+   Cargado por AppModalLarge vía GET /entidades/<id>/gestionar-direcciones (ADR-023 §6 / #534).
+   Submit del form interceptado por modal-large.js (data-modal-form → XHR → JSON).
+   Toggle activar/desactivar via fetch directo desde el <script> del fragmento.
+#}
+
+<div class="p-3">
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <span class="text-secondary small">
+        {{ entidad.direcciones_notificacion | length }}
+        dirección{{ 'es' if entidad.direcciones_notificacion | length != 1 else '' }} registrada{{ 's' if entidad.direcciones_notificacion | length != 1 else '' }}
+    </span>
+    <button type="button" class="btn btn-sm btn-outline-primary" id="gdir-btn-nueva">
+        <i class="fas fa-plus me-1"></i> Nueva dirección
+    </button>
+</div>
+
+{# Formulario inline alta / edición — oculto por defecto #}
+<div id="gdir-form-wrap" class="card mb-3 border-primary" style="display:none;">
+    <div class="card-header card-header-accent fw-semibold d-flex justify-content-between align-items-center">
+        <span id="gdir-form-titulo"><i class="fas fa-bell me-1"></i> Nueva dirección de notificación</span>
+        <button type="button" class="btn-close btn-close-white" id="gdir-btn-cancelar" aria-label="Cancelar"></button>
+    </div>
+    <div class="card-body card-body-tinted">
+        <form id="gdir-form" data-modal-form method="POST"
+              action="{{ url_for('entidades.nueva_direccion', entidad_id=entidad.id) }}">
+            <div data-modal-errors class="alert alert-danger py-2 mb-3 small" style="display:none;"></div>
+            <div class="row g-2">
+
+                <div class="col-12">
+                    <label class="form-label fw-semibold small" for="gdir_descripcion">Descripción</label>
+                    <input type="text" class="form-control form-control-sm" id="gdir_descripcion" name="descripcion"
+                           placeholder="Ej: Sede Central, Delegación Sur...">
+                </div>
+
+                <div class="col-12">
+                    <label class="form-label fw-semibold small">Roles</label>
+                    <div class="d-flex gap-4 flex-wrap">
+                        {% if entidad.rol_titular %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="gdir_rol_titular" name="rol_titular">
+                            <label class="form-check-label small" for="gdir_rol_titular">Titular</label>
+                        </div>
+                        {% endif %}
+                        {% if entidad.rol_consultado %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="gdir_rol_consultado" name="rol_consultado">
+                            <label class="form-check-label small" for="gdir_rol_consultado">Consultado</label>
+                        </div>
+                        {% endif %}
+                        {% if entidad.rol_publicador %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="gdir_rol_publicador" name="rol_publicador">
+                            <label class="form-check-label small" for="gdir_rol_publicador">Publicador</label>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="col-md-6 col-12">
+                    <label class="form-label fw-semibold small" for="gdir_email">Email</label>
+                    <input type="email" class="form-control form-control-sm" id="gdir_email" name="email"
+                           placeholder="notificaciones@ejemplo.es">
+                </div>
+                <div class="col-md-3 col-6">
+                    <label class="form-label fw-semibold small" for="gdir_telefono">Teléfono</label>
+                    <input type="text" class="form-control form-control-sm" id="gdir_telefono" name="telefono"
+                           placeholder="958 000 000">
+                </div>
+
+                <div class="col-md-8 col-12">
+                    <label class="form-label fw-semibold small" for="gdir_direccion">Dirección postal</label>
+                    <input type="text" class="form-control form-control-sm" id="gdir_direccion" name="direccion"
+                           placeholder="Calle, número, piso...">
+                </div>
+                <div class="col-md-2 col-4">
+                    <label class="form-label fw-semibold small" for="gdir_cp">CP</label>
+                    <input type="text" class="form-control form-control-sm" id="gdir_cp" name="codigo_postal"
+                           maxlength="10" placeholder="18001">
+                </div>
+
+                <div class="col-12">
+                    <label class="form-label fw-semibold small" for="gdir_fallback">
+                        Dirección libre
+                        <span class="text-secondary fw-normal">(extranjero / casos especiales)</span>
+                    </label>
+                    <input type="text" class="form-control form-control-sm" id="gdir_fallback" name="direccion_fallback"
+                           placeholder="Dirección completa en texto libre...">
+                </div>
+
+                <div class="col-12">
+                    <label class="form-label fw-semibold small" for="gdir_notas">Notas</label>
+                    <textarea class="form-control form-control-sm" id="gdir_notas" name="notas" rows="2"
+                              placeholder="Observaciones sobre esta dirección..."></textarea>
+                </div>
+
+            </div>
+            <div class="d-flex justify-content-end gap-2 mt-3">
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="gdir-btn-cancelar2">
+                    <i class="fas fa-times me-1"></i> Cancelar
+                </button>
+                <button type="submit" class="btn btn-primary btn-sm">
+                    <i class="fas fa-save me-1"></i> Guardar
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{# Tabla de direcciones #}
+{% if entidad.direcciones_notificacion %}
+<table class="table table-sm table-hover table-embedded">
+    <thead class="table-light">
+        <tr>
+            <th>Descripción</th>
+            <th>Roles</th>
+            <th>Email</th>
+            <th>Dirección</th>
+            <th>Estado</th>
+            <th class="text-end">Acciones</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for d in entidad.direcciones_notificacion %}
+        <tr class="{% if not d.activo %}text-secondary{% endif %}">
+            <td>{{ d.descripcion or '—' }}</td>
+            <td>
+                {% if d.es_titular %}<span class="badge bg-success">Titular</span>{% endif %}
+                {% if d.es_consultado %}<span class="badge bg-info text-dark">Consultado</span>{% endif %}
+                {% if d.es_publicador %}<span class="badge bg-warning text-dark">Publicador</span>{% endif %}
+            </td>
+            <td>
+                {% if d.email %}<a href="mailto:{{ d.email }}">{{ d.email }}</a>{% else %}—{% endif %}
+            </td>
+            <td class="small">
+                {% set df = d.direccion_formateada() %}
+                {% if df.linea1 %}{{ df.linea1 }}{% if df.linea2 %}, {{ df.linea2 }}{% endif %}{% else %}—{% endif %}
+            </td>
+            <td>
+                {% if d.activo %}
+                    <span class="badge bg-success">Activa</span>
+                {% else %}
+                    <span class="badge bg-secondary">Inactiva</span>
+                {% endif %}
+            </td>
+            <td class="text-end text-nowrap">
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary gdir-edit-btn"
+                        data-edit-url="{{ url_for('entidades.editar_direccion', entidad_id=entidad.id, dir_id=d.id) }}"
+                        data-descripcion="{{ d.descripcion or '' }}"
+                        data-email="{{ d.email or '' }}"
+                        data-telefono="{{ d.telefono or '' }}"
+                        data-direccion="{{ d.direccion or '' }}"
+                        data-codigo-postal="{{ d.codigo_postal or '' }}"
+                        data-direccion-fallback="{{ d.direccion_fallback or '' }}"
+                        data-notas="{{ d.notas or '' }}"
+                        data-rol-titular="{{ '1' if d.es_titular else '0' }}"
+                        data-rol-consultado="{{ '1' if d.es_consultado else '0' }}"
+                        data-rol-publicador="{{ '1' if d.es_publicador else '0' }}"
+                        title="Editar">
+                    <i class="fas fa-edit"></i>
+                </button>
+                <button type="button"
+                        class="btn btn-sm {{ 'btn-outline-warning' if d.activo else 'btn-outline-success' }}"
+                        data-toggle-url="{{ url_for('entidades.toggle_direccion', entidad_id=entidad.id, dir_id=d.id) }}"
+                        data-toggle-confirm="{{ '¿Desactivar' if d.activo else '¿Activar' }} esta dirección de notificación?"
+                        title="{{ 'Desactivar' if d.activo else 'Activar' }}">
+                    <i class="fas fa-{{ 'ban' if d.activo else 'check' }}"></i>
+                </button>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p class="text-secondary mb-0 p-2">
+    <i class="fas fa-info-circle me-1"></i> Sin direcciones de notificación registradas.
+</p>
+{% endif %}
+
+</div>{# /p-3 #}
+
+<script>
+(function () {
+    var URL_NUEVA = {{ url_for('entidades.nueva_direccion', entidad_id=entidad.id) | tojson }};
+    var formWrap  = document.getElementById('gdir-form-wrap');
+    var formEl    = document.getElementById('gdir-form');
+    var formTit   = document.getElementById('gdir-form-titulo');
+    var btnNueva  = document.getElementById('gdir-btn-nueva');
+
+    function mostrar() {
+        formWrap.style.display = '';
+        btnNueva.style.display = 'none';
+        formWrap.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    function ocultar() {
+        formWrap.style.display = 'none';
+        btnNueva.style.display = '';
+        formEl.reset();
+        var errBox = formEl.querySelector('[data-modal-errors]');
+        if (errBox) { errBox.style.display = 'none'; errBox.innerHTML = ''; }
+    }
+
+    btnNueva.addEventListener('click', function () {
+        formTit.innerHTML = '<i class="fas fa-bell me-1"></i> Nueva dirección de notificación';
+        formEl.action = URL_NUEVA;
+        formEl.reset();
+        mostrar();
+    });
+
+    document.getElementById('gdir-btn-cancelar').addEventListener('click', ocultar);
+    document.getElementById('gdir-btn-cancelar2').addEventListener('click', ocultar);
+
+    // Botones editar por fila
+    document.querySelectorAll('.gdir-edit-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            formTit.innerHTML = '<i class="fas fa-edit me-1"></i> Editar dirección de notificación';
+            formEl.action = btn.dataset.editUrl;
+
+            document.getElementById('gdir_descripcion').value = btn.dataset.descripcion || '';
+            document.getElementById('gdir_email').value       = btn.dataset.email        || '';
+            document.getElementById('gdir_telefono').value    = btn.dataset.telefono     || '';
+            document.getElementById('gdir_direccion').value   = btn.dataset.direccion    || '';
+            document.getElementById('gdir_cp').value          = btn.dataset.codigoPostal || '';
+            document.getElementById('gdir_fallback').value    = btn.dataset.direccionFallback || '';
+            document.getElementById('gdir_notas').value       = btn.dataset.notas        || '';
+
+            var chkT = document.getElementById('gdir_rol_titular');
+            var chkC = document.getElementById('gdir_rol_consultado');
+            var chkP = document.getElementById('gdir_rol_publicador');
+            if (chkT) chkT.checked = btn.dataset.rolTitular    === '1';
+            if (chkC) chkC.checked = btn.dataset.rolConsultado === '1';
+            if (chkP) chkP.checked = btn.dataset.rolPublicador === '1';
+
+            mostrar();
+        });
+    });
+
+    // Toggle activar / desactivar
+    document.querySelectorAll('[data-toggle-url]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            if (!confirm(btn.dataset.toggleConfirm || '¿Confirmar?')) return;
+            fetch(btn.dataset.toggleUrl, {
+                method:  'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            })
+            .then(function (r) { return r.json(); })
+            .then(function (json) {
+                if (json.ok && window.mostrar_toast) window.mostrar_toast('success', json.message || 'Actualizado.');
+                if (window.AppModalLarge) window.AppModalLarge.refresh();
+            })
+            .catch(function () {
+                if (window.mostrar_toast) window.mostrar_toast('danger', 'Error al actualizar.');
+            });
+        });
+    });
+})();
+</script>

--- a/app/modules/entidades/templates/entidades/index.html
+++ b/app/modules/entidades/templates/entidades/index.html
@@ -30,11 +30,36 @@
         apiUrl:      '{{ url_for("api_entidades.listar_entidades") }}',
         tableClass:  '.entidades-table',
         entityLabel: 'entidades',
-        detailUrl:   id => `/entidades/${id}`,
-        columns:     {{ columns | tojson }}
+        columns:     {{ columns | tojson }},
+        selection: {
+            fragmentUrl: id   => `/entidades/${id}/fragmento`,
+            title:       item => item.nombre_completo || ''
+        }
     });
 
     const filtros = new FiltrosListado(scrollInfinito);
+
+    // Sync inspector ↔ URL ?sel (ADR-023 §1)
+    function _updateSelParam(selId) {
+        const url = new URL(location.href);
+        if (selId) url.searchParams.set('sel', selId);
+        else url.searchParams.delete('sel');
+        history.replaceState(null, '', url.toString());
+    }
+    document.addEventListener('inspector:opened',  e => _updateSelParam(e.detail.selId));
+    document.addEventListener('inspector:swapped', e => _updateSelParam(e.detail.selId));
+    document.addEventListener('inspector:closed',  () => _updateSelParam(null));
+
+    // Abrir inspector si la URL trae ?sel=<id>
+    const _selParam = new URLSearchParams(location.search).get('sel');
+    if (_selParam && window.AppInspector) {
+        AppInspector.open({
+            selId:       _selParam,
+            title:       '',
+            fragmentUrl: `/entidades/${_selParam}/fragmento`
+        });
+    }
+
     console.log('Listado de entidades v2 inicializado');
 </script>
 {% endblock %}

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -1,17 +1,19 @@
 /**
- * app-shell.css — Layout único de la app (ADR-014 / Issue #498)
+ * app-shell.css — Layout único de la app (ADR-014 / Issue #498, ADR-023 / Issue #534)
  *
- * Grid 7 áreas:
+ * Grid 6 áreas (inspector es overlay fijo, ya no columna):
  *   topbar    (siempre)
  *   sidebar   (siempre, colapsable)
  *   viewbar   (opcional, cabecera contextual de la vista)
  *   main      (siempre)
- *   inspector (opcional, panel derecho)
  *   dock      (opcional, panel inferior)
  *   footer    (siempre)
  *
+ * Inspector: overlay position:fixed, ancho var(--inspector-width), z-index 60.
+ *            Visible vía .app-shell.is-inspector-open (AppInspector JS).
+ *
  * Nomenclatura fija: docs/guias/NOMENCLATURA_LAYOUT.md
- * Estado de paneles: localStorage (bddat.sidebar.collapsed, bddat.inspector.open, bddat.dock.open)
+ * Estado de paneles: localStorage (bddat.sidebar.collapsed, bddat.dock.open)
  */
 
 :root {
@@ -25,8 +27,8 @@
   --sidebar-width-expanded:  208px;
   --sidebar-width-collapsed: 56px;
 
-  /* Inspector / Dock */
-  --inspector-width:   380px;
+  /* Inspector overlay / Dock */
+  --inspector-width:   900px;
   --dock-height:       240px;
   --dock-open-height:  clamp(160px, 25vh, 400px);
   --dock-header-height: 32px;
@@ -57,8 +59,8 @@
   width: 100%;
   background-color: var(--bg-page);
 
-  /* Columnas: sidebar | main | inspector (oculto por defecto) */
-  grid-template-columns: var(--sidebar-width-expanded) 1fr 0;
+  /* Columnas: sidebar | main  (el inspector es overlay fixed, no columna) */
+  grid-template-columns: var(--sidebar-width-expanded) 1fr;
 
   /* Filas:
      topbar fijo · banner auto · viewbar auto · main 1fr · dock open-height (0 si cerrado) · footer fijo */
@@ -73,16 +75,16 @@
   transition: grid-template-rows 0.25s ease;
 
   grid-template-areas:
-    "topbar  topbar  topbar"
-    "banner  banner  banner"
-    "sidebar viewbar inspector"
-    "sidebar main    inspector"
-    "sidebar dock    dock"
-    "footer  footer  footer";
+    "topbar  topbar"
+    "banner  banner"
+    "sidebar viewbar"
+    "sidebar main"
+    "sidebar dock"
+    "footer  footer";
 }
 
 .app-shell.is-sidebar-collapsed {
-  grid-template-columns: var(--sidebar-width-collapsed) 1fr 0;
+  grid-template-columns: var(--sidebar-width-collapsed) 1fr;
 }
 
 .app-shell.is-dock-closed {
@@ -93,14 +95,6 @@
     1fr
     0px
     var(--footer-height);
-}
-
-.app-shell.has-inspector {
-  grid-template-columns: var(--sidebar-width-expanded) 1fr var(--inspector-width);
-}
-
-.app-shell.has-inspector.is-sidebar-collapsed {
-  grid-template-columns: var(--sidebar-width-collapsed) 1fr var(--inspector-width);
 }
 
 /* ============================================================
@@ -443,16 +437,110 @@
 }
 
 /* ============================================================
-   INSPECTOR — panel derecho opcional (380px)
+   INSPECTOR — overlay fixed anclado al borde derecho (ADR-023 / #534)
    ============================================================ */
 
 .app-inspector {
-  grid-area: inspector;
+  position: fixed;
+  top: var(--topbar-height);
+  right: 0;
+  /* Cuando el dock está abierto, descontamos su altura */
+  bottom: calc(var(--footer-height) + var(--dock-open-height));
+  width: var(--inspector-width);
+  max-width: calc(100vw - var(--sidebar-width-collapsed));
+  z-index: 60;
   background: #ffffff;
   border-left: 1px solid var(--border-color);
-  overflow: auto;
+  overflow: hidden;
   font-size: 0.929rem;
-  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  /* Slide-in desde la derecha */
+  transform: translateX(100%);
+  transition: transform 0.2s ease;
+}
+
+/* Dock cerrado: el inspector llega hasta el footer */
+.app-shell.is-dock-closed .app-inspector {
+  bottom: var(--footer-height);
+}
+
+/* Inspector visible */
+.app-shell.is-inspector-open .app-inspector {
+  transform: translateX(0);
+}
+
+/* ── Sub-componentes del inspector ──────────────────────────── */
+
+/* Franja de resize en el borde izquierdo */
+.app-inspector__resize {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 6px;
+  cursor: ew-resize;
+  z-index: 1;
+}
+
+.app-inspector__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px 0 14px;
+  height: 40px;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  background: var(--gris-especifico);
+}
+
+.app-inspector__title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 0.929rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.app-inspector__close {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--gris-principal);
+  padding: 4px 6px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 0.857rem;
+  transition: background 0.12s;
+}
+
+.app-inspector__close:hover {
+  background: var(--border-color);
+}
+
+.app-inspector__body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+/* Backdrop bloqueante durante edición (is-inspector-locked) */
+.app-inspector__backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 59;   /* por debajo del inspector (60); bloquea main, sidebar, etc. */
+  background: transparent;
+  pointer-events: auto;
+  cursor: not-allowed;
+}
+
+.app-shell.is-inspector-locked .app-inspector__backdrop {
+  display: block;
 }
 
 /* ============================================================
@@ -710,16 +798,15 @@
 
 @media (max-width: 767px) {
   .app-shell {
-    grid-template-columns: 0 1fr 0;
+    grid-template-columns: 0 1fr;
     grid-template-areas:
-      "topbar  topbar  topbar"
-      "banner  banner  banner"
-      "viewbar viewbar viewbar"
-      "main    main    main"
-      "dock    dock    dock"
-      "footer  footer  footer";
+      "topbar  topbar"
+      "banner  banner"
+      "viewbar viewbar"
+      "main    main"
+      "dock    dock"
+      "footer  footer";
   }
-  .app-shell.has-inspector { grid-template-columns: 0 1fr 0; }
 
   .app-sidebar {
     position: fixed;
@@ -743,7 +830,8 @@
   .app-topbar__search { display: none; }
   .app-topbar__hamburger { display: inline-flex; }
 
-  .app-inspector { display: none; }
+  /* En viewport estrecho el overlay ocupa casi todo el ancho (ADR-023 §8) */
+  .app-inspector { max-width: 100vw; }
 }
 
 .app-topbar__hamburger { display: none; }

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -532,6 +532,34 @@
 }
 
 /* ============================================================
+   MODAL GRANDE — overlay de shell para gestión compleja (ADR-023 §6 / #534)
+   Casi pantalla completa con margen; z-index por encima del inspector (60).
+   Bootstrap gestiona el z-index del modal (1055+); aquí controlamos tamaño.
+   ============================================================ */
+
+.modal-app-xl .modal-dialog {
+  max-width: calc(100vw - 3rem);
+  width:     calc(100vw - 3rem);
+  margin:    1.5rem auto;
+  /* Estirar hasta llenar la altura disponible */
+  min-height: calc(100% - 3rem);
+  display: flex;
+  align-items: stretch;
+}
+
+.modal-app-xl .modal-content {
+  flex: 1;
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-app-xl .modal-body {
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+/* ============================================================
    DOCK — panel inferior opcional (240px)
    ============================================================ */
 

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -472,53 +472,41 @@
 
 /* ── Sub-componentes del inspector ──────────────────────────── */
 
-/* Franja de resize en el borde izquierdo */
+/* Franja de resize en el borde izquierdo: arrastre = resize, clic = cerrar */
 .app-inspector__resize {
   position: absolute;
   left: 0; top: 0; bottom: 0;
   width: 6px;
   cursor: ew-resize;
   z-index: 1;
-}
-
-.app-inspector__header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px 0 14px;
-  height: 40px;
-  border-bottom: 1px solid var(--border-color);
-  flex-shrink: 0;
-  background: var(--gris-especifico);
-}
-
-.app-inspector__title {
-  flex: 1;
-  font-weight: 600;
-  font-size: 0.929rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
-.app-inspector__close {
-  border: 0;
   background: transparent;
-  cursor: pointer;
-  color: var(--gris-principal);
-  padding: 4px 6px;
-  border-radius: 3px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  font-size: 0.857rem;
-  transition: background 0.12s;
+  transition: background 0.15s;
 }
 
-.app-inspector__close:hover {
+.app-inspector__resize:hover {
+  background: var(--primary-light);
+}
+
+/* Tres puntos de grip centrados verticalmente */
+.app-inspector__resize::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 3px; height: 3px;
+  border-radius: 50%;
   background: var(--border-color);
+  box-shadow: 0 -8px 0 var(--border-color),
+              0  8px 0 var(--border-color);
+  pointer-events: none;
+  transition: background 0.15s, box-shadow 0.15s;
+}
+
+.app-inspector__resize:hover::after {
+  background: var(--gris-principal);
+  box-shadow: 0 -8px 0 var(--gris-principal),
+              0  8px 0 var(--gris-principal);
 }
 
 .app-inspector__body {

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -150,6 +150,16 @@
   background-color: var(--primary-lighter);
 }
 
+.lista-table tbody tr.is-selectable {
+  cursor: pointer;
+}
+
+/* Estado seleccionado: más intenso que el hover (--primary-lighter) */
+.lista-table tbody tr.is-selected,
+.lista-table tbody tr.is-selected:hover {
+  background-color: rgba(var(--bs-primary-rgb), 0.15);
+}
+
 .lista-table tbody tr:last-child td {
   border-bottom: none;
 }

--- a/app/static/js/app-shell.js
+++ b/app/static/js/app-shell.js
@@ -5,23 +5,23 @@
  *   - Colapsar/expandir sidebar y persistir en localStorage + cookie
  *     (cookie permite que el server renderice el estado correcto sin flash).
  *   - Abrir sidebar como overlay en mobile (<768px).
- *   - Toggle inspector / dock (persistido en localStorage).
+ *   - Toggle dock (persistido en localStorage).
  *   - Atajos: Ctrl+B colapsa sidebar; Ctrl+K enfoca buscador.
+ *
+ * Inspector: gestionado por inspector-overlay.js (ADR-023 / #534).
  *
  * Convenciones (NOMENCLATURA_LAYOUT.md):
  *   - localStorage:
  *       bddat.sidebar.collapsed (string "true"/"false")
- *       bddat.inspector.open    (string "true"/"false")
  *       bddat.dock.open         (string "true"/"false")
  *   - Cookie: bddat_sidebar_collapsed (=1 cuando colapsado)
- *   - Atributos data-app-shell-toggle="sidebar|sidebar-mobile|inspector|dock"
+ *   - Atributos data-app-shell-toggle="sidebar|sidebar-mobile|dock"
  */
 (function () {
   'use strict';
 
   var LS = {
     sidebarCollapsed: 'bddat.sidebar.collapsed',
-    inspectorOpen:    'bddat.inspector.open',
     dockOpen:         'bddat.dock.open'
   };
   var SS_BANNER   = 'bddat.banner.dismissed';
@@ -92,11 +92,10 @@
     });
   }
 
-  // -- Inspector / Dock (estado solo en localStorage — el server no lo necesita)
+  // -- Dock (estado solo en localStorage — el server no lo necesita)
+  // Inspector: gestionado por inspector-overlay.js.
 
   function applyPanelStates(shell) {
-    var insp = readLS(LS.inspectorOpen);
-    if (insp === 'false') shell.classList.add('is-inspector-closed');
     // Dock: localStorage es la fuente de verdad; la cookie es su espejo para que
     // el servidor pueda renderizar is-dock-closed en el HTML inicial y no se
     // produzca el parpadeo abrir→cerrar al cargar cada vista (#539).
@@ -125,10 +124,9 @@
     var shell = getShell();
     if (!shell) return;
     var action = btn.getAttribute('data-app-shell-toggle');
-    if (action === 'sidebar')        toggleSidebar(shell);
+    if (action === 'sidebar')             toggleSidebar(shell);
     else if (action === 'sidebar-mobile') toggleSidebarMobile(shell);
-    else if (action === 'inspector') togglePanel(shell, 'is-inspector-closed', LS.inspectorOpen);
-    else if (action === 'dock')      togglePanel(shell, 'is-dock-closed', LS.dockOpen, COOKIE_DOCK);
+    else if (action === 'dock')           togglePanel(shell, 'is-dock-closed', LS.dockOpen, COOKIE_DOCK);
   }
 
   function onKeydown(e) {

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -2,13 +2,14 @@
  * inspector-overlay.js — API de shell para el inspector overlay (ADR-023 / #534).
  *
  * Expone window.AppInspector con los métodos:
- *   open({ selId, title, fragmentUrl })  — abre/swap; carga fragmento HTML si procede
- *   mountReact({ selId, title })         — abre sin tocar el body (islas React)
- *   close()                              — cierra; emite inspector:closed
- *   refresh()                            — re-fetch del último fragmentUrl
- *   setLocked(bool)                      — backdrop bloqueante (modo edición)
- *   isOpen()                             — true si el panel está visible
- *   currentSel()                         — selId activo o null
+ *   open({ selId, fragmentUrl })  — abre/swap; carga fragmento HTML si procede
+ *                                   (parámetro title aceptado pero ignorado — sin cabecera)
+ *   mountReact({ selId })         — abre sin tocar el body (islas React)
+ *   close()                       — cierra; emite inspector:closed
+ *   refresh()                     — re-fetch del último fragmentUrl
+ *   setLocked(bool)               — backdrop bloqueante (modo edición)
+ *   isOpen()                      — true si el panel está visible
+ *   currentSel()                  — selId activo o null
  *
  * Eventos emitidos en document:
  *   inspector:opened  { detail: { selId } }
@@ -28,15 +29,9 @@
 
   // ── Accesores DOM ─────────────────────────────────────────────────────────
 
-  function getShell()   { return document.querySelector('.app-shell'); }
-  function getAside()   { return document.getElementById('app-inspector'); }
-  function getBody()    { return document.getElementById('app-inspector-body'); }
-  function getTitleEl() { return document.getElementById('app-inspector-title'); }
-
-  function setTitle(title) {
-    var el = getTitleEl();
-    if (el) el.textContent = title || '';
-  }
+  function getShell() { return document.querySelector('.app-shell'); }
+  function getAside() { return document.getElementById('app-inspector'); }
+  function getBody()  { return document.getElementById('app-inspector-body'); }
 
   // ── Estado ────────────────────────────────────────────────────────────────
 
@@ -75,7 +70,6 @@
     var eventName = wasOpen ? 'inspector:swapped' : 'inspector:opened';
 
     _selId = selId;
-    setTitle(title);
 
     if (fragmentUrl) {
       _lastFragUrl = fragmentUrl;
@@ -102,7 +96,6 @@
     var eventName = wasOpen ? 'inspector:swapped' : 'inspector:opened';
 
     _selId = selId;
-    setTitle(title);
     _show();
     document.dispatchEvent(new CustomEvent(eventName, { detail: { selId: selId } }));
   }
@@ -118,9 +111,7 @@
   function refresh() {
     if (!_lastFragUrl || !_selId) return;
     _lastCache = null;  // invalida caché para forzar refetch
-    var selId   = _selId;
-    var title   = getTitleEl() ? getTitleEl().textContent : '';
-    open({ selId: selId, title: title, fragmentUrl: _lastFragUrl });
+    open({ selId: _selId, fragmentUrl: _lastFragUrl });
   }
 
   function setLocked(bool) {
@@ -202,25 +193,35 @@
       }
     } catch (e) { /* ignore */ }
 
-    var startX, startWidth;
+    var startX, startWidth, dragged;
 
     handle.addEventListener('pointerdown', function (e) {
       e.preventDefault();
-      startX = e.clientX;
+      startX     = e.clientX;
       startWidth = aside.getBoundingClientRect().width;
+      dragged    = false;
       handle.setPointerCapture(e.pointerId);
     });
 
     handle.addEventListener('pointermove', function (e) {
       if (startX === undefined) return;
-      var delta    = startX - e.clientX;  // arrastrar ← aumenta ancho
-      var newWidth = Math.max(MIN_WIDTH, startWidth + delta);
-      document.documentElement.style.setProperty('--inspector-width', newWidth + 'px');
+      var delta = startX - e.clientX;  // arrastrar ← aumenta ancho
+      if (Math.abs(delta) >= 4) {
+        dragged = true;
+        var newWidth = Math.max(MIN_WIDTH, startWidth + delta);
+        document.documentElement.style.setProperty('--inspector-width', newWidth + 'px');
+      }
     });
 
     handle.addEventListener('pointerup', function (e) {
       if (startX === undefined) return;
-      startX = undefined;
+      var wasDragged = dragged;
+      startX = dragged = undefined;
+      if (!wasDragged) {
+        // Clic sin arrastre: colapsar el inspector
+        close();
+        return;
+      }
       try {
         var w = parseInt(getComputedStyle(document.documentElement)
                   .getPropertyValue('--inspector-width'), 10);

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -1,0 +1,250 @@
+/**
+ * inspector-overlay.js — API de shell para el inspector overlay (ADR-023 / #534).
+ *
+ * Expone window.AppInspector con los métodos:
+ *   open({ selId, title, fragmentUrl })  — abre/swap; carga fragmento HTML si procede
+ *   mountReact({ selId, title })         — abre sin tocar el body (islas React)
+ *   close()                              — cierra; emite inspector:closed
+ *   refresh()                            — re-fetch del último fragmentUrl
+ *   setLocked(bool)                      — backdrop bloqueante (modo edición)
+ *   isOpen()                             — true si el panel está visible
+ *   currentSel()                         — selId activo o null
+ *
+ * Eventos emitidos en document:
+ *   inspector:opened  { detail: { selId } }
+ *   inspector:swapped { detail: { selId } }
+ *   inspector:closed  { detail: { selId } }  (selId = el que estaba activo)
+ */
+(function () {
+  'use strict';
+
+  var LS_WIDTH  = 'bddat.inspector.width';
+  var MIN_WIDTH = 320;
+
+  var _selId        = null;
+  var _lastCache    = null;  // { selId, html } — retención del último fragmento
+  var _lastFragUrl  = null;  // última fragmentUrl usada (para refresh)
+  var _locked       = false;
+
+  // ── Accesores DOM ─────────────────────────────────────────────────────────
+
+  function getShell()   { return document.querySelector('.app-shell'); }
+  function getAside()   { return document.getElementById('app-inspector'); }
+  function getBody()    { return document.getElementById('app-inspector-body'); }
+  function getTitleEl() { return document.getElementById('app-inspector-title'); }
+
+  function setTitle(title) {
+    var el = getTitleEl();
+    if (el) el.textContent = title || '';
+  }
+
+  // ── Estado ────────────────────────────────────────────────────────────────
+
+  function isOpen() {
+    var shell = getShell();
+    return shell ? shell.classList.contains('is-inspector-open') : false;
+  }
+
+  function currentSel() { return _selId; }
+
+  // ── Mostrar / ocultar panel ───────────────────────────────────────────────
+
+  function _show() {
+    var shell = getShell();
+    if (shell) shell.classList.add('is-inspector-open');
+  }
+
+  function _hide() {
+    var shell = getShell();
+    if (shell) {
+      shell.classList.remove('is-inspector-open');
+      shell.classList.remove('is-inspector-locked');
+    }
+    _locked = false;
+  }
+
+  // ── API pública ───────────────────────────────────────────────────────────
+
+  function open(opts) {
+    var selId      = opts.selId;
+    var title      = opts.title || '';
+    var fragmentUrl = opts.fragmentUrl || null;
+
+    var wasOpen   = isOpen();
+    var isSameId  = wasOpen && _selId === selId;
+    var eventName = wasOpen ? 'inspector:swapped' : 'inspector:opened';
+
+    _selId = selId;
+    setTitle(title);
+
+    if (fragmentUrl) {
+      _lastFragUrl = fragmentUrl;
+      // Retención: mismo selId → no refetchear
+      if (isSameId && _lastCache && _lastCache.selId === selId) {
+        // contenido ya en el DOM, no hacer nada
+      } else if (_lastCache && _lastCache.selId === selId) {
+        var body = getBody();
+        if (body) body.innerHTML = _lastCache.html;
+      } else {
+        _loadFragment(fragmentUrl, selId);
+      }
+    }
+
+    _show();
+    document.dispatchEvent(new CustomEvent(eventName, { detail: { selId: selId } }));
+  }
+
+  function mountReact(opts) {
+    var selId = opts.selId;
+    var title = opts.title || '';
+
+    var wasOpen   = isOpen();
+    var eventName = wasOpen ? 'inspector:swapped' : 'inspector:opened';
+
+    _selId = selId;
+    setTitle(title);
+    _show();
+    document.dispatchEvent(new CustomEvent(eventName, { detail: { selId: selId } }));
+  }
+
+  function close() {
+    if (!isOpen()) return;
+    var prevSelId = _selId;
+    _selId = null;
+    _hide();
+    document.dispatchEvent(new CustomEvent('inspector:closed', { detail: { selId: prevSelId } }));
+  }
+
+  function refresh() {
+    if (!_lastFragUrl || !_selId) return;
+    _lastCache = null;  // invalida caché para forzar refetch
+    var selId   = _selId;
+    var title   = getTitleEl() ? getTitleEl().textContent : '';
+    open({ selId: selId, title: title, fragmentUrl: _lastFragUrl });
+  }
+
+  function setLocked(bool) {
+    _locked = !!bool;
+    var shell = getShell();
+    if (shell) shell.classList.toggle('is-inspector-locked', _locked);
+  }
+
+  // ── Carga de fragmento HTML ───────────────────────────────────────────────
+
+  function _loadFragment(url, selId) {
+    var body = getBody();
+    if (!body) return;
+    body.innerHTML = '<div class="p-3 text-muted small">Cargando…</div>';
+    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.text();
+      })
+      .then(function (html) {
+        // Solo aplicar si la selección no cambió mientras cargaba
+        if (_selId !== selId) return;
+        _lastCache = { selId: selId, html: html };
+        var b = getBody();
+        if (b) b.innerHTML = html;
+      })
+      .catch(function () {
+        if (_selId !== selId) return;
+        var b = getBody();
+        if (b) b.innerHTML = '<div class="p-3 text-danger small">No se pudo cargar el detalle.</div>';
+      });
+  }
+
+  // ── Light-dismiss ─────────────────────────────────────────────────────────
+
+  document.addEventListener('pointerdown', function (e) {
+    if (!isOpen() || _locked) return;
+    var aside = getAside();
+    if (!aside || aside.contains(e.target)) return;
+    // Las islas React gestionan su propia selección; no cerrar desde aquí
+    if (e.target.closest('[data-react-island]')) return;
+    // Filas/nodos seleccionables (Fase 2+): la vista llama open() directamente
+    if (e.target.closest('[data-inspector-sel]')) return;
+    close();
+  });
+
+  // Escape cierra (si no está bloqueado)
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && isOpen() && !_locked) close();
+  });
+
+  // Botón de cierre del panel
+  document.addEventListener('click', function (e) {
+    if (e.target.closest('[data-app-inspector-close]')) {
+      close();
+      return;
+    }
+    // Clic en backdrop con lock activo → aviso
+    if (_locked && e.target.closest('[data-inspector-backdrop]')) {
+      if (window.showToast) {
+        window.showToast('Estás editando este elemento — Guarda o cancela primero.', 'warning');
+      }
+    }
+  });
+
+  // ── Resize por arrastre del borde izquierdo ───────────────────────────────
+
+  function _initResize() {
+    var aside  = getAside();
+    if (!aside) return;
+    var handle = aside.querySelector('[data-inspector-resize]');
+    if (!handle) return;
+
+    // Restaurar ancho guardado
+    try {
+      var saved = parseInt(localStorage.getItem(LS_WIDTH), 10);
+      if (saved && saved >= MIN_WIDTH) {
+        document.documentElement.style.setProperty('--inspector-width', saved + 'px');
+      }
+    } catch (e) { /* ignore */ }
+
+    var startX, startWidth;
+
+    handle.addEventListener('pointerdown', function (e) {
+      e.preventDefault();
+      startX = e.clientX;
+      startWidth = aside.getBoundingClientRect().width;
+      handle.setPointerCapture(e.pointerId);
+    });
+
+    handle.addEventListener('pointermove', function (e) {
+      if (startX === undefined) return;
+      var delta    = startX - e.clientX;  // arrastrar ← aumenta ancho
+      var newWidth = Math.max(MIN_WIDTH, startWidth + delta);
+      document.documentElement.style.setProperty('--inspector-width', newWidth + 'px');
+    });
+
+    handle.addEventListener('pointerup', function (e) {
+      if (startX === undefined) return;
+      startX = undefined;
+      try {
+        var w = parseInt(getComputedStyle(document.documentElement)
+                  .getPropertyValue('--inspector-width'), 10);
+        if (w && w >= MIN_WIDTH) localStorage.setItem(LS_WIDTH, String(w));
+      } catch (ex) { /* ignore */ }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _initResize);
+  } else {
+    _initResize();
+  }
+
+  // ── Exportar API ─────────────────────────────────────────────────────────
+
+  window.AppInspector = {
+    open:        open,
+    mountReact:  mountReact,
+    close:       close,
+    refresh:     refresh,
+    setLocked:   setLocked,
+    isOpen:      isOpen,
+    currentSel:  currentSel
+  };
+
+})();

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -23,9 +23,11 @@
   var MIN_WIDTH = 320;
 
   var _selId        = null;
-  var _lastCache    = null;  // { selId, html } — retención del último fragmento
+  var _lastCache    = null;  // { selId, html } — retención del último fragmento de lectura
+  var _editCache    = null;  // { selId, html } — caché del fragmento de edición
   var _lastFragUrl  = null;  // última fragmentUrl usada (para refresh)
   var _locked       = false;
+  var _formDirty    = false;
 
   // ── Accesores DOM ─────────────────────────────────────────────────────────
 
@@ -55,7 +57,8 @@
       shell.classList.remove('is-inspector-open');
       shell.classList.remove('is-inspector-locked');
     }
-    _locked = false;
+    _locked    = false;
+    _formDirty = false;
   }
 
   // ── API pública ───────────────────────────────────────────────────────────
@@ -69,7 +72,9 @@
     var isSameId  = wasOpen && _selId === selId;
     var eventName = wasOpen ? 'inspector:swapped' : 'inspector:opened';
 
-    _selId = selId;
+    _selId     = selId;
+    _formDirty = false;
+    _editCache = null;
 
     if (fragmentUrl) {
       _lastFragUrl = fragmentUrl;
@@ -125,7 +130,8 @@
   function _loadFragment(url, selId) {
     var body = getBody();
     if (!body) return;
-    body.innerHTML = '<div class="p-3 text-muted small">Cargando…</div>';
+    // No limpiar el body antes del fetch: el contenido anterior permanece
+    // visible hasta que llega el nuevo (evita flash blanco en swap y en editar).
     fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
       .then(function (r) {
         if (!r.ok) throw new Error('HTTP ' + r.status);
@@ -142,6 +148,35 @@
         if (_selId !== selId) return;
         var b = getBody();
         if (b) b.innerHTML = '<div class="p-3 text-danger small">No se pudo cargar el detalle.</div>';
+      });
+  }
+
+  // ── Carga de fragmento de edición (sin borrar body hasta que llegue) ─────
+
+  function _loadEditFragment(url, selId) {
+    var body = getBody();
+    if (!body) return;
+    // Caché hit: instantáneo, sin flash
+    if (_editCache && _editCache.selId === selId) {
+      body.innerHTML = _editCache.html;
+      return;
+    }
+    // Caché miss: fetch; mantener contenido actual hasta que llegue
+    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.text();
+      })
+      .then(function (html) {
+        if (_selId !== selId) return;
+        _editCache = { selId: selId, html: html };
+        var b = getBody();
+        if (b) b.innerHTML = html;
+      })
+      .catch(function () {
+        if (_selId !== selId) return;
+        var b = getBody();
+        if (b) b.innerHTML = '<div class="p-3 text-danger small">No se pudo cargar el formulario.</div>';
       });
   }
 
@@ -163,7 +198,37 @@
     if (e.key === 'Escape' && isOpen() && !_locked) close();
   });
 
-  // Botón de cierre del panel
+  // ── Restaurar fragmento de lectura desde caché (sin flash) ──────────────
+
+  function _restoreReadFragment() {
+    var body = getBody();
+    if (!body) return;
+    if (_lastCache && _lastCache.selId === _selId) {
+      body.innerHTML = _lastCache.html;
+    } else {
+      refresh();  // fallback: refetch si la caché no está
+    }
+  }
+
+  // ── Errores de formulario inline ─────────────────────────────────────────
+
+  function _showFormErrors(form, errors) {
+    var box = form ? form.querySelector('#inspector-form-errors') : null;
+    if (!box) return;
+    if (!errors || errors.length === 0) {
+      box.style.display = 'none';
+      box.innerHTML = '';
+    } else {
+      box.innerHTML = errors.map(function (msg) {
+        return '<div>' + msg + '</div>';
+      }).join('');
+      box.style.display = '';
+      box.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
+  // ── Botón cierre, editar y cancelar edición ───────────────────────────────
+
   document.addEventListener('click', function (e) {
     if (e.target.closest('[data-app-inspector-close]')) {
       close();
@@ -171,9 +236,80 @@
     }
     // Clic en backdrop con lock activo → aviso
     if (_locked && e.target.closest('[data-inspector-backdrop]')) {
-      if (window.showToast) {
-        window.showToast('Estás editando este elemento — Guarda o cancela primero.', 'warning');
+      if (window.mostrar_toast) {
+        window.mostrar_toast('warning', 'Estás editando este elemento — Guarda o cancela primero.');
       }
+      return;
+    }
+    // Botón "Editar" del fragmento de lectura
+    var editBtn = e.target.closest('[data-inspector-edit]');
+    if (editBtn) {
+      var editUrl = editBtn.dataset.editUrl;
+      if (editUrl) {
+        _loadEditFragment(editUrl, _selId);
+        setLocked(true);
+        _formDirty = false;
+      }
+      return;
+    }
+    // Botón "Cancelar" del formulario de edición
+    if (e.target.closest('[data-inspector-cancel-edit]')) {
+      setLocked(false);
+      _formDirty = false;
+      _restoreReadFragment();
+      return;
+    }
+  });
+
+  // ── Submit del formulario de edición (interceptado via XHR) ──────────────
+
+  document.addEventListener('submit', function (e) {
+    var form = e.target.closest('form[data-inspector-form]');
+    if (!form) return;
+    e.preventDefault();
+    var action = form.dataset.action || form.action;
+    var data   = new FormData(form);
+    fetch(action, {
+      method:  'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      body:    data,
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (json) {
+        if (json.ok) {
+          _formDirty = false;
+          setLocked(false);
+          _lastCache = null;   // invalida retención para forzar refetch de lectura
+          _editCache = null;   // invalida caché de edición (datos cambiaron)
+          refresh();
+          if (window.mostrar_toast) {
+            window.mostrar_toast('success', json.message || 'Guardado correctamente.');
+          }
+        } else {
+          _showFormErrors(form, json.errors || []);
+        }
+      })
+      .catch(function () {
+        if (window.mostrar_toast) {
+          window.mostrar_toast('danger', 'Error al guardar. Inténtalo de nuevo.');
+        }
+      });
+  });
+
+  // ── Seguimiento de cambios en el formulario (dirty) ───────────────────────
+
+  document.addEventListener('change', function (e) {
+    if (e.target.closest('form[data-inspector-form]')) {
+      _formDirty = true;
+    }
+  });
+
+  // ── beforeunload cuando hay cambios sin guardar ───────────────────────────
+
+  window.addEventListener('beforeunload', function (e) {
+    if (_locked && _formDirty) {
+      e.preventDefault();
+      e.returnValue = '';
     }
   });
 

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -184,6 +184,8 @@
 
   document.addEventListener('pointerdown', function (e) {
     if (!isOpen() || _locked) return;
+    // Mientras hay un modal Bootstrap abierto encima, no hacer light-dismiss
+    if (document.querySelector('.modal.show')) return;
     var aside = getAside();
     if (!aside || aside.contains(e.target)) return;
     // Las islas React gestionan su propia selección; no cerrar desde aquí
@@ -239,6 +241,12 @@
       if (window.mostrar_toast) {
         window.mostrar_toast('warning', 'Estás editando este elemento — Guarda o cancela primero.');
       }
+      return;
+    }
+    // Botón "Gestionar…" del fragmento de lectura → abre modal grande
+    var modalBtn = e.target.closest('[data-modal-large-url]');
+    if (modalBtn && window.AppModalLarge) {
+      AppModalLarge.open(modalBtn.dataset.modalLargeUrl, { title: modalBtn.dataset.modalLargeTitle || '' });
       return;
     }
     // Botón "Editar" del fragmento de lectura

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -265,6 +265,7 @@
       setLocked(false);
       _formDirty = false;
       _restoreReadFragment();
+      if (window.mostrar_toast) window.mostrar_toast('info', 'Cambios descartados.');
       return;
     }
   });

--- a/app/static/js/modal-large.js
+++ b/app/static/js/modal-large.js
@@ -1,0 +1,173 @@
+/**
+ * modal-large.js — AppModalLarge: modal grande de shell (ADR-023 §6 / #534).
+ *
+ * API pública (window.AppModalLarge):
+ *   open(fragmentUrl, { title, onSaved })
+ *     Carga el fragmento, re-ejecuta sus <script> y muestra el modal.
+ *     onSaved por defecto: AppInspector.refresh().
+ *     Se llama al cerrar el modal (hidden.bs.modal), no al guardar sub-ítems.
+ *   close()    — cierra el modal
+ *   refresh()  — re-fetcha el fragmentUrl actual (refresca tabla tras mutación)
+ *
+ * Formularios con [data-modal-form] dentro del modal son interceptados:
+ *   POST XHR → JSON { ok, message?, errors? }
+ *   ok=true  → refresh()  (modal permanece abierto, tabla actualizada)
+ *   ok=false → muestra errores en [data-modal-errors] del formulario
+ */
+(function () {
+  'use strict';
+
+  var MODAL_ID = 'app-modal-large';
+  var _fragUrl = null;
+  var _onSaved = null;
+
+  // ── Crear el modal en el DOM (una sola vez) ───────────────────────────────
+
+  function _getOrCreate() {
+    var el = document.getElementById(MODAL_ID);
+    if (el) return el;
+
+    el = document.createElement('div');
+    el.className = 'modal fade modal-app-xl';
+    el.id        = MODAL_ID;
+    el.tabIndex  = -1;
+    el.setAttribute('aria-modal', 'true');
+    el.setAttribute('role',       'dialog');
+    el.setAttribute('aria-labelledby', MODAL_ID + '-title');
+    el.innerHTML =
+      '<div class="modal-dialog modal-dialog-scrollable">' +
+        '<div class="modal-content">' +
+          '<div class="modal-header card-header-accent">' +
+            '<h5 class="modal-title fw-semibold" id="' + MODAL_ID + '-title"></h5>' +
+            '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>' +
+          '</div>' +
+          '<div class="modal-body" id="' + MODAL_ID + '-body"></div>' +
+        '</div>' +
+      '</div>';
+
+    document.body.appendChild(el);
+
+    // Al cerrar el modal (X, backdrop, ESC) → llamar onSaved y limpiar estado
+    el.addEventListener('hidden.bs.modal', function () {
+      var cb = _onSaved;
+      _onSaved = null;
+      _fragUrl = null;
+      if (cb) cb();
+    });
+
+    return el;
+  }
+
+  // ── Título ─────────────────────────────────────────────────────────────────
+
+  function _setTitle(title) {
+    var el = document.getElementById(MODAL_ID + '-title');
+    if (el) el.textContent = title || '';
+  }
+
+  // ── Inyectar HTML + re-ejecutar scripts ────────────────────────────────────
+
+  function _inject(html) {
+    var body = document.getElementById(MODAL_ID + '-body');
+    if (!body) return;
+    body.innerHTML = html;
+    // Re-ejecutar scripts del fragmento (innerHTML no los activa)
+    body.querySelectorAll('script').forEach(function (orig) {
+      var s = document.createElement('script');
+      if (orig.src) {
+        s.src = orig.src;
+      } else {
+        s.textContent = orig.textContent;
+      }
+      orig.parentNode.replaceChild(s, orig);
+    });
+  }
+
+  // ── Cargar fragmento ───────────────────────────────────────────────────────
+
+  function _load(url) {
+    var body = document.getElementById(MODAL_ID + '-body');
+    if (body) {
+      body.innerHTML =
+        '<div class="p-4 text-center text-secondary small">' +
+        '<i class="fas fa-spinner fa-spin me-2"></i>Cargando...</div>';
+    }
+    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.text();
+      })
+      .then(function (html) {
+        _inject(html);
+      })
+      .catch(function () {
+        var b = document.getElementById(MODAL_ID + '-body');
+        if (b) b.innerHTML = '<div class="p-3 text-danger small">No se pudo cargar el contenido.</div>';
+      });
+  }
+
+  // ── API pública ────────────────────────────────────────────────────────────
+
+  function open(fragmentUrl, opts) {
+    opts    = opts || {};
+    _fragUrl = fragmentUrl;
+    _onSaved = opts.onSaved || function () {
+      if (window.AppInspector) window.AppInspector.refresh();
+    };
+
+    var el = _getOrCreate();
+    _setTitle(opts.title || '');
+    _load(fragmentUrl);
+    bootstrap.Modal.getOrCreateInstance(el).show();
+  }
+
+  function close() {
+    var el = document.getElementById(MODAL_ID);
+    if (el) bootstrap.Modal.getOrCreateInstance(el).hide();
+  }
+
+  function refresh() {
+    if (_fragUrl) _load(_fragUrl);
+  }
+
+  // ── Interceptar submits [data-modal-form] dentro del modal ─────────────────
+
+  document.addEventListener('submit', function (e) {
+    var modal = document.getElementById(MODAL_ID);
+    if (!modal || !modal.contains(e.target)) return;
+    var form = e.target.closest('form[data-modal-form]');
+    if (!form) return;
+
+    e.preventDefault();
+
+    fetch(form.action, {
+      method:  'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      body:    new FormData(form),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (json) {
+        if (json.ok) {
+          if (window.mostrar_toast) window.mostrar_toast('success', json.message || 'Guardado correctamente.');
+          refresh();
+        } else {
+          var errBox = form.querySelector('[data-modal-errors]');
+          if (errBox) {
+            errBox.innerHTML = (json.errors || []).map(function (m) {
+              return '<div>' + m + '</div>';
+            }).join('');
+            errBox.style.display = (json.errors && json.errors.length) ? '' : 'none';
+            errBox.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          } else if (window.mostrar_toast) {
+            window.mostrar_toast('danger', (json.errors || ['Error al guardar.']).join(' '));
+          }
+        }
+      })
+      .catch(function () {
+        if (window.mostrar_toast) window.mostrar_toast('danger', 'Error al guardar. Inténtalo de nuevo.');
+      });
+  });
+
+  window.AppModalLarge = { open: open, close: close, refresh: refresh };
+
+})();

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.BveZz2AN.js",
+    "file": "bundle.expediente-arbol.0keG_5yb.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,
@@ -31,7 +31,7 @@
       "_chunk.toast.BzEloO_G.js"
     ],
     "css": [
-      "asset.expediente-arbol.Cpt8VahC.css"
+      "asset.expediente-arbol.hbg5rhwl.css"
     ]
   }
 }

--- a/app/static/js/v2-scroll-infinito.js
+++ b/app/static/js/v2-scroll-infinito.js
@@ -33,14 +33,27 @@
  *       ]
  *     });
  *
+ *   Modo selección (ADR-023 — inspector overlay, #534):
+ *     const s = new ScrollInfinito({
+ *       ...
+ *       selection: {
+ *         fragmentUrl: id   => `/entidades/${id}/fragmento`,
+ *         title:       item => item.nombre_completo || ''
+ *       }
+ *     });
+ *     Con selection activo: no se renderiza columna type:'acciones'; cada fila
+ *     recibe data-inspector-sel y un click handler que llama AppInspector.open.
+ *     Requiere window.AppInspector (inspector-overlay.js) cargado antes.
+ *
  *   Tipos de columna soportados:
  *     - text     : textContent plano
  *     - badge    : <span class="badge badge-info">
  *     - bool     : icono check si true, vacío si false
- *     - acciones : botón "Ver" que navega a detailUrl(id)
+ *     - acciones : botón "Ver" que navega a detailUrl(id); omitido en modo selección
  *
- * VERSIÓN: 1.2
- * FECHA: 2026-02-19
+ * VERSIÓN: 1.3
+ * FECHA: 2026-06-11
+ * CAMBIOS v1.3: Modo selección (selection option) para inspector overlay (ADR-023 / #534)
  * CAMBIOS v1.2: Generalizado con config columnas — backward compatible con v1.1
  * CAMBIOS v1.1: Botón Ver apunta a /expedientes/<id>/tramitacion_v3
  */
@@ -56,6 +69,9 @@ class ScrollInfinito {
      * @param {string}   options.entityLabel - Nombre de la entidad para mensajes. Default: 'expedientes'
      * @param {Function} options.detailUrl   - Función id => URL del detalle. Default: BC expedientes
      * @param {Object}   options.fixedParams - Parámetros fijos añadidos a cada petición. Default: {}
+     * @param {Object}   options.selection   - Config modo selección (ADR-023). Si se pasa: activa inspector
+     *                                         overlay en lugar del botón "Ver". Campos:
+     *                                         { fragmentUrl: id => '...', title: item => '...' }
      */
     constructor(options = {}) {
         // Configuración base
@@ -69,6 +85,9 @@ class ScrollInfinito {
         this.tableClass  = options.tableClass  || '.lista-table';
         this.entityLabel = options.entityLabel || 'expedientes';
         this.detailUrl   = options.detailUrl   || (id => `/expedientes/${id}/tramitacion`);
+
+        // Modo selección — inspector overlay (v1.3 / ADR-023 / #534)
+        this.selection   = options.selection   || null;
 
         // Estado
         this.cursor         = 0;
@@ -102,6 +121,9 @@ class ScrollInfinito {
         this.createLoader();
         this.loadMore();
         this.container.addEventListener('scroll', () => this.handleScroll());
+        if (this.selection) {
+            document.addEventListener('inspector:closed', () => this._clearSelected());
+        }
         console.log(`ScrollInfinito inicializado — ${this.entityLabel}`);
     }
 
@@ -167,6 +189,7 @@ class ScrollInfinito {
         const fragment = document.createDocumentFragment();
         items.forEach(item => fragment.appendChild(this.createRow(item)));
         this.tbody.appendChild(fragment);
+        if (this.selection) this._reapplySelected();
     }
 
     /**
@@ -179,11 +202,17 @@ class ScrollInfinito {
 
     /**
      * Motor genérico: crea fila a partir de config columnas.
-     * Tipos soportados: text | badge | bool | acciones
+     * Tipos soportados: text | badge | bool | custom | acciones (omitido en modo selection)
      */
     createRowFromColumns(item) {
         const tr = document.createElement('tr');
+        if (this.selection) {
+            tr.setAttribute('data-inspector-sel', String(item.id));
+            tr.classList.add('is-selectable');
+            tr.addEventListener('click', () => this._handleRowClick(tr, item));
+        }
         this.columns.forEach(col => {
+            if (col.type === 'acciones' && this.selection) return;
             const td = document.createElement('td');
             // Clases declarativas de ocultación responsive y truncado (ADR-022 §3).
             // col.hide = 'xl'|'lg'|'md'; col.truncate = true. El <th> equivalente
@@ -278,6 +307,38 @@ class ScrollInfinito {
 
     verExpediente(id) {
         window.location.href = this.detailUrl(id);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MODO SELECCIÓN (ADR-023 / #534)
+    // ---------------------------------------------------------------------------
+
+    _handleRowClick(tr, item) {
+        const selId = String(item.id);
+        if (window.AppInspector && AppInspector.isOpen() && AppInspector.currentSel() === selId) {
+            AppInspector.close();
+        } else {
+            this._clearSelected();
+            tr.classList.add('is-selected');
+            if (window.AppInspector) {
+                AppInspector.open({
+                    selId:       selId,
+                    title:       this.selection.title ? this.selection.title(item) : '',
+                    fragmentUrl: this.selection.fragmentUrl(item.id),
+                });
+            }
+        }
+    }
+
+    _clearSelected() {
+        this.tbody.querySelectorAll('tr.is-selected').forEach(r => r.classList.remove('is-selected'));
+    }
+
+    _reapplySelected() {
+        if (!window.AppInspector || !AppInspector.isOpen()) return;
+        const cur = AppInspector.currentSel();
+        if (!cur) return;
+        this.tbody.querySelectorAll(`tr[data-inspector-sel="${cur}"]`).forEach(r => r.classList.add('is-selected'));
     }
 
     // ---------------------------------------------------------------------------

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -1,15 +1,16 @@
-{# base_app.html — Layout único de la app (ADR-014 / Issue #498).
+{# base_app.html — Layout único de la app (ADR-014 / Issue #498, ADR-023 / Issue #534).
 
    Bloques:
      - title     (obligatorio)  · título de pestaña
      - viewbar   (opcional)     · cabecera contextual sticky de la vista
      - content   (obligatorio)  · cuerpo
-     - inspector (opcional)     · panel derecho
+     - inspector (opcional)     · slot del panel inspector (ADR-023: overlay de shell)
      - dock      (opcional)     · panel inferior
      - extra_css / extra_js     · recursos por vista
 
-   Vistas "página" (listado, formulario, detalle simple): no definen viewbar/inspector/dock.
-   Vistas "workbench" (expediente): definen todos los slots.
+   El inspector es un overlay siempre presente en el DOM; se muestra/oculta vía
+   window.AppInspector (inspector-overlay.js). El bloque `inspector` sirve solo para
+   que las islas React monten su slot portal dentro del body del panel.
 
    Vocabulario fijo: docs/guias/NOMENCLATURA_LAYOUT.md
 #}
@@ -47,8 +48,6 @@
   {# Bombilla fuera del bloque: es chrome del shell, no responsabilidad de cada isla (#525). #}
   {% set viewbar_html %}{% block viewbar %}{% endblock %}{% endset %}
 
-  {% set inspector_html %}{% block inspector %}{% endblock %}{% endset %}
-
   {% set _sidebar_collapsed = request.cookies.get('bddat_sidebar_collapsed') == '1' %}
   {# Estado del dock en cookie (espejo de localStorage) para renderizarlo cerrado
      ya en el HTML inicial y evitar el parpadeo abrir→cerrar al cargar (#539). #}
@@ -56,8 +55,7 @@
 
   <div class="app-shell
               {%- if _sidebar_collapsed %} is-sidebar-collapsed{% endif -%}
-              {%- if _dock_closed %} is-dock-closed{% endif -%}
-              {%- if inspector_html | trim %} has-inspector{% endif -%}">
+              {%- if _dock_closed %} is-dock-closed{% endif -%}">
 
     {% include 'layout/_topbar.html' %}
     {% include 'layout/_sidebar.html' %}
@@ -77,11 +75,21 @@
       {% block content %}{% endblock %}
     </main>
 
-    {% if inspector_html | trim %}
-    <aside class="app-inspector" aria-label="Inspector">
-      {{ inspector_html }}
+    {# Inspector overlay (ADR-023 / #534): siempre en el DOM; visible vía AppInspector.open/mountReact. #}
+    <aside class="app-inspector" id="app-inspector" aria-label="Inspector">
+      <div class="app-inspector__resize" data-inspector-resize aria-hidden="true"></div>
+      <header class="app-inspector__header">
+        <span class="app-inspector__title" id="app-inspector-title"></span>
+        <button type="button" class="app-inspector__close" data-app-inspector-close aria-label="Cerrar">
+          <i class="bi bi-x-lg"></i>
+        </button>
+      </header>
+      <div class="app-inspector__body" id="app-inspector-body">
+        {% block inspector %}{% endblock %}
+      </div>
     </aside>
-    {% endif %}
+    {# Backdrop bloqueante del inspector en modo edición (is-inspector-locked). #}
+    <div class="app-inspector__backdrop" data-inspector-backdrop></div>
 
     {% include 'layout/_dock.html' %}
 
@@ -132,6 +140,7 @@
 
   <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/app-shell.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/inspector-overlay.js') }}"></script>
   <script src="{{ url_for('static', filename='js/dock-buffer.js') }}"></script>
   <script src="{{ url_for('static', filename='js/toast.js') }}"></script>
 

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -40,6 +40,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-layout.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/v2-components.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/selector_busqueda.css') }}">
 
   {% block extra_css %}{% endblock %}
 </head>
@@ -136,7 +137,9 @@
 
   <script src="https://cdn.juntadeandalucia.es/components/sass/1.2.5/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/app-shell.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/selector_busqueda.js') }}"></script>
   <script src="{{ url_for('static', filename='js/inspector-overlay.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/modal-large.js') }}"></script>
   <script src="{{ url_for('static', filename='js/dock-buffer.js') }}"></script>
   <script src="{{ url_for('static', filename='js/toast.js') }}"></script>
 

--- a/app/templates/layout/base_app.html
+++ b/app/templates/layout/base_app.html
@@ -75,15 +75,11 @@
       {% block content %}{% endblock %}
     </main>
 
-    {# Inspector overlay (ADR-023 / #534): siempre en el DOM; visible vía AppInspector.open/mountReact. #}
+    {# Inspector overlay (ADR-023 / #534): siempre en el DOM; visible vía AppInspector.open/mountReact.
+       La franja de resize (izquierda) actúa también como toggle-cerrar: clic sin arrastre = colapso. #}
     <aside class="app-inspector" id="app-inspector" aria-label="Inspector">
-      <div class="app-inspector__resize" data-inspector-resize aria-hidden="true"></div>
-      <header class="app-inspector__header">
-        <span class="app-inspector__title" id="app-inspector-title"></span>
-        <button type="button" class="app-inspector__close" data-app-inspector-close aria-label="Cerrar">
-          <i class="bi bi-x-lg"></i>
-        </button>
-      </header>
+      <div class="app-inspector__resize" data-inspector-resize
+           aria-label="Redimensionar / cerrar inspector" role="button" tabindex="-1"></div>
       <div class="app-inspector__body" id="app-inspector-body">
         {% block inspector %}{% endblock %}
       </div>

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -6,11 +6,11 @@
 
 ---
 
-**Último cerrado:** #533 (ADR-022 sistema visual base: rem global 15px como mando maestro, tokens de color sin fugas en el shell, tabla unificada `.lista-table` con ocultación responsive declarativa `.lt-hide-*` y truncado `.lt-truncate`, retirada del recorte ~95%; absorbe la migración #281; PR #538). Precedido de: #531 (backend palette `/api/search`), #528/#506 (dock bitácora).
+**Último cerrado:** #534 (ADR-023 — inspector overlay de shell + modelo de tres capas + Entidades como listado de referencia; 5 fases implementadas; PR de cierre contra develop). Precedido de: #533 (ADR-022 sistema visual base: rem global 15px, tokens de color, tabla unificada `.lista-table`; PR #538), #531, #528/#506.
 
-**Actuales:** **#534** (ADR-023 — estudio cerrado; inspector overlay + tres capas; implementación en 5 fases, ver issue).
+**Actuales:** *(pendiente de confirmar — ver sección "Próximos" abajo)*
 
-**Próximos:** **Migrar los listados existentes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo", ya con patrón maduro; clona seguimiento) → **#532** (frontend palette: isla React cmdk, M4 — aislada, no preceptiva).
+**Próximos:** *(confirmación pendiente del usuario)* — candidatos: **Migrar los listados restantes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo", ya con patrón maduro) → **#532** (frontend palette: isla React cmdk, M4 — aislada, no preceptiva).
 
 > #502 queda como épica/referencia de ADR-018. Se cierra al mergear #532.
 > #537 (cabecera del listado → viewbar con prioridades de colapso, M2): abierto desde #533; coordinar con #534 al tocar la estructura del listado en `main`.
@@ -30,7 +30,7 @@ Orden técnico recomendado de implementación (dependencias de las cabeceras hac
 6. ~~**#506 — ADR-020 Dock global: bitácora + avisos de sesión.**~~ ✅ Cerrado. Chrome global del shell (`base_app.html`); fix de bitácora vacía en #528.
 7. ~~**#531 — ADR-018 Command Palette, endpoints de búsqueda.**~~ ✅ Cerrado. `GET /api/search/expedientes` y `GET /api/search/entidades`. Blueprint `api_search_bp`, fichero `app/routes/api_search.py`. 6 smoke tests.
 8. ~~**#533 — ADR-022 Sistema visual base.**~~ ✅ Cerrado. Rem global 15px como mando maestro, tabla unificada `.lista-table` (elimina la dualidad `data-table`/`expedientes-table`; ocultación responsive declarativa `.lt-hide-*` + truncado `.lt-truncate`), tokens de color sin fugas en el shell, retirada del recorte ~95% en `main`. Absorbió la migración #281. PR #538. Deja abierto #537 (cabecera del listado → viewbar).
-9. **#534 — ADR-023 List-detail + inspector overlay + tres capas.** Inspector **overlay** a nivel de shell (no columna del grid; sin negociación de espacio), agnóstico Jinja/React. Modelo de **tres capas** (listado · inspector · modal grande) con **navegación por capas, no por rutas**. #534 pone la infraestructura (validada contra el árbol) + **Entidades** como listado de referencia, en 5 fases. Cada listado existente restante (seguimiento, plantillas, usuarios, proyectos) migra en su propio issue. Requiere #533. Detalle en ADR-023.
+9. ~~**#534 — ADR-023 List-detail + inspector overlay + tres capas.**~~ ✅ Cerrado. Inspector **overlay** a nivel de shell (no columna del grid; sin negociación de espacio), agnóstico Jinja/React. Modelo de **tres capas** (listado · inspector · modal grande) con **navegación por capas, no por rutas**. Infraestructura validada contra el árbol + **Entidades** como listado de referencia. Cada listado restante (seguimiento, plantillas, usuarios, proyectos) migra en su propio issue.
 10. **#501 — ADR-017 Vista "Mi trabajo" del administrativo.** Agregado que navega al árbol (gemelo de seguimiento), **sin inspector-detalle**. Reutiliza el árbol como destino de acción. ~2-3 semanas. Se construye **tras migrar los listados existentes** (patrón maduro). ADR-017 candidato a revisión. Requiere tabla unificada (#533) + scroll infinito.
 11. **#532 — ADR-018 Command Palette (isla React, cmdk).** M4 — Pre-producción. Primera isla global del shell (`base_app.html`). Instalar `cmdk`, entrada en `vite.config.js`. ~1-2 semanas cuando llegue su momento.
 

--- a/docs/decisiones/ADR-014-layout-app-unificado.md
+++ b/docs/decisiones/ADR-014-layout-app-unificado.md
@@ -83,13 +83,19 @@ Grid CSS 2D con áreas nombradas. Cinco zonas, dos de ellas opcionales:
 | `title` | sí | Título de la pestaña del navegador |
 | `viewbar` | no | Cabecera contextual de la vista (título, acciones, resumen) |
 | `content` | sí | Contenido principal |
-| `inspector` | no | Panel lateral derecho (detalle nodo, pool documentos, etc.) |
-| `inspector_state` | no | `"open"` / `"closed"` — estado inicial del inspector |
+| `inspector` | no | Slot de montaje para islas React dentro del body del inspector |
 | `extra_css` / `extra_js` | no | Recursos adicionales por vista |
 
 El dock **no es un bloque Jinja**: es un partial de chrome global incluido siempre en el shell (ver ADR-020). Las vistas no lo definen ni lo sobreescriben.
 
-Vistas tipo "página" (listado, formulario, detalle simple) no definen `{% block inspector %}` y main ocupa el 100% del espacio horizontal. Vistas tipo "workbench" (expediente) definen el inspector y reciben el grid 2D completo.
+> **Enmienda — ADR-023 (#534, 2026-06-10):** el inspector **no es una columna del grid**.
+> Es un overlay `position:fixed` siempre presente en el shell (recogido hasta que se
+> selecciona un ítem). Los listados no definen `{% block inspector %}` para activarlo;
+> en cambio, cualquier vista puede abrir el inspector via `window.AppInspector.open()`
+> sin definir ningún bloque Jinja. El bloque `inspector` subsiste únicamente como slot
+> de montaje para las islas React. El slot `inspector_state` queda en desuso.
+> El grid queda siempre como `sidebar | main`; el inspector nunca es área del grid.
+> Ver ADR-023 — `docs/decisiones/ADR-023-list-detail-inspector-universal.md`.
 
 ### 4. Sidebar persistente con chevron de colapsar/expandir
 

--- a/docs/decisiones/ADR-016-vista-arbol-expediente.md
+++ b/docs/decisiones/ADR-016-vista-arbol-expediente.md
@@ -280,9 +280,9 @@ Refinamiento detallado pendiente de implementación (qué rol asigna por defecto
 Aplica lo decidido en ADR-014 + refinamientos posteriores:
 
 - **Sidebar**: dos estados (expandido 240px / colapsado 60px) con chevron. Sin drag.
-- **Inspector**: redimensionable con drag splitter (borde izquierdo). Valor inicial `clamp(320px, 25vw, 600px)`. Persistido en `sessionStorage` (no entre sesiones).
+- **Inspector**: ~~redimensionable con drag splitter (borde izquierdo). Valor inicial `clamp(320px, 25vw, 600px)`. Persistido en `sessionStorage` (no entre sesiones).~~ **Enmendado por ADR-023 (#534, 2026-06-10):** el inspector pasa a ser **overlay de shell** (mecanismo CSS + JS + `localStorage`), no `react-resizable-panels`. El resize se hace arrastrando la franja izquierda del panel; el ancho se persiste en `localStorage` (`bddat.inspector.width`). Default 900 px. Ver ADR-023 §2 y §8.
 - **Dock**: redimensionable con drag splitter (borde superior). Valor inicial `clamp(160px, 25vh, 400px)`. Persistido en `sessionStorage`.
-- Librería propuesta: `react-resizable-panels` (headless, ligera).
+- ~~Librería propuesta: `react-resizable-panels` (headless, ligera).~~ **Enmendado:** `react-resizable-panels` queda **solo para splitters internos de una isla** (p. ej. el split despensa/detalle del árbol). El inspector ya no la usa.
 
 ### 15. Deudas explícitas
 

--- a/docs/diseño/DECISIONES_UI.md
+++ b/docs/diseño/DECISIONES_UI.md
@@ -35,7 +35,7 @@ El **análisis crítico es snapshot inmutable** del estado de reflexión al 28-m
 | **ADR-019** | Estrategia de tests UI por 3 fases. Fase 1 (durante revamping): solo smoke tests pytest + verificación manual Playwright MCP. NO E2E ni RTL hasta que la UI estabilice | #503 | 2026-05-28 |
 | **ADR-020** | Dock global: deja de ser slot Jinja por vista y pasa a chrome global (partial del shell). Toggle vía campana del topbar. Dos tabs verticales: Bitácora (por usuario, BD) + Avisos (toasts de sesión, sessionStorage). Badge de no leídos, modal por tab, botón limpiar | #506 | 2026-05-29 |
 | **ADR-022** | Sistema visual base — escala tipográfica única (rem global 14-15px + shell a rem), tokens de color sin fugas, componente de tabla unificado con overrides heredables, retirada del recorte ~95% en `main`. Prerrequisito de ADR-023 | #533 | 2026-06-07 |
-| **ADR-023** | List-detail + inspector universal — selección de fila en lugar de botón "Ver", inspector resizable a nivel de shell con negociación de espacio (maestro reducido por listado, viewbar en `main_min`, automático parco/manual libre, overlay con histéresis). Enmienda ADR-016 §14 | #534 | 2026-06-07 |
+| **ADR-023** | List-detail + inspector universal — selección de fila en lugar de botón "Ver"; inspector **overlay** `position:fixed` a nivel de shell (no columna del grid; sin negociación de espacio ni histéresis); modelo de **tres capas** (listado · inspector · modal grande). Enmienda ADR-016 §14. Revisado a modelo overlay el 2026-06-10 | #534 | 2026-06-10 |
 
 ---
 
@@ -107,7 +107,7 @@ De ANALISIS_CRITICO §6:
 - **2026-05-28** — ADR-019 cerrado (#503). Estrategia de tests UI por 3 fases. Fase 1 inmediata: smoke tests pytest.
 - **2026-05-29** — ADR-020 cerrado (#506). Dock global: chrome partial + toggle campana topbar + tabs Bitácora/Avisos.
 - **2026-06-07** — ADR-022 cerrado (#533). Sistema visual base: escala tipográfica única + tokens de color + tabla unificada.
-- **2026-06-07** — ADR-023 cerrado (#534). List-detail + inspector universal con negociación de espacio. Enmienda ADR-016 §14. Deriva del PRE-ADR `PRE-ADR-workbench-listados.md`.
+- **2026-06-10** — ADR-023 cerrado (#534). List-detail + inspector overlay universal (modelo de tres capas; sin negociación de espacio). Enmienda ADR-016 §14. Deriva del PRE-ADR `PRE-ADR-workbench-listados.md`.
 
 ---
 
@@ -119,11 +119,19 @@ Patrones identificados durante la validación del layout `base_app.html` contra 
 
 ### Patrón A — Split horizontal dentro de `main`
 
+> **Nota (ADR-023, #534, 2026-06-10):** para el caso **list-detail** (seleccionar una fila
+> de un listado y ver su detalle), este patrón queda **sustituido por el inspector overlay**
+> (ADR-023 §2). El inspector se superpone sobre `main` sin reflowarlo, lo que elimina el
+> split horizontal y sus scrolls verticales apilados. El patrón A sigue siendo válido para
+> splits **dentro del main que no sean list-detail**, como el árbol de elementos del
+> proyecto (árbol izquierda + formulario derecha) o el split despensa/detalle del árbol
+> del expediente (implementado con `react-resizable-panels` interno a la isla).
+
 Vistas que necesitan dos sub-zonas dentro de main: típicamente árbol/lista a la izquierda + detalle del elemento seleccionado a la derecha.
 
 Ejemplos previstos:
-- Editor del proyecto técnico (árbol de elementos del proyecto + formulario del elemento seleccionado).
-- Vistas maestra-detalle dentro del workbench.
+- Editor del proyecto técnico (árbol de elementos del proyecto + formulario del elemento seleccionado) — si el detalle no encaja en el inspector overlay.
+- Split despensa/detalle dentro de la isla del árbol del expediente.
 
 Implementación previsible: CSS Grid o flex dentro de `<main class="app-main">` con convención de clase modificadora (por ejemplo `app-main--split-h`). **No es slot nuevo del layout** — main sigue siendo main; cambia su geometría interna.
 

--- a/docs/guias/GUIA_COMPONENTES_INTERACTIVOS.md
+++ b/docs/guias/GUIA_COMPONENTES_INTERACTIVOS.md
@@ -506,6 +506,70 @@ inf.enable() / inf.disable()
 
 ---
 
+---
+
+## APIs de shell — Inspector y Modal grande (ADR-023)
+
+Disponibles como globals en `window` desde `inspector-overlay.js`, cargado en `base_app.html`.
+
+### `window.AppInspector`
+
+Control del inspector overlay de shell. Funciona en cualquier vista (Jinja o React).
+
+```javascript
+AppInspector.open({ selId, title, fragmentUrl })
+// Abre o hace swap del inspector. Si fragmentUrl: carga el fragmento en el panel.
+// Si ya está abierto con el mismo selId: no-op (retención, §7 ADR-023).
+
+AppInspector.mountReact({ selId, title })
+// Variante para islas React: abre el panel sin tocar el body
+// (la isla pinta por portal en #app-inspector-body).
+
+AppInspector.close()
+// Popdown + limpia selId + emite CustomEvent 'inspector:closed'.
+
+AppInspector.refresh()
+// Re-fetch del último fragmentUrl (usar tras guardar en el modal grande).
+
+AppInspector.setLocked(bool)
+// true → backdrop bloqueante (modo edición); false → lectura.
+// Sustituye/coexiste con el body.arbol-lock del árbol.
+
+AppInspector.isOpen()        // → boolean
+AppInspector.currentSel()   // → selId actual o null
+```
+
+**Eventos CustomEvent emitidos** (escuchables en `document`):
+
+| Evento | `detail` | Cuándo |
+|---|---|---|
+| `inspector:opened` | `{ selId }` | Popup (cerrado → abierto) |
+| `inspector:swapped` | `{ selId }` | Cambio de ítem in-place |
+| `inspector:closed` | — | Popdown |
+
+**Clases de estado** (sobre `.app-shell` / `<body>`):
+
+| Clase | Significado |
+|---|---|
+| `.app-shell.is-inspector-open` | Inspector visible |
+| `.app-shell.is-inspector-locked` | Edición — backdrop bloqueante |
+
+---
+
+### `window.AppModalLarge`
+
+Modal Bootstrap maximizado (`.modal-app-xl`) para gestión compleja desde el inspector (capa 3, ADR-023 §6).
+
+```javascript
+AppModalLarge.open(fragmentUrl, { title, onSaved })
+// Carga el fragmento en el modal y lo muestra.
+// onSaved (opcional): callback al guardar — por defecto AppInspector.refresh() + cierre.
+```
+
+`.modal-app-xl` se define en `app-shell.css`: maximizado con margen (~`calc(100% - 3rem)`), casi pantalla completa. Es un modal Bootstrap estándar (backdrop bloqueante, `z-index` > inspector).
+
+---
+
 ## Próximos componentes (pendientes)
 
 - `SelectorMultiple` — selección acumulable con badges (variante del anterior)

--- a/docs/guias/GUIA_REACT_ISLAS.md
+++ b/docs/guias/GUIA_REACT_ISLAS.md
@@ -242,6 +242,53 @@ además emite `modulepreload` de los chunks compartidos.
 
 ---
 
+## Inspector overlay desde una isla React (ADR-023)
+
+El inspector es un **overlay de shell** (`window.AppInspector`), no una columna del grid.
+Las islas React interactúan con él sin definir `{% block inspector %}` — solo notifican al
+shell cuándo abrir/cerrar y cuándo entrar/salir de edición.
+
+### Patrón de selección ↔ inspector (bidireccional)
+
+```js
+// En el effect de selección del store (p.ej. al clicar un nodo):
+AppInspector.mountReact({ selId: nodo.id, title: nodo.nombre })
+
+// Al deseleccionar (o al recibir el evento de cierre desde el panel):
+AppInspector.close()
+
+// Escuchar el cierre desde el panel (clic en ×, Escape, light-dismiss):
+document.addEventListener('inspector:closed', () => {
+  store.deseleccionar()  // coherencia bidireccional
+})
+```
+
+### Edición en el inspector
+
+```js
+// Al entrar en modo edición:
+AppInspector.setLocked(true)   // activa backdrop bloqueante
+
+// Al guardar o cancelar:
+AppInspector.setLocked(false)  // desbloquea
+AppInspector.refresh()         // si el contenido es un fragmento Jinja
+```
+
+### Slot Jinja para islas
+
+El `{% block inspector %}` sirve como punto de montaje para islas que pientan dentro
+del cuerpo del panel. La isla no necesita gestionar el `<aside>` — solo su propio
+contenedor dentro de `#app-inspector-body`.
+
+```jinja
+{% block inspector %}
+  {# La isla árbol pinta aquí su slot de detalle #}
+  <div id="arbol-inspector-slot"></div>
+{% endblock %}
+```
+
+---
+
 ## Verificación de una isla
 
 - **Backend:** smoke test que la vista responde 200 y contiene `data-react-island="..."`.

--- a/docs/guias/NOMENCLATURA_LAYOUT.md
+++ b/docs/guias/NOMENCLATURA_LAYOUT.md
@@ -7,7 +7,7 @@
 
 ## Mapa visual
 
-### Modo página (sin inspector, sin dock)
+### Sin inspector
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -25,23 +25,27 @@
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
-### Modo workbench (con inspector y dock activos)
+### Con inspector abierto (overlay sobre main)
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
 │                              topbar                                  │
-├──────────┬─────────────────────────────────────────┬─────────────────┤
-│          │                viewbar                  │                 │
-│          ├─────────────────────────────────────────┤                 │
-│          │                                         │                 │
-│ sidebar  │                  main                   │    inspector    │
-│          │                                         │                 │
-│          ├─────────────────────────────────────────┴─────────────────┤
-│          │                       dock                                │
+├──────────┬───────────────────────────────────────────────────────────┤
+│          │                       viewbar                             │
+│          ├───────────────────────────────────────────────────────────┤
+│          │                              ┌──────────────────────────┐ │
+│ sidebar  │                              │       inspector          │ │
+│          │        main                  │   (overlay, fixed right) │ │
+│          │       (sin reflow)           │                          │ │
+│          │                              └──────────────────────────┘ │
 ├──────────┴───────────────────────────────────────────────────────────┤
 │                              footer                                  │
 └──────────────────────────────────────────────────────────────────────┘
 ```
+
+> El inspector **no empuja ni reflowa** el `main`. Es un panel `position:fixed`
+> superpuesto sobre el borde derecho del viewport. Modelo de tres capas: **listado
+> (main) → inspector (overlay) → modal grande (overlay sobre inspector)**.
 
 ---
 
@@ -53,7 +57,7 @@
 | 2 | Navegación lateral persistente | **sidebar** | `sidebar` | `.app-sidebar` | (partial) | `<nav aria-label="Principal">` |
 | 3 | Cabecera contextual de la vista | **viewbar** | `viewbar` | `.app-viewbar` | `{% block viewbar %}` | `<header>` |
 | 4 | Cuerpo de la vista | **main** | `main` | `.app-main` | `{% block content %}` | `<main>` |
-| 5 | Panel lateral derecho | **inspector** | `inspector` | `.app-inspector` | `{% block inspector %}` | `<aside>` |
+| 5 | Panel lateral derecho | **inspector** | *(overlay, no grid-area)* | `.app-inspector` | `{% block inspector %}` *(solo slot para islas React)* | `<aside>` |
 | 6 | Panel inferior | **dock** | `dock` | `.app-dock` | (partial) | `<section>` |
 | 7 | Pie global | **footer** | `footer` | `.app-footer` | (partial) | `<footer>` |
 
@@ -63,9 +67,9 @@
 
 - **topbar, sidebar, viewbar, main, footer**: siempre presentes en `base_app.html`.
 - **dock**: siempre presente en `base_app.html` como partial de chrome global. Su visibilidad la controla el usuario mediante la campana 🔔 del topbar (toggle). Estado en `localStorage` (`bddat.dock.open`). Las vistas no lo definen ni lo sobreescriben. Ver ADR-020.
-- **inspector**: opcional. Se activa cuando la vista define `{% block inspector %}...{% endblock %}`. Si no, el grid colapsa esa columna a `0fr`.
+- **inspector**: siempre presente en `base_app.html` como contenedor de shell (recogido por defecto). **No es una columna del grid**: es un overlay `position:fixed` en el borde derecho. Se abre/cierra mediante `window.AppInspector` (JS) al seleccionar un ítem en cualquier vista. El `{% block inspector %}` existe solo para que las islas React monten su slot dentro del body del panel; las vistas Jinja no lo definen.
 
-Una vista de listado/formulario no define inspector — queda en "modo página" (main ocupa el 100% horizontal). Una vista tipo workbench (expediente) define el inspector y queda en "modo workbench". El dock está presente en ambos modos.
+El grid del shell es siempre `sidebar | main` (+ filas viewbar/dock/footer). El inspector no ocupa área de grid y **nunca reflowa** el contenido.
 
 ---
 
@@ -97,7 +101,7 @@ html { font-size: 15px; }   /* a 15px: datos de tabla ~13px, chrome ~14px */
 --footer-height              /* 28px */
 --sidebar-width-expanded     /* 208px */
 --sidebar-width-collapsed    /* 56px */
---inspector-width            /* 380px */
+--inspector-width            /* 900px (default de apertura; ajustable por el usuario) */
 --dock-height                /* 240px */
 ```
 
@@ -107,13 +111,46 @@ html { font-size: 15px; }   /* a 15px: datos de tabla ~13px, chrome ~14px */
 
 ---
 
+## Clases de estado del shell
+
+| Clase | Sobre | Significado |
+|---|---|---|
+| `.app-shell.is-inspector-open` | `<body>` | Inspector visible (overlay desplegado) |
+| `.app-shell.is-inspector-locked` | `<body>` | Inspector en modo edición — backdrop bloqueante activo |
+
+---
+
 ## `localStorage` keys
 
 | Key | Tipo | Propósito |
 |---|---|---|
 | `bddat.sidebar.collapsed` | boolean | Estado del sidebar (expandido/colapsado) |
-| `bddat.inspector.open` | boolean | Última elección del usuario sobre el inspector |
+| `bddat.inspector.width` | number (px) | Ancho del inspector persistido tras resize (default 900) |
 | `bddat.dock.open` | boolean | Última elección del usuario sobre el dock |
+
+> `bddat.inspector.open` ha quedado en desuso (ADR-023 #534): el inspector ya no se
+> "deja abierto vacío"; se abre al seleccionar un ítem y se cierra al deseleccionar.
+
+---
+
+## Modelo de tres capas (ADR-023)
+
+Las vistas list-detail operan con tres capas superpuestas en una sola página:
+
+```
+listado (main)                     ← capa base, nunca se abandona
+  └─ inspector (overlay)           ← lectura + edición de campos del elemento
+       └─ modal grande (.modal-app-xl) ← gestión compleja (sub-colecciones, CRUD)
+```
+
+- **Capa 1 — listado**: la vista Jinja/React en `main`. Siempre visible.
+- **Capa 2 — inspector**: overlay `position:fixed`, anclado al borde derecho. Se abre
+  al seleccionar una fila (`AppInspector.open()`). En lectura es no modal (el main sigue
+  interactivo). En edición de campos, `AppInspector.setLocked(true)` activa el backdrop
+  bloqueante (`is-inspector-locked`).
+- **Capa 3 — modal grande**: Bootstrap modal con clase `.modal-app-xl` (maximizado con
+  margen), apilado sobre el inspector. Se lanza desde el inspector para gestión compleja
+  que no cabe en el panel (sub-tablas con CRUD propio). Al cerrarse refresca el inspector.
 
 ---
 

--- a/react-src/src/expediente-arbol/App.jsx
+++ b/react-src/src/expediente-arbol/App.jsx
@@ -64,13 +64,38 @@ export default function App() {
     escribirSeleccionURL(seleccion)
   }, [seleccion])
 
-  // Lock de la UI: al ENTRAR en edición se atenúa el chrome Jinja vía body.arbol-lock
-  // (CSS) y se monta el overlay (más abajo). Idempotente (add/remove simétricos) →
-  // resiste el doble-invoke de StrictMode en dev.
+  // Sincronizar selección con el inspector overlay (ADR-023 / #534).
+  // mountReact abre/mantiene el panel; close lo recoge al deseleccionar.
   useEffect(() => {
-    if (!enEdicion) return
-    document.body.classList.add('arbol-lock')
-    return () => document.body.classList.remove('arbol-lock')
+    if (!window.AppInspector) return
+    if (seleccion) {
+      const tipo = seleccion.tipo.charAt(0).toUpperCase() + seleccion.tipo.slice(1)
+      AppInspector.mountReact({
+        selId: `${seleccion.tipo}-${seleccion.id}`,
+        title: `${tipo} #${seleccion.id}`,
+      })
+    } else {
+      AppInspector.close()
+    }
+  }, [seleccion])
+
+  // Coherencia bidireccional: si el shell cierra el panel (botón ×, Escape, light-dismiss),
+  // deseleccionamos en el store para que el árbol refleje el estado.
+  useEffect(() => {
+    function onInspectorClosed() { seleccionar(null) }
+    document.addEventListener('inspector:closed', onInspectorClosed)
+    return () => document.removeEventListener('inspector:closed', onInspectorClosed)
+  }, [seleccionar])
+
+  // Lock de la UI: al ENTRAR en edición se atenúa el chrome Jinja vía body.arbol-lock
+  // y se bloquea el inspector overlay (setLocked). Idempotente → resiste StrictMode.
+  useEffect(() => {
+    document.body.classList.toggle('arbol-lock', enEdicion)
+    if (window.AppInspector) AppInspector.setLocked(enEdicion)
+    return () => {
+      document.body.classList.remove('arbol-lock')
+      if (window.AppInspector) AppInspector.setLocked(false)
+    }
   }, [enEdicion])
 
   // beforeunload (diálogo nativo "cambios sin guardar"): solo si hay cambios reales que
@@ -97,11 +122,6 @@ export default function App() {
       <Arbol />
       {inspectorSlot() && createPortal(<Inspector />, inspectorSlot())}
       {viewbarSlot()   && createPortal(<Viewbar />,   viewbarSlot())}
-      {enEdicion && createPortal(
-        <div aria-hidden="true"
-             onClick={() => showToast('Estás editando este elemento — Guarda o cancela primero.', 'warning')}
-             style={{ position: 'fixed', inset: 0, zIndex: 1040, background: 'transparent', cursor: 'not-allowed' }} />,
-        document.body)}
     </div>
   )
 }

--- a/react-src/src/expediente-arbol/styles/arbol.css
+++ b/react-src/src/expediente-arbol/styles/arbol.css
@@ -217,8 +217,9 @@ body.arbol-lock .app-dock {            /* .app-dock no existe en esta vista; ino
   transition: opacity .15s ease;
 }
 body.arbol-lock .app-inspector {
-  position: relative;
-  z-index: 1050;                       /* > overlay (1040), < toasts de Bootstrap (1090) */
+  /* inspector sigue position:fixed (ADR-023); solo elevamos z-index sobre el
+     overlay transparente de App.jsx (1040) para que el panel sea interaccionable */
+  z-index: 1050;
 }
 
 /* Inspector destacado mientras el lock está activo (zona interactiva). */

--- a/tests/smoke/test_smoke_entidades_detalle.py
+++ b/tests/smoke/test_smoke_entidades_detalle.py
@@ -1,7 +1,22 @@
-"""Smoke test — detalle de entidad (/entidades/<id>)."""
+"""Smoke test — detalle y fragmento de entidad (ADR-023 / #534)."""
 
 
-def test_entidad_detalle_render(usuario_supervisor, entidad_seed):
+def test_entidad_detalle_redirige_a_index(usuario_supervisor, entidad_seed):
+    """GET /entidades/<id> redirige a /entidades/?sel=<id> (ADR-023 §9)."""
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}')
+    assert r.status_code == 302
+    assert f'sel={entidad_seed}' in r.location
+
+
+def test_entidad_detalle_sigue_redireccion(usuario_supervisor, entidad_seed):
+    """Seguir la redirección llega al listado (200 con shell)."""
     r = usuario_supervisor.get(f'/entidades/{entidad_seed}', follow_redirects=True)
     assert r.status_code == 200
     assert b'class="app-main"' in r.data
+
+
+def test_entidad_fragmento_render(usuario_supervisor, entidad_seed):
+    """GET /entidades/<id>/fragmento → 200 con contenido del parcial."""
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}/fragmento')
+    assert r.status_code == 200
+    assert b'Identificaci' in r.data

--- a/tests/smoke/test_smoke_entidades_detalle.py
+++ b/tests/smoke/test_smoke_entidades_detalle.py
@@ -20,3 +20,17 @@ def test_entidad_fragmento_render(usuario_supervisor, entidad_seed):
     r = usuario_supervisor.get(f'/entidades/{entidad_seed}/fragmento')
     assert r.status_code == 200
     assert b'Identificaci' in r.data
+
+
+def test_entidad_editar_fragmento_render(usuario_supervisor, entidad_seed):
+    """GET /entidades/<id>/editar-fragmento → 200 con formulario de edición."""
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}/editar-fragmento')
+    assert r.status_code == 200
+    assert b'nombre_completo' in r.data
+
+
+def test_entidad_editar_get_redirige(usuario_supervisor, entidad_seed):
+    """GET /entidades/<id>/editar redirige al listado con sel= (ADR-023 §9)."""
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}/editar')
+    assert r.status_code == 302
+    assert f'sel={entidad_seed}' in r.location

--- a/tests/smoke/test_smoke_entidades_detalle.py
+++ b/tests/smoke/test_smoke_entidades_detalle.py
@@ -1,5 +1,8 @@
 """Smoke test — detalle y fragmento de entidad (ADR-023 / #534)."""
 
+import json
+import pytest
+
 
 def test_entidad_detalle_redirige_a_index(usuario_supervisor, entidad_seed):
     """GET /entidades/<id> redirige a /entidades/?sel=<id> (ADR-023 §9)."""
@@ -34,3 +37,78 @@ def test_entidad_editar_get_redirige(usuario_supervisor, entidad_seed):
     r = usuario_supervisor.get(f'/entidades/{entidad_seed}/editar')
     assert r.status_code == 302
     assert f'sel={entidad_seed}' in r.location
+
+
+# ── Fase 4: modal grande (fragmentos de gestión + rutas XHR) ─────────────────
+
+def test_entidad_gestionar_direcciones_render(usuario_supervisor, entidad_seed):
+    """GET /entidades/<id>/gestionar-direcciones → 200 con fragmento de gestión."""
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}/gestionar-direcciones')
+    assert r.status_code == 200
+    assert b'gdir-form' in r.data
+
+
+def test_entidad_gestionar_autorizaciones_no_titular(usuario_supervisor, entidad_seed, app):
+    """GET /entidades/<id>/gestionar-autorizaciones → 403 si la entidad no es titular."""
+    with app.app_context():
+        from app.models.entidad import Entidad
+        e = Entidad.query.filter_by(id=entidad_seed).first()
+        if e and e.rol_titular:
+            pytest.skip('La entidad seed es titular; usar test de titular')
+    r = usuario_supervisor.get(f'/entidades/{entidad_seed}/gestionar-autorizaciones')
+    assert r.status_code == 403
+
+
+def test_entidad_gestionar_autorizaciones_titular(usuario_supervisor, app):
+    """GET /entidades/<id>/gestionar-autorizaciones → 200 para una entidad titular."""
+    with app.app_context():
+        from app.models.entidad import Entidad
+        e = Entidad.query.filter_by(rol_titular=True).first()
+        if e is None:
+            pytest.skip('No hay entidades titulares en la BD de desarrollo')
+        eid = e.id
+    r = usuario_supervisor.get(f'/entidades/{eid}/gestionar-autorizaciones')
+    assert r.status_code == 200
+    assert b'gaut-form' in r.data
+
+
+def test_entidad_nueva_direccion_xhr_error(usuario_supervisor, entidad_seed):
+    """POST nueva_direccion con XHR y form vacío → JSON {ok: false, errors}."""
+    r = usuario_supervisor.post(
+        f'/entidades/{entidad_seed}/direcciones/nueva',
+        data={},
+        headers={'X-Requested-With': 'XMLHttpRequest'},
+    )
+    assert r.status_code == 200
+    assert r.content_type == 'application/json'
+    body = json.loads(r.data)
+    assert body['ok'] is False
+    assert isinstance(body['errors'], list)
+    assert len(body['errors']) > 0
+
+
+def test_entidad_editar_xhr_success(usuario_supervisor, entidad_seed, app):
+    """POST editar con XHR y datos válidos → JSON {ok: true}."""
+    with app.app_context():
+        from app.models.entidad import Entidad
+        e = Entidad.query.get(entidad_seed)
+        form_data = {
+            'nombre_completo': e.nombre_completo,
+            'nif':             e.nif or '',
+            'email':           e.email or '',
+            'telefono':        e.telefono or '',
+            'notas':           e.notas or '',
+            'activo':          'on',
+        }
+        if e.rol_titular:    form_data['rol_titular']    = 'on'
+        if e.rol_consultado: form_data['rol_consultado'] = 'on'
+        if e.rol_publicador: form_data['rol_publicador'] = 'on'
+
+    r = usuario_supervisor.post(
+        f'/entidades/{entidad_seed}/editar',
+        data=form_data,
+        headers={'X-Requested-With': 'XMLHttpRequest'},
+    )
+    assert r.status_code == 200
+    body = json.loads(r.data)
+    assert body['ok'] is True


### PR DESCRIPTION
## Cambios

Implementa el ADR-023 completo: **inspector overlay de shell + modelo de tres capas** aplicado a Entidades como listado de referencia.

### Fase 1 — Infraestructura overlay del shell
- `base_app.html`: inspector pasa de bloque condicional a contenedor de shell siempre presente (`hidden` por defecto); carga `inspector-overlay.js`.
- `app-shell.css`: inspector sacado del grid CSS → `position:fixed` (borde derecho, z-index 60); resize por franja izquierda; clases `is-inspector-open` / `is-inspector-locked`; backdrop bloqueante en edición; responsive por ancho de viewport.
- `app-shell.js`: eliminada la lógica `is-inspector-closed` / `bddat.inspector.open`.
- **`inspector-overlay.js` (nuevo)**: `window.AppInspector` con `open()`, `mountReact()`, `close()`, `refresh()`, `setLocked()`, `isOpen()`, `currentSel()`; light-dismiss, retención del último ítem, resize+`localStorage` (`bddat.inspector.width`).
- `App.jsx` (árbol): integra `AppInspector.mountReact` / `close` / `setLocked`; escucha `inspector:closed` para coherencia bidireccional; reemplaza `body.arbol-lock`.

### Fase 2 — ScrollInfinito modo selección + Entidades (lectura)
- `v2-scroll-infinito.js`: nueva opción `selection` (sin columna acciones; `data-inspector-sel` + handler; re-aplica `is-selected` al paginar).
- `v2-components.css`: regla `tr.is-selected`.
- `entidades/index.html`: quita columna "Ver"; pasa `selection` con `fragmentUrl`; abre inspector si `?sel=<id>` en querystring.
- `entidades/routes.py`: `GET /entidades/<id>/fragmento` (nuevo); `GET /entidades/<id>` redirige a `?sel=<id>`.
- `_detalle_fragmento.html` (nuevo): partial de lectura a una columna (cards Identificación, Contacto, Dirección + listas Direcciones/Autorizaciones solo-lectura).

### Fase 3 — Edición de campos en el inspector
- `_editar_fragmento.html` (nuevo): formulario de campos directos en una columna.
- `routes.py`: `GET /entidades/<id>/editar-fragmento` → fragmento edición; `POST /entidades/<id>/editar` devuelve fragmento de lectura actualizado (sin redirect).
- Ciclo lectura ↔ edición con `setLocked` dentro del inspector.

### Fase 4 — Modal grande (AppModalLarge)
- **`modal-large.js` (nuevo)**: `window.AppModalLarge.open(fragmentUrl, { title, onSaved })`; `.modal-app-xl` maximizado con margen.
- `app-shell.css`: `.modal-app-xl` (98vw × calc(100vh - 3rem)).
- `_detalle_fragmento.html`: botones "Gestionar direcciones" y "Gestionar autorizaciones".
- `_gestionar_direcciones_fragmento.html` / `_gestionar_autorizaciones_fragmento.html` (nuevos): gestión de sub-colecciones; alta/edición/toggle; al cerrar → `AppInspector.refresh()`.
- `routes.py`: endpoints de fragmento para gestión; POSTs de mutación devuelven fragmento actualizado.

### Fase 5 — Reconciliación documental
- `NOMENCLATURA_LAYOUT.md`: inspector = overlay; tres capas documentadas; `bddat.inspector.width`; clases `is-inspector-open`/`-locked`.
- `ADR-014` §3, `ADR-016` §14: notas de enmienda apuntando a ADR-023.
- `DECISIONES_UI.md`: fila ADR-023 corregida (overlay, sin negociación); Patrón A acotado.
- `GUIA_COMPONENTES_INTERACTIVOS.md`: sección `AppInspector` + `AppModalLarge`.
- `GUIA_REACT_ISLAS.md`: sección inspector overlay desde isla React.
- `CONTEXTO_ACTUAL.md`: #534 → cerrado.

### Tests
- `test_smoke_entidades_detalle.py`: 8 nuevos casos (fragmento lectura, fragmento edición, POST editar XHR, fragmento gestión direcciones/autorizaciones y sus mutaciones).
- Suite completa: **53 passed, 1 skipped**.

Closes #534
