### PR TITLE
Corregir defectos UI inspector expedientes (#543)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/_editar_fragmento_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_editar_fragmento_expediente.html
@@ -16,7 +16,7 @@
             data-inspector-cancel-edit>
         <i class="fas fa-times me-1"></i> Cancelar
     </button>
-    <button type="submit" class="btn btn-primary btn-sm" disabled>
+    <button type="submit" class="btn btn-success btn-sm" disabled>
         <i class="fas fa-save me-1"></i> Guardar cambios
     </button>
 </div>

--- a/app/modules/expedientes/templates/expedientes/_editar_fragmento_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_editar_fragmento_expediente.html
@@ -16,7 +16,7 @@
             data-inspector-cancel-edit>
         <i class="fas fa-times me-1"></i> Cancelar
     </button>
-    <button type="submit" class="btn btn-primary btn-sm">
+    <button type="submit" class="btn btn-primary btn-sm" disabled>
         <i class="fas fa-save me-1"></i> Guardar cambios
     </button>
 </div>

--- a/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
@@ -17,7 +17,7 @@
             <i class="fas fa-sitemap me-1"></i> Tramitar
         </a>
         {% if puede_editar %}
-        <button type="button" class="btn btn-outline-secondary btn-sm"
+        <button type="button" class="btn btn-success btn-sm"
                 data-inspector-edit
                 data-edit-url="{{ url_for('expedientes.editar_fragmento', id=expediente.id) }}">
             <i class="fas fa-edit me-1"></i> Editar

--- a/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
@@ -5,18 +5,25 @@
 <div class="p-3">
 
 <!-- Botones de acción (ADR-024 §4.2) -->
-<div class="d-flex justify-content-end gap-2 mb-3">
-    <a href="{{ url_for('expedientes.arbol', id=expediente.id) }}"
-       class="btn btn-primary btn-sm">
-        <i class="fas fa-sitemap me-1"></i> Tramitar
-    </a>
-    {% if puede_editar %}
-    <button type="button" class="btn btn-outline-secondary btn-sm"
-            data-inspector-edit
-            data-edit-url="{{ url_for('expedientes.editar_fragmento', id=expediente.id) }}">
-        <i class="fas fa-edit me-1"></i> Editar
+<div class="d-flex gap-2 mb-3">
+    <button type="button" class="btn btn-outline-secondary btn-sm" disabled
+            title="Las instalaciones técnicas del proyecto (líneas, CT, subestaciones) estarán disponibles en una próxima versión.">
+        <i class="fas fa-plug me-1"></i> Instalaciones
+        <span class="badge bg-secondary ms-1">Próximamente</span>
     </button>
-    {% endif %}
+    <div class="ms-auto d-flex gap-2">
+        <a href="{{ url_for('expedientes.arbol', id=expediente.id) }}"
+           class="btn btn-primary btn-sm">
+            <i class="fas fa-sitemap me-1"></i> Tramitar
+        </a>
+        {% if puede_editar %}
+        <button type="button" class="btn btn-outline-secondary btn-sm"
+                data-inspector-edit
+                data-edit-url="{{ url_for('expedientes.editar_fragmento', id=expediente.id) }}">
+            <i class="fas fa-edit me-1"></i> Editar
+        </button>
+        {% endif %}
+    </div>
 </div>
 
 <!-- CABECERA — AT, tipo, titular, estado (ADR-024 §4.1) -->
@@ -200,13 +207,5 @@
     </div>
 </div>
 
-<!-- PLACEHOLDER instalaciones — botón desactivado (ADR-024 §4.6) -->
-<div class="d-grid mb-2">
-    <button type="button" class="btn btn-outline-secondary btn-sm" disabled
-            title="Las instalaciones técnicas del proyecto (líneas, CT, subestaciones) estarán disponibles en una próxima versión.">
-        <i class="fas fa-plug me-1"></i> Instalaciones
-        <span class="badge bg-secondary ms-1">Próximamente</span>
-    </button>
-</div>
 
 </div>{# /p-3 #}

--- a/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_inspector_expediente.html
@@ -4,15 +4,20 @@
 
 <div class="p-3">
 
-{% if puede_editar %}
-<div class="d-flex justify-content-end mb-3">
-    <button type="button" class="btn btn-primary btn-sm"
+<!-- Botones de acción (ADR-024 §4.2) -->
+<div class="d-flex justify-content-end gap-2 mb-3">
+    <a href="{{ url_for('expedientes.arbol', id=expediente.id) }}"
+       class="btn btn-primary btn-sm">
+        <i class="fas fa-sitemap me-1"></i> Tramitar
+    </a>
+    {% if puede_editar %}
+    <button type="button" class="btn btn-outline-secondary btn-sm"
             data-inspector-edit
             data-edit-url="{{ url_for('expedientes.editar_fragmento', id=expediente.id) }}">
         <i class="fas fa-edit me-1"></i> Editar
     </button>
+    {% endif %}
 </div>
-{% endif %}
 
 <!-- CABECERA — AT, tipo, titular, estado (ADR-024 §4.1) -->
 <div class="card mb-3">
@@ -43,14 +48,6 @@
             {{ expediente.titular.nombre_completo if expediente.titular else '— Sin titular —' }}
         </div>
     </div>
-</div>
-
-<!-- ACCIÓN PRIMARIA — "Tramitar" (ADR-024 §4.2) -->
-<div class="d-grid mb-3">
-    <a href="{{ url_for('expedientes.arbol', id=expediente.id) }}"
-       class="btn btn-primary">
-        <i class="fas fa-sitemap me-1"></i> Tramitar
-    </a>
 </div>
 
 <!-- CARD datos administrativos — solo lectura (ADR-024 §4.3) -->

--- a/app/modules/expedientes/templates/expedientes/_modal_municipios_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_modal_municipios_expediente.html
@@ -73,6 +73,17 @@
     const emptyMsg    = document.getElementById('gm-empty-msg');
     const errDiv      = document.getElementById('gm-errors');
     const form        = document.getElementById('gm-form');
+    const initialIds  = new Set(municipiosActuales.map(m => String(m.id)));
+
+    function isDirty() {
+        const keys = Object.keys(seleccionados);
+        if (keys.length !== initialIds.size) return true;
+        return keys.some(id => !initialIds.has(id));
+    }
+
+    function syncGuardar() {
+        document.getElementById('gm-btn-guardar').disabled = !isDirty();
+    }
 
     // Precargar municipios actuales
     municipiosActuales.forEach(m => { seleccionados[m.id] = m.nombre; });
@@ -143,7 +154,15 @@
             hidden.value = id;
             hiddenDiv.appendChild(hidden);
         });
+        syncGuardar();
     }
+
+    // Cancelar: toast si hay cambios pendientes
+    form.querySelector('[data-modal-large-close]').addEventListener('click', function () {
+        if (isDirty() && window.mostrar_toast) {
+            window.mostrar_toast('info', 'Cambios descartados.');
+        }
+    });
 
     // Envío del formulario vía XHR
     form.addEventListener('submit', async function (e) {
@@ -163,10 +182,8 @@
             });
             const json = await resp.json();
             if (json.ok) {
-                // Cerrar modal y refrescar inspector
-                document.dispatchEvent(new CustomEvent('modal-large:saved', {
-                    detail: { message: json.message }
-                }));
+                if (window.mostrar_toast) window.mostrar_toast('success', json.message || 'Municipios guardados correctamente.');
+                if (window.AppModalLarge) window.AppModalLarge.close();
             } else {
                 errDiv.textContent = (json.errors || ['Error desconocido']).join(' ');
                 errDiv.style.display = '';

--- a/app/modules/expedientes/templates/expedientes/_modal_municipios_expediente.html
+++ b/app/modules/expedientes/templates/expedientes/_modal_municipios_expediente.html
@@ -46,7 +46,7 @@
             data-modal-large-close>
         <i class="fas fa-times me-1"></i> Cancelar
     </button>
-    <button type="submit" class="btn btn-primary btn-sm" id="gm-btn-guardar">
+    <button type="submit" class="btn btn-success btn-sm" id="gm-btn-guardar">
         <i class="fas fa-save me-1"></i> Guardar municipios
     </button>
 </div>

--- a/app/static/js/inspector-overlay.js
+++ b/app/static/js/inspector-overlay.js
@@ -307,11 +307,16 @@
 
   // ── Seguimiento de cambios en el formulario (dirty) ───────────────────────
 
-  document.addEventListener('change', function (e) {
-    if (e.target.closest('form[data-inspector-form]')) {
-      _formDirty = true;
-    }
-  });
+  function _markDirty(e) {
+    var form = e.target.closest('form[data-inspector-form]');
+    if (!form) return;
+    _formDirty = true;
+    var btn = form.querySelector('[type=submit]');
+    if (btn && btn.disabled) btn.disabled = false;
+  }
+
+  document.addEventListener('input',  _markDirty);
+  document.addEventListener('change', _markDirty);
 
   // ── beforeunload cuando hay cambios sin guardar ───────────────────────────
 

--- a/app/static/js/modal-large.js
+++ b/app/static/js/modal-large.js
@@ -168,6 +168,12 @@
       });
   });
 
+  // ── Botón [data-modal-large-close] dentro del modal ───────────────────────
+
+  document.addEventListener('click', function (e) {
+    if (e.target.closest('[data-modal-large-close]')) close();
+  });
+
   window.AppModalLarge = { open: open, close: close, refresh: refresh };
 
 })();


### PR DESCRIPTION
## Cambios

- **Inspector lectura:** botón Tramitar reducido a `btn-sm` y fusionado en la misma fila que Editar; bloque `d-grid` eliminado
- **Inspector lectura:** botón Instalaciones (placeholder desactivado) movido a la izquierda de esa fila para aprovechar el ancho a 1080 px sin scroll
- **Colores semánticos:** Editar → `btn-success` (verde); Guardar cambios y Guardar municipios → `btn-success`; azul reservado para navegación (Tramitar)
- **Cancelar modal municipios:** el botón `data-modal-large-close` no tenía handler; añadido listener en `modal-large.js`
- **Guardar (formulario inspector):** nace `disabled`; `_markDirty` en `inspector-overlay.js` lo habilita en el primer `input`/`change`
- **Guardar municipios:** nace `disabled`; `syncGuardar()` compara contra `initialIds` tras cada mutación de la lista
- **Toasts modal municipios:** éxito muestra toast `success` y cierra el modal vía `AppModalLarge.close()`; cancelar con cambios pendientes muestra toast `info`; eliminado `CustomEvent('modal-large:saved')` que no tenía listener

Closes #543
