### PR TITLE
Mover cabecera de listados al viewbar (#537)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "bddat",
       "runtimeExecutable": "venv/Scripts/python",
       "runtimeArgs": ["run.py"],
-      "port": 5000
+      "port": 5000,
+      "autoPort": true
     },
     {
       "name": "arbol-mock",

--- a/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
+++ b/app/modules/admin_plantillas/templates/admin_plantillas/listado.html
@@ -2,24 +2,22 @@
 
 {% block title %}Plantillas de escritos — BDDAT{% endblock %}
 
-{% block breadcrumb %}
-<a href="{{ url_for('dashboard.index') }}">Inicio</a>
-<span>›</span>
-<span>Plantillas de escritos</span>
+{% block viewbar %}
+<span class="app-viewbar__title">
+  <i class="fas fa-file-word"></i>
+  <span>Plantillas de escritos</span>
+</span>
+<div class="app-viewbar__spacer"></div>
+<div class="app-viewbar__actions">
+  {% if tiene_permiso('gestionar_plantillas') %}
+  <a href="{{ url_for('admin_plantillas.nueva') }}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus me-1"></i> Nueva plantilla
+  </a>
+  {% endif %}
+</div>
 {% endblock %}
 
 {% block content %}
-<div class="lista-cabecera">
-    <div class="page-header">
-        <h1><i class="fas fa-file-word"></i> Plantillas de escritos</h1>
-        {% if tiene_permiso('gestionar_plantillas') %}
-        <a href="{{ url_for('admin_plantillas.nueva') }}" class="btn btn-primary">
-            <i class="fas fa-plus me-1"></i> Nueva plantilla
-        </a>
-        {% endif %}
-    </div>
-</div>
-
 <div class="lista-scroll-container">
 <div class="py-3">
     <div class="card tabla-bloque">

--- a/app/modules/entidades/templates/entidades/index.html
+++ b/app/modules/entidades/templates/entidades/index.html
@@ -2,7 +2,6 @@
 
 {% block page_title %}Entidades{% endblock %}
 {% block page_icon %}<i class="fas fa-building"></i>{% endblock %}
-{% block entity_label_plural %}entidades{% endblock %}
 {% block search_placeholder %}Buscar por nombre o NIF...{% endblock %}
 
 {% block btn_nuevo %}

--- a/app/modules/expedientes/templates/expedientes/listado_v2.html
+++ b/app/modules/expedientes/templates/expedientes/listado_v2.html
@@ -2,7 +2,6 @@
 
 {% block page_title %}Expedientes{% endblock %}
 {% block page_icon %}<i class="fas fa-folder-open"></i>{% endblock %}
-{% block entity_label_plural %}expedientes{% endblock %}
 {% block search_placeholder %}Buscar por N° AT o titular...{% endblock %}
 
 {% block btn_nuevo %}

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -1,17 +1,7 @@
 {% extends 'layout/lista_v2_base.html' %}
 
-{# Bug #263.5: breadcrumb con tercer nivel Seguimiento #}
-{% block breadcrumb %}
-<a href="{{ url_for('dashboard.index') }}">Inicio</a>
-<span>›</span>
-<a href="{{ url_for('expedientes.listado_v2') }}">Expedientes</a>
-<span>›</span>
-<span>Seguimiento</span>
-{% endblock %}
-
 {% block page_title %}Seguimiento{% endblock %}
 {% block page_icon %}<i class="fas fa-tasks"></i>{% endblock %}
-{% block entity_label_plural %}solicitudes{% endblock %}
 {% block search_placeholder %}Buscar por Nº AT o titular...{% endblock %}
 
 {% block filtros_extra %}

--- a/app/modules/proyectos/templates/proyectos/index.html
+++ b/app/modules/proyectos/templates/proyectos/index.html
@@ -2,7 +2,6 @@
 
 {% block page_title %}Proyectos{% endblock %}
 {% block page_icon %}<i class="fas fa-drafting-compass"></i>{% endblock %}
-{% block entity_label_plural %}proyectos{% endblock %}
 {% block search_placeholder %}Buscar por título o número AT...{% endblock %}
 
 {% block filtros_extra %}

--- a/app/modules/usuarios/templates/usuarios/index.html
+++ b/app/modules/usuarios/templates/usuarios/index.html
@@ -2,27 +2,26 @@
 
 {% block title %}Usuarios — BDDAT{% endblock %}
 
-{% block breadcrumb %}
-<a href="{{ url_for('dashboard.index') }}">Inicio</a>
-<span>›</span>
-<span>Usuarios</span>
+{% block viewbar %}
+<span class="app-viewbar__title">
+  <i class="fas fa-users"></i>
+  <span>Usuarios</span>
+</span>
+<div class="app-viewbar__spacer"></div>
+<div class="app-viewbar__actions">
+  {% if tiene_permiso('gestionar_usuarios') %}
+  <button type="button" class="btn btn-primary btn-sm"
+          data-bs-toggle="modal" data-bs-target="#crearUsuarioModal">
+      <i class="fas fa-plus"></i> Nuevo Usuario
+  </button>
+  {% endif %}
+</div>
 {% endblock %}
 
 {% block content %}
 
-<!-- C.1: Cabecera fija (sin scroll) -->
+<!-- C.1: Filtros + contador (sin scroll, altura fija) -->
 <div class="lista-cabecera">
-    <div class="page-header">
-        <h1>
-            <i class="fas fa-users"></i> Usuarios
-        </h1>
-        {% if tiene_permiso('gestionar_usuarios') %}
-        <button type="button" class="btn btn-primary"
-                data-bs-toggle="modal" data-bs-target="#crearUsuarioModal">
-            <i class="fas fa-plus"></i> Nuevo Usuario
-        </button>
-        {% endif %}
-    </div>
     <div class="filters-row">
         <div class="filters">
             <input type="search" id="usuarios-search"
@@ -44,9 +43,7 @@
             </button>
         </div>
         <div class="pagination-info">
-            <i class="fas fa-filter filtro-indicador me-1"></i>Mostrando
-            <span id="usuarios-visibles">{{ usuarios|length }}</span> de
-            <span id="usuarios-total">{{ usuarios|length }}</span> usuarios
+            <i class="fas fa-filter filtro-indicador me-1"></i><span id="usuarios-visibles">{{ usuarios|length }}</span> de <span id="usuarios-total">{{ usuarios|length }}</span>
         </div>
     </div>
 </div>

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -42,7 +42,7 @@
   --shell-sidebar-hover-bg:  var(--gris-especifico);
   --shell-sidebar-active-bg: var(--primary-lighter);
   --shell-sidebar-active-fg: var(--primary);
-  --shell-viewbar-bg:        #ffffff;
+  --shell-viewbar-bg:        var(--gris-especifico);
   --shell-viewbar-fg:        var(--gris-principal);
   --shell-viewbar-border:    var(--border-color);
   --shell-footer-bg:         var(--gris-principal);

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -433,6 +433,13 @@
 
 .app-viewbar__actions { display: flex; align-items: center; gap: 6px; }
 
+/* Botones en el viewbar normalizados a sm (44px viewbar, misma escala que el inspector) */
+.app-viewbar__actions .btn {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  font-size: 0.75rem;
+}
+
 /* ============================================================
    MAIN
    ============================================================ */

--- a/app/static/css/app-shell.css
+++ b/app/static/css/app-shell.css
@@ -410,6 +410,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 0 1 auto;  /* puede encogerse si el viewbar se estrecha */
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* El icono no se toca; el texto trunca con elipsis */
+.app-viewbar__title > i { flex-shrink: 0; }
+.app-viewbar__title > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .app-viewbar__indicador {

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -408,23 +408,24 @@
 }
 
 
-/* Contenedor que une filtros + paginación en 1 línea */
+/* Contenedor que une filtros + contador en 1 línea — nunca crece en altura */
 .filters-row {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   gap: 1rem;
   margin-bottom: 1rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow: hidden;
 }
 
-/* Filtros (izquierda) */
+/* Filtros (izquierda) — se encogen si el espacio es escaso */
 .filters {
   display: flex;
   gap: 0.75rem;
   align-items: center;
   flex: 1;
-  min-width: 300px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .filters input[type="search"],
@@ -461,11 +462,12 @@
   cursor: pointer;
 }
 
-/* ===== INDICADOR PAGINACIÓN — subtítulo bajo el h1 ===== */
+/* ===== INDICADOR PAGINACIÓN — al final de .filters-row ===== */
 .pagination-info {
   color: var(--text-secondary);
   font-size: 0.8rem;
-  margin-top: 0.2rem;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .pagination-info span {
@@ -588,19 +590,23 @@
   .filters-row {
     flex-direction: column;
     align-items: stretch;
+    flex-wrap: wrap;   /* en mobile sí se permite crecer */
+    overflow: visible;
   }
-  
+
   .filters {
     flex-direction: column;
-    min-width: auto;
+    overflow: visible;
   }
-  
+
   .filters input[type="search"],
   .filters select,
   .filters .btn {
     width: 100%;
     min-width: auto;
   }
-  
-  /* pagination-info es subtítulo del h1, no necesita override en mobile */
+
+  .pagination-info {
+    align-self: flex-start;
+  }
 }

--- a/app/static/css/v2-components.css
+++ b/app/static/css/v2-components.css
@@ -13,7 +13,8 @@
 .lista-cabecera {
   flex-shrink: 0; /* No se comprime */
   background: var(--gris-especifico);
-  padding-bottom: 0; /* El contenido interno maneja su padding */
+  padding-top: 0.625rem;
+  padding-bottom: 0; /* El contenido interno maneja su margen inferior */
   /* Padding lateral modesto del listado (#533): sustituye al recorte ~95% que
      antes daba .content-constrained. Alinea cabecera y filtros con el texto de
      las celdas (1rem). */

--- a/app/templates/layout/lista_v2_base.html
+++ b/app/templates/layout/lista_v2_base.html
@@ -68,27 +68,21 @@
 
 {% block title %}{% block page_title %}Listado{% endblock %} — BDDAT{% endblock %}
 
+{% block viewbar %}
+<span class="app-viewbar__title">
+  {% block page_icon %}<i class="fas fa-list"></i>{% endblock %}
+  <span>{{ self.page_title() }}</span>
+</span>
+<div class="app-viewbar__spacer"></div>
+<div class="app-viewbar__actions">
+  {% block btn_nuevo %}{% endblock %}
+</div>
+{% endblock %}
+
 {% block content %}
 
-<!-- C.1: Super-cabecera del listado (sin scroll) -->
+<!-- C.1: Filtros + contador (sin scroll, altura fija) -->
 <div class="lista-cabecera">
-
-    <!-- Page Header -->
-    <div class="page-header">
-        <div>
-            <h1>
-                {% block page_icon %}<i class="fas fa-list"></i>{% endblock %}
-                {% block page_title_h1 %}{{ self.page_title() }}{% endblock %}
-            </h1>
-            <div class="pagination-info">
-                <i class="fas fa-filter filtro-indicador me-1"></i><span>0</span> de <span>0</span>
-                {% block entity_label_plural %}registros{% endblock %}
-            </div>
-        </div>
-        {% block btn_nuevo %}{% endblock %}
-    </div>
-
-    <!-- Filtros -->
     <div class="filters-row">
         <div class="filters">
             <input type="search"
@@ -98,6 +92,9 @@
             <button class="btn btn-outline-primary btn-limpiar" disabled>
                 <i class="fas fa-times"></i> Limpiar
             </button>
+        </div>
+        <div class="pagination-info">
+            <i class="fas fa-filter filtro-indicador me-1"></i><span>0</span> de <span>0</span>
         </div>
     </div>
 </div>

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -8,9 +8,9 @@
 
 **Último cerrado:** #534 (ADR-023 — inspector overlay de shell + modelo de tres capas + Entidades como listado de referencia; 5 fases implementadas; PR de cierre contra develop). Precedido de: #533 (ADR-022 sistema visual base: rem global 15px, tokens de color, tabla unificada `.lista-table`; PR #538), #531, #528/#506.
 
-**Actuales:** **#537** (cabecera del listado → viewbar con prioridades de colapso, M2 — consolidar antes de migrar otras vistas).
+**Actuales:** **#537** (cabecera del listado → viewbar, M2 — consolidar antes de migrar otras vistas).
 
-**Próximos:** **#537** → **#532** (Command Palette isla React, cmdk, M4) → **Migrar listados restantes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo del administrativo") → **Mi trabajo del supervisor** (issue por crear; posible extensión de #501).
+**Próximos:** **#537** (viewbar) → **#532** (Command Palette isla React, cmdk, M4) → **Migrar listados restantes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo del administrativo") → **Mi trabajo del supervisor** (issue por crear; posible extensión de #501).
 
 > #502 queda como épica/referencia de ADR-018. Se cierra al mergear #532.
 > #537 (cabecera del listado → viewbar con prioridades de colapso, M2): abierto desde #533; coordinar con #534 al tocar la estructura del listado en `main`.

--- a/docs/CONTEXTO_ACTUAL.md
+++ b/docs/CONTEXTO_ACTUAL.md
@@ -8,9 +8,9 @@
 
 **Último cerrado:** #534 (ADR-023 — inspector overlay de shell + modelo de tres capas + Entidades como listado de referencia; 5 fases implementadas; PR de cierre contra develop). Precedido de: #533 (ADR-022 sistema visual base: rem global 15px, tokens de color, tabla unificada `.lista-table`; PR #538), #531, #528/#506.
 
-**Actuales:** *(pendiente de confirmar — ver sección "Próximos" abajo)*
+**Actuales:** **#537** (cabecera del listado → viewbar con prioridades de colapso, M2 — consolidar antes de migrar otras vistas).
 
-**Próximos:** *(confirmación pendiente del usuario)* — candidatos: **Migrar los listados restantes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo", ya con patrón maduro) → **#532** (frontend palette: isla React cmdk, M4 — aislada, no preceptiva).
+**Próximos:** **#537** → **#532** (Command Palette isla React, cmdk, M4) → **Migrar listados restantes** al patrón inspector (seguimiento\*, plantillas, usuarios, proyectos — issues a crear) → **#501** (ADR-017 "Mi trabajo del administrativo") → **Mi trabajo del supervisor** (issue por crear; posible extensión de #501).
 
 > #502 queda como épica/referencia de ADR-018. Se cierra al mergear #532.
 > #537 (cabecera del listado → viewbar con prioridades de colapso, M2): abierto desde #533; coordinar con #534 al tocar la estructura del listado en `main`.

--- a/run.py
+++ b/run.py
@@ -7,5 +7,5 @@ app = create_app(env)
 
 if __name__ == '__main__':
     host = os.environ.get('FLASK_HOST', '127.0.0.1')
-    port = int(os.environ.get('FLASK_PORT', 5000))
+    port = int(os.environ.get('FLASK_PORT', os.environ.get('PORT', 5000)))
     app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
## Cambios

- `lista_v2_base.html`: nuevo `{% block viewbar %}` con título+icono (izquierda) y botón de acción primaria (derecha); elimina `page-header` del bloque `content`
- `.pagination-info` se mueve a `.filters-row` (derecha); elimina etiqueta de entidad — contador pasa de "1-7 de 20 entidades" a "1-7 de 20"
- `usuarios/index.html` y `admin_plantillas/listado.html`: mismo patrón para templates estáticos
- Elimina `{% block entity_label_plural %}` de los 4 hijos V2 (código muerto)
- Elimina `{% block breadcrumb %}` muerto de `seguimiento.html`
- `app-shell.css`: `--shell-viewbar-bg` pasa de `#ffffff` a `var(--gris-especifico)` — zona de cabecera gris unificada; `.app-viewbar__title` trunca con elipsis; botones en `.app-viewbar__actions` normalizados a escala sm (0.75rem / padding reducido)
- `v2-components.css`: `.filters-row` con `flex-wrap:nowrap` + `overflow:hidden` (nunca crece en altura); `.filters min-width:0`; `.pagination-info` como flex-child `flex-shrink:0`; `.lista-cabecera` con `padding-top:0.625rem` para centrado vertical
- `run.py`: lee `PORT` como fallback de `FLASK_PORT` (soporte preview server)
- `.claude/launch.json`: `autoPort:true`

Closes #537
