### PR TITLE
Vista Mi trabajo del administrativo (cola + subir, ADR-017)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -77,7 +77,7 @@ def create_app(config_name='development'):
     app.register_blueprint(wizard_expediente.bp)  # Issue #67
 
     # Registrar blueprints - APIs
-    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento, api_bc, api_bitacora, api_search, api_usuarios, api_plantillas
+    from app.routes import api_expedientes, api_municipios, api_entidades, api_proyectos, api_escritos, api_seguimiento, api_bc, api_bitacora, api_search, api_usuarios, api_plantillas, api_administrativo
 
     app.register_blueprint(api_expedientes.api_bp)                  # usa 'api_bp'
     app.register_blueprint(api_municipios.bp)                       # usa 'bp'
@@ -90,6 +90,7 @@ def create_app(config_name='development'):
     app.register_blueprint(api_search.api_search_bp)                # usa 'api_search_bp' — Issue #531
     app.register_blueprint(api_usuarios.api_usuarios_bp)            # usa 'api_usuarios_bp' — Issue #544
     app.register_blueprint(api_plantillas.api_plantillas_bp)        # usa 'api_plantillas_bp' — Issue #545
+    app.register_blueprint(api_administrativo.api_administrativo_bp) # usa 'api_administrativo_bp' — Issue #501
 
     # Registrar módulos (app/modules/) — Fase 4: auto-discovery
     from app.modules import ModuleRegistry

--- a/app/modules/expedientes/routes.py
+++ b/app/modules/expedientes/routes.py
@@ -339,7 +339,7 @@ def generar_cert(tarea_id):
     """Genera el certificado de plazo cumplido para una tarea ESPERAR_PLAZO."""
     from app.services.certificados import crear_cert
     tarea = Tarea.query.get_or_404(tarea_id)
-    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'gestionar_tarea')
     if resultado:
         return resultado
     try:
@@ -543,9 +543,13 @@ def pool_registrar_rutas(id):
     Recibe JSON: [{ruta, tipo_doc_id, fecha_administrativa, asunto, prioridad}, ...]
     donde ruta es relativa a FILESYSTEM_BASE (con '/' como separador).
     Almacena la ruta absoluta normalizada en Documento.url.
+
+    Permiso 'subir_documento' (ADR-027 / #501): aportar al pool no edita el
+    expediente — el documento nace sin vínculo (huérfano) y es el técnico quien
+    decide si lo encaja. Sin limitación de rol.
     """
     expediente = Expediente.query.get_or_404(id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'subir_documento')
     if resultado:
         return resultado
 
@@ -631,9 +635,12 @@ def pool_registrar_url_externa(id):
     """
     Registra una URL externa en el pool (BOE, Notifica, sede electrónica, etc.)
     sin subir ningún fichero. Recibe JSON, devuelve JSON.
+
+    Permiso 'subir_documento' (ADR-027 / #501): aportar al pool no edita el
+    expediente; sin limitación de rol (igual que pool_registrar_rutas).
     """
     expediente = Expediente.query.get_or_404(id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'subir_documento')
     if resultado:
         return resultado
 

--- a/app/modules/mi_trabajo/__init__.py
+++ b/app/modules/mi_trabajo/__init__.py
@@ -1,0 +1,2 @@
+# Módulo "Mi trabajo" (#501, ADR-017). El blueprint vive en routes.py y lo
+# autodescubre ModuleRegistry (carpeta con routes.py + metadata.json).

--- a/app/modules/mi_trabajo/metadata.json
+++ b/app/modules/mi_trabajo/metadata.json
@@ -1,0 +1,13 @@
+{
+  "module": "mi_trabajo",
+  "name": "Mi trabajo",
+  "icon": "fa-inbox",
+  "order": 5,
+  "permissions": {
+    "list": ["ADMIN", "SUPERVISOR", "TRAMITADOR", "ADMINISTRATIVO"]
+  },
+  "navigation": {
+    "label": "Mi trabajo",
+    "route": "mi_trabajo.index"
+  }
+}

--- a/app/modules/mi_trabajo/routes.py
+++ b/app/modules/mi_trabajo/routes.py
@@ -1,0 +1,63 @@
+"""Blueprint de la vista "Mi trabajo" (#501, ADR-017).
+
+RUTAS:
+    GET /mi_trabajo/                         → role-adaptive:
+        ADMINISTRATIVO  → isla React (cola + subir documento).
+        Resto de roles  → redirect al seguimiento (su "mi trabajo" actual).
+    GET /mi_trabajo/tarea/<id>/fragmento     → parcial de lectura del inspector de
+        la cola (ADR-023 §9 / Opción A): detalle de la tarea en lenguaje del árbol,
+        con "Ir a tramitar". La edición se delega al árbol.
+
+La entrada de sidebar es única para todos los roles (ADR-013); la adaptación por
+rol ocurre en el destino, no en la navegación. El futuro "Mi trabajo del supervisor"
+enriquecerá el caso no-administrativo sin tocar esta entrada.
+"""
+from flask import Blueprint, render_template, redirect, url_for, session
+from flask_login import login_required
+
+from app.models.tareas import Tarea
+from app.models.tipos_expedientes import TipoExpediente
+from app.utils.permisos import verificar_acceso_expediente
+from app.services.detalle_nodo import detalle_de_nodo
+
+bp = Blueprint('mi_trabajo', __name__,
+               url_prefix='/mi_trabajo',
+               template_folder='templates')
+
+
+@bp.route('/')
+@login_required
+def index():
+    """Vista "Mi trabajo" — cola + subir documento para el ADMINISTRATIVO."""
+    if session.get('rol_activo_nombre') != 'ADMINISTRATIVO':
+        # Para tramitador/supervisor/admin su "mi trabajo" hoy es el seguimiento.
+        return redirect(url_for('expedientes.seguimiento'))
+
+    tipos_expediente = [
+        {'id': te.id, 'tipo': te.tipo}
+        for te in TipoExpediente.query.order_by(TipoExpediente.tipo).all()
+    ]
+    return render_template('mi_trabajo/index.html', tipos_expediente=tipos_expediente)
+
+
+@bp.route('/tarea/<int:tarea_id>/fragmento')
+@login_required
+def tarea_fragmento(tarea_id):
+    """Fragmento de lectura del inspector de la cola (ADR-023 §9 / #501).
+
+    Reutiliza detalle_nodo (el mismo detalle que el inspector del árbol). Solo
+    lectura: toda mutación se delega al árbol vía "Ir a tramitar".
+    """
+    tarea = Tarea.query.get_or_404(tarea_id)
+    expediente = tarea.tramite.fase.solicitud.expediente
+    resultado = verificar_acceso_expediente(expediente, 'ver')
+    if resultado:
+        return '', 403
+
+    detalle = detalle_de_nodo(expediente, 'tarea', tarea_id)
+    return render_template(
+        'mi_trabajo/_inspector_cola.html',
+        detalle=detalle,
+        expediente=expediente,
+        tarea_id=tarea_id,
+    )

--- a/app/modules/mi_trabajo/routes.py
+++ b/app/modules/mi_trabajo/routes.py
@@ -17,7 +17,6 @@ from flask_login import login_required
 
 from app.models.tareas import Tarea
 from app.models.tipos_expedientes import TipoExpediente
-from app.models.tipos_documentos import TipoDocumento
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.detalle_nodo import detalle_de_nodo
 
@@ -38,13 +37,7 @@ def index():
         {'id': te.id, 'tipo': te.tipo}
         for te in TipoExpediente.query.order_by(TipoExpediente.tipo).all()
     ]
-    tipos_doc = [
-        {'id': td.id, 'nombre': td.nombre}
-        for td in TipoDocumento.query.order_by(TipoDocumento.nombre).all()
-    ]
-    return render_template('mi_trabajo/index.html',
-                           tipos_expediente=tipos_expediente,
-                           tipos_doc=tipos_doc)
+    return render_template('mi_trabajo/index.html', tipos_expediente=tipos_expediente)
 
 
 @bp.route('/tarea/<int:tarea_id>/fragmento')

--- a/app/modules/mi_trabajo/routes.py
+++ b/app/modules/mi_trabajo/routes.py
@@ -17,6 +17,7 @@ from flask_login import login_required
 
 from app.models.tareas import Tarea
 from app.models.tipos_expedientes import TipoExpediente
+from app.models.tipos_documentos import TipoDocumento
 from app.utils.permisos import verificar_acceso_expediente
 from app.services.detalle_nodo import detalle_de_nodo
 
@@ -37,7 +38,13 @@ def index():
         {'id': te.id, 'tipo': te.tipo}
         for te in TipoExpediente.query.order_by(TipoExpediente.tipo).all()
     ]
-    return render_template('mi_trabajo/index.html', tipos_expediente=tipos_expediente)
+    tipos_doc = [
+        {'id': td.id, 'nombre': td.nombre}
+        for td in TipoDocumento.query.order_by(TipoDocumento.nombre).all()
+    ]
+    return render_template('mi_trabajo/index.html',
+                           tipos_expediente=tipos_expediente,
+                           tipos_doc=tipos_doc)
 
 
 @bp.route('/tarea/<int:tarea_id>/fragmento')

--- a/app/modules/mi_trabajo/templates/mi_trabajo/_inspector_cola.html
+++ b/app/modules/mi_trabajo/templates/mi_trabajo/_inspector_cola.html
@@ -1,0 +1,71 @@
+{# _inspector_cola.html — Parcial de lectura del inspector de la cola (ADR-023 §9 / #501).
+
+   No extiende base_app. Inyectado vía AppInspector.open({ fragmentUrl }).
+   Reutiliza el payload de detalle_nodo (mismo detalle que el inspector del árbol):
+   campos, documentos y plazo de la tarea. Solo lectura — la edición se delega al
+   árbol vía "Ir a tramitar" (deep link al nodo en modo edición).
+
+   Contexto:
+     detalle      — payload de services.detalle_nodo.detalle_de_nodo (tarea)
+     expediente   — Expediente de la tarea
+     tarea_id     — id de la tarea (para el deep link)
+#}
+<div class="p-3 cola-inspector">
+
+  {# ── Cabecera: referencia (ancestros) + cerrar ─────────────────────────── #}
+  <div class="d-flex justify-content-between align-items-start gap-2 mb-3">
+    <div class="text-secondary small">{{ detalle.referencia }}</div>
+    <button type="button" class="btn-close flex-shrink-0"
+            data-app-inspector-close aria-label="Cerrar"></button>
+  </div>
+
+  {# ── Plazo (solo ESPERAR_PLAZO) ────────────────────────────────────────── #}
+  {% if detalle.plazo and detalle.plazo.fecha_limite %}
+  <div class="alert alert-light border py-2 px-3 mb-3 small">
+    <i class="fas fa-hourglass-half me-1"></i>
+    <strong>Plazo:</strong> {{ detalle.plazo.fecha_limite }}
+    {% if detalle.plazo.dias_restantes is not none %}
+      ({{ detalle.plazo.dias_restantes }} d)
+    {% endif %}
+    {% if detalle.plazo.estado %}
+      · {{ detalle.plazo.estado }}
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# ── Campos del nodo ───────────────────────────────────────────────────── #}
+  {% if detalle.campos %}
+  <dl class="row mb-3 small gx-2 gy-1">
+    {% for c in detalle.campos %}
+    <dt class="col-5 text-secondary fw-normal">{{ c.etiqueta }}</dt>
+    <dd class="col-7 mb-0">{{ c.valor }}</dd>
+    {% endfor %}
+  </dl>
+  {% endif %}
+
+  {# ── Documentos vinculados ─────────────────────────────────────────────── #}
+  {% if detalle.documentos %}
+  <div class="mb-3">
+    <div class="fw-semibold small mb-1">Documentos</div>
+    <ul class="list-unstyled small mb-0">
+      {% for d in detalle.documentos %}
+      <li class="mb-1">
+        <span class="badge bg-light text-dark border me-1">{{ d.rol|capitalize }}</span>
+        <a href="{{ d.enlace }}" target="_blank" rel="noopener">{{ d.nombre }}</a>
+        {% if d.tipo_doc %}<span class="text-secondary">· {{ d.tipo_doc }}</span>{% endif %}
+        {% if d.fecha %}<span class="text-secondary">· {{ d.fecha }}</span>{% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% else %}
+  <p class="text-secondary small">Sin documentos vinculados todavía.</p>
+  {% endif %}
+
+  {# ── CTA: la edición vive en el árbol (deep link a la tarea) ────────────── #}
+  <a class="btn btn-primary btn-sm w-100"
+     href="{{ url_for('expedientes.arbol', id=expediente.id) }}?nodo=tarea-{{ tarea_id }}">
+    <i class="fas fa-arrow-right me-1"></i> Ir a tramitar
+  </a>
+
+</div>

--- a/app/modules/mi_trabajo/templates/mi_trabajo/index.html
+++ b/app/modules/mi_trabajo/templates/mi_trabajo/index.html
@@ -14,10 +14,9 @@
 
 {% block content %}
   <div id="app-root"
-       class="h-100"
+       style="flex:1; min-height:0; display:flex; flex-direction:column"
        data-react-island="mi-trabajo"
        data-tipos-expediente='{{ tipos_expediente | tojson }}'
-       data-tipos-doc='{{ tipos_doc | tojson }}'
        {{ user_ctx_attrs() }}></div>
 {% endblock %}
 

--- a/app/modules/mi_trabajo/templates/mi_trabajo/index.html
+++ b/app/modules/mi_trabajo/templates/mi_trabajo/index.html
@@ -17,6 +17,7 @@
        class="h-100"
        data-react-island="mi-trabajo"
        data-tipos-expediente='{{ tipos_expediente | tojson }}'
+       data-tipos-doc='{{ tipos_doc | tojson }}'
        {{ user_ctx_attrs() }}></div>
 {% endblock %}
 

--- a/app/modules/mi_trabajo/templates/mi_trabajo/index.html
+++ b/app/modules/mi_trabajo/templates/mi_trabajo/index.html
@@ -1,0 +1,25 @@
+{# index.html — Vista "Mi trabajo" del administrativo (#501, ADR-017).
+
+   Isla React "mi-trabajo" sobre base_app. La viewbar (título + tabs
+   [Cola] [Subir documento]) la renderiza la propia isla por portal sobre el slot,
+   igual que el árbol (#523). El inspector de la cola usa el overlay global del
+   shell (AppInspector.open) — no se declara {% block inspector %}. #}
+{% extends "layout/base_app.html" %}
+
+{% block title %}Mi trabajo{% endblock %}
+
+{% block viewbar %}
+  <div id="mi-trabajo-viewbar-slot" style="display:contents"></div>
+{% endblock %}
+
+{% block content %}
+  <div id="app-root"
+       class="h-100"
+       data-react-island="mi-trabajo"
+       data-tipos-expediente='{{ tipos_expediente | tojson }}'
+       {{ user_ctx_attrs() }}></div>
+{% endblock %}
+
+{% block extra_js %}
+  {{ react_bundle('mi-trabajo') }}
+{% endblock %}

--- a/app/routes/api_administrativo.py
+++ b/app/routes/api_administrativo.py
@@ -1,0 +1,62 @@
+"""API de la vista "Mi trabajo" del administrativo (#501, ADR-017).
+
+ENDPOINT:
+    GET /api/administrativo/cola — Cola transversal de tareas administrativas
+        pendientes (NOTIFICAR / ELABORAR / ESPERAR_PLAZO no finalizadas), con
+        contexto por fila y paginación por cursor.
+
+        Params:
+            cursor             (int, default 0)            — Paginación por Tarea.id
+            limit              (int, default 50, max 100)  — Filas por página
+            search             (str, opcional)             — Nº AT / titular
+            tipo_expediente_id (int, opcional)             — Filtra por tipo de expediente
+            pendiente          (str, opcional)             — Código de estado de dominio
+            plazo              (str, opcional)             — vencido|hoy|semana|sin_plazo
+
+        Respuesta: {'data': [...], 'next_cursor': int, 'has_more': bool}
+
+La SUBIDA de documentos NO tiene endpoint propio: reutiliza el flujo del pool ya
+existente (expedientes.pool_registrar_rutas / pool_registrar_url_externa), abierto
+a todos los roles vía permiso 'subir_documento' (ADR-027 / #501).
+
+La cola es visible para todos los roles (ADR-013): solo requiere sesión.
+"""
+import logging
+
+from flask import Blueprint, request, jsonify
+from flask_login import login_required
+
+from app.services.cola_administrativo import construir_cola
+
+api_administrativo_bp = Blueprint('api_administrativo', __name__, url_prefix='/api/administrativo')
+
+log = logging.getLogger(__name__)
+
+
+@api_administrativo_bp.route('/cola', methods=['GET'])
+@login_required
+def cola():
+    """Página de la cola de trabajo administrativo (ADR-017 §2)."""
+    try:
+        cursor = int(request.args.get('cursor', 0))
+        if cursor < 0:
+            return jsonify({'error': 'cursor debe ser >= 0'}), 400
+        limit = int(request.args.get('limit', 50))
+    except ValueError:
+        return jsonify({'error': 'Parámetros numéricos inválidos'}), 400
+
+    filtros = {
+        'search':    request.args.get('search', '').strip(),
+        'pendiente': request.args.get('pendiente', '').strip() or None,
+        'plazo':     request.args.get('plazo', '').strip() or None,
+    }
+
+    tipo_exp_raw = request.args.get('tipo_expediente_id', '').strip()
+    if tipo_exp_raw:
+        try:
+            filtros['tipo_expediente_id'] = int(tipo_exp_raw)
+        except ValueError:
+            return jsonify({'error': 'tipo_expediente_id debe ser entero'}), 400
+
+    resultado = construir_cola(cursor=cursor, limit=limit, filtros=filtros)
+    return jsonify(resultado)

--- a/app/routes/api_bc.py
+++ b/app/routes/api_bc.py
@@ -112,7 +112,7 @@ def _res_error(res):
 def crear_solicitud(exp_id):
     """Crea una o varias solicitudes en el expediente (multi-select de tipos)."""
     expediente = Expediente.query.get_or_404(exp_id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -152,7 +152,7 @@ def crear_solicitud(exp_id):
 @login_required
 def crear_fase(sol_id):
     sol = Solicitud.query.get_or_404(sol_id)
-    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    resultado = verificar_acceso_expediente(sol.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -183,7 +183,7 @@ _FASES_QUE_REQUIEREN_CERT_IP_CONSULTAS = frozenset({'RESOLUCION', 'AAU_AAUS_INTE
 @login_required
 def crear_tramite(fase_id):
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -210,7 +210,7 @@ def crear_tramite(fase_id):
 @login_required
 def crear_tarea(tram_id):
     tramite = Tramite.query.get_or_404(tram_id)
-    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'gestionar_tarea')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -242,7 +242,7 @@ def crear_tarea(tram_id):
 @login_required
 def editar_solicitud(sol_id):
     sol = Solicitud.query.get_or_404(sol_id)
-    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    resultado = verificar_acceso_expediente(sol.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -256,7 +256,7 @@ def editar_solicitud(sol_id):
 @login_required
 def editar_fase(fase_id):
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -279,7 +279,7 @@ def editar_fase(fase_id):
 @login_required
 def editar_tramite(tram_id):
     tramite = Tramite.query.get_or_404(tram_id)
-    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -293,7 +293,7 @@ def editar_tramite(tram_id):
 @login_required
 def editar_tarea(tarea_id):
     tarea = Tarea.query.get_or_404(tarea_id)
-    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'gestionar_tarea')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -321,7 +321,7 @@ def editar_tarea(tarea_id):
 @login_required
 def borrar_solicitud(sol_id):
     sol = Solicitud.query.get_or_404(sol_id)
-    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    resultado = verificar_acceso_expediente(sol.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -341,7 +341,7 @@ def borrar_solicitud(sol_id):
 @login_required
 def borrar_fase(fase_id):
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -361,7 +361,7 @@ def borrar_fase(fase_id):
 @login_required
 def borrar_tramite(tram_id):
     tramite = Tramite.query.get_or_404(tram_id)
-    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -381,7 +381,7 @@ def borrar_tramite(tram_id):
 @login_required
 def borrar_tarea(tarea_id):
     tarea = Tarea.query.get_or_404(tarea_id)
-    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'gestionar_tarea')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -405,7 +405,7 @@ def borrar_tarea(tarea_id):
 @login_required
 def finalizar_solicitud(sol_id):
     sol = Solicitud.query.get_or_404(sol_id)
-    resultado = verificar_acceso_expediente(sol.expediente, 'editar')
+    resultado = verificar_acceso_expediente(sol.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     if sol.estado == 'RESUELTA':
@@ -417,7 +417,7 @@ def finalizar_solicitud(sol_id):
 @login_required
 def finalizar_fase(fase_id):
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     if fase.finalizada:
@@ -429,7 +429,7 @@ def finalizar_fase(fase_id):
 @login_required
 def finalizar_tramite(tram_id):
     tramite = Tramite.query.get_or_404(tram_id)
-    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tramite.fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     if tramite.finalizado:
@@ -441,7 +441,7 @@ def finalizar_tramite(tram_id):
 @login_required
 def finalizar_tarea(tarea_id):
     tarea = Tarea.query.get_or_404(tarea_id)
-    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(tarea.tramite.fase.solicitud.expediente, 'gestionar_tarea')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     if tarea.ejecutada:
@@ -514,7 +514,7 @@ def crear_traslado(fase_id):
         tipo                     str   'ORGANISMO' | 'TITULAR'
     """
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
     return _ejecutar_crear_traslado(fase, request.form)
@@ -587,7 +587,7 @@ def _ejecutar_crear_traslado(fase, form):
 @login_required
 def listar_organismos(exp_id):
     expediente = Expediente.query.get_or_404(exp_id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -599,7 +599,7 @@ def listar_organismos(exp_id):
 @login_required
 def crear_organismo(exp_id):
     expediente = Expediente.query.get_or_404(exp_id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -644,7 +644,7 @@ def crear_organismo(exp_id):
 @login_required
 def editar_organismo(exp_id, oid):
     expediente = Expediente.query.get_or_404(exp_id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -667,7 +667,7 @@ def editar_organismo(exp_id, oid):
 @login_required
 def borrar_organismo(exp_id, oid):
     expediente = Expediente.query.get_or_404(exp_id)
-    resultado = verificar_acceso_expediente(expediente, 'editar')
+    resultado = verificar_acceso_expediente(expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 
@@ -715,7 +715,7 @@ def _calcular_plazo_consulta(expediente, solicitud) -> int:
 @login_required
 def enviar_consultas(fase_id):
     fase = Fase.query.get_or_404(fase_id)
-    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'editar')
+    resultado = verificar_acceso_expediente(fase.solicitud.expediente, 'gestionar_estructura')
     if resultado:
         return jsonify({'ok': False, 'error': 'Acceso denegado'}), 403
 

--- a/app/routes/api_expedientes.py
+++ b/app/routes/api_expedientes.py
@@ -491,9 +491,11 @@ def crear_hijo_nodo(expediente_id, padre_tipo, padre_id):
     Bloqueo motor: {error, motivo, url_norma} 422.
     """
     expediente = Expediente.query.get_or_404(expediente_id)
-    denegado = verificar_acceso_expediente(expediente, 'editar')
-    if denegado:
-        return denegado
+    # Hoja vs estructura (ADR-017 §6): bajo trámite se crean tareas (gestionar_tareas,
+    # incluye ADMINISTRATIVO); el resto crea estructura (gestionar_estructura_expediente).
+    accion = 'gestionar_tarea' if padre_tipo == 'tramite' else 'gestionar_estructura'
+    if verificar_acceso_expediente(expediente, accion):
+        return jsonify({'error': 'No tienes permiso para esta acción'}), 403
 
     try:
         padre = _resolver_nodo(expediente, padre_tipo, padre_id)
@@ -575,9 +577,11 @@ def editar_nodo(expediente_id, tipo, nodo_id):
     Respuesta éxito: {ok:true} 200. Bloqueo motor: {error, motivo, url_norma} 422.
     """
     expediente = Expediente.query.get_or_404(expediente_id)
-    denegado = verificar_acceso_expediente(expediente, 'editar')
-    if denegado:
-        return denegado
+    # Hoja (tarea → gestionar_tareas, incluye ADMINISTRATIVO) vs estructura
+    # (solicitud/fase/trámite → gestionar_estructura_expediente). ADR-017 §6.
+    accion = 'gestionar_tarea' if tipo == 'tarea' else 'gestionar_estructura'
+    if verificar_acceso_expediente(expediente, accion):
+        return jsonify({'error': 'No tienes permiso para esta acción'}), 403
 
     try:
         nodo = _resolver_nodo(expediente, tipo, nodo_id)
@@ -628,9 +632,10 @@ def borrar_nodo(expediente_id, tipo, nodo_id):
     Sin body. Respuesta éxito: {ok:true} 200. Bloqueo motor: {error, motivo, url_norma} 422.
     """
     expediente = Expediente.query.get_or_404(expediente_id)
-    denegado = verificar_acceso_expediente(expediente, 'editar')
-    if denegado:
-        return denegado
+    # Mismo criterio hoja/estructura que editar_nodo (ADR-017 §6).
+    accion = 'gestionar_tarea' if tipo == 'tarea' else 'gestionar_estructura'
+    if verificar_acceso_expediente(expediente, accion):
+        return jsonify({'error': 'No tienes permiso para esta acción'}), 403
 
     try:
         nodo = _resolver_nodo(expediente, tipo, nodo_id)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -4,6 +4,18 @@ from app.models.usuarios import Usuario
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
+# Roles que aterrizan en "Mi trabajo" tras login (#501, ADR-017 §1). La vista se
+# adapta al rol: ADMINISTRATIVO ve la cola; TRAMITADOR/SUPERVISOR van al seguimiento.
+# ADMIN sigue aterrizando en el dashboard.
+_ROLES_MI_TRABAJO = {'ADMINISTRATIVO', 'TRAMITADOR', 'SUPERVISOR'}
+
+
+def _destino_post_login(rol_nombre):
+    """Endpoint de aterrizaje tras login según el rol activo (#501)."""
+    if rol_nombre in _ROLES_MI_TRABAJO:
+        return 'mi_trabajo.index'
+    return 'dashboard.index'
+
 
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
@@ -43,7 +55,7 @@ def login():
             session['rol_activo_nombre'] = rol.nombre
             flash(f'Bienvenido, {usuario.nombre}! Trabajando como {rol.nombre}.', 'success')
             next_page = session.pop('next_after_rol', None) or request.args.get('next')
-            return redirect(next_page if next_page else url_for('dashboard.index'))
+            return redirect(next_page if next_page else url_for(_destino_post_login(rol.nombre)))
 
         # Primera pasada: validar credenciales
         siglas = request.form.get('siglas')
@@ -66,7 +78,7 @@ def login():
                 session['rol_activo_nombre'] = rol.nombre
                 flash(f'Bienvenido, {usuario.nombre}!', 'success')
                 next_page = request.args.get('next')
-                return redirect(next_page if next_page else url_for('dashboard.index'))
+                return redirect(next_page if next_page else url_for(_destino_post_login(rol.nombre)))
             else:
                 # Guardar usuario pendiente y next en sesión para la segunda pasada
                 session['pending_login_id'] = usuario.id

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -136,7 +136,10 @@ def cambiar_rol(rol_id):
     session['rol_activo_id'] = rol.id
     session['rol_activo_nombre'] = rol.nombre
     flash(f'Rol cambiado a {rol.nombre}.', 'info')
-    return redirect(request.referrer or url_for('dashboard.index'))
+    # Aterrizar en el "home" del nuevo rol (#501): cambiar a ADMINISTRATIVO lleva a su
+    # cola; a tramitador/supervisor, al seguimiento. Evita quedarse en una vista del
+    # rol anterior (p. ej. el seguimiento del tramitador al volver a administrativo).
+    return redirect(url_for(_destino_post_login(rol.nombre)))
 
 
 @bp.route('/logout')

--- a/app/services/cola_administrativo.py
+++ b/app/services/cola_administrativo.py
@@ -1,0 +1,282 @@
+"""
+cola_administrativo.py — Agregador de la cola de "Mi trabajo" del administrativo (#501, ADR-017 §2).
+
+Listado transversal (atraviesa todos los expedientes EN_TRAMITE) de las tareas que
+son trabajo administrativo típico: NOTIFICAR, ELABORAR y ESPERAR_PLAZO no finalizadas.
+NO incluye ANALIZAR (trabajo del técnico); la "puerta abierta" del permiso permite al
+admin actuar sobre cualquier tarea desde el árbol, pero la cola solo OFRECE su
+subconjunto (es una guía, no un límite de acceso — ADR-017 §6).
+
+El estado de cada tarea sale del núcleo único `estado_dominio` (#558) — la misma verdad
+que el árbol y el seguimiento. El plazo de ESPERAR_PLAZO se resuelve en el backend
+(calendario hábil) vía `arbol_expediente.plazo_tarea`. La cola NO añade columnas nuevas
+respecto al diseño: amplía qué tareas selecciona y el texto de "Pendiente" (directiva #2).
+
+"Tocado por" queda DIFERIDO (placeholder en el front); aquí viaja como None (#501 §3).
+
+Salida: {'data': [fila...], 'next_cursor': int, 'has_more': bool}.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import or_, cast, String
+from sqlalchemy.orm import joinedload
+
+from app import db
+from app.models.tareas import Tarea
+from app.models.tramites import Tramite
+from app.models.fases import Fase
+from app.models.solicitudes import Solicitud
+from app.models.expedientes import Expediente
+from app.models.entidad import Entidad
+from app.models.documentos import Documento
+from app.models.documentos_tarea import DocumentoTarea
+from app.models.tipos_tareas import TipoTarea
+
+import app.services.estado_dominio as ed
+from app.services.arbol_expediente import plazo_tarea
+
+log = logging.getLogger(__name__)
+
+# Tipos de tarea que la cola ofrece como trabajo administrativo (ADR-017 §2).
+TIPOS_COLA = ('NOTIFICAR', 'ELABORAR', 'ESPERAR_PLAZO')
+
+
+# ---------------------------------------------------------------------------
+# API pública
+# ---------------------------------------------------------------------------
+
+def construir_cola(*, cursor: int = 0, limit: int = 50, filtros: dict | None = None) -> dict:
+    """
+    Construye una página de la cola administrativa.
+
+    Cursor por `Tarea.id`. Como el descarte de tareas FIN / de solicitudes resueltas
+    ocurre en Python (depende de documentos y plazo, no es SQL puro), se lee una
+    ventana mayor que `limit` y se emite hasta `limit` filas pendientes. Una página
+    puede salir corta: el front sigue paginando mientras `has_more` sea True.
+    """
+    filtros = filtros or {}
+    limit = min(max(limit, 1), 100)
+    ventana = limit * 4
+
+    tareas = _query_base(cursor, filtros).limit(ventana + 1).all()
+    hay_mas_db = len(tareas) > ventana
+    tareas = tareas[:ventana]
+
+    data: list[dict] = []
+    ultimo_id = cursor
+    corte = False
+    for tarea in tareas:
+        ultimo_id = tarea.id
+        fila = _fila_si_pendiente(tarea, filtros)
+        if fila is not None:
+            data.append(fila)
+            if len(data) >= limit:
+                corte = True
+                break
+
+    return {
+        'data': data,
+        'next_cursor': ultimo_id,
+        'has_more': corte or hay_mas_db,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query base (filtros SQL: tipo de tarea, cursor, búsqueda, tipo de expediente)
+# ---------------------------------------------------------------------------
+
+def _query_base(cursor: int, filtros: dict):
+    q = (
+        db.session.query(Tarea)
+        .join(Tramite, Tarea.tramite_id == Tramite.id)
+        .join(Fase, Tramite.fase_id == Fase.id)
+        .join(Solicitud, Fase.solicitud_id == Solicitud.id)
+        .join(Expediente, Solicitud.expediente_id == Expediente.id)
+        .join(TipoTarea, Tarea.tipo_tarea_id == TipoTarea.id)
+        .outerjoin(Entidad, Expediente.titular_id == Entidad.id)
+        .options(
+            joinedload(Tarea.tipo_tarea),
+            joinedload(Tarea.vinculos_documento)
+                .joinedload(DocumentoTarea.documento).joinedload(Documento.tipo_doc),
+            joinedload(Tarea.vinculos_documento)
+                .joinedload(DocumentoTarea.documento).joinedload(Documento.notificacion),
+            joinedload(Tarea.tramite).joinedload(Tramite.tipo_tramite),
+            joinedload(Tarea.tramite).joinedload(Tramite.fase).joinedload(Fase.tipo_fase),
+            joinedload(Tarea.tramite).joinedload(Tramite.fase)
+                .joinedload(Fase.solicitud).joinedload(Solicitud.tipo_solicitud),
+            joinedload(Tarea.tramite).joinedload(Tramite.fase)
+                .joinedload(Fase.solicitud).joinedload(Solicitud.expediente)
+                .joinedload(Expediente.titular),
+        )
+        .filter(TipoTarea.codigo.in_(TIPOS_COLA))
+    )
+
+    if cursor > 0:
+        q = q.filter(Tarea.id > cursor)
+
+    search = (filtros.get('search') or '').strip()
+    if search:
+        num_at = search.upper().removeprefix('AT-').removeprefix('AT')
+        q = q.filter(or_(
+            cast(Expediente.numero_at, String).ilike(f'%{num_at}%'),
+            Entidad.nombre_completo.ilike(f'%{search}%'),
+        ))
+
+    tipo_expediente_id = filtros.get('tipo_expediente_id')
+    if tipo_expediente_id:
+        q = q.filter(Expediente.tipo_expediente_id == tipo_expediente_id)
+
+    return q.order_by(Tarea.id.asc())
+
+
+# ---------------------------------------------------------------------------
+# Selección y serialización de filas (filtros computados: estado y plazo)
+# ---------------------------------------------------------------------------
+
+def _fila_si_pendiente(tarea, filtros: dict) -> dict | None:
+    """Devuelve la fila si la tarea es trabajo pendiente y pasa los filtros; si no, None."""
+    sol = tarea.tramite.fase.solicitud
+    if not sol.activa:                       # solo solicitudes EN_TRAMITE
+        return None
+
+    estado, plazo = _estado_y_plazo(tarea)
+    if estado == 'FIN':                       # ya hecha: no es trabajo pendiente
+        return None
+
+    f_pendiente = filtros.get('pendiente')
+    if f_pendiente and estado != f_pendiente:
+        return None
+
+    f_plazo = filtros.get('plazo')
+    if f_plazo and _bucket_plazo(plazo) != f_plazo:
+        return None
+
+    return _fila(tarea, estado, plazo)
+
+
+def _estado_y_plazo(tarea) -> tuple[str, dict | None]:
+    """Estado de dominio de la tarea (+ plazo resuelto si es ESPERAR_PLAZO).
+
+    Réplica de la lógica de seguimiento._estado_tarea, defensiva: un fallo de plazo
+    degrada a None (el núcleo lo mapea a PENDIENTE_TRAMITAR) sin tumbar la fila.
+    """
+    tt = getattr(tarea, 'tipo_tarea', None)
+    codigo = tt.codigo if tt else None
+    plazo = None
+    if codigo == 'ESPERAR_PLAZO':
+        try:
+            plazo = plazo_tarea(tarea, tarea.tramite)
+        except Exception as exc:  # noqa: BLE001 — un plazo no debe tumbar la cola
+            log.warning('cola: plazo no disponible para tarea %s — %s', tarea.id, exc)
+    return ed.estado_tarea(tarea, plazo=plazo), plazo
+
+
+def _fila(tarea, estado: str, plazo: dict | None) -> dict:
+    tramite = tarea.tramite
+    fase = tramite.fase
+    sol = fase.solicitud
+    exp = sol.expediente
+    titular = exp.titular if exp else None
+    return {
+        'tarea_id':      tarea.id,
+        'expediente_id': exp.id if exp else None,
+        'num_at':        exp.numero_at if exp else None,
+        'titular':       titular.nombre_completo if titular else '—',
+        'solicitud':     sol.tipo_solicitud.siglas if sol.tipo_solicitud else '—',
+        'fase':          _nombre_tipo(fase.tipo_fase),
+        'tramite':       _nombre_tipo(tramite.tipo_tramite),
+        'tarea':         tarea.tipo_tarea.codigo if tarea.tipo_tarea else '—',
+        'pendiente':         _mensaje_pendiente(tarea, estado),
+        'pendiente_codigo':  estado,
+        'plazo':         plazo,
+        'tocado_por':    None,   # diferido (#501 §3): el front pinta '—'
+    }
+
+
+# ---------------------------------------------------------------------------
+# Texto de "Pendiente" por tipo de tarea + estado de dominio (ADR-017 §2)
+# ---------------------------------------------------------------------------
+
+def _mensaje_pendiente(tarea, estado: str) -> str:
+    codigo = tarea.tipo_tarea.codigo if tarea.tipo_tarea else None
+
+    if codigo == 'NOTIFICAR':
+        if estado == 'PENDIENTE_TRAMITAR':
+            return 'falta doc firmado'
+        if estado == 'NOTIFICACION_FALLIDA':
+            return 'notificación fallida — 2º intento'
+        if estado == 'NOTIFICACION_AGOTADA':
+            return 'notificación agotada — procede edicto'
+        # PENDIENTE_NOTIFICAR: distingue por presencia de justificante (producido)
+        if tarea.documento_producido is None:
+            return 'esperando justificante'
+        return 'esperando registro de resultado'
+
+    if codigo == 'ELABORAR':
+        if estado == 'PENDIENTE_FIRMA':
+            return 'pendiente de firma'
+        return 'pendiente elaborar'
+
+    if codigo == 'ESPERAR_PLAZO':
+        if estado == 'PENDIENTE_ESTUDIO':       # plazo vencido → hay que actuar
+            return 'plazo vencido — incorporar'
+        if estado == 'PENDIENTE_TRAMITAR':
+            return 'pendiente iniciar plazo'
+        return _texto_espera(tarea)             # PENDIENTE_PLAZOS
+
+    return 'pendiente'
+
+
+def _texto_espera(tarea) -> str:
+    """Afina "esperando recepción" por el tipo de trámite/fase (ADR-017 §2, ilustrativo)."""
+    tramite = tarea.tramite
+    cod_tramite = _codigo(tramite.tipo_tramite if tramite else None)
+    cod_fase = _codigo(tramite.fase.tipo_fase if tramite and tramite.fase else None)
+
+    if 'PUBLICACION' in cod_tramite:
+        return 'esperando publicación efectiva'
+    if 'INFORMACION_PUBLICA' in cod_fase:
+        return 'esperando alegaciones'
+    if 'CONSULTA' in cod_tramite:
+        return 'esperando informe del organismo'
+    if 'REQUERIMIENTO' in cod_tramite or 'SUBSAN' in cod_tramite:
+        return 'esperando subsanación'
+    return 'esperando recepción'
+
+
+# ---------------------------------------------------------------------------
+# Plazo → bucket para el filtro (hoy / semana / vencido / sin_plazo)
+# ---------------------------------------------------------------------------
+
+def _bucket_plazo(plazo: dict | None) -> str:
+    if not plazo:
+        return 'sin_plazo'
+    if plazo.get('estado') == 'VENCIDO':
+        return 'vencido'
+    dias = plazo.get('dias_restantes')
+    if dias is None:
+        return 'sin_plazo'
+    if dias < 0:
+        return 'vencido'
+    if dias == 0:
+        return 'hoy'
+    if dias <= 7:
+        return 'semana'
+    return 'futuro'
+
+
+# ---------------------------------------------------------------------------
+# Utilidades
+# ---------------------------------------------------------------------------
+
+def _nombre_tipo(tipo) -> str:
+    """Nombre legible de un tipo de catálogo (nombre → código → '—')."""
+    if tipo is None:
+        return '—'
+    return getattr(tipo, 'nombre', None) or getattr(tipo, 'codigo', None) or '—'
+
+
+def _codigo(tipo) -> str:
+    return (getattr(tipo, 'codigo', None) or '') if tipo is not None else ''

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -51,7 +51,7 @@
     ]
   },
   "src/expediente-arbol/index.jsx": {
-    "file": "bundle.expediente-arbol.CmEm8cdo.js",
+    "file": "bundle.expediente-arbol.CexMODXC.js",
     "name": "expediente-arbol",
     "src": "src/expediente-arbol/index.jsx",
     "isEntry": true,
@@ -62,6 +62,16 @@
     ],
     "css": [
       "asset.expediente-arbol.hbg5rhwl.css"
+    ]
+  },
+  "src/mi-trabajo/index.jsx": {
+    "file": "bundle.mi-trabajo.DiB4Xv3L.js",
+    "name": "mi-trabajo",
+    "src": "src/mi-trabajo/index.jsx",
+    "isEntry": true,
+    "imports": [
+      "_chunk.toast.JponFgs_.js",
+      "_chunk.api.D03Nd58a.js"
     ]
   }
 }

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -65,7 +65,7 @@
     ]
   },
   "src/mi-trabajo/index.jsx": {
-    "file": "bundle.mi-trabajo.N2xNPKmy.js",
+    "file": "bundle.mi-trabajo.C4A-kQ2R.js",
     "name": "mi-trabajo",
     "src": "src/mi-trabajo/index.jsx",
     "isEntry": true,

--- a/app/static/js/react/manifest.json
+++ b/app/static/js/react/manifest.json
@@ -65,7 +65,7 @@
     ]
   },
   "src/mi-trabajo/index.jsx": {
-    "file": "bundle.mi-trabajo.DiB4Xv3L.js",
+    "file": "bundle.mi-trabajo.N2xNPKmy.js",
     "name": "mi-trabajo",
     "src": "src/mi-trabajo/index.jsx",
     "isEntry": true,

--- a/app/utils/permisos.py
+++ b/app/utils/permisos.py
@@ -36,7 +36,32 @@ PERMISOS = {
 
     'acceder_tablas_maestras':   {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
     'gestionar_tablas_maestras': {'ADMIN', 'SUPERVISOR'},
+
+    # Árbol del expediente — frontera hoja / estructura (ADR-017 §6, #501).
+    # "Puerta abierta": gestionar_tareas habilita COMPLETAR cualquier tarea ya
+    # prevista (incluye ADMINISTRATIVO); la bitácora es la rendición de cuentas.
+    # gestionar_estructura_expediente (crear/editar/borrar solicitudes, fases,
+    # trámites) es "tramitar" → propio del TRAMITADOR, NO del ADMINISTRATIVO.
+    'gestionar_tareas':              {'ADMIN', 'SUPERVISOR', 'TRAMITADOR', 'ADMINISTRATIVO'},
+    'gestionar_estructura_expediente': {'ADMIN', 'SUPERVISOR', 'TRAMITADOR'},
 }
+
+# Mapa acción → permiso para verificar_acceso_expediente. Las acciones de mutación
+# (todas menos 'acceder') comprueban su permiso específico; el resto cae a acceder.
+# 'subir_documento' es acceder_expediente a propósito: aportar un documento al pool
+# NO edita el expediente (nace con vínculos indirectos, ADR-027) — sin limitación de
+# rol. El borrado del pool sí es del técnico (usa 'editar').
+_PERMISO_POR_ACCION = {
+    'editar':               'editar_expediente',
+    'gestionar_tarea':      'gestionar_tareas',
+    'gestionar_estructura': 'gestionar_estructura_expediente',
+    'subir_documento':      'acceder_expediente',
+}
+
+# Acciones que, si las ejecuta un TRAMITADOR sobre un expediente ajeno, dejan traza
+# en bitácora (actuación fuera de asignación). Subir al pool no cuenta: no toca el
+# expediente.
+_ACCIONES_CON_TRAZA_AJENA = {'editar', 'gestionar_tarea', 'gestionar_estructura'}
 
 
 def tiene_permiso(nombre):
@@ -80,20 +105,24 @@ def verificar_acceso_expediente(expediente, accion='acceder'):
     """
     Verifica acceso al expediente y gestiona el indicador de asignación.
 
+    `accion` ∈ {'acceder'/'ver', 'editar', 'gestionar_tarea',
+    'gestionar_estructura', 'subir_documento'} → cada una comprueba su permiso
+    según _PERMISO_POR_ACCION (las desconocidas caen a acceder_expediente).
+
     - Establece g.expediente_actual para que el context processor
       pueda inyectar el indicador de bombilla en el layout.
-    - Si la acción es 'editar' y el expediente es ajeno, registra
+    - Si la acción muta el expediente y este es ajeno (TRAMITADOR), registra
       en bitácora (sin commit — responsabilidad del consumidor).
     - Devuelve None si el acceso es correcto, o un redirect si no.
     """
     g.expediente_actual = expediente
 
-    permiso = 'editar_expediente' if accion == 'editar' else 'acceder_expediente'
+    permiso = _PERMISO_POR_ACCION.get(accion, 'acceder_expediente')
     if not tiene_permiso(permiso):
         flash(f'No tienes permisos para {accion} este expediente', 'danger')
         return redirect(url_for('expedientes.listado_v2'))
 
-    if accion == 'editar' and es_expediente_ajeno(expediente):
+    if accion in _ACCIONES_CON_TRAZA_AJENA and es_expediente_ajeno(expediente):
         bitacora.registrar(
             usuario_id=current_user.id,
             operacion='ALTERAR',

--- a/app/utils/permisos.py
+++ b/app/utils/permisos.py
@@ -8,7 +8,7 @@ Añadir un permiso nuevo = una entrada aquí + el check en el endpoint.
 La evaluación usa siempre el rol ACTIVO de sesión, no todos los roles del usuario,
 para que el cambio de rol tenga efecto real.
 """
-from flask import flash, g, redirect, session, url_for
+from flask import flash, g, redirect, request, session, url_for
 from flask_login import current_user
 
 from app.services import bitacora
@@ -72,6 +72,15 @@ def tiene_permiso(nombre):
     return rol_activo in PERMISOS.get(nombre, set())
 
 
+def _es_peticion_json():
+    """True si la petición es de una API/isla (espera JSON), no una navegación HTML."""
+    return (
+        'application/json' in request.headers.get('Accept', '')
+        or request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+        or request.is_json
+    )
+
+
 def es_expediente_ajeno(expediente):
     """
     True si el rol activo es TRAMITADOR y el expediente no está asignado al usuario.
@@ -119,7 +128,11 @@ def verificar_acceso_expediente(expediente, accion='acceder'):
 
     permiso = _PERMISO_POR_ACCION.get(accion, 'acceder_expediente')
     if not tiene_permiso(permiso):
-        flash(f'No tienes permisos para {accion} este expediente', 'danger')
+        # En peticiones JSON/XHR (API de islas React) NO encolar flash: se quedaría
+        # colgado para la siguiente página HTML. El front muestra su propio aviso y
+        # el endpoint debe devolver 403 JSON (no este redirect, que el fetch seguiría).
+        if not _es_peticion_json():
+            flash(f'No tienes permisos para {accion} este expediente', 'danger')
         return redirect(url_for('expedientes.listado_v2'))
 
     if accion in _ACCIONES_CON_TRAZA_AJENA and es_expediente_ajeno(expediente):

--- a/react-src/src/expediente-arbol/components/Arbol.jsx
+++ b/react-src/src/expediente-arbol/components/Arbol.jsx
@@ -10,7 +10,7 @@ import React, { useMemo, useCallback } from 'react'
 import { ReactFlow, Background, Controls } from '@xyflow/react'
 import { useArbolStore } from '../store.js'
 import { construirGrafo } from '../layout.js'
-import { tienePermiso } from '../../shared/auth.js'
+import { puedeEditarNodo } from '../../shared/auth.js'
 import NodoExpediente from './nodos/NodoExpediente.jsx'
 import NodoSolicitud from './nodos/NodoSolicitud.jsx'
 import NodoFase from './nodos/NodoFase.jsx'
@@ -57,7 +57,7 @@ export default function Arbol() {
   const onNodeDoubleClick = useCallback(
     (_, node) => {
       if (node.data.tipo === 'tareas') return
-      if (!tienePermiso('editar_expediente')) return
+      if (!puedeEditarNodo(node.data.tipo)) return
       entrarEdicion({ tipo: node.data.tipo, id: node.data.id })
     },
     [entrarEdicion],

--- a/react-src/src/expediente-arbol/components/Inspector.jsx
+++ b/react-src/src/expediente-arbol/components/Inspector.jsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { useArbolStore, selectHayCambios } from '../store.js'
 import { api } from '../../shared/api.js'
 import { showToast } from '../../shared/ui/toast.js'
-import { tienePermiso } from '../../shared/auth.js'
+import { puedeEditarNodo } from '../../shared/auth.js'
 import Semaforo from './nodos/Semaforo.jsx'
 import Despensa from './Despensa.jsx'
 
@@ -282,8 +282,8 @@ function Editor() {
   const firstRef = React.useRef(null)
   React.useEffect(() => { if (firstRef.current) firstRef.current.focus() }, [campos])
 
-  const puedeBorrar = tienePermiso('editar_expediente') &&
-                      seleccion && seleccion.tipo !== 'expediente'
+  const puedeBorrar = seleccion && seleccion.tipo !== 'expediente' &&
+                      puedeEditarNodo(seleccion.tipo)
 
   if (cargando) return <div className="text-muted small">Cargando editor…</div>
   if (!campos.length)
@@ -384,7 +384,7 @@ export default function Inspector() {
   const nodo = buscarNodo(arbol, seleccion)
   if (modoEdicion) return <InspectorEdicion nodo={nodo} />
   const esHoja = seleccion.tipo === 'tarea'
-  const puedeEditar = tienePermiso('editar_expediente')
+  const puedeEditar = puedeEditarNodo(seleccion.tipo)
 
   return (
     <div className="p-3 d-flex flex-column h-100">

--- a/react-src/src/expediente-arbol/components/MenuContextual.jsx
+++ b/react-src/src/expediente-arbol/components/MenuContextual.jsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { useArbolStore } from '../store.js'
 import { api } from '../../shared/api.js'
 import { showToast } from '../../shared/ui/toast.js'
-import { tienePermiso } from '../../shared/auth.js'
+import { puedeEditarNodo, puedeCrearHijoDe } from '../../shared/auth.js'
 
 async function copiarReferencia(ref) {
   try {
@@ -71,7 +71,8 @@ export default function MenuContextual() {
   const py = Math.min(y, window.innerHeight - MENU_H - 8)
 
   const esTarea    = sel.tipo === 'tarea'
-  const puedeEditar = tienePermiso('editar_expediente') && sel.tipo !== 'expediente'
+  const puedeEditar    = puedeEditarNodo(sel.tipo) && sel.tipo !== 'expediente'
+  const puedeCrearHijo = puedeCrearHijoDe(sel.tipo)
 
   const tipos        = tiposCreables?.tipos || []
   const permitidos   = tipos.filter((t) => t.permitido)
@@ -114,6 +115,7 @@ export default function MenuContextual() {
       {/* ── Nodo no-tarea ── */}
       {!esTarea && (
         <>
+          {puedeCrearHijo && (
           <div className="arbol-menu__submenu-wrap"
                onMouseEnter={() => setSubmenuActivo('crear-hijo')}
                onMouseLeave={() => setSubmenuActivo(null)}>
@@ -148,6 +150,7 @@ export default function MenuContextual() {
               </div>
             )}
           </div>
+          )}
           {puedeEditar && (
             <div className="arbol-menu__item" onClick={handleEditar}>✏️ Editar</div>
           )}

--- a/react-src/src/mi-trabajo/App.jsx
+++ b/react-src/src/mi-trabajo/App.jsx
@@ -25,16 +25,15 @@ function leerJSON(attr, fallback) {
 export default function App() {
   const [tab, setTab] = useState('cola')
   const [tiposExpediente] = useState(() => leerJSON('data-tipos-expediente', []))
-  const [tiposDoc] = useState(() => leerJSON('data-tipos-doc', []))
 
   return (
-    <div className="h-100 d-flex flex-column">
+    <div className="d-flex flex-column" style={{ flex: 1, minHeight: 0 }}>
       {viewbarSlot() && createPortal(
         <Viewbar tab={tab} onTab={setTab} />, viewbarSlot(),
       )}
       {tab === 'cola'
         ? <Cola tiposExpediente={tiposExpediente} />
-        : <SubirDocumento tiposDoc={tiposDoc} />}
+        : <SubirDocumento />}
     </div>
   )
 }

--- a/react-src/src/mi-trabajo/App.jsx
+++ b/react-src/src/mi-trabajo/App.jsx
@@ -1,0 +1,40 @@
+// App.jsx — raíz de la isla "Mi trabajo" (#501, ADR-017).
+//
+// Dos modos en v1 (Cola / Subir documento) por tabs. Los tabs viven en la viewbar
+// del shell: se portalan sobre el slot #mi-trabajo-viewbar-slot (mismo patrón que
+// el árbol, #523). El inspector de la cola usa el overlay global del shell.
+import React, { useState } from 'react'
+import { createPortal } from 'react-dom'
+import Viewbar from './components/Viewbar.jsx'
+import Cola from './components/Cola.jsx'
+import SubirDocumento from './components/SubirDocumento.jsx'
+
+const viewbarSlot = () => document.getElementById('mi-trabajo-viewbar-slot')
+
+function leerJSON(attr, fallback) {
+  const el = document.querySelector('[data-react-island="mi-trabajo"]')
+  const raw = el && el.getAttribute(attr)
+  if (!raw) return fallback
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return fallback
+  }
+}
+
+export default function App() {
+  const [tab, setTab] = useState('cola')
+  const [tiposExpediente] = useState(() => leerJSON('data-tipos-expediente', []))
+  const [tiposDoc] = useState(() => leerJSON('data-tipos-doc', []))
+
+  return (
+    <div className="h-100 d-flex flex-column">
+      {viewbarSlot() && createPortal(
+        <Viewbar tab={tab} onTab={setTab} />, viewbarSlot(),
+      )}
+      {tab === 'cola'
+        ? <Cola tiposExpediente={tiposExpediente} />
+        : <SubirDocumento tiposDoc={tiposDoc} />}
+    </div>
+  )
+}

--- a/react-src/src/mi-trabajo/components/Cola.jsx
+++ b/react-src/src/mi-trabajo/components/Cola.jsx
@@ -1,8 +1,9 @@
 // Cola.jsx — listado transversal de tareas administrativas pendientes (#501, ADR-017 §2).
 //
-// Tabla densa con scroll infinito por cursor. Click en fila → inspector overlay de
-// LECTURA del agregado (Opción A, ADR-023 §9): el fragmento es el detalle de la
-// tarea en lenguaje del árbol, con "Ir a tramitar". La edición se delega al árbol.
+// Usa el chrome de listados de la app (lista-cabecera / lista-scroll-container /
+// card.tabla-bloque / lista-table, ADR-022) para que se vea como el resto. Scroll
+// infinito por cursor. Click en fila → inspector overlay de LECTURA (Opción A,
+// ADR-023 §9): detalle de la tarea en lenguaje del árbol + "Ir a tramitar".
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../../shared/api.js'
 
@@ -34,8 +35,8 @@ export default function Cola({ tiposExpediente }) {
     return p
   }, [search, tipoExp, plazo])
 
-  // Carga una página. En reset arranca de cursor 0. El bucle salta ventanas que solo
-  // traen tareas FIN (data vacía pero has_more): así el scroll nunca se "atasca".
+  // Carga una página. El bucle salta ventanas que solo traen tareas FIN (data vacía
+  // pero has_more): así el scroll nunca se "atasca".
   const cargar = useCallback(async (reset = false) => {
     if (cargandoRef.current) return
     if (!reset && !hasMore) return
@@ -60,7 +61,7 @@ export default function Cola({ tiposExpediente }) {
     }
   }, [cursor, hasMore, params])
 
-  // Recargar al cambiar filtros (con debounce para el search).
+  // Recargar al cambiar filtros (debounce para el search).
   useEffect(() => {
     const t = setTimeout(() => cargar(true), 250)
     return () => clearTimeout(t)
@@ -91,67 +92,70 @@ export default function Cola({ tiposExpediente }) {
   }
 
   return (
-    <div className="d-flex flex-column h-100">
-      {/* Filtros */}
-      <div className="d-flex flex-wrap align-items-center gap-2 p-2 border-bottom">
-        <input
-          type="search" className="form-control form-control-sm" style={{ maxWidth: 240 }}
-          placeholder="Nº AT o titular…" value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <select className="form-select form-select-sm" style={{ width: 'auto' }}
-                value={tipoExp} onChange={(e) => setTipoExp(e.target.value)}>
-          <option value="">Tipo: todos</option>
-          {tiposExpediente.map((te) => <option key={te.id} value={te.id}>{te.tipo}</option>)}
-        </select>
-        <select className="form-select form-select-sm" style={{ width: 'auto' }}
-                value={plazo} onChange={(e) => setPlazo(e.target.value)}>
-          {PLAZOS.map((p) => <option key={p.v} value={p.v}>{p.t}</option>)}
-        </select>
-        <span className="text-secondary small ms-auto">{filas.length} tarea(s)</span>
+    <div className="d-flex flex-column" style={{ flex: 1, minHeight: 0 }}>
+      {/* C.1 — filtros + contador (chrome de listados) */}
+      <div className="lista-cabecera">
+        <div className="filters-row">
+          <div className="filters">
+            <input type="search" placeholder="Nº AT o titular…" aria-label="Buscar"
+                   value={search} onChange={(e) => setSearch(e.target.value)} />
+            <select value={tipoExp} onChange={(e) => setTipoExp(e.target.value)} aria-label="Tipo de expediente">
+              <option value="">Tipo: todos</option>
+              {tiposExpediente.map((te) => <option key={te.id} value={te.id}>{te.tipo}</option>)}
+            </select>
+            <select value={plazo} onChange={(e) => setPlazo(e.target.value)} aria-label="Plazo">
+              {PLAZOS.map((p) => <option key={p.v} value={p.v}>{p.t}</option>)}
+            </select>
+          </div>
+          <div className="pagination-info"><span>{filas.length}</span> tarea(s)</div>
+        </div>
       </div>
 
-      {/* Tabla densa con scroll infinito */}
-      <div ref={scrollRef} onScroll={onScroll} className="flex-grow-1" style={{ overflowY: 'auto' }}>
-        <table className="table table-hover table-sm align-middle small mb-0">
-          <thead className="table-light" style={{ position: 'sticky', top: 0, zIndex: 1 }}>
-            <tr>
-              <th>AT</th><th>Titular</th><th>Solicitud</th><th>Fase</th>
-              <th>Trámite</th><th>Tarea</th><th>Pendiente</th><th>Tocado por</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filas.map((f) => (
-              <tr key={f.tarea_id}
-                  className={selId === f.tarea_id ? 'table-active' : ''}
-                  style={{ cursor: 'pointer' }}
-                  onClick={() => abrirFila(f)}>
-                <td className="fw-semibold text-nowrap">AT-{f.num_at}</td>
-                <td className="text-truncate" style={{ maxWidth: 160 }} title={f.titular}>{f.titular}</td>
-                <td className="text-nowrap">{f.solicitud}</td>
-                <td className="text-truncate" style={{ maxWidth: 150 }} title={f.fase}>{f.fase}</td>
-                <td className="text-truncate" style={{ maxWidth: 170 }} title={f.tramite}>{f.tramite}</td>
-                <td className="text-nowrap">{f.tarea}</td>
-                <td>
-                  {f.pendiente}
-                  {f.plazo && f.plazo.fecha_limite && (
-                    <span className="badge bg-light text-dark border ms-1">
-                      {f.plazo.dias_restantes != null ? `${f.plazo.dias_restantes} d` : f.plazo.estado}
-                    </span>
-                  )}
-                </td>
-                <td className="text-secondary">{f.tocado_por || '—'}</td>
-              </tr>
-            ))}
-            {!cargando && filas.length === 0 && (
-              <tr>
-                <td colSpan={8} className="text-center text-secondary py-4">
-                  No hay tareas administrativas pendientes con estos filtros.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+      {/* C.2 — contenedor scrollable con la tabla unificada */}
+      <div className="lista-scroll-container" ref={scrollRef} onScroll={onScroll}>
+        <div className="py-3">
+          <div className="card tabla-bloque">
+            <table className="lista-table cola-table">
+              <thead>
+                <tr>
+                  <th>AT</th><th>Titular</th><th>Solicitud</th><th>Fase</th>
+                  <th>Trámite</th><th>Tarea</th><th>Pendiente</th><th>Tocado por</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filas.map((f) => (
+                  <tr key={f.tarea_id}
+                      className={selId === f.tarea_id ? 'table-active' : ''}
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => abrirFila(f)}>
+                    <td className="fw-semibold text-nowrap">AT-{f.num_at}</td>
+                    <td title={f.titular}>{f.titular}</td>
+                    <td className="text-nowrap">{f.solicitud}</td>
+                    <td title={f.fase}>{f.fase}</td>
+                    <td title={f.tramite}>{f.tramite}</td>
+                    <td className="text-nowrap">{f.tarea}</td>
+                    <td>
+                      {f.pendiente}
+                      {f.plazo && f.plazo.fecha_limite && (
+                        <span className="badge bg-light text-dark border ms-1">
+                          {f.plazo.dias_restantes != null ? `${f.plazo.dias_restantes} d` : f.plazo.estado}
+                        </span>
+                      )}
+                    </td>
+                    <td className="text-secondary">{f.tocado_por || '—'}</td>
+                  </tr>
+                ))}
+                {!cargando && filas.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="text-center text-secondary py-4">
+                      No hay tareas administrativas pendientes con estos filtros.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
         {cargando && (
           <div className="text-center text-secondary small py-3">
             <i className="fas fa-spinner fa-spin me-1" /> Cargando…

--- a/react-src/src/mi-trabajo/components/Cola.jsx
+++ b/react-src/src/mi-trabajo/components/Cola.jsx
@@ -1,0 +1,163 @@
+// Cola.jsx — listado transversal de tareas administrativas pendientes (#501, ADR-017 §2).
+//
+// Tabla densa con scroll infinito por cursor. Click en fila → inspector overlay de
+// LECTURA del agregado (Opción A, ADR-023 §9): el fragmento es el detalle de la
+// tarea en lenguaje del árbol, con "Ir a tramitar". La edición se delega al árbol.
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '../../shared/api.js'
+
+const PLAZOS = [
+  { v: '',          t: 'Plazo: todos' },
+  { v: 'vencido',   t: 'Vencido' },
+  { v: 'hoy',       t: 'Hoy' },
+  { v: 'semana',    t: 'Esta semana' },
+  { v: 'sin_plazo', t: 'Sin plazo' },
+]
+
+export default function Cola({ tiposExpediente }) {
+  const [filas, setFilas] = useState([])
+  const [cursor, setCursor] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const [cargando, setCargando] = useState(false)
+  const [selId, setSelId] = useState(null)
+  const [search, setSearch] = useState('')
+  const [tipoExp, setTipoExp] = useState('')
+  const [plazo, setPlazo] = useState('')
+  const scrollRef = useRef(null)
+  const cargandoRef = useRef(false)
+
+  const params = useCallback((cur) => {
+    const p = new URLSearchParams({ cursor: cur, limit: 50 })
+    if (search) p.set('search', search)
+    if (tipoExp) p.set('tipo_expediente_id', tipoExp)
+    if (plazo) p.set('plazo', plazo)
+    return p
+  }, [search, tipoExp, plazo])
+
+  // Carga una página. En reset arranca de cursor 0. El bucle salta ventanas que solo
+  // traen tareas FIN (data vacía pero has_more): así el scroll nunca se "atasca".
+  const cargar = useCallback(async (reset = false) => {
+    if (cargandoRef.current) return
+    if (!reset && !hasMore) return
+    cargandoRef.current = true
+    setCargando(true)
+    try {
+      let cur = reset ? 0 : cursor
+      let primera = reset
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const data = await api.get(`/api/administrativo/cola?${params(cur)}`)
+        cur = data.next_cursor
+        if (primera) { setFilas(data.data); primera = false }
+        else if (data.data.length) setFilas((prev) => [...prev, ...data.data])
+        setCursor(data.next_cursor)
+        setHasMore(data.has_more)
+        if (data.data.length > 0 || !data.has_more) break
+      }
+    } finally {
+      cargandoRef.current = false
+      setCargando(false)
+    }
+  }, [cursor, hasMore, params])
+
+  // Recargar al cambiar filtros (con debounce para el search).
+  useEffect(() => {
+    const t = setTimeout(() => cargar(true), 250)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, tipoExp, plazo])
+
+  // Deseleccionar la fila cuando el shell cierra el inspector.
+  useEffect(() => {
+    const onClosed = () => setSelId(null)
+    document.addEventListener('inspector:closed', onClosed)
+    return () => document.removeEventListener('inspector:closed', onClosed)
+  }, [])
+
+  const onScroll = () => {
+    const el = scrollRef.current
+    if (!el || cargandoRef.current || !hasMore) return
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 120) cargar(false)
+  }
+
+  const abrirFila = (fila) => {
+    setSelId(fila.tarea_id)
+    if (window.AppInspector) {
+      window.AppInspector.open({
+        selId: `tarea-${fila.tarea_id}`,
+        fragmentUrl: `/mi_trabajo/tarea/${fila.tarea_id}/fragmento`,
+      })
+    }
+  }
+
+  return (
+    <div className="d-flex flex-column h-100">
+      {/* Filtros */}
+      <div className="d-flex flex-wrap align-items-center gap-2 p-2 border-bottom">
+        <input
+          type="search" className="form-control form-control-sm" style={{ maxWidth: 240 }}
+          placeholder="Nº AT o titular…" value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select className="form-select form-select-sm" style={{ width: 'auto' }}
+                value={tipoExp} onChange={(e) => setTipoExp(e.target.value)}>
+          <option value="">Tipo: todos</option>
+          {tiposExpediente.map((te) => <option key={te.id} value={te.id}>{te.tipo}</option>)}
+        </select>
+        <select className="form-select form-select-sm" style={{ width: 'auto' }}
+                value={plazo} onChange={(e) => setPlazo(e.target.value)}>
+          {PLAZOS.map((p) => <option key={p.v} value={p.v}>{p.t}</option>)}
+        </select>
+        <span className="text-secondary small ms-auto">{filas.length} tarea(s)</span>
+      </div>
+
+      {/* Tabla densa con scroll infinito */}
+      <div ref={scrollRef} onScroll={onScroll} className="flex-grow-1" style={{ overflowY: 'auto' }}>
+        <table className="table table-hover table-sm align-middle small mb-0">
+          <thead className="table-light" style={{ position: 'sticky', top: 0, zIndex: 1 }}>
+            <tr>
+              <th>AT</th><th>Titular</th><th>Solicitud</th><th>Fase</th>
+              <th>Trámite</th><th>Tarea</th><th>Pendiente</th><th>Tocado por</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filas.map((f) => (
+              <tr key={f.tarea_id}
+                  className={selId === f.tarea_id ? 'table-active' : ''}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => abrirFila(f)}>
+                <td className="fw-semibold text-nowrap">AT-{f.num_at}</td>
+                <td className="text-truncate" style={{ maxWidth: 160 }} title={f.titular}>{f.titular}</td>
+                <td className="text-nowrap">{f.solicitud}</td>
+                <td className="text-truncate" style={{ maxWidth: 150 }} title={f.fase}>{f.fase}</td>
+                <td className="text-truncate" style={{ maxWidth: 170 }} title={f.tramite}>{f.tramite}</td>
+                <td className="text-nowrap">{f.tarea}</td>
+                <td>
+                  {f.pendiente}
+                  {f.plazo && f.plazo.fecha_limite && (
+                    <span className="badge bg-light text-dark border ms-1">
+                      {f.plazo.dias_restantes != null ? `${f.plazo.dias_restantes} d` : f.plazo.estado}
+                    </span>
+                  )}
+                </td>
+                <td className="text-secondary">{f.tocado_por || '—'}</td>
+              </tr>
+            ))}
+            {!cargando && filas.length === 0 && (
+              <tr>
+                <td colSpan={8} className="text-center text-secondary py-4">
+                  No hay tareas administrativas pendientes con estos filtros.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        {cargando && (
+          <div className="text-center text-secondary small py-3">
+            <i className="fas fa-spinner fa-spin me-1" /> Cargando…
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/react-src/src/mi-trabajo/components/SubirDocumento.jsx
+++ b/react-src/src/mi-trabajo/components/SubirDocumento.jsx
@@ -1,0 +1,167 @@
+// SubirDocumento.jsx — subida puntual al pool del expediente (#501, ADR-017 §4).
+//
+// No hay subida multipart en BDDAT: se reutiliza el flujo del pool ya existente.
+//   - "URL externa" (BOE/BOJA/Notifica…) se registra inline → POST pool_registrar_url_externa.
+//   - Ficheros del servidor → enlaza a la página de pool del expediente (explorador completo).
+// El admin elige primero el expediente (reutiliza /api/search, el de Ctrl+K). El toast
+// de confirmación muestra el AT destino para detectar de un vistazo un error de expediente.
+// El histórico NO persiste: solo un log efímero de lo subido en esta sesión (hablado, #501).
+import React, { useRef, useState } from 'react'
+import { api } from '../../shared/api.js'
+import { showToast } from '../../shared/ui/toast.js'
+
+export default function SubirDocumento({ tiposDoc }) {
+  const [q, setQ] = useState('')
+  const [resultados, setResultados] = useState([])
+  const [exp, setExp] = useState(null)           // {id, label}
+  const [url, setUrl] = useState('')
+  const [tipoDoc, setTipoDoc] = useState('')
+  const [fecha, setFecha] = useState('')
+  const [asunto, setAsunto] = useState('')
+  const [registrando, setRegistrando] = useState(false)
+  const [log, setLog] = useState([])             // efímero (sesión); no BD, no persiste
+  const buscarTimer = useRef(null)
+
+  const buscar = (texto) => {
+    setQ(texto)
+    setExp(null)
+    clearTimeout(buscarTimer.current)
+    if (texto.trim().length < 2) { setResultados([]); return }
+    buscarTimer.current = setTimeout(async () => {
+      try {
+        const data = await api.get(
+          `/api/search?tipos=expedientes&q=${encodeURIComponent(texto)}&limit=8`,
+        )
+        const grupo = (data.grupos || []).find((g) => g.tipo === 'expedientes')
+        setResultados(grupo ? grupo.resultados : [])
+      } catch {
+        setResultados([])
+      }
+    }, 250)
+  }
+
+  const elegir = (r) => {
+    setExp({ id: r.id, label: r.label })
+    setResultados([])
+    setQ(r.label)
+  }
+
+  const registrarUrl = async () => {
+    if (!exp || !url.trim()) return
+    setRegistrando(true)
+    try {
+      await api.post(`/expedientes/${exp.id}/documentos/url-externa`, {
+        url: url.trim(),
+        tipo_doc_id: tipoDoc || 1,
+        fecha_administrativa: fecha || null,
+        asunto: asunto.trim(),
+      })
+      showToast(`Documento registrado en ${exp.label}`, 'success')
+      setLog((prev) => [
+        { k: Date.now(), txt: `${exp.label} · ${asunto.trim() || url.trim()}` },
+        ...prev,
+      ])
+      setUrl(''); setAsunto(''); setFecha(''); setTipoDoc('')
+    } catch (e) {
+      showToast(e.message || 'No se pudo registrar el documento', 'danger')
+    } finally {
+      setRegistrando(false)
+    }
+  }
+
+  return (
+    <div className="p-3" style={{ maxWidth: 760, overflowY: 'auto' }}>
+      {/* Selector de expediente destino */}
+      <label className="form-label fw-semibold">Expediente destino</label>
+      <div className="position-relative mb-3">
+        <input className="form-control" placeholder="Nº AT, titular o proyecto…"
+               value={q} onChange={(e) => buscar(e.target.value)} />
+        {resultados.length > 0 && (
+          <div className="list-group position-absolute w-100 shadow-sm" style={{ zIndex: 5 }}>
+            {resultados.map((r) => (
+              <button type="button" key={r.id}
+                      className="list-group-item list-group-item-action py-1"
+                      onClick={() => elegir(r)}>
+                <div className="fw-semibold small">{r.label}</div>
+                {r.breadcrumb && (
+                  <div className="text-secondary" style={{ fontSize: '.78em' }}>{r.breadcrumb}</div>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!exp ? (
+        <p className="text-secondary small">Elige primero el expediente destino.</p>
+      ) : (
+        <>
+          <div className="alert alert-light border py-2 px-3 small">
+            Destino: <strong>{exp.label}</strong>
+          </div>
+
+          {/* Vía 1 — URL externa (inline) */}
+          <div className="card mb-3">
+            <div className="card-body">
+              <h6 className="card-title"><i className="fas fa-link me-1" /> Añadir URL externa</h6>
+              <p className="text-secondary small">
+                BOE, BOJA, Notifica, sede electrónica… No se sube fichero; se registra el enlace.
+              </p>
+              <input className="form-control form-control-sm mb-2" placeholder="https://…"
+                     value={url} onChange={(e) => setUrl(e.target.value)} />
+              <div className="row g-2 mb-2">
+                <div className="col-sm-6">
+                  <select className="form-select form-select-sm" value={tipoDoc}
+                          onChange={(e) => setTipoDoc(e.target.value)}>
+                    <option value="">— Tipo de documento —</option>
+                    {tiposDoc.map((t) => <option key={t.id} value={t.id}>{t.nombre}</option>)}
+                  </select>
+                </div>
+                <div className="col-sm-6">
+                  <input type="date" className="form-control form-control-sm"
+                         value={fecha} onChange={(e) => setFecha(e.target.value)} />
+                </div>
+              </div>
+              <input className="form-control form-control-sm mb-2" placeholder="Asunto (opcional)"
+                     value={asunto} onChange={(e) => setAsunto(e.target.value)} />
+              <button className="btn btn-primary btn-sm"
+                      disabled={registrando || !url.trim()} onClick={registrarUrl}>
+                <i className="fas fa-save me-1" /> Registrar URL
+              </button>
+            </div>
+          </div>
+
+          {/* Vía 2 — ficheros del servidor (reutiliza el explorador del pool) */}
+          <div className="card mb-3">
+            <div className="card-body d-flex justify-content-between align-items-center gap-3">
+              <div>
+                <h6 className="card-title mb-1"><i className="fas fa-server me-1" /> Ficheros del servidor</h6>
+                <p className="text-secondary small mb-0">
+                  Explorador del servidor corporativo (descargas de BandeJA, carpetas…).
+                </p>
+              </div>
+              <a className="btn btn-outline-primary btn-sm flex-shrink-0"
+                 href={`/expedientes/${exp.id}/documentos`}>
+                Abrir explorador <i className="fas fa-arrow-right ms-1" />
+              </a>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Log efímero de la sesión (no persiste) */}
+      {log.length > 0 && (
+        <div className="mt-3">
+          <div className="fw-semibold small mb-1">Subido en esta sesión</div>
+          <ul className="list-unstyled small mb-0">
+            {log.map((l) => (
+              <li key={l.k} className="text-secondary">
+                <i className="fas fa-check text-success me-1" />{l.txt}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/react-src/src/mi-trabajo/components/SubirDocumento.jsx
+++ b/react-src/src/mi-trabajo/components/SubirDocumento.jsx
@@ -1,25 +1,16 @@
-// SubirDocumento.jsx — subida puntual al pool del expediente (#501, ADR-017 §4).
+// SubirDocumento.jsx — alta de documentos al pool del expediente (#501, ADR-017 §4).
 //
-// No hay subida multipart en BDDAT: se reutiliza el flujo del pool ya existente.
-//   - "URL externa" (BOE/BOJA/Notifica…) se registra inline → POST pool_registrar_url_externa.
-//   - Ficheros del servidor → enlaza a la página de pool del expediente (explorador completo).
-// El admin elige primero el expediente (reutiliza /api/search, el de Ctrl+K). El toast
-// de confirmación muestra el AT destino para detectar de un vistazo un error de expediente.
-// El histórico NO persiste: solo un log efímero de lo subido en esta sesión (hablado, #501).
+// No hay subida multipart en BDDAT. La gestión documental completa (ficheros del
+// servidor + URLs externas) ya vive en la página de pool del expediente. Esta
+// pestaña solo aporta lo que faltaba: ELEGIR el expediente (reutiliza /api/search,
+// el de Ctrl+K) y entrar a su gestor — un único método, un único sitio (feedback #4).
 import React, { useRef, useState } from 'react'
 import { api } from '../../shared/api.js'
-import { showToast } from '../../shared/ui/toast.js'
 
-export default function SubirDocumento({ tiposDoc }) {
+export default function SubirDocumento() {
   const [q, setQ] = useState('')
   const [resultados, setResultados] = useState([])
-  const [exp, setExp] = useState(null)           // {id, label}
-  const [url, setUrl] = useState('')
-  const [tipoDoc, setTipoDoc] = useState('')
-  const [fecha, setFecha] = useState('')
-  const [asunto, setAsunto] = useState('')
-  const [registrando, setRegistrando] = useState(false)
-  const [log, setLog] = useState([])             // efímero (sesión); no BD, no persiste
+  const [exp, setExp] = useState(null)        // {id, label}
   const buscarTimer = useRef(null)
 
   const buscar = (texto) => {
@@ -46,41 +37,17 @@ export default function SubirDocumento({ tiposDoc }) {
     setQ(r.label)
   }
 
-  const registrarUrl = async () => {
-    if (!exp || !url.trim()) return
-    setRegistrando(true)
-    try {
-      await api.post(`/expedientes/${exp.id}/documentos/url-externa`, {
-        url: url.trim(),
-        tipo_doc_id: tipoDoc || 1,
-        fecha_administrativa: fecha || null,
-        asunto: asunto.trim(),
-      })
-      showToast(`Documento registrado en ${exp.label}`, 'success')
-      setLog((prev) => [
-        { k: Date.now(), txt: `${exp.label} · ${asunto.trim() || url.trim()}` },
-        ...prev,
-      ])
-      setUrl(''); setAsunto(''); setFecha(''); setTipoDoc('')
-    } catch (e) {
-      showToast(e.message || 'No se pudo registrar el documento', 'danger')
-    } finally {
-      setRegistrando(false)
-    }
-  }
-
   return (
-    <div className="p-3" style={{ maxWidth: 760, overflowY: 'auto' }}>
-      {/* Selector de expediente destino */}
+    <div className="p-3" style={{ maxWidth: 760 }}>
       <label className="form-label fw-semibold">Expediente destino</label>
       <div className="position-relative mb-3">
         <input className="form-control" placeholder="Nº AT, titular o proyecto…"
                value={q} onChange={(e) => buscar(e.target.value)} />
         {resultados.length > 0 && (
-          <div className="list-group position-absolute w-100 shadow-sm" style={{ zIndex: 5 }}>
+          <div className="list-group position-absolute w-100 shadow" style={{ zIndex: 1050 }}>
             {resultados.map((r) => (
               <button type="button" key={r.id}
-                      className="list-group-item list-group-item-action py-1"
+                      className="list-group-item list-group-item-action py-2"
                       onClick={() => elegir(r)}>
                 <div className="fw-semibold small">{r.label}</div>
                 {r.breadcrumb && (
@@ -95,71 +62,19 @@ export default function SubirDocumento({ tiposDoc }) {
       {!exp ? (
         <p className="text-secondary small">Elige primero el expediente destino.</p>
       ) : (
-        <>
-          <div className="alert alert-light border py-2 px-3 small">
-            Destino: <strong>{exp.label}</strong>
-          </div>
-
-          {/* Vía 1 — URL externa (inline) */}
-          <div className="card mb-3">
-            <div className="card-body">
-              <h6 className="card-title"><i className="fas fa-link me-1" /> Añadir URL externa</h6>
-              <p className="text-secondary small">
-                BOE, BOJA, Notifica, sede electrónica… No se sube fichero; se registra el enlace.
+        <div className="card tabla-bloque">
+          <div className="card-body d-flex justify-content-between align-items-center gap-3">
+            <div>
+              <h6 className="mb-1"><i className="fas fa-folder-open me-1" /> {exp.label}</h6>
+              <p className="text-secondary small mb-0">
+                Gestor de documentos del expediente: subir ficheros del servidor corporativo
+                (descargas de BandeJA, carpetas…) y registrar URLs externas (BOE, BOJA, Notifica…).
               </p>
-              <input className="form-control form-control-sm mb-2" placeholder="https://…"
-                     value={url} onChange={(e) => setUrl(e.target.value)} />
-              <div className="row g-2 mb-2">
-                <div className="col-sm-6">
-                  <select className="form-select form-select-sm" value={tipoDoc}
-                          onChange={(e) => setTipoDoc(e.target.value)}>
-                    <option value="">— Tipo de documento —</option>
-                    {tiposDoc.map((t) => <option key={t.id} value={t.id}>{t.nombre}</option>)}
-                  </select>
-                </div>
-                <div className="col-sm-6">
-                  <input type="date" className="form-control form-control-sm"
-                         value={fecha} onChange={(e) => setFecha(e.target.value)} />
-                </div>
-              </div>
-              <input className="form-control form-control-sm mb-2" placeholder="Asunto (opcional)"
-                     value={asunto} onChange={(e) => setAsunto(e.target.value)} />
-              <button className="btn btn-primary btn-sm"
-                      disabled={registrando || !url.trim()} onClick={registrarUrl}>
-                <i className="fas fa-save me-1" /> Registrar URL
-              </button>
             </div>
+            <a className="btn btn-primary flex-shrink-0" href={`/expedientes/${exp.id}/documentos`}>
+              Abrir gestor <i className="fas fa-arrow-right ms-1" />
+            </a>
           </div>
-
-          {/* Vía 2 — ficheros del servidor (reutiliza el explorador del pool) */}
-          <div className="card mb-3">
-            <div className="card-body d-flex justify-content-between align-items-center gap-3">
-              <div>
-                <h6 className="card-title mb-1"><i className="fas fa-server me-1" /> Ficheros del servidor</h6>
-                <p className="text-secondary small mb-0">
-                  Explorador del servidor corporativo (descargas de BandeJA, carpetas…).
-                </p>
-              </div>
-              <a className="btn btn-outline-primary btn-sm flex-shrink-0"
-                 href={`/expedientes/${exp.id}/documentos`}>
-                Abrir explorador <i className="fas fa-arrow-right ms-1" />
-              </a>
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Log efímero de la sesión (no persiste) */}
-      {log.length > 0 && (
-        <div className="mt-3">
-          <div className="fw-semibold small mb-1">Subido en esta sesión</div>
-          <ul className="list-unstyled small mb-0">
-            {log.map((l) => (
-              <li key={l.k} className="text-secondary">
-                <i className="fas fa-check text-success me-1" />{l.txt}
-              </li>
-            ))}
-          </ul>
         </div>
       )}
     </div>

--- a/react-src/src/mi-trabajo/components/Viewbar.jsx
+++ b/react-src/src/mi-trabajo/components/Viewbar.jsx
@@ -1,31 +1,36 @@
-// Viewbar.jsx — título + tabs de "Mi trabajo" (#501). Se portala sobre la viewbar
-// del shell. Solo clases Bootstrap (ADR-015).
+// Viewbar.jsx — título + conmutador de modo de "Mi trabajo" (#501).
+// Se portala sobre la viewbar del shell (app-viewbar__*), igual que el árbol.
+// Estándar JdA/Bootstrap: btn-group con btn-outline-primary + iconos FontAwesome
+// (nada de emoji, que quedaban fuera de lugar respecto al CDN de la Junta).
 import React from 'react'
 
 const TABS = [
-  { id: 'cola',  label: '📋 Cola' },
-  { id: 'subir', label: '📤 Subir documento' },
+  { id: 'cola',  label: 'Tareas pendientes', icon: 'fa-tasks' },
+  { id: 'subir', label: 'Subir documento',   icon: 'fa-upload' },
 ]
 
 export default function Viewbar({ tab, onTab }) {
   return (
-    <div className="d-flex align-items-center gap-3 w-100">
-      <span className="fw-semibold text-nowrap">
-        <i className="fas fa-inbox me-1" /> Mi trabajo
-      </span>
-      <ul className="nav nav-pills gap-1 mb-0">
+    <>
+      <div className="app-viewbar__title">
+        <i className="fas fa-inbox me-2" aria-hidden="true" />
+        <strong>Mi trabajo</strong>
+      </div>
+      <div className="app-viewbar__spacer" />
+      <div className="btn-group btn-group-sm" role="group" aria-label="Modo de Mi trabajo">
         {TABS.map((t) => (
-          <li className="nav-item" key={t.id}>
-            <button
-              type="button"
-              className={`nav-link py-1 px-2 ${tab === t.id ? 'active' : ''}`}
-              onClick={() => onTab(t.id)}
-            >
-              {t.label}
-            </button>
-          </li>
+          <button
+            key={t.id}
+            type="button"
+            className={`btn btn-outline-primary${tab === t.id ? ' active' : ''}`}
+            aria-pressed={tab === t.id}
+            onClick={() => onTab(t.id)}
+          >
+            <i className={`fas ${t.icon} me-1`} aria-hidden="true" />
+            {t.label}
+          </button>
         ))}
-      </ul>
-    </div>
+      </div>
+    </>
   )
 }

--- a/react-src/src/mi-trabajo/components/Viewbar.jsx
+++ b/react-src/src/mi-trabajo/components/Viewbar.jsx
@@ -1,0 +1,31 @@
+// Viewbar.jsx — título + tabs de "Mi trabajo" (#501). Se portala sobre la viewbar
+// del shell. Solo clases Bootstrap (ADR-015).
+import React from 'react'
+
+const TABS = [
+  { id: 'cola',  label: '📋 Cola' },
+  { id: 'subir', label: '📤 Subir documento' },
+]
+
+export default function Viewbar({ tab, onTab }) {
+  return (
+    <div className="d-flex align-items-center gap-3 w-100">
+      <span className="fw-semibold text-nowrap">
+        <i className="fas fa-inbox me-1" /> Mi trabajo
+      </span>
+      <ul className="nav nav-pills gap-1 mb-0">
+        {TABS.map((t) => (
+          <li className="nav-item" key={t.id}>
+            <button
+              type="button"
+              className={`nav-link py-1 px-2 ${tab === t.id ? 'active' : ''}`}
+              onClick={() => onTab(t.id)}
+            >
+              {t.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/react-src/src/mi-trabajo/index.jsx
+++ b/react-src/src/mi-trabajo/index.jsx
@@ -1,0 +1,6 @@
+// Entry de la isla "mi-trabajo" (#501, ADR-017).
+// Auto-montaje: busca [data-react-island="mi-trabajo"] y renderiza App ahí.
+import { mountIsland } from '../shared/mountIsland.js'
+import App from './App.jsx'
+
+mountIsland('mi-trabajo', App)

--- a/react-src/src/shared/auth.js
+++ b/react-src/src/shared/auth.js
@@ -42,3 +42,21 @@ export function getRolActivo() {
 export function tienePermiso(nombre) {
   return getPermisos().includes(nombre)
 }
+
+// Permisos del árbol por tipo de nodo (ADR-017 §6 / #501). Frontera hoja/estructura:
+// las tareas se gobiernan con gestionar_tareas (incluye ADMINISTRATIVO); la estructura
+// (solicitud/fase/trámite) con gestionar_estructura_expediente; el expediente con
+// editar_expediente. El backend impone lo mismo; esto solo oculta botones que darían 403.
+
+export function puedeEditarNodo(tipo) {
+  if (tipo === 'tarea') return tienePermiso('gestionar_tareas')
+  if (tipo === 'expediente') return tienePermiso('editar_expediente')
+  return tienePermiso('gestionar_estructura_expediente')  // solicitud / fase / tramite
+}
+
+export function puedeCrearHijoDe(tipoPadre) {
+  // El permiso depende del tipo de HIJO: bajo trámite se crean tareas (hoja →
+  // gestionar_tareas); bajo expediente/solicitud/fase se crea estructura.
+  if (tipoPadre === 'tramite') return tienePermiso('gestionar_tareas')
+  return tienePermiso('gestionar_estructura_expediente')
+}

--- a/react-src/vite.config.js
+++ b/react-src/vite.config.js
@@ -17,6 +17,7 @@ const ISLANDS = {
   'diagrama-esftt':   resolve(__dirname, 'src/diagrama-esftt/index.jsx'),
   'expediente-arbol': resolve(__dirname, 'src/expediente-arbol/index.jsx'),
   'command-palette':  resolve(__dirname, 'src/command-palette/index.jsx'),
+  'mi-trabajo':       resolve(__dirname, 'src/mi-trabajo/index.jsx'),
 }
 
 export default defineConfig(({ command }) => {

--- a/tests/smoke/test_smoke_cola_administrativo.py
+++ b/tests/smoke/test_smoke_cola_administrativo.py
@@ -1,0 +1,37 @@
+"""Smoke de la cola de "Mi trabajo" del administrativo (#501, ADR-017 §2).
+
+Verifica el contrato del endpoint contra la BD de desarrollo: forma de la respuesta
+y de las filas. No asume que haya tareas pendientes (la cola puede salir vacía).
+"""
+
+_CLAVES_RESPUESTA = {'data', 'next_cursor', 'has_more'}
+_CLAVES_FILA = {
+    'tarea_id', 'expediente_id', 'num_at', 'titular', 'solicitud',
+    'fase', 'tramite', 'tarea', 'pendiente', 'pendiente_codigo', 'plazo', 'tocado_por',
+}
+_TIPOS_TAREA_VALIDOS = {'NOTIFICAR', 'ELABORAR', 'ESPERAR_PLAZO'}
+
+
+def test_cola_responde_contrato(usuario_administrativo):
+    r = usuario_administrativo.get('/api/administrativo/cola?limit=20')
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert _CLAVES_RESPUESTA.issubset(payload.keys())
+    assert isinstance(payload['data'], list)
+
+
+def test_cola_filas_bien_formadas(usuario_administrativo):
+    r = usuario_administrativo.get('/api/administrativo/cola?limit=20')
+    payload = r.get_json()
+    for fila in payload['data']:
+        assert _CLAVES_FILA.issubset(fila.keys())
+        # Solo tipos administrativos; nunca FIN; nunca ANALIZAR
+        assert fila['tarea'] in _TIPOS_TAREA_VALIDOS
+        assert fila['pendiente_codigo'] != 'FIN'
+        assert fila['pendiente']  # texto no vacío
+
+
+def test_cola_visible_para_tramitador(usuario_tramitador):
+    """ADR-013: la cola es visible para todos los roles, no solo el administrativo."""
+    r = usuario_tramitador.get('/api/administrativo/cola?limit=5')
+    assert r.status_code == 200

--- a/tests/smoke/test_smoke_mi_trabajo.py
+++ b/tests/smoke/test_smoke_mi_trabajo.py
@@ -1,0 +1,43 @@
+"""Smoke de la vista "Mi trabajo" (#501, ADR-017 / ADR-019).
+
+Ruta role-adaptive:
+  - ADMINISTRATIVO → isla React (cola + subir) sobre base_app.
+  - resto de roles → redirect al seguimiento (su "mi trabajo" actual).
+"""
+import pytest
+
+
+def test_mi_trabajo_admin_renderiza_shell(usuario_administrativo):
+    r = usuario_administrativo.get('/mi_trabajo/')
+    assert r.status_code == 200
+    assert b'class="app-main"' in r.data
+    assert b'data-react-island="mi-trabajo"' in r.data
+
+
+def test_mi_trabajo_tramitador_redirige_a_seguimiento(usuario_tramitador):
+    r = usuario_tramitador.get('/mi_trabajo/', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/expedientes/seguimiento' in r.headers.get('Location', '')
+
+
+def test_inspector_cola_fragmento(usuario_administrativo, app):
+    """El fragmento del inspector de la cola entrega el detalle + 'Ir a tramitar'."""
+    with app.app_context():
+        from app.models.tareas import Tarea
+        t = Tarea.query.first()
+        if t is None:
+            pytest.skip('No hay tareas en la BD de desarrollo')
+        tarea_id = t.id
+
+    r = usuario_administrativo.get(f'/mi_trabajo/tarea/{tarea_id}/fragmento')
+    assert r.status_code == 200
+    assert 'Ir a tramitar'.encode('utf-8') in r.data
+
+
+def test_destino_post_login_por_rol():
+    """Redirección post-login (#501): a "Mi trabajo" salvo ADMIN (dashboard)."""
+    from app.routes.auth import _destino_post_login
+    assert _destino_post_login('ADMINISTRATIVO') == 'mi_trabajo.index'
+    assert _destino_post_login('TRAMITADOR') == 'mi_trabajo.index'
+    assert _destino_post_login('SUPERVISOR') == 'mi_trabajo.index'
+    assert _destino_post_login('ADMIN') == 'dashboard.index'

--- a/tests/test_501_permisos_administrativo.py
+++ b/tests/test_501_permisos_administrativo.py
@@ -84,6 +84,43 @@ def test_administrativo_puede_subir_al_pool(usuario_administrativo, expediente_s
     )
 
 
+_NODO_INEXISTENTE = 999999999
+
+
+def test_admin_puede_editar_tarea_en_arbol(usuario_administrativo, expediente_seed):
+    """Endpoint REAL del árbol (api_expedientes): editar una TAREA pasa el permiso.
+
+    Se usa un nodo inexistente para no mutar datos: si el permiso pasa, el endpoint
+    llega a resolver el nodo y devuelve 404 (no 403/405). Eso prueba gestionar_tareas.
+    """
+    r = usuario_administrativo.patch(
+        f'/api/expedientes/{expediente_seed}/nodo/tarea/{_NODO_INEXISTENTE}',
+        json={'notas': 'x'},
+    )
+    assert r.status_code not in (403, 405), (
+        f'El ADMINISTRATIVO debería poder editar tareas en el árbol (status {r.status_code})'
+    )
+
+
+def test_admin_no_puede_editar_estructura_en_arbol(usuario_administrativo, expediente_seed):
+    """Editar una FASE (estructura) está vedado al ADMINISTRATIVO → 403 JSON (no redirect)."""
+    r = usuario_administrativo.patch(
+        f'/api/expedientes/{expediente_seed}/nodo/fase/{_NODO_INEXISTENTE}',
+        json={'observaciones': 'x'},
+    )
+    assert r.status_code == 403, f'Editar estructura no debería permitirse al admin (status {r.status_code})'
+    assert r.is_json, 'La denegación debe ser 403 JSON, no un redirect (evita el 405 al seguirlo)'
+
+
+def test_admin_no_puede_crear_fase_en_arbol(usuario_administrativo, expediente_seed):
+    """Crear hijo bajo una SOLICITUD (=fase, estructura) vedado al admin → 403."""
+    r = usuario_administrativo.post(
+        f'/api/expedientes/{expediente_seed}/nodo/solicitud/{_NODO_INEXISTENTE}/hijos',
+        json={'tipo_id': 1},
+    )
+    assert r.status_code == 403
+
+
 def test_tramitador_sigue_pudiendo_crear_fase(usuario_tramitador, solicitud_id):
     """Control de no-regresión: el TRAMITADOR conserva la gestión de estructura.
 

--- a/tests/test_501_permisos_administrativo.py
+++ b/tests/test_501_permisos_administrativo.py
@@ -1,0 +1,93 @@
+"""Permisos del ADMINISTRATIVO sobre el árbol del expediente (#501, ADR-017 §6).
+
+Frontera hoja / estructura:
+  - gestionar_tareas        → incluye ADMINISTRATIVO (completar tareas previstas).
+  - gestionar_estructura_*  → NO incluye ADMINISTRATIVO (crear fases/trámites/solicitudes).
+  - subir al pool           → sin limitación de rol (ADR-027).
+
+Control de acceso: verificar_acceso_expediente devuelve redirect (truthy) si falla
+el permiso; api_bc lo traduce a 403 JSON. Las rutas del pool devuelven ese redirect
+directamente (302). Por eso las aserciones distinguen 302/403 (bloqueo) del resto.
+"""
+import pytest
+
+from app.utils.permisos import PERMISOS
+
+
+# ---------------------------------------------------------------------------
+# Definición del dict PERMISOS (sin BD)
+# ---------------------------------------------------------------------------
+
+def test_gestionar_tareas_incluye_administrativo():
+    assert 'ADMINISTRATIVO' in PERMISOS['gestionar_tareas']
+
+
+def test_gestionar_estructura_excluye_administrativo():
+    assert 'ADMINISTRATIVO' not in PERMISOS['gestionar_estructura_expediente']
+    # Pero sí el tramitador (que "tramita" por definición).
+    assert 'TRAMITADOR' in PERMISOS['gestionar_estructura_expediente']
+
+
+# ---------------------------------------------------------------------------
+# Efecto real en los endpoints
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def solicitud_id(app):
+    with app.app_context():
+        from app.models.solicitudes import Solicitud
+        s = Solicitud.query.first()
+        if s is None:
+            pytest.skip('No hay solicitudes en la BD de desarrollo')
+        return s.id
+
+
+@pytest.fixture
+def tramite_id(app):
+    with app.app_context():
+        from app.models.tramites import Tramite
+        t = Tramite.query.first()
+        if t is None:
+            pytest.skip('No hay trámites en la BD de desarrollo')
+        return t.id
+
+
+def test_administrativo_no_puede_crear_fase(usuario_administrativo, solicitud_id):
+    """Estructura: crear fase está vedado al ADMINISTRATIVO → 403."""
+    r = usuario_administrativo.post(f'/api/bc/solicitud/{solicitud_id}/fases/nueva',
+                                    data={'tipo_fase_id': '1'})
+    assert r.status_code == 403, f'ADMINISTRATIVO no debería crear fases (status {r.status_code})'
+
+
+def test_administrativo_puede_actuar_sobre_tarea(usuario_administrativo, tramite_id):
+    """Hoja: el permiso de tarea pasa para ADMINISTRATIVO.
+
+    Sin tipo_tarea_id el endpoint responde 400 (validación), pero NUNCA 403: eso
+    confirma que el guard de permiso (gestionar_tareas) dejó pasar al admin.
+    """
+    r = usuario_administrativo.post(f'/api/bc/tramite/{tramite_id}/tareas/nueva', data={})
+    assert r.status_code != 403, 'El permiso gestionar_tareas debería incluir al ADMINISTRATIVO'
+
+
+def test_administrativo_puede_subir_al_pool(usuario_administrativo, expediente_seed):
+    """Pool: registrar una URL externa no edita el expediente → sin bloqueo de rol.
+
+    El permiso 'subir_documento' (acceder_expediente) deja pasar al admin; lo que
+    venga después (validación/registro) no es 302/403 de permiso.
+    """
+    r = usuario_administrativo.post(
+        f'/expedientes/{expediente_seed}/documentos/url-externa',
+        json={'url': 'https://www.boe.es/test-501', 'tipo_doc_id': 1},
+    )
+    assert r.status_code not in (302, 403), (
+        f'El ADMINISTRATIVO debería poder registrar en el pool (status {r.status_code})'
+    )
+
+
+def test_tramitador_sigue_pudiendo_crear_fase(usuario_tramitador, solicitud_id):
+    """Control de no-regresión: el TRAMITADOR conserva la gestión de estructura.
+
+    Sin tipo_fase_id válido puede dar 400/404/422, pero nunca 403 de permiso.
+    """
+    r = usuario_tramitador.post(f'/api/bc/solicitud/{solicitud_id}/fases/nueva', data={})
+    assert r.status_code != 403, 'El TRAMITADOR debe conservar gestionar_estructura_expediente'


### PR DESCRIPTION
Implementa la vista **"Mi trabajo"** del rol ADMINISTRATIVO (ADR-017): cola transversal de tareas pendientes + subida de documentos al pool, reutilizando el árbol del expediente como destino de cada acción.

## Cambios

### Permisos (ADR-017 §6)
- Nuevos permisos `gestionar_tareas` (incluye ADMINISTRATIVO) y `gestionar_estructura_expediente` (no). `verificar_acceso_expediente` mapea acciones nuevas (`gestionar_tarea` / `gestionar_estructura` / `subir_documento`) y no encola flash en peticiones JSON.
- CRUD del árbol (`api_expedientes` /nodo/…) gateado por **tipo de nodo**: tarea → `gestionar_tareas`; estructura → `gestionar_estructura_expediente`; crear-hijo según el tipo del hijo. Denegación → **403 JSON** (no redirect). Igual en `api_bc` (API heredada) y en `generar_cert`.
- Pool sin limitación de rol: `pool_registrar_rutas` / `url-externa` → `subir_documento` (= `acceder_expediente`); aportar al pool no edita el expediente (ADR-027).

### Cola administrativa
- `services/cola_administrativo.py`: agregador transversal sobre expedientes EN_TRAMITE; selecciona NOTIFICAR / ELABORAR / ESPERAR_PLAZO no finalizadas reutilizando el núcleo `estado_dominio` (#558); texto de "Pendiente" por tipo+estado.
- `GET /api/administrativo/cola` con cursor, filtros (búsqueda, tipo de expediente, plazo) y scroll infinito.

### Módulo y vista
- Módulo `mi_trabajo` (autodescubierto): ruta `/mi_trabajo/` **role-adaptive** (ADMINISTRATIVO → isla; resto → seguimiento) + entrada única de sidebar. Redirección post-login y cambio de rol al "home" del rol.
- Isla React `mi-trabajo`: pestañas **Tareas pendientes** / **Subir documento** (estándar JdA), tabla con el chrome de listados (`lista-table`), e inspector-detalle de lectura (Opción A, ADR-023 §9) con "Ir a tramitar" al árbol. Subir documento = elegir expediente (reutiliza `/api/search`) + gestor de documentos del expediente.

### Árbol del expediente
- Acciones filtradas por tipo de nodo (`puedeEditarNodo` / `puedeCrearHijoDe`): el admin solo ve editar/crear/borrar sobre hojas.

### Tests
- `test_501_permisos_administrativo` (incl. endpoints reales del árbol: admin edita tarea / estructura → 403 JSON) + smokes de `/mi_trabajo/` y de la cola.

## Fuera de alcance (ADR-017)
Modo Calendario, auto-clasificación heurística (#304/#305), columna/filtro "Tocado por" (placeholder `—`) e histórico de subidas.

Closes #501
