### PR TITLE
[REFACTOR] #558 unificar el núcleo de reglas de estado (estado_dominio)

### DIFF
--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -52,16 +52,21 @@ const sfTipoExpediente = new SelectorFiltro('#sf-tipo-expediente', [
 
 const colsMeta = {{ columns | tojson }};
 
-// Mapas de texto y color por estado interno (§4.2 / §4.3)
+// Mapas de texto y color por estado del núcleo (estado_dominio, #558).
+// La familia de notificar (NOTIFICAR/FALLIDA/AGOTADA) comparte la etiqueta
+// "NOTIFICAR"; lo que escala es el color (azul → naranja → rojo).
 const TEXTO_ESTADO = {
-    'PENDIENTE_TRAMITAR':  'TRAMITAR',
-    'PENDIENTE_ESTUDIO':   'ESTUDIAR',
-    'PENDIENTE_ELABORAR':  'ELABORAR',
-    'PENDIENTE_NOTIFICAR': 'NOTIFICAR',
-    'PENDIENTE_SUBSANAR':  'SUBSANAR',
-    'PENDIENTE_PLAZOS':    'PLAZOS',
-    'PENDIENTE_CERRAR':    'CERRAR',
-    'FIN':                 'FIN',
+    'PENDIENTE_TRAMITAR':   'TRAMITAR',
+    'PENDIENTE_ESTUDIO':    'ESTUDIO',
+    'PENDIENTE_REDACTAR':   'REDACTAR',
+    'PENDIENTE_FIRMA':      'FIRMA',
+    'PENDIENTE_NOTIFICAR':  'NOTIFICAR',
+    'NOTIFICACION_FALLIDA': 'NOTIFICAR',
+    'NOTIFICACION_AGOTADA': 'NOTIFICAR',
+    'PENDIENTE_CERRAR':     'CERRAR',
+    'PENDIENTE_SUBSANAR':   'SUBSANAR',
+    'PENDIENTE_PLAZOS':     'PLAZOS',
+    'FIN':                  'FIN',
 };
 const COLOR_CLASE = {
     'rojo':     'pista-rojo',

--- a/app/services/arbol_expediente.py
+++ b/app/services/arbol_expediente.py
@@ -31,7 +31,7 @@ from app.models.tramites import Tramite
 from app.models.tareas import Tarea
 from app.models.documentos_tarea import DocumentoTarea
 from app.models.documentos import Documento
-from app.services import estado_semaforo as sem
+from app.services import estado_dominio as sem
 
 log = logging.getLogger(__name__)
 

--- a/app/services/estado_dominio.py
+++ b/app/services/estado_dominio.py
@@ -1,56 +1,65 @@
 """
-estado_semaforo.py — Estado-semáforo (color fino) por nodo del árbol del expediente.
+estado_dominio.py — Núcleo único de reglas de estado del árbol ESFTT.
 
-FUENTE DE VERDAD: docs/referencia/MODELO_ESTADOS_SEMAFORO.md (§2 colores, §3 tareas,
-§4 contenedores, §5 agregación/prioridad). Lo consume `services/arbol_expediente.py`
-para decorar cada nodo con `semaforo {estado, color, propio}`.
+FUENTE DE VERDAD: docs/referencia/MODELO_ESTADOS_SEMAFORO.md.
+Una sola fuente para las dos proyecciones que deducen el estado del mismo árbol de
+dominio (Solicitud → Fase → Trámite → Tarea):
+  - `services/arbol_expediente.py` — proyección por NODO (vista de árbol): decora
+    cada nodo 1:1 y usa el flag `propio`.
+  - `services/seguimiento.py` — proyección por PISTAS (listado de seguimiento):
+    agrega varias fases en una celda, con contador y nota.
 
-Por qué un servicio NUEVO y no `seguimiento.py`:
-  - `seguimiento.py` razona por PISTAS (grupos de fases por tipo), no por nodo del árbol.
-  - Arrastra la deuda `PENDIENTE_ELABORAR` (un único 🟡); este modelo lo desdobla en
-    `PENDIENTE_REDACTAR` 🔴 + `PENDIENTE_FIRMA` 🟡 mirando el tipo de doc BORRADOR_FIRMA.
-  Se reutiliza el *algoritmo* (recorrido abajo-arriba + mayor prioridad), no su código.
-  La unificación de ambos consumidores queda como deuda (MODELO §10).
+De aquí salen, compartidos por ambas: el vocabulario canónico, la regla de hoja
+`estado_tarea`, las reglas de contenedor (`estado_tramite/fase/solicitud/expediente`),
+las tablas `COLOR`/`PRIORIDAD` y el helper `mayor_prioridad`. Lo que NO vive aquí es
+el *alcance* de la agregación (qué nodos compiten) ni las decoraciones propias de
+cada vista (contador/nota/relabel de seguimiento; serialización del árbol).
+
+Unifica la deuda histórica `seguimiento.py`↔`estado_semaforo.py` (MODELO §10, #558):
+vocabulario fino (REDACTAR/FIRMA), escalada de notificar (🔵→🟠→🔴, derivada de
+`Notificacion`) y un único orden de prioridad canónico, coherente con el color
+(🔴 > 🟠 > 🟡 > 🔵 > ⚪ > 🟢).
 
 CONTRATO de las funciones contenedor: devuelven `(estado, propio)`.
-  - `estado`: código del estado-semáforo (agregado del subárbol si el nodo está en curso).
-  - `propio`: True si el nodo "tiene algo que decir POR SÍ MISMO" (sin hijos → TRAMITAR;
-    fase PDTE_CIERRE; solicitud todo-FIN-pero-EN_TRAMITE). El front rellena el círculo
-    cuando `propio` (nodo expandido) o siempre con el color agregado si el nodo está
-    colapsado (MODELO §5/§7). Las tareas (hojas) van siempre rellenas.
+  - `estado`: código de estado de dominio (agregado del subárbol si está en curso).
+  - `propio`: True si el nodo "tiene algo que decir POR SÍ MISMO" (sin hijos →
+    TRAMITAR; fase PDTE_CIERRE; solicitud todo-FIN-pero-EN_TRAMITE). El árbol rellena
+    el círculo cuando `propio` (nodo expandido) o con el color agregado si está
+    colapsado. Las tareas (hojas) van siempre rellenas.
 """
 from __future__ import annotations
 
 from typing import Optional
 
-# --- §2: nombre de color por estado (el front mapea nombre → paleta JdA) ---
+# --- Color por estado (MODELO §2; el front mapea nombre → paleta JdA) ---
+# El orden refleja la prioridad: el color es coherente con la urgencia (#558).
 COLOR: dict[str, str] = {
     'PENDIENTE_TRAMITAR':   'rojo',
     'PENDIENTE_ESTUDIO':    'rojo',
     'PENDIENTE_REDACTAR':   'rojo',
     'NOTIFICACION_AGOTADA': 'rojo',
+    'PENDIENTE_CERRAR':     'naranja',
+    'NOTIFICACION_FALLIDA': 'naranja',
     'PENDIENTE_FIRMA':      'amarillo',
     'PENDIENTE_NOTIFICAR':  'azul',
-    'NOTIFICACION_FALLIDA': 'naranja',
-    'PENDIENTE_CERRAR':     'naranja',
     'PENDIENTE_PLAZOS':     'gris',
-    'PENDIENTE_SUBSANAR':   'gris',
     'FIN':                  'verde',
 }
 
-# --- §5: prioridad (1 = más urgente; se queda el de menor número al agregar) ---
+# --- Prioridad canónica (1 = más urgente; al agregar se queda el de menor número) ---
+# Orden ratificado #558: gradiente de "trabajo del tramitador". Monótono con el color,
+# sin empates entre bandas distintas (el ganador de cada celda es determinista).
 PRIORIDAD: dict[str, int] = {
-    'PENDIENTE_TRAMITAR':   1,
-    'PENDIENTE_ESTUDIO':    2,
-    'PENDIENTE_REDACTAR':   3,
-    'NOTIFICACION_AGOTADA': 3,
-    'PENDIENTE_FIRMA':      4,
-    'PENDIENTE_NOTIFICAR':  5,
-    'NOTIFICACION_FALLIDA': 6,
-    'PENDIENTE_CERRAR':     6,
-    'PENDIENTE_SUBSANAR':   7,
-    'PENDIENTE_PLAZOS':     7,
-    'FIN':                  8,
+    'PENDIENTE_TRAMITAR':   1,   # 🔴 trabajo del tramitador
+    'PENDIENTE_ESTUDIO':    2,   # 🔴 (analizar · decidir resultado de fase finalizadora)
+    'PENDIENTE_REDACTAR':   3,   # 🔴
+    'NOTIFICACION_AGOTADA': 4,   # 🔴 procede publicación en boletín
+    'PENDIENTE_CERRAR':     5,   # 🟠 nuestra gestión (formalizar cierre de fase)
+    'NOTIFICACION_FALLIDA': 6,   # 🟠 2º intento de notificación pendiente
+    'PENDIENTE_FIRMA':      7,   # 🟡 no depende del tramitador, pero paraliza si falta
+    'PENDIENTE_NOTIFICAR':  8,   # 🔵 a la espera de un externo
+    'PENDIENTE_PLAZOS':     9,   # ⚪ espera pasiva
+    'FIN':                  10,  # 🟢
 }
 
 # Tipo de documento cuyo consumo distingue PENDIENTE_FIRMA de PENDIENTE_REDACTAR (§3 ELABORAR).
@@ -58,12 +67,12 @@ _TIPO_BORRADOR_FIRMA = 'BORRADOR_FIRMA'
 
 
 def color(estado: str) -> str:
-    """Nombre de color (§2) de un estado-semáforo; 'gris' si desconocido."""
+    """Nombre de color (MODELO §2) de un estado; 'gris' si desconocido."""
     return COLOR.get(estado, 'gris')
 
 
-def _mayor_prioridad(estados: list[str]) -> str:
-    """Estado de mayor prioridad (menor número §5) de una lista no vacía.
+def mayor_prioridad(estados: list[str]) -> str:
+    """Estado de mayor prioridad (menor número) de una lista no vacía.
 
     Si la lista llega vacía (no debería en un nodo en curso), degrada a FIN.
     """
@@ -78,9 +87,9 @@ def _mayor_prioridad(estados: list[str]) -> str:
 
 def estado_tarea(tarea, plazo: Optional[dict] = None) -> str:
     """
-    Estado-semáforo de una tarea según su tipo (MODELO §3).
+    Estado de dominio de una tarea según su tipo (MODELO §3).
 
-    `plazo` es el dict ya resuelto por arbol_expediente para ESPERAR_PLAZO
+    `plazo` es el dict ya resuelto por la proyección para ESPERAR_PLAZO
     ({estado, fecha_limite, dias_restantes} o None) — no se recalcula aquí.
     Regla general §3: verde = tarea ejecutada (salvo NOTIFICAR, que depende del
     resultado de la notificación).
@@ -148,13 +157,13 @@ def _tiene_borrador_firma(tarea) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Contenedores (§4) — reciben los estados-semáforo ya computados de sus hijos
+# Contenedores (§4) — reciben los estados ya computados de sus hijos
 # ---------------------------------------------------------------------------
 
 def estado_tramite(tramite, estados_tareas: list[str]) -> tuple[str, bool]:
     if not tramite.tareas:                 # planificado: sin tareas aún
         return ('PENDIENTE_TRAMITAR', True)
-    return (_mayor_prioridad(estados_tareas), False)
+    return (mayor_prioridad(estados_tareas), False)
 
 
 def estado_fase(fase, estados_tramites: list[str]) -> tuple[str, bool]:
@@ -162,13 +171,13 @@ def estado_fase(fase, estados_tramites: list[str]) -> tuple[str, bool]:
         return ('PENDIENTE_TRAMITAR', True)
     if fase.pdte_cierre:                   # todos los trámites cerrados, falta formalizar
         # Solo las finalizadoras requieren resultado_fase_id explícito (el técnico
-        # tiene la última palabra). Las intermedias cierran por documento_resultado_id;
-        # su resultado_fase_id debe quedar NULL.
+        # tiene la última palabra). Las intermedias cierran por documento_resultado_id
+        # (un certificado de fase); su resultado_fase_id debe quedar NULL → van a CERRAR.
         es_finalizadora = getattr(fase.tipo_fase, 'es_finalizadora', False)
         if es_finalizadora and fase.resultado_fase_id is None:
             return ('PENDIENTE_ESTUDIO', True)   # 🔴 falta decidir resultado
         return ('PENDIENTE_CERRAR', True)        # 🟠 falta documento formalizador
-    return (_mayor_prioridad(estados_tramites), False)
+    return (mayor_prioridad(estados_tramites), False)
 
 
 def estado_solicitud(solicitud, estados_fases: list[str]) -> tuple[str, bool]:
@@ -176,7 +185,7 @@ def estado_solicitud(solicitud, estados_fases: list[str]) -> tuple[str, bool]:
         return ('PENDIENTE_TRAMITAR', True)
     if solicitud.estado != 'EN_TRAMITE':   # finalizada / archivada
         return ('FIN', False)
-    agregado = _mayor_prioridad(estados_fases)
+    agregado = mayor_prioridad(estados_fases)
     if agregado == 'FIN':                  # todas las fases en FIN pero sigue EN_TRAMITE
         return ('PENDIENTE_CERRAR', True)  # 🟠 lista para cerrar
     return (agregado, False)
@@ -185,4 +194,4 @@ def estado_solicitud(solicitud, estados_fases: list[str]) -> tuple[str, bool]:
 def estado_expediente(expediente, estados_solicitudes: list[str]) -> tuple[str, bool]:
     if not estados_solicitudes:            # expediente sin solicitudes
         return ('PENDIENTE_TRAMITAR', True)
-    return (_mayor_prioridad(estados_solicitudes), False)
+    return (mayor_prioridad(estados_solicitudes), False)

--- a/app/services/seguimiento.py
+++ b/app/services/seguimiento.py
@@ -1,22 +1,23 @@
 """
-seguimiento.py — Deducción de estado de pistas para el listado inteligente.
+seguimiento.py — Proyección por PISTAS del estado del árbol (listado de seguimiento).
 
-Implementa el algoritmo de ANALISIS_LISTADO_INTELIGENTE.md §5.
-Recorre el árbol Solicitud → Fases → Trámites → Tareas de abajo arriba
-y devuelve el estado más urgente de cada pista.
+Proyecta el núcleo `estado_dominio` sobre las 5 pistas (SOL/CONSULTAS/MA/IP/RES) de la
+fila del listado inteligente. Las reglas de estado (hoja, contenedor, prioridad, color)
+viven en `estado_dominio`; aquí solo está lo propio de esta vista:
+  - el agrupamiento de fases en pistas (PISTAS),
+  - el contador de elementos en el estado ganador (count) y la nota (tooltip),
+  - el relabel de la pista SOL: la espera de plazo se muestra como subsanación,
+  - fin_total para el color de la celda SOLICITUD.
 
-La completitud se deduce de documentos (Documento.fecha_administrativa),
-no de campos fecha_inicio/fecha_fin (eliminados del modelo ESFTT).
+Salida: {pista → EstadoPista(codigo, color, count, nota)}; None para pistas N/A.
+
+La completitud se deduce de documentos (Documento.fecha_administrativa), no de campos
+fecha_inicio/fecha_fin (eliminados del modelo ESFTT).
 
 Uso:
     from app.services.seguimiento import estado_solicitud, fin_total
-
-    estados = estado_solicitud(solicitud_id)
-    # → {'SOL': EstadoPista(codigo='PENDIENTE_ESTUDIO', color='rojo', count=1), ...}
-    # → None para pistas N/A (sin fases de ese tipo en la solicitud)
-
-    es_fin = fin_total(estados)
-    # → True si todas las pistas con fases están en FIN
+    estados = estado_solicitud(solicitud_id)   # → {'SOL': EstadoPista(...), 'CONSULTAS': None, ...}
+    es_fin = fin_total(estados)                 # → True si todas las pistas con fases están en FIN
 """
 from __future__ import annotations
 
@@ -28,16 +29,16 @@ import logging
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.models.solicitudes import Solicitud
+import app.services.estado_dominio as ed
 
 log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Constantes
+# Constantes de la proyección
 # ---------------------------------------------------------------------------
 
-# Pistas y los tipos_fases que las componen.
-# Orden de aparición en el listado.
+# Pistas y los tipos_fases que las componen. Orden de aparición en el listado.
 PISTAS: dict[str, list[str]] = {
     'SOL':      ['ANALISIS_SOLICITUD'],
     'CONSULTAS': ['CONSULTAS', 'CONSULTA_MINISTERIO'],
@@ -51,36 +52,6 @@ PISTAS: dict[str, list[str]] = {
 # El resto de pistas devuelven None (N/A) cuando no tienen fases.
 PISTAS_OBLIGATORIAS = {'SOL'}
 
-# Color canónico de cada estado (§4.1)
-COLOR: dict[str, str] = {
-    'PENDIENTE_TRAMITAR':               'rojo',
-    'PENDIENTE_ESTUDIO':                'rojo',
-    'NOTIFICACION_AGOTADA':             'rojo',
-    'PENDIENTE_ELABORAR':               'amarillo',
-    'NOTIFICACION_FALLIDA':             'naranja',
-    'PENDIENTE_CERRAR':                 'naranja',
-    'PENDIENTE_NOTIFICAR':              'azul',
-    'PENDIENTE_RESULTADO_NOTIFICACION': 'azul',
-    'PENDIENTE_SUBSANAR':               'gris',
-    'PENDIENTE_PLAZOS':                 'gris',
-    'FIN':                              'verde',
-}
-
-# Prioridad numérica por §4.2 (1 = más urgente, 10 = menos urgente)
-PRIORIDAD: dict[str, int] = {
-    'PENDIENTE_TRAMITAR':               1,
-    'PENDIENTE_ESTUDIO':                2,
-    'NOTIFICACION_AGOTADA':             3,
-    'PENDIENTE_ELABORAR':               3,
-    'NOTIFICACION_FALLIDA':             4,
-    'PENDIENTE_CERRAR':                 4,
-    'PENDIENTE_NOTIFICAR':              5,
-    'PENDIENTE_RESULTADO_NOTIFICACION': 5,
-    'PENDIENTE_SUBSANAR':               6,
-    'PENDIENTE_PLAZOS':                 7,
-    'FIN':                              8,
-}
-
 
 # ---------------------------------------------------------------------------
 # Resultado público
@@ -88,8 +59,8 @@ PRIORIDAD: dict[str, int] = {
 
 @dataclass
 class EstadoPista:
-    """Estado deducido para una pista de una solicitud."""
-    codigo: str    # p.ej. 'PENDIENTE_ESTUDIO'
+    """Estado proyectado para una pista de una solicitud."""
+    codigo: str    # p.ej. 'PENDIENTE_ESTUDIO' (o 'PENDIENTE_SUBSANAR' en la pista SOL)
     color: str     # p.ej. 'rojo'
     count: int = 1 # elementos en el estado de mayor prioridad (para contador visible)
     nota: Optional[str] = None  # notas de la tarea activa (para tooltip en seguimiento)
@@ -106,7 +77,7 @@ def estado_solicitud(solicitud_id: int) -> dict[str, Optional[EstadoPista]]:
     Returns:
         Dict con claves SOL, CONSULTAS, MA, IP, RES.
         None  → pista N/A (sin fases de ese tipo).
-        EstadoPista → estado más urgente, con contador acumulado desde los niveles inferiores.
+        EstadoPista → estado más urgente del núcleo, con contador acumulado.
         PENDIENTE_TRAMITAR en todas las pistas obligatorias si la BD no está disponible.
     """
     try:
@@ -125,28 +96,26 @@ def estado_solicitud(solicitud_id: int) -> dict[str, Optional[EstadoPista]]:
             fases = [f for f in sol.fases if f.tipo_fase.codigo in tipos_fases]
         except (AttributeError, OperationalError, ProgrammingError) as exc:
             log.warning('seguimiento: error accediendo a fases de pista %s — %s', pista, exc)
-            if pista in PISTAS_OBLIGATORIAS:
-                result[pista] = EstadoPista('PENDIENTE_TRAMITAR', 'rojo')
-            else:
-                result[pista] = None
+            result[pista] = _na_o_tramitar(pista)
             continue
 
         if not fases:
-            if pista in PISTAS_OBLIGATORIAS:
-                result[pista] = EstadoPista('PENDIENTE_TRAMITAR', 'rojo')
-            else:
-                result[pista] = None
+            result[pista] = _na_o_tramitar(pista)
             continue
 
         if all(f.finalizada for f in fases):
-            result[pista] = EstadoPista('FIN', 'verde', count=1)
+            result[pista] = EstadoPista('FIN', ed.color('FIN'), count=1)
             continue
 
         fases_abiertas = [f for f in fases if not f.finalizada]
-        acc = _acumular([_estado_fase(f, pista) for f in fases_abiertas])
+        acc: dict[str, int] = {}
+        for f in fases_abiertas:
+            _acumular(acc, _acc_fase(f))
+
         ganador, count = _mayor_prioridad(acc)
+        codigo = _relabel(pista, ganador)
         nota = _nota_activa(fases_abiertas)
-        result[pista] = EstadoPista(ganador, COLOR[ganador], count, nota)
+        result[pista] = EstadoPista(codigo, ed.color(ganador), count, nota)
 
     return result
 
@@ -161,114 +130,63 @@ def fin_total(estados: dict[str, Optional[EstadoPista]]) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Algoritmo §5 — deducción jerárquica
+# Walk de acumulación — cuenta elementos por estado, con las reglas del núcleo
 # ---------------------------------------------------------------------------
 
-def _estado_fase(fase, pista: str) -> tuple[str, int]:
-    """Estado de una fase no finalizada (documento_resultado_id IS NULL)."""
-    if fase.planificada:  # sin trámites aún
-        return ('PENDIENTE_TRAMITAR', 1)
-
-    tramites = sorted(fase.tramites, key=lambda t: t.id)
-    tramites_activos = [t for t in tramites if not t.finalizado]
-
-    if not tramites_activos:
-        # Todos los trámites completados — esperando que el técnico formalice el resultado de fase
-        if fase.resultado_fase_id is None:
-            return ('PENDIENTE_ESTUDIO', 1)
-        return ('PENDIENTE_CERRAR', 1)
-
-    acc = _acumular([_estado_tramite(t, pista) for t in tramites_activos])
-    return _mayor_prioridad(acc)
-
-
-def _estado_tramite(tramite, pista: str) -> tuple[str, int]:
-    """Estado de un trámite no finalizado."""
-    if tramite.planificado:  # sin tareas aún
-        return ('PENDIENTE_TRAMITAR', 1)
-
-    tareas = list(tramite.tareas)
-    tareas_sin_ejecutar = [t for t in tareas if not t.ejecutada]
-
-    if not tareas_sin_ejecutar:
-        # Todas ejecutadas — verificar notificaciones pendientes o fallidas (#418)
-        estado_notif = _estado_notificaciones_tramite(tareas)
-        if estado_notif:
-            return (estado_notif, 1)
-        return ('PENDIENTE_CERRAR', 1)  # fallback: no debería alcanzarse
-
-    acc = _acumular([_estado_tarea(t, pista) for t in tareas_sin_ejecutar])
-    return _mayor_prioridad(acc)
-
-
-def _estado_notificaciones_tramite(tareas) -> Optional[str]:
-    """Detecta tareas NOTIFICAR ejecutadas sin resultado registrado o con resultado fallido."""
-    for t in tareas:
-        if not (t.tipo_tarea and t.tipo_tarea.codigo == 'NOTIFICAR' and t.ejecutada):
+def _acc_fase(fase) -> dict[str, int]:
+    """{estado: count} de una fase no finalizada, según el núcleo."""
+    if fase.planificada:                       # sin trámites aún
+        return {'PENDIENTE_TRAMITAR': 1}
+    if fase.pdte_cierre:                        # cierre: ESTUDIO (finalizadora) o CERRAR
+        estado, _ = ed.estado_fase(fase, [])
+        return {estado: 1}
+    acc: dict[str, int] = {}
+    for tr in fase.tramites:
+        if tr.finalizado:
             continue
-        doc = t.documento_producido
-        notif = getattr(doc, 'notificacion', None) if doc else None
-        if notif is None:
-            return 'PENDIENTE_RESULTADO_NOTIFICACION'
-        if notif.resultado == 'INCORRECTA':
-            return 'NOTIFICACION_AGOTADA' if notif.numero_intento == 2 else 'NOTIFICACION_FALLIDA'
-    return None
+        _acumular(acc, _acc_tramite(tr))
+    return acc
 
 
-def _estado_tarea(tarea, pista: str) -> tuple[str, int]:
-    """Estado de una tarea no ejecutada. §4.4"""
-    if tarea.planificada:  # sin documentos asignados aún
-        return ('PENDIENTE_TRAMITAR', 1)
+def _acc_tramite(tramite) -> dict[str, int]:
+    """{estado: count} de un trámite no finalizado, según el núcleo."""
+    if tramite.planificado:                    # sin tareas aún
+        return {'PENDIENTE_TRAMITAR': 1}
+    acc: dict[str, int] = {}
+    for ta in tramite.tareas:
+        estado = _estado_tarea(ta)
+        acc[estado] = acc.get(estado, 0) + 1
+    return acc
 
+
+def _estado_tarea(tarea) -> str:
+    """Estado de dominio de una tarea (hoja); resuelve el plazo si es ESPERAR_PLAZO."""
     tipo_rel = getattr(tarea, 'tipo_tarea', None)
-    if tipo_rel is None:
-        log.warning('seguimiento: tarea %s sin tipo_tarea — tratando como PENDIENTE_TRAMITAR', getattr(tarea, 'id', '?'))
-        return ('PENDIENTE_TRAMITAR', 1)
-    tipo = tipo_rel.codigo
-
-    if tipo == 'ANALIZAR':
-        if not tarea.documentos_consumidos:
-            return ('PENDIENTE_TRAMITAR', 1)
-        return ('PENDIENTE_ESTUDIO', 1)    # doc recibido, hay que analizar y redactar informe
-
-    if tipo == 'ELABORAR':
-        return ('PENDIENTE_ELABORAR', 1)
-
-    if tipo == 'NOTIFICAR':
-        if not tarea.documentos_consumidos:
-            return ('PENDIENTE_TRAMITAR', 1)   # falta doc firmado
-        return ('PENDIENTE_NOTIFICAR', 1)      # doc firmado, falta justificante
-
-    if tipo == 'ESPERAR_PLAZO':
-        return (_estado_esperar_plazo(tarea, pista), 1)
-
-    return ('PENDIENTE_TRAMITAR', 1)  # tipo desconocido — seguro por defecto
+    tipo = tipo_rel.codigo if tipo_rel else None
+    plazo = _plazo_tarea(tarea) if tipo == 'ESPERAR_PLAZO' else None
+    return ed.estado_tarea(tarea, plazo=plazo)
 
 
-def _estado_esperar_plazo(tarea, pista: str) -> str:
+def _plazo_tarea(tarea) -> Optional[dict]:
+    """Resuelve el estado de plazo (server-only) de una tarea ESPERAR_PLAZO.
+
+    Defensivo: cualquier fallo degrada a None (el núcleo lo mapea a TRAMITAR) sin
+    tumbar la fila completa.
     """
-    ESPERAR_PLAZO: §4.4 — consulta catalogo_plazos en lugar de parsear Tarea.notas.
-    Sin entrada configurada → PENDIENTE_TRAMITAR (tarea sin configurar).
-    Con entrada pero sin documento consumido aún → estado_espera (esperando inicio de cómputo).
-    Plazo vencido → PENDIENTE_ESTUDIO.
-    """
-    from app.services.plazos import obtener_estado_plazo, tiene_plazo_configurado
-
-    variables = _variables_esperar_plazo(tarea)
-
-    if not tiene_plazo_configurado('TAREA', 'ESPERAR_PLAZO', variables):
-        return 'PENDIENTE_TRAMITAR'
-
-    estado_espera = 'PENDIENTE_SUBSANAR' if pista == 'SOL' else 'PENDIENTE_PLAZOS'
-
-    ep = obtener_estado_plazo(tarea, 'TAREA', variables=variables)
-
-    if ep.estado == 'VENCIDO':
-        return 'PENDIENTE_ESTUDIO'
-    return estado_espera   # SIN_PLAZO (sin doc), EN_PLAZO, PROXIMO_VENCER
+    from app.services.plazos import obtener_estado_plazo
+    try:
+        ep = obtener_estado_plazo(tarea, 'TAREA', variables=_variables_esperar_plazo(tarea))
+        return {'estado': ep.estado}
+    except Exception as exc:  # noqa: BLE001 — un plazo no debe tumbar la fila entera
+        log.warning('seguimiento: plazo no disponible para tarea %s — %s', getattr(tarea, 'id', '?'), exc)
+        return None
 
 
 def _variables_esperar_plazo(tarea) -> dict:
+    """Variables del motor para resolver el plazo (tipo_tramite).
+
+    Público: lo reutiliza también services/certificados.py.
+    """
     try:
         tt = tarea.tramite.tipo_tramite
         return {'tipo_tramite': tt.codigo} if tt else {}
@@ -278,13 +196,38 @@ def _variables_esperar_plazo(tarea) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Helpers internos
+# Helpers de proyección
 # ---------------------------------------------------------------------------
+
+def _relabel(pista: str, estado: str) -> str:
+    """En la pista SOL la espera de plazo se muestra como subsanación (mismo gris)."""
+    if pista == 'SOL' and estado == 'PENDIENTE_PLAZOS':
+        return 'PENDIENTE_SUBSANAR'
+    return estado
+
+
+def _na_o_tramitar(pista: str) -> Optional[EstadoPista]:
+    """Pista sin fases: TRAMITAR si es obligatoria, None (N/A) si no."""
+    if pista in PISTAS_OBLIGATORIAS:
+        return EstadoPista('PENDIENTE_TRAMITAR', 'rojo')
+    return None
+
+
+def _mayor_prioridad(acc: dict[str, int]) -> tuple[str, int]:
+    """(estado_ganador, count) del estado de menor número de prioridad (núcleo)."""
+    ganador = min(acc, key=lambda e: ed.PRIORIDAD.get(e, 99))
+    return ganador, acc[ganador]
+
+
+def _acumular(acc: dict[str, int], otro: dict[str, int]) -> None:
+    """Suma counts por estado de `otro` dentro de `acc` (in-place)."""
+    for estado, n in otro.items():
+        acc[estado] = acc.get(estado, 0) + n
 
 
 def _nota_activa(fases_abiertas) -> Optional[str]:
     """
-    Devuelve las notas de la primera tarea no ejecutada encontrada en las fases abiertas.
+    Devuelve las notas de la primera tarea no ejecutada de las fases abiertas.
     Se usa para poblar el tooltip en el listado de seguimiento.
     """
     for fase in fases_abiertas:
@@ -295,17 +238,3 @@ def _nota_activa(fases_abiertas) -> Optional[str]:
                 if not tarea.ejecutada and tarea.notas:
                     return tarea.notas
     return None
-
-
-def _acumular(resultados: list[tuple[str, int]]) -> dict[str, int]:
-    """Suma counts por estado interno a través de los niveles del árbol."""
-    acc: dict[str, int] = {}
-    for estado, n in resultados:
-        acc[estado] = acc.get(estado, 0) + n
-    return acc
-
-
-def _mayor_prioridad(acumulado: dict[str, int]) -> tuple[str, int]:
-    """(estado_ganador, count) del estado de menor número en §4.2 (más urgente)."""
-    ganador = min(acumulado, key=lambda e: PRIORIDAD[e])
-    return ganador, acumulado[ganador]

--- a/docs/diseño/INVENTARIO_BACKEND.md
+++ b/docs/diseño/INVENTARIO_BACKEND.md
@@ -132,10 +132,11 @@ La cascada de la deducción:
 
 Existe además un **expediente.heredado** booleano que marca expedientes legacy con datos incompletos (decoupling del motor).
 
-### 2.2 Estado para listado de seguimiento (`services/seguimiento.py`)
+### 2.2 Estado por pista del listado de seguimiento (`services/seguimiento.py`)
 
-Calcula por solicitud el estado por **pista** (SOL, CONSULTAS, MA, IP, RES). Cada pista devuelve un `EstadoPista(codigo, color, count, nota)`. 11 estados posibles ordenados por prioridad:
-`PENDIENTE_TRAMITAR` (rojo) > `PENDIENTE_ESTUDIO` > `NOTIFICACION_AGOTADA` > `PENDIENTE_ELABORAR` (amarillo) > `NOTIFICACION_FALLIDA` (naranja) > `PENDIENTE_CERRAR` > `PENDIENTE_NOTIFICAR` (azul) > `PENDIENTE_RESULTADO_NOTIFICACION` > `PENDIENTE_SUBSANAR` (gris) > `PENDIENTE_PLAZOS` > `FIN` (verde).
+Proyección por **pista** (SOL, CONSULTAS, MA, IP, RES) del núcleo `services/estado_dominio.py` (#558). Cada pista devuelve un `EstadoPista(codigo, color, count, nota)`. Vocabulario y prioridad canónicos (1 = más urgente, coherente con el color):
+`PENDIENTE_TRAMITAR` (🔴) > `PENDIENTE_ESTUDIO` (🔴) > `PENDIENTE_REDACTAR` (🔴) > `NOTIFICACION_AGOTADA` (🔴) > `PENDIENTE_CERRAR` (🟠) > `NOTIFICACION_FALLIDA` (🟠) > `PENDIENTE_FIRMA` (🟡) > `PENDIENTE_NOTIFICAR` (🔵) > `PENDIENTE_PLAZOS` (⚪) > `FIN` (🟢).
+La familia de notificar comparte la etiqueta "NOTIFICAR" (lo que escala es el color). `PENDIENTE_SUBSANAR` es el relabel de `PENDIENTE_PLAZOS` en la pista SOL.
 
 Insumo directo para reemplazar la hoja Calc "pendiente de *".
 

--- a/docs/referencia/MODELO_ESTADOS_SEMAFORO.md
+++ b/docs/referencia/MODELO_ESTADOS_SEMAFORO.md
@@ -2,7 +2,8 @@
 
 **Estado:** Vigente
 **Fecha:** 2026-05-30
-**Relacionado:** #500 (vista de árbol), ADR-016, `app/services/seguimiento.py`,
+**Relacionado:** #500 (vista de árbol), #558 (núcleo unificado), ADR-016,
+`app/services/estado_dominio.py` (núcleo), `app/services/seguimiento.py`,
 mockup `docs/mockups/Mockup_Nodo_Arbol.html`.
 **Supera:** §4.1–§4.4 de `docs/historial/ANALISIS_LISTADO_INTELIGENTE.md` (histórico; allí
 `PUBLICAR`, `REDACTAR`/`FIRMAR` como tareas e `INCORPORAR` ya no existen).
@@ -34,12 +35,14 @@ mockup `docs/mockups/Mockup_Nodo_Arbol.html`.
 
 ## 2. Semántica de colores
 
+Ordenados por urgencia; la prioridad de §5 es coherente con esta escala (#558).
+
 | Color | Significado |
 |---|---|
-| 🔴 Rojo | Acción pendiente del tramitador |
-| 🟡 Amarillo | En espera de algo interno que no depende del tramitador (firma) |
-| 🔵 Azul | En espera de un externo ajeno a la administración (destinatario, boletín) |
-| 🟠 Naranja | Listo para cerrar / reintento disponible |
+| 🔴 Rojo | Acción del tramitador (incl. notificación agotada → procede boletín) |
+| 🟠 Naranja | Gestión nuestra: cerrar fase / 2.º intento de notificación |
+| 🟡 Amarillo | Espera interna que no depende del tramitador (firma); paraliza si falta |
+| 🔵 Azul | Espera de un externo ajeno a la administración (destinatario, boletín) |
 | ⚪ Gris | Espera pasiva (plazo legal, respuesta de administrado u organismo) |
 | 🟢 Verde | Finalizado |
 
@@ -98,8 +101,9 @@ con la **barra de progreso** (§9).
 | Nodo | Situación | Estado | Color |
 |---|---|---|---|
 | Cualquiera | sin hijos (planificado) | PENDIENTE_TRAMITAR | 🔴 |
-| Fase | `PDTE_CIERRE` sin `resultado_fase` | PENDIENTE_ESTUDIO | 🔴 |
-| Fase | `PDTE_CIERRE` con resultado, falta formalizar | PENDIENTE_CERRAR | 🟠 |
+| Fase finalizadora | `PDTE_CIERRE` sin `resultado_fase` (falta decidir) | PENDIENTE_ESTUDIO | 🔴 |
+| Fase finalizadora | `PDTE_CIERRE` con resultado, falta formalizar | PENDIENTE_CERRAR | 🟠 |
+| Fase intermedia | `PDTE_CIERRE` (cierra por certificado; `resultado_fase` NULL) | PENDIENTE_CERRAR | 🟠 |
 | Solicitud | todas las pistas en FIN pero aún EN_TRAMITE | PENDIENTE_CERRAR | 🟠 |
 | Cualquiera | en curso con hijos | **mayor prioridad** del subárbol (§5) |
 | Cualquiera | finalizado | FIN | 🟢 |
@@ -108,23 +112,27 @@ con la **barra de progreso** (§9).
 
 ## 5. Agregación de abajo arriba (colapso) y prioridad
 
-Mismo algoritmo que `seguimiento.py`: se recorre de abajo arriba y prevalece el estado de
-**mayor prioridad**; el contador acumula a través de niveles.
+El núcleo `estado_dominio` (#558) es la única fuente, compartida por la vista de árbol y
+por `seguimiento.py`: se recorre de abajo arriba y prevalece el estado de **mayor
+prioridad**; cada proyección acumula su propio contador.
 
-**Prioridad** (1 = más urgente; alineada con `seguimiento.PRIORIDAD`, refinable):
+**Prioridad canónica** (1 = más urgente; orden total, coherente con el color):
 
 | # | Estado | Color |
 |---|---|---|
 | 1 | PENDIENTE_TRAMITAR | 🔴 |
 | 2 | PENDIENTE_ESTUDIO | 🔴 |
 | 3 | PENDIENTE_REDACTAR | 🔴 |
-| 3 | NOTIFICACION_AGOTADA | 🔴 |
-| 4 | PENDIENTE_FIRMA | 🟡 |
-| 5 | PENDIENTE_NOTIFICAR | 🔵 |
+| 4 | NOTIFICACION_AGOTADA | 🔴 |
+| 5 | PENDIENTE_CERRAR | 🟠 |
 | 6 | NOTIFICACION_FALLIDA | 🟠 |
-| 6 | PENDIENTE_CERRAR | 🟠 |
-| 7 | PENDIENTE_SUBSANAR / PENDIENTE_PLAZOS | ⚪ |
-| 8 | FIN | 🟢 |
+| 7 | PENDIENTE_FIRMA | 🟡 |
+| 8 | PENDIENTE_NOTIFICAR | 🔵 |
+| 9 | PENDIENTE_PLAZOS | ⚪ |
+| 10 | FIN | 🟢 |
+
+`PENDIENTE_SUBSANAR` no es del núcleo: es el relabel de `PENDIENTE_PLAZOS` en la pista SOL
+del seguimiento (mismo gris).
 
 ---
 
@@ -220,15 +228,15 @@ inicio/fin), en el **footer** (raya superior), simple y sin adornos.
   `estado` de dominio). `services/arbol_expediente.py` deberá computarlo por nodo —mirando
   **tipos** de documento consumidos (ELABORAR → `BORRADOR_FIRMA`) y filas **`Notificacion`**
   (resultado + `numero_intento`)— y propagar la mayor prioridad a los no-hoja, **reutilizando
-  `seguimiento.py`** (vía servicio nuevo `estado_semaforo.py`, sin tocar la lógica de pistas).
+  `seguimiento.py`** (hecho en #558 vía el núcleo `estado_dominio.py`).
 - **Plazo (barra):** la v1 semántica usa el `estado` de plazo ya disponible. La proporcional
   (diferida) exigirá el progreso en días hábiles + plazo de **solicitud** y de **lectura de
   notificación** por intento.
 - **Documentos:** sin cambios de backend.
 
-**Deuda a alinear:** `seguimiento.py` tiene hoy `PENDIENTE_ELABORAR` (🟡 único); este modelo lo
-desdobla en `PENDIENTE_REDACTAR` (🔴) + `PENDIENTE_FIRMA` (🟡). Unificar ambos consumidores
-contra este documento al implementar el círculo.
+**Deuda resuelta (#558):** unificada en el núcleo `estado_dominio`. `seguimiento.py` y la
+vista de árbol son ahora proyecciones sobre la misma fuente; `PENDIENTE_ELABORAR` (🟡 único)
+queda desdoblado en `PENDIENTE_REDACTAR` (🔴) + `PENDIENTE_FIRMA` (🟡).
 
 ---
 
@@ -238,4 +246,4 @@ contra este documento al implementar el círculo.
 - Scheduler + Playwright que envíe a firma las tareas en estado FIRMA.
 - Barra de plazo **proporcional** (progreso en días hábiles), plazo de **solicitud** y de
   **lectura de notificación** por intento.
-- Refinar la prioridad numérica fina al unificar con `seguimiento.PRIORIDAD`.
+- ~~Refinar la prioridad numérica fina al unificar con `seguimiento.PRIORIDAD`.~~ Hecho en #558 (§5).

--- a/tests/test_350_seguimiento_esperar_plazo.py
+++ b/tests/test_350_seguimiento_esperar_plazo.py
@@ -1,17 +1,22 @@
-"""Tests issue #350 — _estado_esperar_plazo consulta catalogo_plazos.
+"""Tests issue #350 (revalidado en #558) — estado de tareas ESPERAR_PLAZO en seguimiento.
+
+Tras #558 la regla de hoja vive en el núcleo (estado_dominio) y la proyección de
+seguimiento (a) resuelve el plazo real vía services.plazos y (b) relabela la pista SOL
+(la espera de plazo se muestra como subsanación). Aquí se prueba esa integración con el
+cómputo de plazo real (catálogo seed de #350 + fechas hábiles).
 
 Requieren:
-  - BD con migraciones 350 aplicadas:
-      350_variable_tipo_tramite  (tipo_tramite en catalogo_variables)
-      350_seed_catalogo_plazos   (6 entradas ESPERAR_PLAZO en catalogo_plazos)
+  - BD con migraciones 350 aplicadas (350_variable_tipo_tramite, 350_seed_catalogo_plazos).
   - Fixture app_ctx (rollback automático por test).
 
 Escenarios:
-  A) tipo_tramite sin entrada en catálogo → PENDIENTE_TRAMITAR
-  B) tipo_tramite configurado, plazo activo, pista no SOL → PENDIENTE_PLAZOS
+  A) tipo_tramite sin entrada en catálogo → SIN_PLAZO → PENDIENTE_TRAMITAR
+  B) tipo_tramite configurado, plazo activo → PENDIENTE_PLAZOS
   C) tipo_tramite configurado, plazo vencido → PENDIENTE_ESTUDIO
-  D) tipo_tramite configurado, sin documento (inicio cómputo no disponible) → PENDIENTE_PLAZOS
-  E) tipo_tramite configurado, plazo activo, pista SOL → PENDIENTE_SUBSANAR
+  D) tipo_tramite configurado, sin documento de inicio de cómputo → SIN_PLAZO →
+     PENDIENTE_TRAMITAR  (cambio de #558: el núcleo unifica "sin cómputo" con el árbol;
+     antes seguimiento lo trataba como espera/PLAZOS).
+  E) plazo activo en la pista SOL → el relabel lo muestra como PENDIENTE_SUBSANAR.
 
 Fechas de referencia (REQUERIMIENTO_SUBSANACION, 10 días hábiles, sin festivos):
   doc_fecha      = 2026-01-05 (lun)
@@ -29,14 +34,16 @@ HOY_VENCIDO  = date(2026, 1, 20)
 
 
 def _mock_tarea(tipo_tramite_codigo, doc_fecha=None):
-    """Mock mínimo de Tarea para _estado_esperar_plazo.
+    """Mock mínimo de Tarea ESPERAR_PLAZO no ejecutada para la regla de hoja.
 
-    - tipo_tarea.codigo = 'ESPERAR_PLAZO'  (requerido por _get_tipo_elemento_codigo)
-    - tramite.tipo_tramite.codigo          (requerido por _variables_esperar_plazo)
-    - documentos_consumidos[0].fecha_administrativa (requerido por
-      _resolver_campo_fecha con campo_fecha {'rol': 'CONSUMIDO'} — ADR-010)
+    - ejecutada/planificada = False → el núcleo llega a la rama de plazo.
+    - tipo_tarea.codigo = 'ESPERAR_PLAZO'
+    - tramite.tipo_tramite.codigo  (para _variables_esperar_plazo)
+    - documentos_consumidos[0].fecha_administrativa  (inicio de cómputo, ADR-010)
     """
     tarea = MagicMock()
+    tarea.ejecutada = False
+    tarea.planificada = False
     tarea.tipo_tarea = MagicMock(codigo='ESPERAR_PLAZO')
     tarea.tramite = MagicMock()
     tarea.tramite.tipo_tramite = MagicMock(codigo=tipo_tramite_codigo)
@@ -49,42 +56,29 @@ def _mock_tarea(tipo_tramite_codigo, doc_fecha=None):
     return tarea
 
 
+def _estado(tarea):
+    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
+         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
+        from app.services.seguimiento import _estado_tarea
+        return _estado_tarea(tarea)
+
+
 # ---------------------------------------------------------------------------
-# A) Sin entrada en catálogo → PENDIENTE_TRAMITAR
+# A) Sin entrada en catálogo → SIN_PLAZO → PENDIENTE_TRAMITAR
 # ---------------------------------------------------------------------------
 
 def test_sin_entrada_catalogo_devuelve_pendiente_tramitar(app_ctx):
-    """SOLICITUD_COMPATIBILIDAD no tiene plazo configurado en el seed de #350.
-    Debe devolver PENDIENTE_TRAMITAR independientemente de fechas.
-    """
-    from app.services.seguimiento import _estado_esperar_plazo
-
     tarea = _mock_tarea('SOLICITUD_COMPATIBILIDAD', doc_fecha=DOC_FECHA)
-
-    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
-         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
-        resultado = _estado_esperar_plazo(tarea, 'MA')
-
-    assert resultado == 'PENDIENTE_TRAMITAR'
+    assert _estado(tarea) == 'PENDIENTE_TRAMITAR'
 
 
 # ---------------------------------------------------------------------------
-# B) Plazo activo, pista no SOL → PENDIENTE_PLAZOS
+# B) Plazo activo → PENDIENTE_PLAZOS
 # ---------------------------------------------------------------------------
 
-def test_plazo_activo_pista_ma_devuelve_pendiente_plazos(app_ctx):
-    """REQUERIMIENTO_SUBSANACION con 6 días hábiles restantes.
-    Pista 'MA' (no SOL) → PENDIENTE_PLAZOS.
-    """
-    from app.services.seguimiento import _estado_esperar_plazo
-
+def test_plazo_activo_devuelve_pendiente_plazos(app_ctx):
     tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
-
-    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
-         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
-        resultado = _estado_esperar_plazo(tarea, 'MA')
-
-    assert resultado == 'PENDIENTE_PLAZOS'
+    assert _estado(tarea) == 'PENDIENTE_PLAZOS'
 
 
 # ---------------------------------------------------------------------------
@@ -92,53 +86,36 @@ def test_plazo_activo_pista_ma_devuelve_pendiente_plazos(app_ctx):
 # ---------------------------------------------------------------------------
 
 def test_plazo_vencido_devuelve_pendiente_estudio(app_ctx):
-    """REQUERIMIENTO_SUBSANACION con plazo vencido (hoy > fecha_limite).
-    El técnico debe actuar → PENDIENTE_ESTUDIO.
-    """
-    from app.services.seguimiento import _estado_esperar_plazo
-
     tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
-
     with patch('app.services.plazos._hoy', return_value=HOY_VENCIDO), \
          patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
-        resultado = _estado_esperar_plazo(tarea, 'MA')
-
+        from app.services.seguimiento import _estado_tarea
+        resultado = _estado_tarea(tarea)
     assert resultado == 'PENDIENTE_ESTUDIO'
 
 
 # ---------------------------------------------------------------------------
-# D) Sin documento de inicio de cómputo → estado_espera (SIN_PLAZO)
+# D) Sin documento de inicio de cómputo → SIN_PLAZO → PENDIENTE_TRAMITAR (#558)
 # ---------------------------------------------------------------------------
 
-def test_sin_documento_devuelve_pendiente_plazos(app_ctx):
-    """REQUERIMIENTO_SUBSANACION con entrada en catálogo pero sin documento_usado.
-    obtener_estado_plazo devuelve SIN_PLAZO → estado_espera → PENDIENTE_PLAZOS.
-    """
-    from app.services.seguimiento import _estado_esperar_plazo
-
+def test_sin_documento_devuelve_pendiente_tramitar(app_ctx):
+    """Configurado en catálogo pero sin documento que inicie el cómputo: el núcleo lo
+    mapea a PENDIENTE_TRAMITAR (unificado con el árbol), no a una espera de plazo."""
     tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=None)
-
-    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
-         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
-        resultado = _estado_esperar_plazo(tarea, 'MA')
-
-    assert resultado == 'PENDIENTE_PLAZOS'
+    assert _estado(tarea) == 'PENDIENTE_TRAMITAR'
 
 
 # ---------------------------------------------------------------------------
-# E) Plazo activo, pista SOL → PENDIENTE_SUBSANAR
+# E) Pista SOL → el relabel muestra la espera de plazo como subsanación
 # ---------------------------------------------------------------------------
 
-def test_plazo_activo_pista_sol_devuelve_pendiente_subsanar(app_ctx):
-    """REQUERIMIENTO_SUBSANACION en pista SOL (solicitud del interesado).
-    Plazo activo → PENDIENTE_SUBSANAR en lugar de PENDIENTE_PLAZOS.
-    """
-    from app.services.seguimiento import _estado_esperar_plazo
+def test_relabel_sol_muestra_subsanar(app_ctx):
+    from app.services.seguimiento import _relabel
 
     tarea = _mock_tarea('REQUERIMIENTO_SUBSANACION', doc_fecha=DOC_FECHA)
+    estado = _estado(tarea)
+    assert estado == 'PENDIENTE_PLAZOS'
 
-    with patch('app.services.plazos._hoy', return_value=HOY_EN_PLAZO), \
-         patch('app.services.plazos._obtener_inhabiles_bd', return_value=frozenset()):
-        resultado = _estado_esperar_plazo(tarea, 'SOL')
-
-    assert resultado == 'PENDIENTE_SUBSANAR'
+    # En SOL se relabela; en el resto de pistas se mantiene PLAZOS.
+    assert _relabel('SOL', estado) == 'PENDIENTE_SUBSANAR'
+    assert _relabel('MA', estado) == 'PENDIENTE_PLAZOS'

--- a/tests/test_558_estado_dominio.py
+++ b/tests/test_558_estado_dominio.py
@@ -1,0 +1,221 @@
+"""
+test_558_estado_dominio.py — Núcleo único de reglas de estado (#558).
+
+Tests unitarios puros: el núcleo es duck-typed (solo lee atributos), así que se
+prueba con dobles ligeros sin tocar la BD. Cubre:
+  - la regla de hoja estado_tarea para los 4 tipos y sus subestados,
+  - las reglas de contenedor (incluido el cierre de fase es_finalizadora-aware),
+  - el orden de prioridad canónico y su coherencia con el color.
+"""
+from types import SimpleNamespace
+
+import app.services.estado_dominio as ed
+
+
+# ---------------------------------------------------------------------------
+# Dobles ligeros
+# ---------------------------------------------------------------------------
+
+def _doc(tipo_codigo=None, notif=None):
+    tipo_doc = SimpleNamespace(codigo=tipo_codigo) if tipo_codigo else None
+    return SimpleNamespace(tipo_doc=tipo_doc, notificacion=notif)
+
+
+def _notif(resultado, numero_intento=1):
+    return SimpleNamespace(resultado=resultado, numero_intento=numero_intento)
+
+
+def _tarea(codigo, *, consumidos=(), producido=None):
+    cons = list(consumidos)
+    return SimpleNamespace(
+        tipo_tarea=SimpleNamespace(codigo=codigo),
+        documentos_consumidos=cons,
+        documento_producido=producido,
+        ejecutada=producido is not None,
+        planificada=(not cons and producido is None),
+    )
+
+
+def _fase(*, planificada=False, pdte_cierre=False, finalizadora=False, resultado_fase_id=None):
+    return SimpleNamespace(
+        planificada=planificada,
+        pdte_cierre=pdte_cierre,
+        tipo_fase=SimpleNamespace(es_finalizadora=finalizadora),
+        resultado_fase_id=resultado_fase_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hoja — ANALIZAR
+# ---------------------------------------------------------------------------
+
+def test_analizar_planificada_tramitar():
+    assert ed.estado_tarea(_tarea('ANALIZAR')) == 'PENDIENTE_TRAMITAR'
+
+def test_analizar_consumido_estudio():
+    assert ed.estado_tarea(_tarea('ANALIZAR', consumidos=[_doc()])) == 'PENDIENTE_ESTUDIO'
+
+def test_analizar_producido_fin():
+    assert ed.estado_tarea(_tarea('ANALIZAR', consumidos=[_doc()], producido=_doc())) == 'FIN'
+
+
+# ---------------------------------------------------------------------------
+# Hoja — ELABORAR (REDACTAR / FIRMA)
+# ---------------------------------------------------------------------------
+
+def test_elaborar_sin_consumido_tramitar():
+    assert ed.estado_tarea(_tarea('ELABORAR')) == 'PENDIENTE_TRAMITAR'
+
+def test_elaborar_sin_borrador_redactar():
+    assert ed.estado_tarea(_tarea('ELABORAR', consumidos=[_doc()])) == 'PENDIENTE_REDACTAR'
+
+def test_elaborar_con_borrador_firma():
+    t = _tarea('ELABORAR', consumidos=[_doc(), _doc(tipo_codigo='BORRADOR_FIRMA')])
+    assert ed.estado_tarea(t) == 'PENDIENTE_FIRMA'
+
+def test_elaborar_producido_fin():
+    t = _tarea('ELABORAR', consumidos=[_doc(tipo_codigo='BORRADOR_FIRMA')], producido=_doc())
+    assert ed.estado_tarea(t) == 'FIN'
+
+
+# ---------------------------------------------------------------------------
+# Hoja — NOTIFICAR (escalada 🔵 → 🟠 → 🔴 vía Notificacion)
+# ---------------------------------------------------------------------------
+
+def test_notificar_sin_consumido_tramitar():
+    assert ed.estado_tarea(_tarea('NOTIFICAR')) == 'PENDIENTE_TRAMITAR'
+
+def test_notificar_sin_resultado_notificar():
+    assert ed.estado_tarea(_tarea('NOTIFICAR', consumidos=[_doc()])) == 'PENDIENTE_NOTIFICAR'
+
+def test_notificar_correcta_fin():
+    t = _tarea('NOTIFICAR', consumidos=[_doc()], producido=_doc(notif=_notif('CORRECTA')))
+    assert ed.estado_tarea(t) == 'FIN'
+
+def test_notificar_incorrecta_1_fallida():
+    t = _tarea('NOTIFICAR', consumidos=[_doc()], producido=_doc(notif=_notif('INCORRECTA', 1)))
+    assert ed.estado_tarea(t) == 'NOTIFICACION_FALLIDA'
+
+def test_notificar_incorrecta_2_agotada():
+    t = _tarea('NOTIFICAR', consumidos=[_doc()], producido=_doc(notif=_notif('INCORRECTA', 2)))
+    assert ed.estado_tarea(t) == 'NOTIFICACION_AGOTADA'
+
+
+# ---------------------------------------------------------------------------
+# Hoja — ESPERAR_PLAZO (mapea el estado de plazo ya resuelto por la proyección)
+# ---------------------------------------------------------------------------
+
+def test_esperar_plazo_sin_plazo_tramitar():
+    t = _tarea('ESPERAR_PLAZO', consumidos=[_doc()])
+    assert ed.estado_tarea(t, plazo=None) == 'PENDIENTE_TRAMITAR'
+    assert ed.estado_tarea(t, plazo={'estado': 'SIN_PLAZO'}) == 'PENDIENTE_TRAMITAR'
+
+def test_esperar_plazo_en_plazo_plazos():
+    t = _tarea('ESPERAR_PLAZO', consumidos=[_doc()])
+    assert ed.estado_tarea(t, plazo={'estado': 'EN_PLAZO'}) == 'PENDIENTE_PLAZOS'
+
+def test_esperar_plazo_vencido_estudio():
+    t = _tarea('ESPERAR_PLAZO', consumidos=[_doc()])
+    assert ed.estado_tarea(t, plazo={'estado': 'VENCIDO'}) == 'PENDIENTE_ESTUDIO'
+
+
+# ---------------------------------------------------------------------------
+# Contenedor — TRÁMITE
+# ---------------------------------------------------------------------------
+
+def test_tramite_planificado_tramitar():
+    assert ed.estado_tramite(SimpleNamespace(tareas=[]), []) == ('PENDIENTE_TRAMITAR', True)
+
+def test_tramite_agrega_mayor_prioridad():
+    estados = ['PENDIENTE_NOTIFICAR', 'PENDIENTE_REDACTAR', 'FIN']
+    assert ed.estado_tramite(SimpleNamespace(tareas=[1, 2, 3]), estados) == ('PENDIENTE_REDACTAR', False)
+
+
+# ---------------------------------------------------------------------------
+# Contenedor — FASE (cierre es_finalizadora-aware, el fix de #558)
+# ---------------------------------------------------------------------------
+
+def test_fase_planificada_tramitar():
+    assert ed.estado_fase(_fase(planificada=True), []) == ('PENDIENTE_TRAMITAR', True)
+
+def test_fase_finalizadora_sin_resultado_estudio():
+    f = _fase(pdte_cierre=True, finalizadora=True, resultado_fase_id=None)
+    assert ed.estado_fase(f, []) == ('PENDIENTE_ESTUDIO', True)
+
+def test_fase_finalizadora_con_resultado_cerrar():
+    f = _fase(pdte_cierre=True, finalizadora=True, resultado_fase_id=5)
+    assert ed.estado_fase(f, []) == ('PENDIENTE_CERRAR', True)
+
+def test_fase_intermedia_pdte_cierre_cerrar():
+    # El fix: una intermedia (resultado_fase_id siempre NULL) va a CERRAR, no a ESTUDIO.
+    f = _fase(pdte_cierre=True, finalizadora=False, resultado_fase_id=None)
+    assert ed.estado_fase(f, []) == ('PENDIENTE_CERRAR', True)
+
+def test_fase_en_curso_agrega():
+    f = _fase()
+    assert ed.estado_fase(f, ['PENDIENTE_CERRAR', 'PENDIENTE_NOTIFICAR']) == ('PENDIENTE_CERRAR', False)
+
+
+# ---------------------------------------------------------------------------
+# Contenedor — SOLICITUD / EXPEDIENTE
+# ---------------------------------------------------------------------------
+
+def test_solicitud_sin_fases_tramitar():
+    assert ed.estado_solicitud(SimpleNamespace(fases=[], estado='EN_TRAMITE'), []) == ('PENDIENTE_TRAMITAR', True)
+
+def test_solicitud_no_en_tramite_fin():
+    assert ed.estado_solicitud(SimpleNamespace(fases=[1], estado='RESUELTA'), ['FIN']) == ('FIN', False)
+
+def test_solicitud_todo_fin_pero_en_tramite_cerrar():
+    sol = SimpleNamespace(fases=[1, 2], estado='EN_TRAMITE')
+    assert ed.estado_solicitud(sol, ['FIN', 'FIN']) == ('PENDIENTE_CERRAR', True)
+
+def test_solicitud_en_tramite_agrega():
+    sol = SimpleNamespace(fases=[1, 2], estado='EN_TRAMITE')
+    assert ed.estado_solicitud(sol, ['FIN', 'PENDIENTE_FIRMA']) == ('PENDIENTE_FIRMA', False)
+
+def test_expediente_sin_solicitudes_tramitar():
+    assert ed.estado_expediente(SimpleNamespace(), []) == ('PENDIENTE_TRAMITAR', True)
+
+def test_expediente_agrega():
+    assert ed.estado_expediente(SimpleNamespace(), ['FIN', 'PENDIENTE_CERRAR']) == ('PENDIENTE_CERRAR', False)
+
+
+# ---------------------------------------------------------------------------
+# Orden canónico y coherencia color↔prioridad
+# ---------------------------------------------------------------------------
+
+def test_mayor_prioridad_lista_vacia_fin():
+    assert ed.mayor_prioridad([]) == 'FIN'
+
+def test_orden_naranja_gana_a_azul():
+    # Inversión decidida en #558: 🟠 (gestión nuestra) más urgente que 🔵 (espera externa).
+    assert ed.mayor_prioridad(['PENDIENTE_NOTIFICAR', 'PENDIENTE_CERRAR']) == 'PENDIENTE_CERRAR'
+    assert ed.mayor_prioridad(['PENDIENTE_NOTIFICAR', 'NOTIFICACION_FALLIDA']) == 'NOTIFICACION_FALLIDA'
+
+def test_orden_naranja_gana_a_amarillo():
+    assert ed.mayor_prioridad(['PENDIENTE_FIRMA', 'PENDIENTE_CERRAR']) == 'PENDIENTE_CERRAR'
+
+def test_orden_agotada_gana_a_naranja():
+    assert ed.mayor_prioridad(['PENDIENTE_CERRAR', 'NOTIFICACION_AGOTADA']) == 'NOTIFICACION_AGOTADA'
+
+def test_orden_tramitar_gana_a_todo():
+    todos = list(ed.PRIORIDAD)
+    assert ed.mayor_prioridad(todos) == 'PENDIENTE_TRAMITAR'
+
+def test_color_mapea_segun_banda():
+    assert ed.color('NOTIFICACION_AGOTADA') == 'rojo'
+    assert ed.color('PENDIENTE_CERRAR') == 'naranja'
+    assert ed.color('PENDIENTE_FIRMA') == 'amarillo'
+    assert ed.color('PENDIENTE_NOTIFICAR') == 'azul'
+    assert ed.color('PENDIENTE_PLAZOS') == 'gris'
+    assert ed.color('FIN') == 'verde'
+    assert ed.color('DESCONOCIDO') == 'gris'
+
+def test_coherencia_color_monotono_con_prioridad():
+    # La prioridad es monótona con la banda de color (sin inversiones): ordenando los
+    # estados por prioridad, el índice de banda nunca retrocede.
+    banda = {'rojo': 0, 'naranja': 1, 'amarillo': 2, 'azul': 3, 'gris': 4, 'verde': 5}
+    por_prioridad = sorted(ed.PRIORIDAD, key=ed.PRIORIDAD.get)
+    indices = [banda[ed.color(e)] for e in por_prioridad]
+    assert indices == sorted(indices)


### PR DESCRIPTION
## Resumen

Unifica el núcleo de reglas de estado del árbol ESFTT en un único servicio `estado_dominio`, consumido por las dos proyecciones (vista de árbol y listado de seguimiento). Cierra la deuda histórica `seguimiento.py`↔`estado_semaforo.py` (MODELO §10).

## Decisiones ratificadas

- **Tabla prioridad/color canónica**, coherente con el color: 🔴 > 🟠 > 🟡 > 🔵 > ⚪ > 🟢 (gradiente "trabajo del tramitador"), orden total sin empates entre bandas → ganador de celda determinista.
- **Reglas de contenedor al núcleo**, con el cierre de fase `es_finalizadora`-aware (intermedia → CERRAR; finalizadora sin resultado → ESTUDIO).
- **Vocabulario fino** REDACTAR/FIRMA también en la fila de seguimiento.
- **Notificar**: escalada 🔵→🟠→🔴 derivada de `Notificacion`, bajo una única etiqueta "NOTIFICAR".

## Cambios de comportamiento

- Árbol: con el orden nuevo, CERRAR 🟠 gana a NOTIFICAR 🔵 (antes al revés).
- Seguimiento: ELABORAR 🟡 → REDACTAR 🔴 / FIRMA 🟡; fase **intermedia** pdte. cierre → CERRAR 🟠 (antes ESTUDIO 🔴); ESPERAR_PLAZO sin documento de inicio → TRAMITAR (antes PLAZOS); RESULTADO_NOTIFICACION se funde en NOTIFICAR (mismo azul).

## Arquitectura

- `estado_dominio.py` (núcleo): vocabulario, `estado_tarea`, reglas de contenedor, COLOR/PRIORIDAD, `mayor_prioridad`.
- `seguimiento.py`: proyección por pista (PISTAS, count, nota, fin_total, relabel SOL→SUBSANAR). API pública intacta.
- `arbol_expediente.py`: proyección por nodo (solo cambia el import).

## Tests

- Nuevo `test_558_estado_dominio` (35 casos: hoja, contenedor, orden, coherencia color↔prioridad).
- `test_350` revalidado a la nueva estructura con el cómputo de plazo real.
- Suite completa: **726 passed**; los 8 fallos restantes son **preexistentes en develop** (organismos / e2e_art131 / permisos toggle), ajenos a este PR.

## Fuera de alcance (issue aparte)

El rediseño documental de notificar (justificante fallido como documento consumido + trámite de notificación infructuosa, art. 44 LPACAP). El núcleo queda preparado con los tres niveles.

> Verificación visual de la fila de seguimiento y del árbol: pendiente del revisor.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
