### PR TITLE
ADR-026: la vigencia normativa es de la regla, no de la variable

### DIFF
--- a/docs/decisiones/ADR-026-vigencia-normativa-es-de-la-regla-no-de-la-variable.md
+++ b/docs/decisiones/ADR-026-vigencia-normativa-es-de-la-regla-no-de-la-variable.md
@@ -1,0 +1,65 @@
+# ADR-026 — La vigencia normativa es una propiedad de la regla, no de la variable
+
+**Estado:** Adoptada
+**Fecha:** 2026-06-18
+**Issue:** #556 (efecto colateral detectado durante el diseño) · #561 (implementación del drop de `activa` y la red de seguridad)
+**Relacionado con:** ADR-001 (motor agnóstico) · ADR-025 (#553, ensamblador del escrito). Fuentes de verdad afectadas: `docs/referencia/DISEÑO_CONTEXT_ASSEMBLER.md` y el modelo `app/models/motor_reglas.py`.
+
+---
+
+## Contexto
+
+Al abordar #556 (exponer las variables del motor en las plantillas de escritos) se cuestionó qué significaba que una variable pudiera "estar activa o no", y en concreto el valor `obsoleta = (norma derogada, …)` del eje **Estado** del diccionario de variables (`DISEÑO_CONTEXT_ASSEMBLER.md`).
+
+El modelo mental implícito era: *la variable nace de una norma; si la norma se deroga, la variable se obsoleta.* Es un **error conceptual**:
+
+1. **Una variable es un hecho del expediente** — una realidad física (tensión, longitud, subterránea) o administrativa (tiene AAU, es PTD) — **evaluable con independencia de qué norma esté vigente**. Que la norma que dio origen al concepto se derogue no impide ni desaconseja medir la realidad.
+2. **Una variable puede alimentar varias reglas de normas distintas.** El propio diccionario ya lo refleja: `tension_nominal_kv` cita Decreto 9/2011 + RD 337/2014; `requiere_aau` cita D356/2010 + DL 26/2021 + Ley 2/2026. Atar la vida de la variable a "su" norma es incoherente: si se deroga una de ellas pero otra regla sobre la misma variable sigue vigente, desactivar la variable rompería esa segunda regla.
+3. **La derogación no es retroactiva** a los expedientes en curso. El sistema ya modela transitoriedad por fecha (p. ej. `fecha_inicio_expediente_ambiental` discrimina GICA vs Ley 2/2026). Mientras haya expedientes bajo la norma anterior, ni la regla está muerta ni, mucho menos, su variable.
+4. **Dejar de evaluar una variable no es neutro, es descontrolado.** Si una variable pasara a `null`, las actuaciones del motor condicionadas a su `true` se dejarían de bloquear (la condición ya no se cumple) y, en las plantillas, un fragmento gobernado por `true`/`false` quedaría en estado incierto. La ausencia de cómputo no equivale a "no aplica".
+
+La vigencia normativa, por tanto, es una propiedad de la **decisión** (la regla), no del **hecho** (la variable). El modelo ya lo soporta: `reglas_motor.activa` y `excepciones_motor.activa` existen precisamente para desactivar reglas preservando trazabilidad; `obsoleta` como estado de variable nunca llegó a existir en BD — vivía solo en el documento.
+
+---
+
+## Decisión
+
+### 1. La vigencia normativa es de la regla, nunca de la variable
+
+Cuando una norma se deroga: se desactiva la **regla** (`reglas_motor.activa = false`) y/o se crea la regla complementaria. La variable **se sigue computando igual**. El "uso" de una variable (qué reglas o plantillas la referencian) es derivado e informativo: **nunca impide computarla**.
+
+### 2. Se elimina `obsoleta` como estado de variable
+
+El eje **Estado** del diccionario refleja **un único eje: la implementación** (de papel a código): `definida` → `pendiente de implementar` → `implementada`. Se retira el valor `obsoleta = (norma derogada)`. Si en algún caso extremo una variable hubiera de retirarse, el disparador sería que **el concepto desaparece del dominio** (se elimina el campo del modelo, deja de existir la distinción) **y** ningún consumidor la usa — **nunca** la derogación de una norma.
+
+### 3. `norma_id` de la variable es documental
+
+Indica dónde apareció el concepto; puede ser múltiple. **No es dueña del ciclo de vida** de la variable. Que una de esas normas se derogue no la afecta.
+
+### 4. `catalogo_variables.activa` no es vigencia (y su drop se trata aparte)
+
+El flag `activa` **no codifica vigencia normativa**: es la **compuerta de implementación** ("¿existe la función en el Variable Registry?"). La verificación durante #556 mostró que **es portante** (filtra `build()` en `app/services/assembler.py:183`), no vestigial como se había supuesto. Su posible eliminación —y la red de seguridad que debe acompañarla— se decide en **#561**, no en este ADR.
+
+### 5. La red de seguridad vive en los tests, no en un registro de usos
+
+La protección contra romper consumidores (reglas y, sobre todo, plantillas) al borrar el código de cómputo de una variable se construye con **tests de existencia/resolubilidad** sobre conjuntos enumerables (registry, consultas nombradas, plantillas registradas), no con un registro de qué plantilla usa qué variable (ataría la libertad de creación). Detalle y alcance en **#561**.
+
+---
+
+## Consecuencias
+
+- **`DISEÑO_CONTEXT_ASSEMBLER.md`** se actualiza: eje Estado sin `obsoleta`, recuadro de principio (vigencia = regla; la variable se computa siempre; `null` = descontrolado), `norma_id` documental, y la descripción de `build()` ajustada a la realidad (consulta `catalogo_variables` con `activa=True` e invoca el registry).
+- **#556** se corrige: la afirmación de su cuerpo de que `activa` es "vestigial / todas `true` / drift de doc a ajustar a la realidad" era **inexacta** — el flag es portante.
+- **No hay cambio de esquema en este ADR.** El drop de la columna `activa` y la red de tests son **#561**.
+
+---
+
+## Alternativas descartadas
+
+### A. Mantener `obsoleta` como estado de la variable
+
+Confunde la vigencia (propiedad de la regla) con la existencia (propiedad de la variable) y rompe el caso real de variables compartidas por varias normas: derogar una desactivaría una variable que otra regla vigente todavía necesita.
+
+### B. Registro variable↔plantilla para detectar consumidores
+
+Llevar un registro de qué plantilla usa qué variable ataría la libertad de creación de plantillas (se crean como parte del trabajo diario, sin intervención del programador). La red correcta son tests de existencia (variables + consultas) y de resolubilidad de tokens (plantillas, que **sí** son enumerables) — ver #561.

--- a/docs/referencia/DISEÑO_CONTEXT_ASSEMBLER.md
+++ b/docs/referencia/DISEÑO_CONTEXT_ASSEMBLER.md
@@ -1,8 +1,8 @@
 # ContextAssembler — Diseño del contrato de variables
 
-> **Fecha:** 2026-04-05 · **Actualizado:** 2026-04-21
-> **Estado:** En construcción — diccionario de variables activo; patrón Variable Registry y ciclo de vida definidos (sesión 2026-04-21).
-> **Referencia de arquitectura:** `DISEÑO_MOTOR_AGNOSTICO.md`
+> **Fecha:** 2026-04-05 · **Actualizado:** 2026-06-18
+> **Estado:** En construcción — diccionario de variables activo; patrón Variable Registry y ciclo de vida definidos (sesión 2026-04-21). Vigencia normativa reencuadrada como propiedad de la regla, no de la variable (ADR-026, sesión 2026-06-18).
+> **Referencia de arquitectura:** `DISEÑO_MOTOR_AGNOSTICO.md` · `decisiones/ADR-026` (vigencia = regla, no variable)
 
 Este documento define el contrato de entrada del ContextAssembler: qué variables
 existen, cómo se tipan, de qué norma proceden y cuál es su estado de implementación.
@@ -97,16 +97,34 @@ vive ahí. Si es calculado, no persiste.
 
 ## Columna Estado — valores y significado
 
+El estado refleja **un único eje: la implementación de la variable** (de papel a código).
+No refleja vigencia normativa (eso es de la regla) ni uso (eso es derivado).
+
 | Valor | Significado |
 |---|---|
 | `definida` | Variable nombrada, tipada y con norma de origen registrada. Puede o no estar en código. |
 | `pendiente de implementar` | Definida aquí pero aún no existe en modelo, ContextAssembler ni motor. |
-| `implementada` | Existe en el modelo de BD (si es `dato`), o en el ContextAssembler (si es `calculado`/`derivado_documento`), y el motor la evalúa. |
-| `obsoleta` | Ya no aplica (norma derogada, diseño cambiado). Mantener fila para trazabilidad; no borrar. |
+| `implementada` | Existe en el modelo de BD (si es `dato`), o en el ContextAssembler (si es `calculado`/`derivado_*`), y el motor la evalúa. Una vez aquí, **se computa siempre**. |
+| `retirada` | El **concepto** que medía ya no existe en el dominio (se eliminó el campo del modelo, desapareció la distinción en la realidad) **y** ningún consumidor la referencia. Mantener fila para trazabilidad. **Nunca se retira por derogación de una norma** — eso desactiva la regla, no la variable. |
 
 > Mantener este campo actualizado es tan importante como la propia definición: es el
 > **inventario de cobertura real del motor**. Cuando una variable pasa a `implementada`,
 > significa que la regla jurídica asociada está activa en producción.
+
+> **Principio (ADR-026) — la vigencia normativa no es un estado de la variable.**
+> Una variable es un hecho del expediente (una realidad física o administrativa),
+> evaluable con independencia de qué norma esté vigente, y puede alimentar varias
+> reglas de normas distintas. Cuando una norma se deroga se desactiva la **regla**
+> (`reglas_motor.activa`) y/o se crea la complementaria; la variable se sigue
+> computando igual. El "uso" de una variable (qué reglas o plantillas la referencian)
+> es derivado e informativo: **nunca impide computarla**.
+>
+> **Por qué se computa siempre:** si una variable dejara de evaluarse y pasara a `null`,
+> el comportamiento queda *descontrolado*, no neutro. En el motor, las actuaciones
+> condicionadas a su `true` se dejarían de bloquear → se ejecutarían indebidamente.
+> En las plantillas, un fragmento gobernado por `true`/`false` pasa a incierto. Una
+> variable, una vez en el catálogo, se computa siempre (valor definido, o `None`
+> deliberado para "no aplica"); nunca se deja caer en silencio.
 
 ---
 
@@ -114,6 +132,12 @@ vive ahí. Si es calculado, no persiste.
 
 Las variables crecen en el paso `MAPEO_CONTEXTO` del protocolo de extracción
 (`GUIA_NORMAS.md §5`). Antes de tocar código, toda variable nueva se define aquí.
+
+> **"Norma de origen" es documental, no dueña del ciclo de vida** (ADR-026). Indica
+> dónde apareció el concepto; puede ser múltiple (varias variables ya citan dos o más
+> normas). Que una de esas normas se derogue no afecta a la variable; afecta a la regla
+> que la usaba. En el modelo, `catalogo_variables.norma_id` es solo la norma principal
+> a efectos de presentación.
 
 | Variable | Tipo | Naturaleza | Norma de origen y descripción | Estado |
 |---|---|---|---|---|
@@ -234,9 +258,11 @@ variables = build(expediente.id)   # dict completo de todas las variables
 resultado  = evaluar('INICIAR', 'FASE', fase.tipo_fase_id, variables)
 ```
 
-`build()` recorre `_REGISTRY` y llama cada función con el contexto del expediente.
-Devuelve un dict plano: `{'intermunicipal': True, 'tension_nominal_kv': 220, ...}`.
-Las variables no aplicables llegan como `None`.
+`build()` consulta `catalogo_variables` (hoy con `activa = True`) y, por cada fila,
+invoca su función en `_REGISTRY` con el contexto del expediente. Devuelve un dict plano:
+`{'intermunicipal': True, 'tension_nominal_kv': 220, ...}`. Las variables no aplicables
+llegan como `None`. *(El flag `activa` resultó ser portante, no vestigial; su posible
+eliminación —pasando `build()` a iterar el registry directamente— se evalúa en #561.)*
 
 `evaluar()` carga las reglas activas para `(accion, sujeto, tipo_sujeto_id)` de BD,
 resuelve cada condición buscando `variables[v.nombre]` en el dict y aplicando el operador
@@ -248,3 +274,8 @@ esa regla se activa.
 Toda variable referenciada en `condiciones_regla` debe existir en `catalogo_variables`
 (integridad referencial por FK) y tener su función en el registry (`activa = true`).
 Un comando `flask sync_variables` puede verificar que ambos lados están alineados.
+
+> La red de seguridad frente a borrar el código de cómputo de una variable se construye
+> con **tests de existencia/resolubilidad** sobre conjuntos enumerables (registry,
+> consultas nombradas, plantillas registradas), no con un registro de qué consumidor usa
+> qué variable. Alcance y diseño en **#561**.


### PR DESCRIPTION
## Cambios

- **Nuevo ADR-026** — la vigencia normativa es propiedad de la **regla** (`reglas_motor.activa`), nunca de la variable. Una variable es un hecho del expediente, evaluable con independencia de la norma vigente, y puede alimentar varias reglas de normas distintas.
- **`DISEÑO_CONTEXT_ASSEMBLER.md`** — eje Estado sin `obsoleta` (con `retirada` acotada al dominio, nunca por derogación), recuadro de principio (la variable se computa siempre; `null` = descontrolado, no neutro), `norma_id` documental, y descripción de `build()` conforme a la realidad (filtra `catalogo_variables` por `activa`, no recorre el registry).
- **#556 corregido** — el flag `activa` no es vestigial: es portante (filtra `build()` en `app/services/assembler.py:183`).
- **Spin-off [#561](https://github.com/genete/bddat/issues/561)** — drop de la columna `activa` + red de seguridad (tests de existencia de cómputo para variables/consultas y de resolubilidad de tokens de plantillas), a re-analizar en su momento.

Esta rama es la corrección conceptual/documental; **no implementa ni cierra** el feature de #556.

Refs #556 #561
