### PR TITLE
Inspector de detalle del listado de seguimiento

### DIFF
--- a/app/modules/expedientes/metadata.json
+++ b/app/modules/expedientes/metadata.json
@@ -36,8 +36,7 @@
       { "key": "pista_CONSULTAS",      "label": "CONSULTAS",        "type": "custom" },
       { "key": "pista_MA",             "label": "MA",               "type": "custom" },
       { "key": "pista_IP",             "label": "IP",               "type": "custom" },
-      { "key": "pista_RES",            "label": "RESOLUCI\u00d3N",  "type": "custom" },
-      { "key": "_acciones",            "label": "",                 "type": "custom" }
+      { "key": "pista_RES",            "label": "RESOLUCI\u00d3N",  "type": "custom" }
     ]
   }
 }

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -67,6 +67,34 @@ def seguimiento():
     )
 
 
+@bp.route('/seguimiento/<int:solicitud_id>/fragmento')
+@login_required
+def seguimiento_fragmento(solicitud_id):
+    """Fragmento de lectura del inspector de seguimiento (ADR-023 §9 / #559).
+
+    Detalle del agregado de una solicitud en el lenguaje del árbol (semáforo por
+    nodo). Solo lectura: la edición se delega al árbol vía "Ir a tramitar". El color
+    de cada nodo sale de estado_dominio (#558) → misma verdad que verás al saltar.
+    """
+    from app.services.arbol_expediente import construir_arbol_solicitud
+
+    sol = Solicitud.query.get_or_404(solicitud_id)
+    resultado = verificar_acceso_expediente(sol.expediente, 'ver')
+    if resultado:
+        return '', 403
+
+    arbol = construir_arbol_solicitud(solicitud_id)
+    if arbol is None:
+        return '', 404
+
+    return render_template(
+        'expedientes/_inspector_seguimiento.html',
+        solicitud=arbol['solicitud'],
+        expediente=arbol['expediente'],
+        cuello_botella=arbol['cuello_botella'],
+    )
+
+
 @bp.route('/')
 @login_required
 def listado_v2():

--- a/app/modules/expedientes/templates/expedientes/_inspector_seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/_inspector_seguimiento.html
@@ -1,0 +1,134 @@
+{# _inspector_seguimiento.html — Parcial de lectura del inspector de seguimiento (ADR-023 §9 / #559).
+
+   No extiende base_app.html. Inyectado vía AppInspector.open({ fragmentUrl }).
+   Lenguaje = el del ÁRBOL (semáforo por nodo), no el de pistas: el inspector enseña
+   exactamente el mismo estado que verás al saltar al árbol (cero "tercera verdad").
+   El color de cada nodo sale de estado_dominio (#558); aquí solo se pinta.
+
+   Solo lectura: toda mutación se delega al árbol vía "Ir a tramitar" y los enlaces
+   por nodo (?nodo=<tipo>-<id>).
+
+   Contexto:
+     solicitud      — nodo serializado (arbol_expediente._serializar_solicitud)
+     expediente     — {id, numero_at, codigo, titular}
+     cuello_botella — {tipo, id} del nodo de mayor prioridad
+#}
+
+{# Significado del color (paridad con el hover del árbol, Semaforo.jsx) #}
+{% set SIGNIFICADO = {
+    'rojo':     'Acción pendiente del tramitador',
+    'amarillo': 'En espera de firma',
+    'azul':     'En espera de un externo (destinatario o boletín)',
+    'naranja':  'Listo para cerrar o reintento disponible',
+    'gris':     'Espera pasiva (plazo legal o respuesta)',
+    'verde':    'Finalizado',
+} %}
+
+{% set arbol_url = url_for('expedientes.arbol', id=expediente.id) %}
+
+{# Círculo-semáforo: relleno si el nodo "tiene algo que decir por sí mismo" (propio),
+   hueco con borde gris si agrega a sus hijos (idéntico criterio que el árbol). #}
+{% macro sem_dot(s) %}
+<span class="seg-sem{% if s.propio %} is-relleno{% endif %}"
+      data-color="{{ s.color }}" title="{{ SIGNIFICADO.get(s.color, '') }}"></span>
+{% endmacro %}
+
+{# dd/mm/yyyy a partir de un ISO 'YYYY-MM-DD' (sin dependencias de filtros) #}
+{% macro fecha(iso) %}{{ iso[8:10] }}/{{ iso[5:7] }}/{{ iso[0:4] }}{% endmacro %}
+
+<div class="p-3 seg-inspector">
+
+  {# ── Cabecera: solicitud + salto al árbol ─────────────────────────────── #}
+  <div class="d-flex justify-content-between align-items-start gap-2 mb-3">
+    <div class="seg-cab">
+      <div class="d-flex align-items-center gap-2">
+        {{ sem_dot(solicitud.semaforo) }}
+        <span class="fw-semibold">{{ expediente.codigo }}</span>
+        <span class="badge bg-secondary">{{ solicitud.siglas or '—' }}</span>
+      </div>
+      <div class="text-secondary small mt-1">{{ solicitud.descripcion or '' }}</div>
+      <div class="text-secondary small">
+        {{ expediente.titular or '—' }}
+        {% if solicitud.fecha_presentacion %}
+          · Presentada {{ fecha(solicitud.fecha_presentacion) }}
+        {% endif %}
+      </div>
+    </div>
+    <a class="btn btn-primary btn-sm flex-shrink-0"
+       href="{{ arbol_url }}?nodo={{ cuello_botella.tipo }}-{{ cuello_botella.id }}">
+      <i class="fas fa-arrow-right me-1"></i> Ir a tramitar
+    </a>
+  </div>
+
+  {# ── Árbol de lectura: fase → trámite → tarea ─────────────────────────── #}
+  {% if solicitud.fases %}
+  <div class="seg-arbol">
+    {% for fase in solicitud.fases %}
+    <div class="seg-nivel seg-nivel--fase">
+      <a class="seg-nodo" href="{{ arbol_url }}?nodo=fase-{{ fase.id }}">
+        {{ sem_dot(fase.semaforo) }}
+        <i class="fas fa-layer-group seg-ico"></i>
+        <span class="seg-nombre">{{ fase.nombre or fase.tipo_codigo }}</span>
+        {% if fase.resultado %}
+          <span class="badge bg-light text-dark border ms-1">{{ fase.resultado }}</span>
+        {% endif %}
+      </a>
+
+      {% for tramite in fase.tramites %}
+      <div class="seg-nivel seg-nivel--tramite">
+        <a class="seg-nodo" href="{{ arbol_url }}?nodo=tramite-{{ tramite.id }}">
+          {{ sem_dot(tramite.semaforo) }}
+          <i class="fas fa-diagram-project seg-ico"></i>
+          <span class="seg-nombre">{{ tramite.nombre or tramite.tipo_codigo }}</span>
+        </a>
+
+        {% for tarea in tramite.tareas %}
+        <div class="seg-nivel seg-nivel--tarea">
+          <a class="seg-nodo" href="{{ arbol_url }}?nodo=tarea-{{ tarea.id }}">
+            {{ sem_dot(tarea.semaforo) }}
+            <i class="fas fa-circle-dot seg-ico"></i>
+            <span class="seg-nombre">{{ tarea.nombre or tarea.tipo_codigo }}</span>
+
+            {# Decoradores de tarea: plazo (ESPERAR_PLAZO), resultado (NOTIFICAR), docs #}
+            {% if tarea.plazo and tarea.plazo.fecha_limite %}
+              <span class="seg-dec seg-plazo seg-plazo--{{ tarea.plazo.estado|lower }}">
+                <i class="fas fa-hourglass-half"></i>
+                {{ fecha(tarea.plazo.fecha_limite) }}
+                {% if tarea.plazo.dias_restantes is not none %}
+                  ({{ tarea.plazo.dias_restantes }} d)
+                {% endif %}
+              </span>
+            {% endif %}
+            {% if tarea.resultado %}
+              <span class="seg-dec badge bg-light text-dark border">{{ tarea.resultado }}</span>
+            {% endif %}
+            {% if tarea.doc_consumido.presente %}
+              <span class="seg-dec text-secondary" title="Documentos consumidos">
+                <i class="fas fa-arrow-down"></i>{{ tarea.doc_consumido.count }}
+              </span>
+            {% endif %}
+            {% if tarea.doc_producido.presente %}
+              <span class="seg-dec text-secondary" title="Documento producido">
+                <i class="fas fa-arrow-up"></i>{{ tarea.doc_producido.count }}
+              </span>
+            {% endif %}
+          </a>
+          {% if tarea.notas %}
+          <div class="seg-notas text-secondary small">
+            <i class="fas fa-sticky-note me-1"></i>{{ tarea.notas }}
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}{# tareas #}
+      </div>
+      {% endfor %}{# tramites #}
+    </div>
+    {% endfor %}{# fases #}
+  </div>
+  {% else %}
+  <p class="text-secondary mb-0">
+    <i class="fas fa-info-circle me-1"></i> Esta solicitud aún no tiene fases en tramitación.
+  </p>
+  {% endif %}
+
+</div>{# /seg-inspector #}

--- a/app/modules/expedientes/templates/expedientes/seguimiento.html
+++ b/app/modules/expedientes/templates/expedientes/seguimiento.html
@@ -132,12 +132,8 @@ const renderFns = {
     'pista_MA':        (val) => renderPista(val),
     'pista_IP':        (val) => renderPista(val),
     'pista_RES':       (val) => renderPista(val),
-
-    '_acciones': (val, item) =>
-        `<a href="/expedientes/${item.expediente_id}/arbol?nodo=solicitud-${item.id}"
-             class="btn-accion-ver">
-            <i class="fas fa-eye"></i> Ver
-         </a>`,
+    // La columna _acciones (type:'acciones') la omite el modo selección de
+    // ScrollInfinito: la fila entera abre el inspector (ADR-023 / #559).
 };
 
 const columns = colsMeta.map(col =>
@@ -210,6 +206,12 @@ const scrollInfinito = new SeguimientoScroll({
     tableClass:  '.seguimiento-table',
     entityLabel: 'solicitudes',
     columns,
+    // Modo selección (ADR-023 / #559): click en fila → inspector de lectura del
+    // agregado; la edición se delega al árbol vía "Ir a tramitar".
+    selection: {
+        fragmentUrl: id   => `/expedientes/seguimiento/${id}/fragmento`,
+        title:       item => `AT-${item.num_at} · ${item.tipo_solicitud || ''}`,
+    },
 });
 
 // FiltrosSeguimiento extiende FiltrosListado para gestionar los dos filtros
@@ -248,6 +250,26 @@ class FiltrosSeguimiento extends FiltrosListado {
 }
 
 const filtros = new FiltrosSeguimiento(scrollInfinito);
+
+// ===== SYNC INSPECTOR ↔ URL ?sel (ADR-023 §1, igual que entidades) =====
+function _updateSelParam(selId) {
+    const url = new URL(location.href);
+    if (selId) url.searchParams.set('sel', selId);
+    else url.searchParams.delete('sel');
+    history.replaceState(null, '', url.toString());
+}
+document.addEventListener('inspector:opened',  e => _updateSelParam(e.detail.selId));
+document.addEventListener('inspector:swapped', e => _updateSelParam(e.detail.selId));
+document.addEventListener('inspector:closed',  () => _updateSelParam(null));
+
+// Abrir el inspector si la URL trae ?sel=<solicitud_id> al cargar.
+const _selParam = new URLSearchParams(location.search).get('sel');
+if (_selParam && window.AppInspector) {
+    AppInspector.open({
+        selId:       _selParam,
+        fragmentUrl: `/expedientes/seguimiento/${_selParam}/fragmento`,
+    });
+}
 
 // Reparte el espacio sobrante: TITULAR 40% / PROYECTO 60% (mínimo 100px cada uno)
 // CSS calc() no funciona con rem en table-layout:fixed → medimos el DOM.

--- a/app/services/arbol_expediente.py
+++ b/app/services/arbol_expediente.py
@@ -55,6 +55,44 @@ def _sumar_agregados(acc: dict, otro: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Opciones de carga ansiosa (compartidas por el árbol completo y la solicitud única)
+# ---------------------------------------------------------------------------
+
+def _opciones_solicitud() -> list:
+    """Eager-loading de la jerarquía Solicitud→Fase→Trámite→Tarea→Documento.
+
+    selectinload para colecciones (evita el producto cartesiano de joinedload
+    anidado) + joinedload para escalares → sin N+1. Lo comparten construir_arbol
+    (todas las solicitudes del expediente) y construir_arbol_solicitud (una sola).
+    """
+    return [
+        joinedload(Solicitud.tipo_solicitud),
+        joinedload(Solicitud.documento_solicitud),
+        selectinload(Solicitud.fases).joinedload(Fase.tipo_fase),
+        selectinload(Solicitud.fases).joinedload(Fase.resultado_fase),
+        selectinload(Solicitud.fases)
+        .selectinload(Fase.tramites).joinedload(Tramite.tipo_tramite),
+        selectinload(Solicitud.fases)
+        .selectinload(Fase.tramites)
+        .selectinload(Tramite.tareas).joinedload(Tarea.tipo_tarea),
+        # Documento + tipo_doc (detectar BORRADOR_FIRMA en ELABORAR, §3).
+        selectinload(Solicitud.fases)
+        .selectinload(Fase.tramites)
+        .selectinload(Tramite.tareas)
+        .selectinload(Tarea.vinculos_documento)
+        .joinedload(DocumentoTarea.documento)
+        .joinedload(Documento.tipo_doc),
+        # Documento + notificacion (resultado/intento de NOTIFICAR, §3).
+        selectinload(Solicitud.fases)
+        .selectinload(Fase.tramites)
+        .selectinload(Tramite.tareas)
+        .selectinload(Tarea.vinculos_documento)
+        .joinedload(DocumentoTarea.documento)
+        .joinedload(Documento.notificacion),
+    ]
+
+
+# ---------------------------------------------------------------------------
 # API pública
 # ---------------------------------------------------------------------------
 
@@ -86,31 +124,7 @@ def construir_arbol(expediente_id: int) -> Optional[dict]:
         solicitudes = (
             Solicitud.query
             .filter_by(expediente_id=expediente_id)
-            .options(
-                joinedload(Solicitud.tipo_solicitud),
-                joinedload(Solicitud.documento_solicitud),
-                selectinload(Solicitud.fases).joinedload(Fase.tipo_fase),
-                selectinload(Solicitud.fases).joinedload(Fase.resultado_fase),
-                selectinload(Solicitud.fases)
-                .selectinload(Fase.tramites).joinedload(Tramite.tipo_tramite),
-                selectinload(Solicitud.fases)
-                .selectinload(Fase.tramites)
-                .selectinload(Tramite.tareas).joinedload(Tarea.tipo_tarea),
-                # Documento + tipo_doc (detectar BORRADOR_FIRMA en ELABORAR, §3).
-                selectinload(Solicitud.fases)
-                .selectinload(Fase.tramites)
-                .selectinload(Tramite.tareas)
-                .selectinload(Tarea.vinculos_documento)
-                .joinedload(DocumentoTarea.documento)
-                .joinedload(Documento.tipo_doc),
-                # Documento + notificacion (resultado/intento de NOTIFICAR, §3).
-                selectinload(Solicitud.fases)
-                .selectinload(Fase.tramites)
-                .selectinload(Tramite.tareas)
-                .selectinload(Tarea.vinculos_documento)
-                .joinedload(DocumentoTarea.documento)
-                .joinedload(Documento.notificacion),
-            )
+            .options(*_opciones_solicitud())
             .order_by(Solicitud.id)
             .all()
         )
@@ -128,6 +142,88 @@ def construir_arbol(expediente_id: int) -> Optional[dict]:
     exp_data['semaforo'] = _semaforo(est_exp, propio_exp)
 
     return {'expediente': exp_data, 'solicitudes': sols_data}
+
+
+def construir_arbol_solicitud(solicitud_id: int) -> Optional[dict]:
+    """
+    Árbol serializado de UNA solicitud para el inspector de seguimiento (#559).
+
+    Reutiliza el serializador por nodo del árbol completo (`_serializar_solicitud`)
+    cargando solo la solicitud pedida con el mismo eager-loading — no el expediente
+    entero. Así el inspector enseña EXACTAMENTE el mismo estado/semáforo que el árbol
+    al que delega la edición (cero "tercera verdad": el color sale de estado_dominio,
+    #558).
+
+    Devuelve None si la solicitud no existe o la BD no está disponible. Si existe:
+        {
+          'solicitud':      <nodo serializado, ADR-016 §16>,
+          'expediente':     {'id', 'numero_at', 'codigo', 'titular'},  # contexto del salto
+          'cuello_botella': {'tipo', 'id'},  # nodo de mayor prioridad → "Ir a tramitar"
+        }
+    """
+    try:
+        sol = (
+            Solicitud.query
+            .options(
+                joinedload(Solicitud.expediente).joinedload(Expediente.titular),
+                *_opciones_solicitud(),
+            )
+            .get(solicitud_id)
+        )
+    except (OperationalError, ProgrammingError) as exc:
+        log.warning('arbol_expediente: BD no disponible para solicitud %s — %s', solicitud_id, exc)
+        return None
+
+    if sol is None:
+        return None
+
+    sol_data = _serializar_solicitud(sol)
+    exp = sol.expediente
+
+    return {
+        'solicitud': sol_data,
+        'expediente': {
+            'id': exp.id if exp else None,
+            'numero_at': exp.numero_at if exp else None,
+            'codigo': f'AT-{exp.numero_at}' if exp else None,
+            'titular': exp.titular.nombre_completo if exp and exp.titular else None,
+        },
+        'cuello_botella': _cuello_botella(sol_data),
+    }
+
+
+def _cuello_botella(sol_data: dict) -> dict:
+    """
+    Nodo de mayor prioridad del subárbol de una solicitud → destino de "Ir a tramitar".
+
+    Recorre el árbol ya serializado y se queda con el nodo cuyo estado tiene la menor
+    PRIORIDAD del núcleo (más urgente). A igualdad de prioridad prefiere el nodo más
+    profundo (la tarea concreta sobre su trámite/fase), que es la acción accionable.
+
+    Si nada gana a la propia solicitud (p. ej. todo en FIN pero pendiente de cerrar),
+    devuelve la solicitud. Siempre devuelve {'tipo', 'id'} navegable con ?nodo.
+    """
+    mejor = {
+        'tipo': 'solicitud',
+        'id': sol_data['id'],
+        'prio': sem.PRIORIDAD.get(sol_data['semaforo']['estado'], 99),
+        'prof': 0,
+    }
+
+    def _visitar(nodo: dict, prof: int) -> None:
+        nonlocal mejor
+        prio = sem.PRIORIDAD.get(nodo['semaforo']['estado'], 99)
+        if prio < mejor['prio'] or (prio == mejor['prio'] and prof > mejor['prof']):
+            mejor = {'tipo': nodo['tipo'], 'id': nodo['id'], 'prio': prio, 'prof': prof}
+        # Cada nivel guarda sus hijos bajo una única clave (fases/tramites/tareas).
+        for clave in ('fases', 'tramites', 'tareas'):
+            for hijo in nodo.get(clave, []):
+                _visitar(hijo, prof + 1)
+
+    for fase in sol_data['fases']:
+        _visitar(fase, 1)
+
+    return {'tipo': mejor['tipo'], 'id': mejor['id']}
 
 
 def _semaforo(estado: str, propio: bool) -> dict:
@@ -254,6 +350,7 @@ def _serializar_tarea(tarea, tramite) -> tuple[dict, dict]:
         'estado': tarea.estado,
         'doc_consumido': {'presente': bool(consumidos), 'count': len(consumidos)},
         'doc_producido': {'presente': producido is not None, 'count': 1 if producido is not None else 0},
+        'notas': tarea.notas or None,
         'plazo': None,       # solo ESPERAR_PLAZO
         'resultado': None,   # solo NOTIFICAR
     }

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -332,6 +332,69 @@ table a.badge:hover {
 .pista-naranja  { background-color: #ffe5d0; color: #7d3f00; }
 .pista-verde    { background-color: #d1e7dd; color: #0a3622; }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+   Inspector de seguimiento (#559, ADR-023) — árbol de lectura en el lenguaje del
+   árbol (semáforo por nodo). Reusa los tokens --sem-* del shell (v2-theme.css).
+   ───────────────────────────────────────────────────────────────────────────── */
+
+/* Círculo-semáforo: hueco con borde gris por defecto; relleno con el color del
+   estado cuando el nodo "tiene algo que decir por sí mismo" (propio). Réplica del
+   .arbol-sem del bundle React, pero a nivel de shell. */
+.seg-sem {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1.5px solid var(--sem-gris);
+    background: transparent;
+    flex-shrink: 0;
+    display: inline-block;
+}
+.seg-sem.is-relleno[data-color="rojo"]     { background: var(--sem-rojo);     border-color: var(--sem-rojo); }
+.seg-sem.is-relleno[data-color="naranja"]  { background: var(--sem-naranja);  border-color: var(--sem-naranja); }
+.seg-sem.is-relleno[data-color="amarillo"] { background: var(--sem-amarillo); border-color: var(--sem-amarillo); }
+.seg-sem.is-relleno[data-color="azul"]     { background: var(--sem-azul);     border-color: var(--sem-azul); }
+.seg-sem.is-relleno[data-color="gris"]     { background: var(--sem-gris);     border-color: var(--sem-gris); }
+.seg-sem.is-relleno[data-color="verde"]    { background: var(--sem-verde);    border-color: var(--sem-verde); }
+
+/* Indentación por nivel mediante guía vertical izquierda (fase→trámite→tarea). */
+.seg-arbol { margin-top: 0.25rem; }
+.seg-nivel--tramite,
+.seg-nivel--tarea {
+    margin-left: 0.65rem;
+    padding-left: 0.65rem;
+    border-left: 1px solid var(--border-color);
+}
+.seg-nivel--fase + .seg-nivel--fase { margin-top: 0.35rem; }
+
+/* Fila-nodo clicable: salta al árbol al ?nodo correspondiente. */
+.seg-nodo {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.28rem 0.4rem;
+    border-radius: 0.25rem;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.86rem;
+    line-height: 1.2;
+}
+.seg-nodo:hover { background: var(--gris-especifico); color: var(--text-primary); }
+.seg-nivel--fase    > .seg-nodo { font-weight: 600; }
+.seg-nivel--tramite > .seg-nodo { font-weight: 500; }
+
+.seg-ico { color: var(--text-secondary); width: 1em; text-align: center; flex-shrink: 0; }
+.seg-nombre { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Decoradores de tarea (plazo, resultado, documentos): no rompen línea, a la derecha. */
+.seg-dec { margin-left: 0.35rem; font-size: 0.76rem; white-space: nowrap; flex-shrink: 0; }
+.seg-plazo { padding: 0.05em 0.4em; border-radius: 0.2rem; }
+.seg-plazo--vencido        { background-color: #f8d7da; color: #721c24; }
+.seg-plazo--proximo_vencer { background-color: #ffe5d0; color: #7d3f00; }
+.seg-plazo--en_plazo,
+.seg-plazo--indefinido     { background-color: #e2e3e5; color: #41464b; }
+
+.seg-notas { margin: 0 0 0.25rem 1.9rem; }
+
 /* Columna SOLICITUD — color según estado global (§2) */
 .tipo-solicitud-celda {
     display: inline-block;
@@ -431,8 +494,7 @@ table a.badge:hover {
 .seguimiento-table th:nth-child(10),
 .seguimiento-table td:nth-child(10) { width: var(--seg-pista-w); } /* RESOLUCIÓN */
 
-.seguimiento-table th:nth-child(11),
-.seguimiento-table td:nth-child(11) { width: 4.5rem; }             /* Acciones */
+/* (La columna 11 "Acciones" se retiró en #559: la fila abre el inspector.) */
 
 /* Pill base Nº AT — mismo tamaño en todas las filas, solo cambia el color (#263) */
 .num-at-pill {

--- a/app/static/css/v2-theme.css
+++ b/app/static/css/v2-theme.css
@@ -29,6 +29,19 @@
   --warning: #ffc107;          /* Bootstrap warning - Advertencias, próximo vencimiento */
   --danger: #dc3545;           /* Bootstrap danger - Errores, vencido */
   --info: #0dcaf0;             /* Bootstrap info - En trámite, información */
+
+  /* ===== PALETA SEMÁFORO (estado de dominio, MODELO §2 / #558) ===== */
+  /* Único canal cromático del estado de cada nodo del árbol. estado_dominio.COLOR
+   * mapea estado→NOMBRE (rojo, naranja…); estos tokens mapean NOMBRE→hex sólido.
+   * Hogar canónico en el shell: lo consume el inspector de seguimiento (#559).
+   * Valores v0 (mockup); iterar a paleta JdA. El bundle del árbol aún define su
+   * propia copia en .react-flow (deuda: que herede de aquí — spin-off #559). */
+  --sem-rojo:     #cc3b3b;
+  --sem-naranja:  #e0892b;
+  --sem-amarillo: #e9c43d;
+  --sem-azul:     #3b78cc;
+  --sem-gris:     #9a9a9a;
+  --sem-verde:    #3a9b4e;
   
   /* Grises corporativos Junta */
   --gris-principal: #111111;   /* Texto principal (var(--bs-gris-principal)) */

--- a/tests/smoke/test_smoke_expedientes_seguimiento.py
+++ b/tests/smoke/test_smoke_expedientes_seguimiento.py
@@ -4,8 +4,32 @@ Precursor del área "Mi trabajo" (#501, aún no implementada).
 Cuando exista /mi_trabajo/, añadir test_smoke_mi_trabajo.py en ese mismo PR.
 """
 
+import pytest
+
 
 def test_expedientes_seguimiento_render(usuario_supervisor):
     r = usuario_supervisor.get('/expedientes/seguimiento/', follow_redirects=True)
     assert r.status_code == 200
     assert b'class="app-main"' in r.data
+
+
+# ── Inspector de seguimiento (ADR-023 / #559) ────────────────────────────────
+
+def test_seguimiento_fragmento_render(usuario_supervisor, app):
+    """GET /expedientes/seguimiento/<id>/fragmento → 200 con el detalle del agregado."""
+    with app.app_context():
+        from app.models.solicitudes import Solicitud
+        sol = Solicitud.query.first()
+        if sol is None:
+            pytest.skip('No hay solicitudes en la BD de desarrollo')
+        sol_id = sol.id
+    r = usuario_supervisor.get(f'/expedientes/seguimiento/{sol_id}/fragmento')
+    assert r.status_code == 200
+    # El botón de delegación al árbol está siempre presente en el fragmento.
+    assert 'Ir a tramitar'.encode() in r.data
+
+
+def test_seguimiento_fragmento_inexistente(usuario_supervisor):
+    """GET del fragmento de una solicitud inexistente → 404."""
+    r = usuario_supervisor.get('/expedientes/seguimiento/99999999/fragmento')
+    assert r.status_code == 404


### PR DESCRIPTION
## Cambios

Intercala un **inspector de lectura** (overlay ADR-023) entre el listado de seguimiento y el árbol: click en fila → detalle del agregado de la solicitud en el lenguaje del árbol (semáforo por nodo); la edición se delega al árbol vía "Ir a tramitar". Desbloqueado por #558.

**Backend**
- `construir_arbol_solicitud(solicitud_id)` en `arbol_expediente.py`: reutiliza el serializador por nodo del árbol (`_serializar_solicitud`) cargando una sola solicitud con el mismo eager-loading, factorizado a `_opciones_solicitud()` compartido con `construir_arbol`.
- `_cuello_botella()`: nodo de mayor prioridad del subárbol (núcleo `estado_dominio`), prefiriendo el más profundo → destino del botón primario. El nodo tarea expone ahora `notas`.
- Ruta `GET /expedientes/seguimiento/<id>/fragmento` con `verificar_acceso_expediente(...,'ver')`.

**Frontend**
- `_inspector_seguimiento.html`: árbol de lectura fase→trámite→tarea con semáforo por nodo, plazos/resultado/docs/notas; cada nodo enlaza a su `?nodo` del árbol; botón primario "Ir a tramitar" al cuello de botella.
- `seguimiento.html`: modo selección de `ScrollInfinito` + sync `inspector ↔ ?sel` (patrón de entidades); retirado el botón "Ver". `metadata.json`: eliminada la columna `_acciones` (la fila abre el inspector).
- Paso 1 de unificación de color: tokens `--sem-*` al `:root` del shell (`v2-theme.css`); el inspector los consume vía `.seg-*` (`custom.css`) sin duplicar hex. `estado_dominio.COLOR` (#558) ya unificaba estado→nombre; estos tokens mapean nombre→hex sólido.

**Tests**
- Smoke del fragmento (200 con datos / 404) en `test_smoke_expedientes_seguimiento.py`. Suite smoke completa en verde.

## Notas
- La convergencia del bundle del árbol con los tokens `--sem-*` del shell (que `arbol.css` herede en vez de redefinir) queda como spin-off, a abordar al iterar la paleta a JdA.
- Detectado en verificación (fuera de alcance): los listados v2 no reflejan sus filtros en la URL, así que recargar con `?sel` reabre el inspector pero resetea los filtros — spin-off transversal a `FiltrosListado`.

Closes #559
